### PR TITLE
Add empty file creation from the folder context menu

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -128,7 +128,7 @@ Legend: **P0** blocks the milestone, **P1** is required for its exit criteria, *
 - [x] **P0** Open files with the default application
 - [ ] **P0** Add an Open With chooser
 - [x] **P0** Create folders from `Ctrl+Shift+N` and the folder background menu
-- [ ] **P0** Create an empty file
+- [x] **P0** Create an empty file
 - [x] **P0** Replace the selected row label with an inline rename input on `F2`, preserving the extension selection and showing validation feedback in place
 - [ ] **P1** Executable-file policy and confirmation
 

--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -10,8 +10,8 @@ use gtk::{gio, glib, prelude::*};
 use crate::{
     model::Location,
     services::{
-        CreateDirectoryRequest, DeleteRequest, LoadHandle, OperationEvent, OperationProvider,
-        PasteRequest, RenameRequest, RestoreRequest, validate_basename,
+        CreateDirectoryRequest, CreateFileRequest, DeleteRequest, LoadHandle, OperationEvent,
+        OperationProvider, PasteRequest, RenameRequest, RestoreRequest, validate_basename,
     },
 };
 
@@ -200,6 +200,39 @@ impl OperationProvider for LocalOperationProvider {
             };
             match folder.make_directory_future(glib::Priority::DEFAULT).await {
                 Ok(()) => emit(OperationEvent::Created {
+                    request_id: request.id,
+                }),
+                Err(error) => emit(OperationEvent::Failed {
+                    request_id: request.id,
+                    message: error.to_string(),
+                }),
+            }
+        });
+        LoadHandle::new(move || task.abort())
+    }
+
+    fn create_file(
+        &self,
+        request: CreateFileRequest,
+        emit: Rc<dyn Fn(OperationEvent)>,
+    ) -> LoadHandle {
+        let task = glib::MainContext::default().spawn_local(async move {
+            let parent = gio_file(&request.parent);
+            let file = match validated_child(&parent, &request.name) {
+                Ok(file) => file,
+                Err(message) => {
+                    emit(OperationEvent::Failed {
+                        request_id: request.id,
+                        message: message.to_owned(),
+                    });
+                    return;
+                }
+            };
+            match file
+                .create_future(gio::FileCreateFlags::NONE, glib::Priority::DEFAULT)
+                .await
+            {
+                Ok(_) => emit(OperationEvent::Created {
                     request_id: request.id,
                 }),
                 Err(error) => emit(OperationEvent::Failed {

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -11,10 +11,10 @@ use crate::{
     app::navigation::{EntryInsertion, EntrySplice, NavigationPath, NavigationState},
     model::{FileEntry, Location, SortDirection, SortKey, ViewPreferences},
     services::{
-        CreateDirectoryRequest, DeleteRequest, DirectoryChange, DirectoryEvent, DirectoryRequest,
-        FileSource, LoadHandle, LocationValidationError, OperationEvent, OperationProvider,
-        OperationRequestId, PasteRequest, RenameRequest, RequestId, RestoreRequest,
-        validate_basename,
+        CreateDirectoryRequest, CreateFileRequest, DeleteRequest, DirectoryChange, DirectoryEvent,
+        DirectoryRequest, FileSource, LoadHandle, LocationValidationError, OperationEvent,
+        OperationProvider, OperationRequestId, PasteRequest, RenameRequest, RequestId,
+        RestoreRequest, validate_basename,
     },
 };
 
@@ -622,6 +622,25 @@ impl Browser {
         let request_id = self.begin_operation();
         let load = provider.create_directory(
             CreateDirectoryRequest {
+                id: request_id,
+                parent,
+                name,
+            },
+            self.operation_callback(request_id, false),
+        );
+        self.operation_load.replace(Some(load));
+    }
+
+    pub fn create_file(self: &Rc<Self>, parent: Location, name: String) {
+        let Some(provider) = self.operation_provider.borrow().clone() else {
+            self.emit(BrowserEvent::OperationFailed {
+                message: "File operations are unavailable".to_owned(),
+            });
+            return;
+        };
+        let request_id = self.begin_operation();
+        let load = provider.create_file(
+            CreateFileRequest {
                 id: request_id,
                 parent,
                 name,

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -11,8 +11,8 @@ pub use file_source::{
     LocationValidationError, RequestId,
 };
 pub use operations::{
-    CreateDirectoryRequest, DeleteRequest, OperationEvent, OperationProvider, OperationRequestId,
-    PasteRequest, RenameRequest, RestoreRequest, validate_basename,
+    CreateDirectoryRequest, CreateFileRequest, DeleteRequest, OperationEvent, OperationProvider,
+    OperationRequestId, PasteRequest, RenameRequest, RestoreRequest, validate_basename,
 };
 pub use preview::{
     Preview, PreviewContent, PreviewEvent, PreviewProvider, PreviewRequest, PreviewRequestId,

--- a/src/services/operations.rs
+++ b/src/services/operations.rs
@@ -41,6 +41,13 @@ pub struct CreateDirectoryRequest {
 }
 
 #[derive(Clone, Debug)]
+pub struct CreateFileRequest {
+    pub id: OperationRequestId,
+    pub parent: Location,
+    pub name: String,
+}
+
+#[derive(Clone, Debug)]
 pub struct PasteRequest {
     pub id: OperationRequestId,
     pub destination: Location,
@@ -114,6 +121,11 @@ pub trait OperationProvider {
     fn create_directory(
         &self,
         request: CreateDirectoryRequest,
+        emit: Rc<dyn Fn(OperationEvent)>,
+    ) -> LoadHandle;
+    fn create_file(
+        &self,
+        request: CreateFileRequest,
         emit: Rc<dyn Fn(OperationEvent)>,
     ) -> LoadHandle;
     fn paste(&self, request: PasteRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle;

--- a/src/style.css
+++ b/src/style.css
@@ -2212,7 +2212,7 @@ menubutton.grid-thumbnail-menu > button:focus-visible {
   outline-offset: -2px;
 }
 
-.file-grid.creating-folder > child:focus-visible .grid-card {
+.file-grid.creating-entry > child:focus-visible .grid-card {
   outline: none;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -1700,7 +1700,7 @@ menubutton.column-header-action > button:focus-visible image {
   font-size: 0.88em;
 }
 
-.new-folder-row {
+.new-entry-row {
   background: alpha(@theme_muted, 0.24);
   border-radius: 6px;
   color: @theme_text;
@@ -1708,7 +1708,7 @@ menubutton.column-header-action > button:focus-visible image {
   padding: 4px;
 }
 
-.new-folder-row .file-icon {
+.new-entry-row .file-icon {
   color: @theme_accent;
 }
 

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -415,7 +415,7 @@ impl BrowserView {
     }
 
     pub fn cancel_new_entry(&self) -> bool {
-        self.state.cancel_new_entry() || self.state.mode_views.borrow().cancel_new_folder()
+        self.state.cancel_new_entry() || self.state.mode_views.borrow().cancel_new_entry()
     }
 
     pub fn rename_is_active(&self) -> bool {
@@ -425,7 +425,7 @@ impl BrowserView {
 
     pub fn new_entry_is_active(&self) -> bool {
         self.state.active_new_entry.borrow().is_some()
-            || self.state.mode_views.borrow().new_folder_is_active()
+            || self.state.mode_views.borrow().new_entry_is_active()
     }
 
     pub fn preview_occupied_width(&self) -> i32 {
@@ -540,11 +540,7 @@ impl BrowserView {
                 .location_at(depth)
                 .map(|location| (depth, location))
         }) {
-            if mode == BrowserMode::Columns {
-                self.state.begin_new_entry(depth, location, true);
-            } else {
-                self.state.mode_views.borrow().begin_new_folder(depth);
-            }
+            self.state.begin_new_entry(depth, location, true);
         }
     }
 
@@ -696,6 +692,13 @@ impl ViewState {
     }
 
     fn begin_new_entry(self: &Rc<Self>, depth: usize, location: Location, is_directory: bool) {
+        if self.mode_views.borrow().mode() != BrowserMode::Columns {
+            self.cancel_new_entry();
+            self.mode_views
+                .borrow()
+                .begin_new_entry(depth, is_directory);
+            return;
+        }
         self.cancel_new_entry();
         self.cancel_rename();
         let columns = self.columns.borrow();

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -60,8 +60,9 @@ struct ColumnView {
     bound_rows: Rc<RefCell<Vec<BoundRow>>>,
     entry_count: Rc<Cell<usize>>,
     spinner: gtk::Spinner,
-    new_folder_row: gtk::Box,
-    new_folder_entry: gtk::Entry,
+    new_entry_row: gtk::Box,
+    new_entry_icon: gtk::Image,
+    new_entry_entry: gtk::Entry,
 }
 
 struct ActiveRename {
@@ -71,8 +72,9 @@ struct ActiveRename {
     spacer: gtk::Box,
 }
 
-struct ActiveNewFolder {
+struct ActiveNewEntry {
     location: Location,
+    is_directory: bool,
     row: gtk::Box,
     field: gtk::Entry,
 }
@@ -214,7 +216,7 @@ pub(super) struct ViewState {
     peek_enabled: Cell<bool>,
     single_click_previews: Cell<bool>,
     active_rename: RefCell<Option<ActiveRename>>,
-    active_new_folder: RefCell<Option<ActiveNewFolder>>,
+    active_new_entry: RefCell<Option<ActiveNewEntry>>,
     delete_progress: RefCell<Option<DeleteProgressView>>,
     pin_handler: RefCell<Option<PinHandler>>,
     browser: Rc<Browser>,
@@ -321,7 +323,7 @@ impl BrowserView {
             peek_enabled: Cell::new(true),
             single_click_previews: Cell::new(true),
             active_rename: RefCell::new(None),
-            active_new_folder: RefCell::new(None),
+            active_new_entry: RefCell::new(None),
             delete_progress: RefCell::new(None),
             pin_handler: RefCell::new(None),
             browser,
@@ -412,8 +414,8 @@ impl BrowserView {
         self.state.cancel_rename()
     }
 
-    pub fn cancel_new_folder(&self) -> bool {
-        self.state.cancel_new_folder() || self.state.mode_views.borrow().cancel_new_folder()
+    pub fn cancel_new_entry(&self) -> bool {
+        self.state.cancel_new_entry() || self.state.mode_views.borrow().cancel_new_folder()
     }
 
     pub fn rename_is_active(&self) -> bool {
@@ -421,8 +423,8 @@ impl BrowserView {
             || self.state.mode_views.borrow().rename_is_active()
     }
 
-    pub fn new_folder_is_active(&self) -> bool {
-        self.state.active_new_folder.borrow().is_some()
+    pub fn new_entry_is_active(&self) -> bool {
+        self.state.active_new_entry.borrow().is_some()
             || self.state.mode_views.borrow().new_folder_is_active()
     }
 
@@ -539,7 +541,7 @@ impl BrowserView {
                 .map(|location| (depth, location))
         }) {
             if mode == BrowserMode::Columns {
-                self.state.begin_new_folder(depth, location);
+                self.state.begin_new_entry(depth, location, true);
             } else {
                 self.state.mode_views.borrow().begin_new_folder(depth);
             }
@@ -693,28 +695,35 @@ impl ViewState {
         }
     }
 
-    fn begin_new_folder(self: &Rc<Self>, depth: usize, location: Location) {
-        self.cancel_new_folder();
+    fn begin_new_entry(self: &Rc<Self>, depth: usize, location: Location, is_directory: bool) {
+        self.cancel_new_entry();
         self.cancel_rename();
         let columns = self.columns.borrow();
         let Some(column) = columns.get(depth) else {
             return;
         };
-        column.new_folder_entry.remove_css_class("error");
-        column.new_folder_entry.set_tooltip_text(None);
-        column.new_folder_entry.set_text("");
-        column.new_folder_row.set_visible(true);
-        self.active_new_folder.replace(Some(ActiveNewFolder {
+        let icon_name = if is_directory {
+            crate::assets::icons::FOLDER
+        } else {
+            crate::assets::icons::DOCUMENTS
+        };
+        crate::assets::set_primary_icon(&column.new_entry_icon, icon_name);
+        column.new_entry_entry.remove_css_class("error");
+        column.new_entry_entry.set_tooltip_text(None);
+        column.new_entry_entry.set_text("");
+        column.new_entry_row.set_visible(true);
+        self.active_new_entry.replace(Some(ActiveNewEntry {
             location,
-            row: column.new_folder_row.clone(),
-            field: column.new_folder_entry.clone(),
+            is_directory,
+            row: column.new_entry_row.clone(),
+            field: column.new_entry_entry.clone(),
         }));
-        column.new_folder_entry.grab_focus();
+        column.new_entry_entry.grab_focus();
     }
 
-    fn submit_new_folder(self: &Rc<Self>, field: &gtk::Entry) {
+    fn submit_new_entry(self: &Rc<Self>, field: &gtk::Entry) {
         if !self
-            .active_new_folder
+            .active_new_entry
             .borrow()
             .as_ref()
             .is_some_and(|active| active.field == *field)
@@ -726,16 +735,20 @@ impl ViewState {
             field.grab_focus();
             return;
         }
-        let Some(active) = self.active_new_folder.take() else {
+        let Some(active) = self.active_new_entry.take() else {
             return;
         };
         active.row.set_visible(false);
         field.set_text("");
-        self.browser.create_directory(active.location, name);
+        if active.is_directory {
+            self.browser.create_directory(active.location, name);
+        } else {
+            self.browser.create_file(active.location, name);
+        }
     }
 
-    fn cancel_new_folder(&self) -> bool {
-        let Some(active) = self.active_new_folder.take() else {
+    fn cancel_new_entry(&self) -> bool {
+        let Some(active) = self.active_new_entry.take() else {
             return false;
         };
         active.field.set_text("");
@@ -2017,7 +2030,7 @@ impl ViewState {
     }
 
     fn begin_rename(self: &Rc<Self>) -> bool {
-        self.cancel_new_folder();
+        self.cancel_new_entry();
         self.sync_mode_selection();
         let Some((depth, source_position, entry)) = self.browser.rename_item() else {
             return false;
@@ -3192,35 +3205,35 @@ impl ViewState {
                 browser.retry_column(depth);
             }
         });
-        let new_folder_row = gtk::Box::new(gtk::Orientation::Horizontal, 8);
-        new_folder_row.add_css_class("file-row");
-        new_folder_row.add_css_class("new-folder-row");
-        new_folder_row.set_visible(false);
-        let new_folder_icon = crate::assets::primary_icon(crate::assets::icons::FOLDER, 17);
-        new_folder_icon.add_css_class("file-icon");
-        let new_folder_entry = gtk::Entry::new();
-        new_folder_entry.add_css_class("inline-rename");
-        new_folder_entry.set_hexpand(true);
-        new_folder_entry.connect_changed(|field| {
+        let new_entry_row = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+        new_entry_row.add_css_class("file-row");
+        new_entry_row.add_css_class("new-entry-row");
+        new_entry_row.set_visible(false);
+        let new_entry_icon = crate::assets::primary_icon(crate::assets::icons::FOLDER, 17);
+        new_entry_icon.add_css_class("file-icon");
+        let new_entry_entry = gtk::Entry::new();
+        new_entry_entry.add_css_class("inline-rename");
+        new_entry_entry.set_hexpand(true);
+        new_entry_entry.connect_changed(|field| {
             update_basename_validation(field);
         });
-        new_folder_row.append(&new_folder_icon);
-        new_folder_row.append(&new_folder_entry);
+        new_entry_row.append(&new_entry_icon);
+        new_entry_row.append(&new_entry_entry);
         let weak_state = Rc::downgrade(self);
-        new_folder_entry.connect_activate(move |field| {
+        new_entry_entry.connect_activate(move |field| {
             if let Some(state) = weak_state.upgrade() {
-                state.submit_new_folder(field);
+                state.submit_new_entry(field);
             }
         });
-        let new_folder_focus = gtk::EventControllerFocus::new();
+        let new_entry_focus = gtk::EventControllerFocus::new();
         let weak_state = Rc::downgrade(self);
-        let field = new_folder_entry.clone();
-        new_folder_focus.connect_leave(move |_| {
+        let field = new_entry_entry.clone();
+        new_entry_focus.connect_leave(move |_| {
             if let Some(state) = weak_state.upgrade() {
-                state.submit_new_folder(&field);
+                state.submit_new_entry(&field);
             }
         });
-        new_folder_entry.add_controller(new_folder_focus);
+        new_entry_entry.add_controller(new_entry_focus);
 
         let presentation = LoadPresentation::new(&scroll, Some(retry));
         install_directory_drop_target(self, &presentation.stack, location.clone());
@@ -3254,7 +3267,7 @@ impl ViewState {
             source_position,
             depth,
         );
-        column.append(&new_folder_row);
+        column.append(&new_entry_row);
         column.append(&presentation.stack);
 
         let shell = gtk::Box::new(gtk::Orientation::Horizontal, 0);
@@ -3324,8 +3337,9 @@ impl ViewState {
             bound_rows,
             entry_count,
             spinner,
-            new_folder_row,
-            new_folder_entry,
+            new_entry_row,
+            new_entry_icon,
+            new_entry_entry,
         });
 
         self.refresh_active_path_rows();
@@ -3546,7 +3560,7 @@ impl ViewState {
             self.hovered_column.set(None);
         }
         self.cancel_rename();
-        self.cancel_new_folder();
+        self.cancel_new_entry();
         self.horizontal_scroll_generation
             .set(self.horizontal_scroll_generation.get().saturating_add(1));
         while self.columns.borrow().len() > len {
@@ -3720,21 +3734,31 @@ pub(super) fn install_folder_context_menu(
     popover.add_css_class("folder-context-popover");
 
     let new_folder = context_menu_option("New Folder", Some("Ctrl+Shift+N"));
+    let new_file = context_menu_option("New File", None);
     let paste = context_menu_option("Paste", Some("Ctrl+V"));
     let select_all = context_menu_option("Select All", Some("Ctrl+A"));
     let properties = context_menu_option("Properties", None);
     content.append(&new_folder);
+    content.append(&new_file);
     content.append(&paste);
     content.append(&select_all);
     content.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
     content.append(&properties);
 
-    let pending_new_folder = Rc::new(Cell::new(false));
-    let pending_for_click = pending_new_folder.clone();
+    let pending_new_entry = Rc::new(Cell::new(None));
+    let pending_for_click = pending_new_entry.clone();
     let new_folder_popover = popover.downgrade();
     new_folder.connect_clicked(move |_| {
-        pending_for_click.set(true);
+        pending_for_click.set(Some(true));
         if let Some(popover) = new_folder_popover.upgrade() {
+            popover.popdown();
+        }
+    });
+    let pending_for_click = pending_new_entry.clone();
+    let new_file_popover = popover.downgrade();
+    new_file.connect_clicked(move |_| {
+        pending_for_click.set(Some(false));
+        if let Some(popover) = new_file_popover.upgrade() {
             popover.popdown();
         }
     });
@@ -3742,14 +3766,14 @@ pub(super) fn install_folder_context_menu(
     let folder = location.clone();
     popover.connect_closed(move |popover| {
         popover.unparent();
-        if !pending_new_folder.replace(false) {
+        let Some(is_directory) = pending_new_entry.take() else {
             return;
-        }
+        };
         let weak = weak.clone();
         let folder = folder.clone();
         glib::idle_add_local_once(move || {
             if let Some(state) = weak.upgrade() {
-                state.begin_new_folder(depth, folder);
+                state.begin_new_entry(depth, folder, is_directory);
             }
         });
     });

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -61,7 +61,8 @@ struct ActiveModeRename {
     label: gtk::Label,
 }
 
-struct ActiveModeNewFolder {
+struct ActiveModeNewEntry {
+    is_directory: bool,
     field: gtk::Entry,
     placeholder: Option<gtk::StringList>,
     stack: Option<gtk::Stack>,
@@ -89,7 +90,8 @@ struct Pane {
     bound_items: Rc<RefCell<Vec<BoundModeItem>>>,
     filter_entry: Option<gtk::Entry>,
     filter_button: Option<gtk::ToggleButton>,
-    new_folder_placeholder: Option<gtk::StringList>,
+    new_entry_placeholder: Option<gtk::StringList>,
+    new_entry_is_directory: Option<Rc<Cell<bool>>>,
 }
 
 pub struct ModeViews {
@@ -104,7 +106,7 @@ pub struct ModeViews {
     cut_locations: Rc<RefCell<Vec<Location>>>,
     context_state: RefCell<Option<Weak<super::browser::ViewState>>>,
     active_rename: Rc<RefCell<Option<ActiveModeRename>>>,
-    active_new_folder: Rc<RefCell<Option<ActiveModeNewFolder>>>,
+    active_new_entry: Rc<RefCell<Option<ActiveModeNewEntry>>>,
     mode: BrowserMode,
     density: BrowserDensity,
     grid_thumbnail_size: Rc<Cell<i32>>,
@@ -163,7 +165,7 @@ impl ModeViews {
             cut_locations: Rc::new(RefCell::new(Vec::new())),
             context_state: RefCell::new(None),
             active_rename: Rc::new(RefCell::new(None)),
-            active_new_folder: Rc::new(RefCell::new(None)),
+            active_new_entry: Rc::new(RefCell::new(None)),
             mode: BrowserMode::Columns,
             density: BrowserDensity::Compact,
             grid_thumbnail_size: Rc::new(Cell::new(DEFAULT_GRID_THUMBNAIL_SIZE)),
@@ -197,23 +199,23 @@ impl ModeViews {
         self.active_rename.borrow().is_some()
     }
 
-    pub fn new_folder_is_active(&self) -> bool {
-        self.active_new_folder.borrow().is_some()
+    pub fn new_entry_is_active(&self) -> bool {
+        self.active_new_entry.borrow().is_some()
     }
 
-    pub fn cancel_new_folder(&self) -> bool {
-        let Some(active) = self.active_new_folder.take() else {
+    pub fn cancel_new_entry(&self) -> bool {
+        let Some(active) = self.active_new_entry.take() else {
             return false;
         };
         active.field.set_text("");
         active.field.remove_css_class("error");
         active.field.set_tooltip_text(None);
-        finish_mode_new_folder(&active);
+        finish_mode_new_entry(&active);
         true
     }
 
-    pub fn begin_new_folder(&self, depth: usize) -> bool {
-        self.cancel_new_folder();
+    pub fn begin_new_entry(&self, depth: usize, is_directory: bool) -> bool {
+        self.cancel_new_entry();
         self.cancel_rename();
         let pane = match self.mode {
             BrowserMode::Columns => return false,
@@ -226,18 +228,22 @@ impl ModeViews {
         let Some(pane) = pane else {
             return false;
         };
-        let Some(placeholder) = pane.new_folder_placeholder.as_ref() else {
+        let Some(placeholder) = pane.new_entry_placeholder.as_ref() else {
             return false;
         };
+        let Some(entry_kind) = pane.new_entry_is_directory.as_ref() else {
+            return false;
+        };
+        entry_kind.set(is_directory);
         placeholder.splice(0, placeholder.n_items(), &[""]);
         pane.stack.set_visible_child_name("content");
         let bound_items = pane.bound_items.clone();
-        let active = self.active_new_folder.clone();
+        let active = self.active_new_entry.clone();
         let placeholder = placeholder.clone();
         let stack = pane.stack.clone();
         let source_model = pane.model.clone();
         let view = pane.view.clone();
-        view.add_css_class("creating-folder");
+        view.add_css_class("creating-entry");
         if let Ok(grid) = view.clone().downcast::<gtk::GridView>() {
             grid.scroll_to(0, gtk::ListScrollFlags::FOCUS, None);
         } else if let Ok(list) = view.clone().downcast::<gtk::ListView>() {
@@ -256,11 +262,12 @@ impl ModeViews {
             });
             let Some(field) = field else {
                 placeholder.splice(0, placeholder.n_items(), &[]);
-                view.remove_css_class("creating-folder");
+                view.remove_css_class("creating-entry");
                 return;
             };
             field.set_text("");
-            active.replace(Some(ActiveModeNewFolder {
+            active.replace(Some(ActiveModeNewEntry {
+                is_directory,
                 field: field.clone(),
                 placeholder: Some(placeholder),
                 stack: Some(stack),
@@ -394,7 +401,7 @@ impl ModeViews {
     }
 
     pub fn set_mode(&mut self, mode: BrowserMode) {
-        self.cancel_new_folder();
+        self.cancel_new_entry();
         self.cancel_rename();
         self.mode = mode;
         self.stack.set_visible_child_name(match mode {
@@ -453,7 +460,7 @@ impl ModeViews {
                 | BrowserEvent::ColumnsTruncated { .. }
                 | BrowserEvent::ColumnAdded { .. }
         ) {
-            self.cancel_new_folder();
+            self.cancel_new_entry();
         }
         match event {
             BrowserEvent::Reset => {
@@ -482,7 +489,7 @@ impl ModeViews {
                     GridOptions {
                         peek_state: self.context_state.borrow().clone(),
                         thumbnail_size: self.grid_thumbnail_size.clone(),
-                        active_new_folder: self.active_new_folder.clone(),
+                        active_new_entry: self.active_new_entry.clone(),
                     },
                     *depth,
                     &location.display_name(),
@@ -498,7 +505,7 @@ impl ModeViews {
                     self.single_click_previews.clone(),
                     self.transfer_handler.clone(),
                     self.cut_locations.clone(),
-                    self.active_new_folder.clone(),
+                    self.active_new_entry.clone(),
                     *depth,
                     &location.display_name(),
                 );
@@ -705,7 +712,7 @@ impl ModeViews {
             GridOptions {
                 peek_state: self.context_state.borrow().clone(),
                 thumbnail_size: self.grid_thumbnail_size.clone(),
-                active_new_folder: self.active_new_folder.clone(),
+                active_new_entry: self.active_new_entry.clone(),
             },
             depth,
             &snapshot.location.display_name(),
@@ -730,7 +737,7 @@ impl ModeViews {
             self.single_click_previews.clone(),
             self.transfer_handler.clone(),
             self.cut_locations.clone(),
-            self.active_new_folder.clone(),
+            self.active_new_entry.clone(),
             depth,
             &snapshot.location.display_name(),
         );
@@ -752,11 +759,11 @@ fn widget_has_focus(widget: &impl IsA<gtk::Widget>, focused: Option<&gtk::Widget
 struct GridOptions {
     peek_state: Option<Weak<super::browser::ViewState>>,
     thumbnail_size: Rc<Cell<i32>>,
-    active_new_folder: Rc<RefCell<Option<ActiveModeNewFolder>>>,
+    active_new_entry: Rc<RefCell<Option<ActiveModeNewEntry>>>,
 }
 
-fn submit_mode_new_folder(
-    active: &RefCell<Option<ActiveModeNewFolder>>,
+fn submit_mode_new_entry(
+    active: &RefCell<Option<ActiveModeNewEntry>>,
     browser: &Weak<Browser>,
     location: &Option<Location>,
     field: &gtk::Entry,
@@ -776,17 +783,21 @@ fn submit_mode_new_folder(
     let Some(active) = active.take() else {
         return;
     };
-    finish_mode_new_folder(&active);
+    finish_mode_new_entry(&active);
     if let (Some(browser), Some(location)) = (browser.upgrade(), location.clone()) {
-        browser.create_directory(location, name);
+        if active.is_directory {
+            browser.create_directory(location, name);
+        } else {
+            browser.create_file(location, name);
+        }
     }
 }
 
-fn finish_mode_new_folder(active: &ActiveModeNewFolder) {
+fn finish_mode_new_entry(active: &ActiveModeNewEntry) {
     active.field.set_text("");
     active.field.remove_css_class("error");
     active.field.set_tooltip_text(None);
-    active.view.remove_css_class("creating-folder");
+    active.view.remove_css_class("creating-entry");
     if let Some(placeholder) = active.placeholder.as_ref() {
         placeholder.splice(0, placeholder.n_items(), &[]);
     }
@@ -928,7 +939,7 @@ fn build_grid_pane(
 ) -> Pane {
     let controls = grid_controls(&browser, depth, options.thumbnail_size.get());
     let thumbnail_size = options.thumbnail_size;
-    let active_new_folder = options.active_new_folder;
+    let active_new_entry = options.active_new_entry;
     let (pane, content, model, stack, status, spinner) = pane_base(
         title,
         "grid-pane",
@@ -949,9 +960,10 @@ fn build_grid_pane(
         query.is_empty() || item.string().to_lowercase().contains(query.as_str())
     });
     let filtered_model = gtk::FilterListModel::new(Some(model.clone()), Some(filter.clone()));
-    let new_folder_placeholder = gtk::StringList::new(&[]);
+    let new_entry_placeholder = gtk::StringList::new(&[]);
+    let new_entry_is_directory = Rc::new(Cell::new(true));
     let flattened_models = gio::ListStore::new::<gio::ListModel>();
-    flattened_models.append(&new_folder_placeholder.clone().upcast::<gio::ListModel>());
+    flattened_models.append(&new_entry_placeholder.clone().upcast::<gio::ListModel>());
     flattened_models.append(&filtered_model.clone().upcast::<gio::ListModel>());
     let view_model = gtk::FlattenListModel::new(Some(flattened_models));
     let selection = gtk::MultiSelection::new(Some(view_model.clone()));
@@ -971,7 +983,7 @@ fn build_grid_pane(
     let filtered_for_setup = view_model.clone().upcast::<gio::ListModel>();
     let transfers_for_setup = transfer_handler.clone();
     let peek_for_setup = options.peek_state;
-    let active_for_setup = active_new_folder.clone();
+    let active_for_setup = active_new_entry.clone();
     let folder_location = browser.location_at(depth);
     factory.connect_setup(move |_, item| {
         let Some(item) = item.downcast_ref::<gtk::ListItem>() else {
@@ -1009,7 +1021,7 @@ fn build_grid_pane(
         let browser_for_submit = browser_for_setup.clone();
         let location_for_submit = folder_location.clone();
         field.connect_activate(move |field| {
-            submit_mode_new_folder(
+            submit_mode_new_entry(
                 &active_for_submit,
                 &browser_for_submit,
                 &location_for_submit,
@@ -1022,7 +1034,7 @@ fn build_grid_pane(
         let location_for_leave = folder_location.clone();
         let field_for_leave = field.clone();
         focus.connect_leave(move |_| {
-            submit_mode_new_folder(
+            submit_mode_new_entry(
                 &active_for_leave,
                 &browser_for_leave,
                 &location_for_leave,
@@ -1074,6 +1086,7 @@ fn build_grid_pane(
     let filtered_for_bind = view_model.clone().upcast::<gio::ListModel>();
     let cuts_for_bind = cut_locations.clone();
     let thumbnail_size_for_bind = thumbnail_size.clone();
+    let entry_kind_for_bind = new_entry_is_directory.clone();
     factory.connect_bind(move |_, item| {
         let Some(item) = item.downcast_ref::<gtk::ListItem>() else {
             return;
@@ -1117,7 +1130,12 @@ fn build_grid_pane(
             icon.set_opacity(if entry.is_directory() { 1.0 } else { 0.72 });
         } else {
             card.remove_css_class("cut-item");
-            crate::assets::set_primary_icon(&icon, crate::assets::icons::FOLDER);
+            let icon_name = if entry_kind_for_bind.get() {
+                crate::assets::icons::FOLDER
+            } else {
+                crate::assets::icons::DOCUMENTS
+            };
+            crate::assets::set_primary_icon(&icon, icon_name);
             icon.set_opacity(1.0);
             label.set_visible(false);
             field.set_visible(true);
@@ -1208,7 +1226,8 @@ fn build_grid_pane(
         bound_items,
         filter_entry: Some(controls.filter_entry),
         filter_button: Some(controls.filter_button),
-        new_folder_placeholder: Some(new_folder_placeholder),
+        new_entry_placeholder: Some(new_entry_placeholder),
+        new_entry_is_directory: Some(new_entry_is_directory),
     }
 }
 
@@ -1478,7 +1497,7 @@ fn build_explorer_pane(
     single_click_previews: Rc<Cell<bool>>,
     transfer_handler: TransferHandlerSlot,
     cut_locations: Rc<RefCell<Vec<Location>>>,
-    active_new_folder: Rc<RefCell<Option<ActiveModeNewFolder>>>,
+    active_new_entry: Rc<RefCell<Option<ActiveModeNewEntry>>>,
     depth: usize,
     title: &str,
 ) -> Pane {
@@ -1512,9 +1531,10 @@ fn build_explorer_pane(
         *filter_query.borrow_mut() = entry.text().to_lowercase();
         filter.changed(gtk::FilterChange::Different);
     });
-    let new_folder_placeholder = gtk::StringList::new(&[]);
+    let new_entry_placeholder = gtk::StringList::new(&[]);
+    let new_entry_is_directory = Rc::new(Cell::new(true));
     let flattened_models = gio::ListStore::new::<gio::ListModel>();
-    flattened_models.append(&new_folder_placeholder.clone().upcast::<gio::ListModel>());
+    flattened_models.append(&new_entry_placeholder.clone().upcast::<gio::ListModel>());
     flattened_models.append(&filtered_model.upcast::<gio::ListModel>());
     let view_model = gtk::FlattenListModel::new(Some(flattened_models));
     let view_model_object = view_model.clone().upcast::<gio::ListModel>();
@@ -1532,7 +1552,7 @@ fn build_explorer_pane(
     let browser_for_setup = Rc::downgrade(&browser);
     let previews_for_setup = single_click_previews.clone();
     let transfers_for_setup = transfer_handler.clone();
-    let active_for_setup = active_new_folder.clone();
+    let active_for_setup = active_new_entry.clone();
     let source_for_setup = model.clone();
     let view_model_for_setup = view_model_object.clone();
     let folder_location = browser.location_at(depth);
@@ -1562,7 +1582,7 @@ fn build_explorer_pane(
         let browser_for_submit = browser_for_setup.clone();
         let location_for_submit = folder_location.clone();
         field.connect_activate(move |field| {
-            submit_mode_new_folder(
+            submit_mode_new_entry(
                 &active_for_submit,
                 &browser_for_submit,
                 &location_for_submit,
@@ -1575,7 +1595,7 @@ fn build_explorer_pane(
         let location_for_leave = folder_location.clone();
         let field_for_leave = field.clone();
         focus.connect_leave(move |_| {
-            submit_mode_new_folder(
+            submit_mode_new_entry(
                 &active_for_leave,
                 &browser_for_leave,
                 &location_for_leave,
@@ -1633,6 +1653,7 @@ fn build_explorer_pane(
     let source_for_bind = model.clone();
     let view_model_for_bind = view_model_object.clone();
     let cuts_for_bind = cut_locations.clone();
+    let entry_kind_for_bind = new_entry_is_directory.clone();
     factory.connect_bind(move |_, item| {
         let Some(item) = item.downcast_ref::<gtk::ListItem>() else {
             return;
@@ -1686,7 +1707,12 @@ fn build_explorer_pane(
             modified.set_label(&entry_modified(&entry));
         } else {
             row.remove_css_class("cut-item");
-            crate::assets::set_primary_icon(&icon, crate::assets::icons::FOLDER);
+            let icon_name = if entry_kind_for_bind.get() {
+                crate::assets::icons::FOLDER
+            } else {
+                crate::assets::icons::DOCUMENTS
+            };
+            crate::assets::set_primary_icon(&icon, icon_name);
             name.set_visible(false);
             field.set_visible(true);
             size.set_label("");
@@ -1745,7 +1771,8 @@ fn build_explorer_pane(
         bound_items,
         filter_entry: Some(filter_entry),
         filter_button: Some(filter_button),
-        new_folder_placeholder: Some(new_folder_placeholder),
+        new_entry_placeholder: Some(new_entry_placeholder),
+        new_entry_is_directory: Some(new_entry_is_directory),
     }
 }
 

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -401,13 +401,13 @@ fn install_keyboard_navigation(
         if key == gtk::gdk::Key::F2 && view.begin_rename() {
             return glib::Propagation::Stop;
         }
-        if key == gtk::gdk::Key::Escape && view.cancel_new_folder() {
+        if key == gtk::gdk::Key::Escape && view.cancel_new_entry() {
             return glib::Propagation::Stop;
         }
         if key == gtk::gdk::Key::Escape && view.cancel_rename() {
             return glib::Propagation::Stop;
         }
-        if view.rename_is_active() || view.new_folder_is_active() {
+        if view.rename_is_active() || view.new_entry_is_active() {
             return glib::Propagation::Proceed;
         }
         if key == gtk::gdk::Key::Escape && view.dismiss_focused_filter() {


### PR DESCRIPTION
## Summary
- Generalizes the existing "New Folder" inline entry into a shared new-entry row that creates either a directory or an empty file
- Adds a "New File" option to the folder background context menu, alongside "New Folder"
- Adds `CreateFileRequest`/`OperationProvider::create_file`, implemented in the local adapter via `gio::File::create_future`
- Checks off "Create an empty file" in `docs/todo.md`

Closes the P0 work-breakdown item for creating an empty file.

## Test plan
- [x] `./scripts/check.sh` (fmt, clippy `-D warnings`, tests, cargo-deny, typos) passes
- [x] `cargo test` — 112 passed
- [x] Manually ran the app and confirmed the folder browser still opens correctly and "New Folder" (Ctrl+Shift+N and context menu) is unaffected