### PR TITLE
feat(preview): sandbox untrusted parsing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,12 @@
 # Agent Instructions
 
+## Git workflow
+
+- Never commit or push directly to `main`. Work from a GitHub issue and submit changes through a pull request.
+- Name branches `<type>/<issue-number>-<short-kebab-description>`, for example `feat/6-sandbox-previews`. Use Conventional Commit types such as `feat`, `fix`, `docs`, `refactor`, `test`, `perf`, `build`, `ci`, and `chore`.
+- Write commits and pull request titles in Conventional Commits format: `<type>(optional-scope): <imperative description>`.
+- Keep commits focused. Use `!` and a `BREAKING CHANGE:` footer for breaking changes, and reference the issue in the pull request body.
+
 ## Test organization
 
 - Do not place test implementations inline with production code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,32 @@ installs missing native dependencies (prompting for `sudo`) and installs
 make start-dev
 ```
 
+## Branching and pull requests
+
+All changes to `main` go through a pull request. The normal process is:
+
+1. Create or select a GitHub issue and assign it before starting work.
+2. Update local `main`, then create a branch from it.
+3. Name the branch `<type>/<issue-number>-<short-kebab-description>`, such as `feat/6-sandbox-previews` or `fix/42-preview-timeout`.
+4. Make focused Conventional Commits and push the branch.
+5. Open a pull request that references the issue and wait for CI.
+6. The maintainer tests the pull request before it is merged. Do not push directly to `main`.
+
+Use the Conventional Commit form for commit messages and pull request titles:
+
+```text
+<type>(optional-scope): <imperative description>
+```
+
+Common types are `feat`, `fix`, `docs`, `refactor`, `test`, `perf`, `build`, `ci`, and `chore`. Examples:
+
+```text
+feat(preview): sandbox untrusted image parsing
+fix(navigation): preserve selection after reload
+```
+
+Use `!` after the type or scope and add a `BREAKING CHANGE:` footer when a change is incompatible. Keep unrelated changes in separate commits.
+
 ## Required checks
 
 Before opening a pull request:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Strata is not yet available through Arch's package repositories. Download the ar
 Install the runtime libraries and optional video-thumbnail helper on Arch or Omarchy:
 
 ```bash
-sudo pacman -S --needed fontconfig gtk4 gtksourceview5 poppler-glib ffmpegthumbnailer
+sudo pacman -S --needed bubblewrap fontconfig gtk4 gtksourceview5 poppler-glib ffmpegthumbnailer
 ```
 
 Then verify, extract, and install the downloaded archive (replace the filename with the release you downloaded):
@@ -70,7 +70,7 @@ tar -xzf strata-<version>-<target>.tar.gz
 install -Dm755 strata-<version>-<target>/strata ~/.local/bin/strata
 ```
 
-Ensure `~/.local/bin` is on `PATH`, then run `strata`. Image thumbnails work without `ffmpegthumbnailer`; when that optional program is unavailable, video files fall back to their video icon.
+Ensure `~/.local/bin` is on `PATH`, then run `strata`. Image thumbnails work without `ffmpegthumbnailer`; when that optional program is unavailable, video files fall back to their video icon. Bubblewrap is required: preview parsing fails closed rather than running untrusted native parsers without a sandbox. See [Preview sandbox](docs/preview-sandbox.md) for the providers, permissions, and resource limits.
 
 #### Optional RAW photo thumbnails
 
@@ -186,7 +186,7 @@ The architectural boundaries and performance workflow are documented in [`docs/a
 On Arch Linux:
 
 ```bash
-sudo pacman -S --needed base-devel rust fontconfig gtk4 gtksourceview5 poppler-glib
+sudo pacman -S --needed base-devel rust bubblewrap fontconfig gtk4 gtksourceview5 poppler-glib
 ```
 
 Run Strata:

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ Strata is not yet available through Arch's package repositories. Download the ar
 - `x86_64-unknown-linux-gnu` for Intel and AMD PCs
 - `aarch64-unknown-linux-gnu` for ARM64 PCs
 
-Install the runtime libraries and optional video-thumbnail helper on Arch or Omarchy:
+Install the runtime libraries and optional video preview tools on Arch or Omarchy:
 
 ```bash
-sudo pacman -S --needed bubblewrap fontconfig gtk4 gtksourceview5 poppler-glib ffmpegthumbnailer
+sudo pacman -S --needed bubblewrap ffmpeg ffmpegthumbnailer fontconfig gtk4 gtksourceview5 poppler-glib
 ```
 
 Then verify, extract, and install the downloaded archive (replace the filename with the release you downloaded):
@@ -70,7 +70,7 @@ tar -xzf strata-<version>-<target>.tar.gz
 install -Dm755 strata-<version>-<target>/strata ~/.local/bin/strata
 ```
 
-Ensure `~/.local/bin` is on `PATH`, then run `strata`. Image thumbnails work without `ffmpegthumbnailer`; when that optional program is unavailable, video files fall back to their video icon. Bubblewrap is required: preview parsing fails closed rather than running untrusted native parsers without a sandbox. See [Preview sandbox](docs/preview-sandbox.md) for the providers, permissions, and resource limits.
+Ensure `~/.local/bin` is on `PATH`, then run `strata`. Image thumbnails work without `ffmpegthumbnailer`; when `ffmpegthumbnailer` or `ffmpeg` is unavailable, video files fall back to their video icon or an unavailable preview. Bubblewrap is required: preview parsing fails closed rather than running untrusted native parsers without a sandbox. See [Preview sandbox](docs/preview-sandbox.md) for the providers, permissions, and resource limits.
 
 #### Optional RAW photo thumbnails
 

--- a/docs/preview-sandbox.md
+++ b/docs/preview-sandbox.md
@@ -1,0 +1,26 @@
+# Preview sandbox
+
+Strata treats files shown while browsing as untrusted. Native parsers do not receive the user's normal filesystem or network access.
+
+## Sandboxed providers
+
+The following providers run in a short-lived helper process:
+
+- GDK Pixbuf image and camera RAW loaders;
+- Poppler PDF thumbnail and page rendering;
+- ImageMagick and `dcraw`/`dcraw_emu` RAW fallbacks; and
+- `ffmpegthumbnailer` media thumbnails.
+
+Image and media previews are normalized to PNG by the helper. Media previews are intentionally static so GStreamer does not parse an untrusted file in the Strata process. Plain-text previews remain in-process and are limited to 1 MB; they do not invoke a native format parser.
+
+## Isolation and limits
+
+Strata starts its own executable in a bubblewrap sandbox. The sandbox has:
+
+- a new user, mount, PID, IPC, UTS, cgroup, and network namespace;
+- read-only access to `/usr`, required runtime libraries and font/ImageMagick configuration, the Strata executable, and exactly one canonicalized input file;
+- writable access only to private mode-0700 output and temporary directories;
+- an empty environment with a nonexistent home directory;
+- 512 MB address-space, 10-second CPU, 32 MB file-size, and 12-second wall-clock limits.
+
+The parent accepts only a bounded PNG result. Cancellation or timeout kills bubblewrap, which is the sandbox PID-namespace init process, and therefore tears down all helper descendants. A missing bubblewrap installation, renderer crash, malformed result, timeout, or permission failure is fail-closed and produces the normal fallback icon or **Preview unavailable** message.

--- a/docs/preview-sandbox.md
+++ b/docs/preview-sandbox.md
@@ -11,7 +11,7 @@ The following providers run in a short-lived helper process:
 - ImageMagick and `dcraw`/`dcraw_emu` RAW fallbacks; and
 - `ffmpegthumbnailer` media thumbnails.
 
-Image and media previews are normalized to PNG by the helper. Media previews are intentionally static so GStreamer does not parse an untrusted file in the Strata process. Plain-text previews remain in-process and are limited to 1 MB; they do not invoke a native format parser.
+Image previews are normalized to PNG by the helper. Video previews are transcoded to a fixed WebM profile and limited to the first 30 seconds before GTK receives them, so GStreamer never parses the selected untrusted file directly. Plain-text previews remain in-process and are limited to 1 MB; they do not invoke a native format parser.
 
 ## Isolation and limits
 
@@ -21,6 +21,6 @@ Strata starts its own executable in a bubblewrap sandbox. The sandbox has:
 - read-only access to `/usr`, required runtime libraries and font/ImageMagick configuration, the Strata executable, and exactly one canonicalized input file;
 - writable access only to private mode-0700 output and temporary directories;
 - an empty environment with a nonexistent home directory;
-- 1 GB address-space, 10-second CPU, 32 MB file-size, and 12-second wall-clock limits.
+- 1.25 GB address-space, 10-second CPU, 32 MB file-size, and 12-second wall-clock limits.
 
 The parent accepts only a bounded PNG result. Cancellation or timeout kills bubblewrap, which is the sandbox PID-namespace init process, and therefore tears down all helper descendants. A missing bubblewrap installation, renderer crash, malformed result, timeout, or permission failure is fail-closed and produces the normal fallback icon or **Preview unavailable** message.

--- a/docs/preview-sandbox.md
+++ b/docs/preview-sandbox.md
@@ -21,6 +21,6 @@ Strata starts its own executable in a bubblewrap sandbox. The sandbox has:
 - read-only access to `/usr`, required runtime libraries and font/ImageMagick configuration, the Strata executable, and exactly one canonicalized input file;
 - writable access only to private mode-0700 output and temporary directories;
 - an empty environment with a nonexistent home directory;
-- 512 MB address-space, 10-second CPU, 32 MB file-size, and 12-second wall-clock limits.
+- 1 GB address-space, 10-second CPU, 32 MB file-size, and 12-second wall-clock limits.
 
 The parent accepts only a bounded PNG result. Cancellation or timeout kills bubblewrap, which is the sandbox PID-namespace init process, and therefore tears down all helper descendants. A missing bubblewrap installation, renderer crash, malformed result, timeout, or permission failure is fail-closed and produces the normal fallback icon or **Preview unavailable** message.

--- a/src/adapters/local_preview.rs
+++ b/src/adapters/local_preview.rs
@@ -6,6 +6,7 @@ use gtk::{gio, glib, prelude::*};
 
 use crate::{
     model::Location,
+    sandbox::{Cancellation, ParseOperation},
     services::{
         LoadHandle, Preview, PreviewContent, PreviewEvent, PreviewProvider, PreviewRequest,
         content_family, has_plain_text_extension,
@@ -19,6 +20,8 @@ impl PreviewProvider for LocalPreviewProvider {
     fn load(&self, request: PreviewRequest, emit: Rc<dyn Fn(PreviewEvent)>) -> LoadHandle {
         let request_id = request.id;
         let entry = request.entry.clone();
+        let cancellation = Cancellation::default();
+        let cancellation_for_task = cancellation.clone();
         let task = glib::MainContext::default().spawn_local(async move {
             let file = file_for_location(&entry.location);
             let info = match file
@@ -54,10 +57,39 @@ impl PreviewProvider for LocalPreviewProvider {
                 };
             }
 
-            if matches!(content, PreviewContent::Pdf { .. }) {
-                content = match render_pdf(&file, request.pdf_page).await {
-                    Ok((png, page, pages)) => PreviewContent::Pdf { png, page, pages },
-                    Err(message) => {
+            let operation = match content {
+                PreviewContent::Pdf { .. } => Some(ParseOperation::PreviewPdf),
+                PreviewContent::Image => Some(ParseOperation::PreviewImage),
+                PreviewContent::Media => Some(ParseOperation::PreviewMedia),
+                PreviewContent::Text { .. }
+                | PreviewContent::Rasterized { .. }
+                | PreviewContent::Unsupported => None,
+            };
+            if let Some(operation) = operation {
+                let Some(path) = entry.location.native_path().map(ToOwned::to_owned) else {
+                    emit(PreviewEvent::Failed {
+                        request_id,
+                        entry,
+                        message: "Only local files can be previewed safely".to_owned(),
+                    });
+                    return;
+                };
+                let value = request.pdf_page;
+                let cancellation = cancellation_for_task.clone();
+                content = match gio::spawn_blocking(move || {
+                    crate::sandbox::parse(&path, operation, value, &cancellation)
+                })
+                .await
+                {
+                    Ok(Ok(output)) if operation == ParseOperation::PreviewPdf => {
+                        PreviewContent::Pdf {
+                            png: output.png,
+                            page: output.page,
+                            pages: output.pages,
+                        }
+                    }
+                    Ok(Ok(output)) => PreviewContent::Rasterized { png: output.png },
+                    Ok(Err(message)) => {
                         emit(PreviewEvent::Failed {
                             request_id,
                             entry,
@@ -65,6 +97,7 @@ impl PreviewProvider for LocalPreviewProvider {
                         });
                         return;
                     }
+                    Err(_) => return,
                 };
             } else if matches!(content, PreviewContent::Text { .. }) {
                 content = match read_text(&file, request.text_byte_limit).await {
@@ -88,7 +121,10 @@ impl PreviewProvider for LocalPreviewProvider {
             }));
         });
 
-        LoadHandle::new(move || task.abort())
+        LoadHandle::new(move || {
+            cancellation.cancel();
+            task.abort();
+        })
     }
 }
 
@@ -97,53 +133,6 @@ fn file_for_location(location: &Location) -> gio::File {
         .native_path()
         .map(gio::File::for_path)
         .unwrap_or_else(|| gio::File::for_uri(location.uri_value().unwrap_or_default()))
-}
-
-async fn render_pdf(file: &gio::File, page: i32) -> Result<(Vec<u8>, i32, i32), String> {
-    let uri = file.uri().to_string();
-    gio::spawn_blocking(move || render_pdf_blocking(&uri, page))
-        .await
-        .map_err(|_| "The PDF renderer stopped unexpectedly".to_owned())?
-}
-
-fn render_pdf_blocking(uri: &str, requested_page: i32) -> Result<(Vec<u8>, i32, i32), String> {
-    const MAX_WIDTH: f64 = 1400.0;
-    const MAX_HEIGHT: f64 = 1800.0;
-    const MAX_PIXELS: f64 = 2_500_000.0;
-
-    let document = poppler::Document::from_file(uri, None).map_err(|error| error.to_string())?;
-    let pages = document.n_pages();
-    if pages <= 0 {
-        return Err("This PDF has no pages".to_owned());
-    }
-    let page_index = requested_page.clamp(0, pages - 1);
-    let page = document
-        .page(page_index)
-        .ok_or_else(|| "Unable to load that PDF page".to_owned())?;
-    let (page_width, page_height) = page.size();
-    if page_width <= 0.0 || page_height <= 0.0 {
-        return Err("The PDF page has invalid dimensions".to_owned());
-    }
-
-    let scale = (MAX_WIDTH / page_width)
-        .min(MAX_HEIGHT / page_height)
-        .min((MAX_PIXELS / (page_width * page_height)).sqrt());
-    let width = (page_width * scale).ceil() as i32;
-    let height = (page_height * scale).ceil() as i32;
-    let surface = cairo::ImageSurface::create(cairo::Format::ARgb32, width, height)
-        .map_err(|error| error.to_string())?;
-    let context = cairo::Context::new(&surface).map_err(|error| error.to_string())?;
-    context.set_source_rgb(1.0, 1.0, 1.0);
-    context.paint().map_err(|error| error.to_string())?;
-    context.scale(scale, scale);
-    page.render(&context);
-    surface.flush();
-
-    let mut png = Vec::new();
-    surface
-        .write_to_png(&mut png)
-        .map_err(|error| error.to_string())?;
-    Ok((png, page_index, pages))
 }
 
 async fn read_text(file: &gio::File, byte_limit: usize) -> Result<(String, bool), glib::Error> {

--- a/src/adapters/local_preview.rs
+++ b/src/adapters/local_preview.rs
@@ -63,6 +63,7 @@ impl PreviewProvider for LocalPreviewProvider {
                 PreviewContent::Media => Some(ParseOperation::PreviewMedia),
                 PreviewContent::Text { .. }
                 | PreviewContent::Rasterized { .. }
+                | PreviewContent::SandboxedMedia { .. }
                 | PreviewContent::Unsupported => None,
             };
             if let Some(operation) = operation {
@@ -83,12 +84,15 @@ impl PreviewProvider for LocalPreviewProvider {
                 {
                     Ok(Ok(output)) if operation == ParseOperation::PreviewPdf => {
                         PreviewContent::Pdf {
-                            png: output.png,
+                            png: output.data,
                             page: output.page,
                             pages: output.pages,
                         }
                     }
-                    Ok(Ok(output)) => PreviewContent::Rasterized { png: output.png },
+                    Ok(Ok(output)) if operation == ParseOperation::PreviewMedia => {
+                        PreviewContent::SandboxedMedia { data: output.data }
+                    }
+                    Ok(Ok(output)) => PreviewContent::Rasterized { png: output.data },
                     Ok(Err(message)) => {
                         emit(PreviewEvent::Failed {
                             request_id,

--- a/src/adapters/local_preview/tests.rs
+++ b/src/adapters/local_preview/tests.rs
@@ -2,10 +2,6 @@
 
 use std::fs;
 
-use gtk::gio::prelude::FileExt;
-
-use super::render_pdf_blocking;
-
 #[test]
 fn renders_requested_pdf_pages_within_the_pixel_budget() {
     let path = std::env::temp_dir().join(format!(
@@ -25,11 +21,22 @@ fn renders_requested_pdf_pages_within_the_pixel_budget() {
     }
     surface.finish();
 
-    let uri = gtk::gio::File::for_path(&path).uri();
-    let (png, page, pages) = render_pdf_blocking(&uri, 1).expect("render second PDF page");
+    let output_directory = path.with_extension("output");
+    fs::create_dir(&output_directory).expect("create output directory");
+    let output = output_directory.join("result.png");
+    crate::sandbox_helper::run(&[
+        "preview-pdf".to_owned(),
+        path.to_string_lossy().into_owned(),
+        output.to_string_lossy().into_owned(),
+        "1".to_owned(),
+    ])
+    .expect("render second PDF page");
+    let png = fs::read(&output).expect("read rendered page");
+    let metadata =
+        fs::read_to_string(output_directory.join("result.meta")).expect("read PDF metadata");
     let _removed = fs::remove_file(path);
+    let _removed = fs::remove_dir_all(output_directory);
 
-    assert_eq!(page, 1);
-    assert_eq!(pages, 2);
+    assert_eq!(metadata, "1 2");
     assert!(png.starts_with(b"\x89PNG\r\n\x1a\n"));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@ mod app;
 mod assets;
 mod metrics;
 mod model;
+mod sandbox;
+mod sandbox_helper;
 mod services;
 mod ui;
 
@@ -13,6 +15,18 @@ use gtk::{gio, prelude::*};
 const APPLICATION_ID: &str = "io.github.lgse.Strata";
 
 fn main() -> gtk::glib::ExitCode {
+    let arguments: Vec<_> = std::env::args().collect();
+    if arguments
+        .get(1)
+        .is_some_and(|value| value == "--preview-helper")
+    {
+        if let Err(error) = sandbox_helper::run(&arguments[2..]) {
+            eprintln!("Preview helper failed: {error}");
+            return gtk::glib::ExitCode::FAILURE;
+        }
+        return gtk::glib::ExitCode::SUCCESS;
+    }
+
     metrics::initialize();
     if let Err(error) = tracing_subscriber::fmt::try_init() {
         eprintln!("Unable to initialize logging: {error}");

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -39,6 +39,14 @@ impl ParseOperation {
             Self::PreviewMedia => "preview-media",
         }
     }
+
+    fn output_name(self) -> &'static str {
+        if self == Self::PreviewMedia {
+            "result.webm"
+        } else {
+            "result.png"
+        }
+    }
 }
 
 #[derive(Clone, Default)]
@@ -55,7 +63,7 @@ impl Cancellation {
 }
 
 pub(crate) struct ParseOutput {
-    pub(crate) png: Vec<u8>,
+    pub(crate) data: Vec<u8>,
     pub(crate) page: i32,
     pub(crate) pages: i32,
 }
@@ -109,18 +117,18 @@ pub(crate) fn parse(
         return Err("The sandboxed preview renderer failed".to_owned());
     }
 
-    let png_path = output.path().join("result.png");
-    let metadata =
-        fs::metadata(&png_path).map_err(|_| "The preview renderer produced no image".to_owned())?;
+    let result_path = output.path().join(operation.output_name());
+    let metadata = fs::metadata(&result_path)
+        .map_err(|_| "The preview renderer produced no output".to_owned())?;
     if metadata.len() == 0 || metadata.len() > MAX_OUTPUT_BYTES {
-        return Err("The preview renderer produced an invalid image size".to_owned());
+        return Err("The preview renderer produced an invalid output size".to_owned());
     }
-    let png = fs::read(png_path).map_err(|error| error.to_string())?;
-    if !png.starts_with(b"\x89PNG\r\n\x1a\n") {
+    let data = fs::read(result_path).map_err(|error| error.to_string())?;
+    if operation != ParseOperation::PreviewMedia && !data.starts_with(b"\x89PNG\r\n\x1a\n") {
         return Err("The preview renderer produced invalid image data".to_owned());
     }
     let (page, pages) = read_metadata(&output.path().join("result.meta"));
-    Ok(ParseOutput { png, page, pages })
+    Ok(ParseOutput { data, page, pages })
 }
 
 fn sandbox_command(
@@ -184,7 +192,7 @@ fn sandbox_command(
     command.args([
         "--",
         "/usr/bin/prlimit",
-        "--as=1073741824",
+        "--as=1342177280",
         "--cpu=10",
         "--fsize=33554432",
         "--",
@@ -192,8 +200,8 @@ fn sandbox_command(
         "--preview-helper",
         operation.argument(),
         "/input",
-        "/output/result.png",
     ]);
+    command.arg(format!("/output/{}", operation.output_name()));
     command.arg(value.to_string());
     command
 }

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+    thread,
+    time::{Duration, Instant},
+};
+
+const WALL_TIME_LIMIT: Duration = Duration::from_secs(12);
+const MAX_OUTPUT_BYTES: u64 = 32 * 1024 * 1024;
+static NEXT_DIRECTORY: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ParseOperation {
+    ThumbnailImage,
+    ThumbnailRaw,
+    ThumbnailPdf,
+    ThumbnailVideo,
+    PreviewImage,
+    PreviewPdf,
+    PreviewMedia,
+}
+
+impl ParseOperation {
+    fn argument(self) -> &'static str {
+        match self {
+            Self::ThumbnailImage => "thumbnail-image",
+            Self::ThumbnailRaw => "thumbnail-raw",
+            Self::ThumbnailPdf => "thumbnail-pdf",
+            Self::ThumbnailVideo => "thumbnail-video",
+            Self::PreviewImage => "preview-image",
+            Self::PreviewPdf => "preview-pdf",
+            Self::PreviewMedia => "preview-media",
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct Cancellation(Arc<AtomicBool>);
+
+impl Cancellation {
+    pub(crate) fn cancel(&self) {
+        self.0.store(true, Ordering::Release);
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::Acquire)
+    }
+}
+
+pub(crate) struct ParseOutput {
+    pub(crate) png: Vec<u8>,
+    pub(crate) page: i32,
+    pub(crate) pages: i32,
+}
+
+pub(crate) fn parse(
+    input: &Path,
+    operation: ParseOperation,
+    value: i32,
+    cancellation: &Cancellation,
+) -> Result<ParseOutput, String> {
+    if cancellation.is_cancelled() {
+        return Err("Preview cancelled".to_owned());
+    }
+    let input = input
+        .canonicalize()
+        .map_err(|error| format!("Unable to open preview input: {error}"))?;
+    if !input.is_file() {
+        return Err("Preview input is not a regular file".to_owned());
+    }
+
+    let output = PrivateOutput::create().map_err(|error| error.to_string())?;
+    let executable = std::env::current_exe()
+        .map_err(|error| format!("Unable to locate the Strata executable: {error}"))?;
+    let mut command = sandbox_command(&executable, &input, output.path(), operation, value);
+    let mut child = command
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| format!("Unable to start the preview sandbox: {error}"))?;
+    let started = Instant::now();
+
+    let status = loop {
+        if cancellation.is_cancelled() {
+            terminate(&mut child);
+            return Err("Preview cancelled".to_owned());
+        }
+        if started.elapsed() >= WALL_TIME_LIMIT {
+            terminate(&mut child);
+            return Err("The preview renderer timed out".to_owned());
+        }
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => thread::sleep(Duration::from_millis(20)),
+            Err(error) => {
+                terminate(&mut child);
+                return Err(format!("Unable to monitor the preview renderer: {error}"));
+            }
+        }
+    };
+    if !status.success() {
+        return Err("The sandboxed preview renderer failed".to_owned());
+    }
+
+    let png_path = output.path().join("result.png");
+    let metadata =
+        fs::metadata(&png_path).map_err(|_| "The preview renderer produced no image".to_owned())?;
+    if metadata.len() == 0 || metadata.len() > MAX_OUTPUT_BYTES {
+        return Err("The preview renderer produced an invalid image size".to_owned());
+    }
+    let png = fs::read(png_path).map_err(|error| error.to_string())?;
+    if !png.starts_with(b"\x89PNG\r\n\x1a\n") {
+        return Err("The preview renderer produced invalid image data".to_owned());
+    }
+    let (page, pages) = read_metadata(&output.path().join("result.meta"));
+    Ok(ParseOutput { png, page, pages })
+}
+
+fn sandbox_command(
+    executable: &Path,
+    input: &Path,
+    output: &Path,
+    operation: ParseOperation,
+    value: i32,
+) -> Command {
+    let mut command = Command::new("bwrap");
+    command.args([
+        "--unshare-all",
+        "--die-with-parent",
+        "--new-session",
+        "--clearenv",
+        "--setenv",
+        "PATH",
+        "/usr/bin",
+        "--setenv",
+        "HOME",
+        "/nonexistent",
+        "--setenv",
+        "XDG_CACHE_HOME",
+        "/tmp/cache",
+        "--proc",
+        "/proc",
+        "--dev",
+        "/dev",
+        "--tmpfs",
+        "/tmp",
+        "--dir",
+        "/app",
+        "--dir",
+        "/etc",
+        "--ro-bind",
+        "/usr",
+        "/usr",
+        "--ro-bind-try",
+        "/lib",
+        "/lib",
+        "--ro-bind-try",
+        "/lib64",
+        "/lib64",
+        "--ro-bind-try",
+        "/etc/fonts",
+        "/etc/fonts",
+        "--ro-bind-try",
+        "/etc/ld.so.cache",
+        "/etc/ld.so.cache",
+        "--ro-bind-try",
+        "/etc/ImageMagick-7",
+        "/etc/ImageMagick-7",
+        "--ro-bind-try",
+        "/etc/ImageMagick-6",
+        "/etc/ImageMagick-6",
+        "--ro-bind",
+    ]);
+    command.arg(executable).arg("/app/strata");
+    command.arg("--ro-bind").arg(input).arg("/input");
+    command.arg("--bind").arg(output).arg("/output");
+    command.args([
+        "--",
+        "/usr/bin/prlimit",
+        "--as=536870912",
+        "--cpu=10",
+        "--fsize=33554432",
+        "--nproc=64",
+        "--",
+        "/app/strata",
+        "--preview-helper",
+        operation.argument(),
+        "/input",
+        "/output/result.png",
+    ]);
+    command.arg(value.to_string());
+    command
+}
+
+fn terminate(child: &mut std::process::Child) {
+    // bwrap is the PID-namespace init process. Killing it tears down every process in
+    // the sandbox, including descendants started by ImageMagick or thumbnail tools.
+    let _killed = child.kill();
+    let _waited = child.wait();
+}
+
+fn read_metadata(path: &Path) -> (i32, i32) {
+    let Ok(value) = fs::read_to_string(path) else {
+        return (0, 0);
+    };
+    let mut values = value
+        .split_whitespace()
+        .filter_map(|part| part.parse().ok());
+    (values.next().unwrap_or(0), values.next().unwrap_or(0))
+}
+
+struct PrivateOutput(PathBuf);
+
+impl PrivateOutput {
+    fn create() -> io::Result<Self> {
+        use std::os::unix::fs::DirBuilderExt;
+
+        let path = std::env::temp_dir().join(format!(
+            "strata-preview-{}-{}",
+            std::process::id(),
+            NEXT_DIRECTORY.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::DirBuilder::new().mode(0o700).create(&path)?;
+        Ok(Self(path))
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for PrivateOutput {
+    fn drop(&mut self) {
+        let _removed = fs::remove_dir_all(&self.0);
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -184,10 +184,9 @@ fn sandbox_command(
     command.args([
         "--",
         "/usr/bin/prlimit",
-        "--as=536870912",
+        "--as=1073741824",
         "--cpu=10",
         "--fsize=33554432",
-        "--nproc=64",
         "--",
         "/app/strata",
         "--preview-helper",

--- a/src/sandbox/tests.rs
+++ b/src/sandbox/tests.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::path::Path;
+
+use super::{Cancellation, ParseOperation, parse, sandbox_command};
+
+#[test]
+fn sandbox_exposes_only_runtime_input_and_private_output() {
+    let command = sandbox_command(
+        Path::new("/tmp/strata"),
+        Path::new("/home/alice/Downloads/untrusted.pdf"),
+        Path::new("/tmp/private-output"),
+        ParseOperation::PreviewPdf,
+        2,
+    );
+    let arguments: Vec<_> = command
+        .get_args()
+        .map(|argument| argument.to_string_lossy().into_owned())
+        .collect();
+    let joined = arguments.join(" ");
+
+    assert!(joined.contains("--unshare-all"));
+    assert!(joined.contains("--clearenv"));
+    assert!(joined.contains("--ro-bind /home/alice/Downloads/untrusted.pdf /input"));
+    assert!(joined.contains("--bind /tmp/private-output /output"));
+    assert!(joined.contains("--as=536870912"));
+    assert!(joined.contains("--cpu=10"));
+    assert!(joined.contains("--fsize=33554432"));
+    assert!(!joined.contains("--ro-bind /home /home"));
+    assert!(!joined.contains("--share-net"));
+}
+
+#[test]
+fn cancelled_requests_fail_without_starting_a_renderer() {
+    let cancellation = Cancellation::default();
+    cancellation.cancel();
+    let error = parse(
+        Path::new("does-not-need-to-exist"),
+        ParseOperation::PreviewImage,
+        0,
+        &cancellation,
+    )
+    .err()
+    .expect("cancelled parse must fail");
+
+    assert_eq!(error, "Preview cancelled");
+}

--- a/src/sandbox/tests.rs
+++ b/src/sandbox/tests.rs
@@ -23,9 +23,12 @@ fn sandbox_exposes_only_runtime_input_and_private_output() {
     assert!(joined.contains("--clearenv"));
     assert!(joined.contains("--ro-bind /home/alice/Downloads/untrusted.pdf /input"));
     assert!(joined.contains("--bind /tmp/private-output /output"));
-    assert!(joined.contains("--as=536870912"));
+    assert!(joined.contains("--as=1073741824"));
     assert!(joined.contains("--cpu=10"));
     assert!(joined.contains("--fsize=33554432"));
+    // RLIMIT_NPROC counts every process owned by the host user, not just the
+    // sandbox, and can prevent legitimate media decoders from starting.
+    assert!(!joined.contains("--nproc"));
     assert!(!joined.contains("--ro-bind /home /home"));
     assert!(!joined.contains("--share-net"));
 }

--- a/src/sandbox/tests.rs
+++ b/src/sandbox/tests.rs
@@ -23,7 +23,7 @@ fn sandbox_exposes_only_runtime_input_and_private_output() {
     assert!(joined.contains("--clearenv"));
     assert!(joined.contains("--ro-bind /home/alice/Downloads/untrusted.pdf /input"));
     assert!(joined.contains("--bind /tmp/private-output /output"));
-    assert!(joined.contains("--as=1073741824"));
+    assert!(joined.contains("--as=1342177280"));
     assert!(joined.contains("--cpu=10"));
     assert!(joined.contains("--fsize=33554432"));
     // RLIMIT_NPROC counts every process owned by the host user, not just the

--- a/src/sandbox_helper.rs
+++ b/src/sandbox_helper.rs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::{fs, path::Path, process::Command};
+
+use gdk_pixbuf::prelude::*;
+use gtk::gio;
+
+pub(crate) fn run(arguments: &[String]) -> Result<(), String> {
+    let [operation, input, output, value] = arguments else {
+        return Err("Invalid preview helper arguments".to_owned());
+    };
+    let input = Path::new(input);
+    let output = Path::new(output);
+    let value = value
+        .parse::<i32>()
+        .map_err(|_| "Invalid preview helper size or page".to_owned())?;
+
+    let (png, metadata) = match operation.as_str() {
+        "thumbnail-image" => (render_pixbuf(input, value.clamp(16, 256))?, None),
+        "thumbnail-raw" => (render_raw(input, value.clamp(16, 256))?, None),
+        "thumbnail-pdf" => (render_pdf_thumbnail(input, value.clamp(16, 256))?, None),
+        "thumbnail-video" => (render_media(input, value.clamp(16, 256))?, None),
+        "preview-image" => (render_pixbuf(input, 1400)?, None),
+        "preview-pdf" => {
+            let (png, page, pages) = render_pdf_page(input, value)?;
+            (png, Some(format!("{page} {pages}")))
+        }
+        "preview-media" => (render_media(input, 1400)?, None),
+        _ => return Err("Unknown preview helper operation".to_owned()),
+    };
+    fs::write(output, png).map_err(|error| error.to_string())?;
+    if let Some(metadata) = metadata {
+        fs::write(output.with_file_name("result.meta"), metadata)
+            .map_err(|error| error.to_string())?;
+    }
+    Ok(())
+}
+
+fn render_pixbuf(path: &Path, size: i32) -> Result<Vec<u8>, String> {
+    gdk_pixbuf::Pixbuf::from_file_at_scale(path, size, size, true)
+        .map_err(|error| error.to_string())?
+        .save_to_bufferv("png", &[])
+        .map_err(|error| error.to_string())
+}
+
+fn render_raw(path: &Path, size: i32) -> Result<Vec<u8>, String> {
+    render_pixbuf(path, size)
+        .or_else(|_| render_imagemagick(path, size))
+        .or_else(|_| render_dcraw(path, size))
+}
+
+fn render_imagemagick(path: &Path, size: i32) -> Result<Vec<u8>, String> {
+    for executable in ["magick", "convert"] {
+        let output = Command::new(executable)
+            .arg(path)
+            .args(["-auto-orient", "-thumbnail"])
+            .arg(format!("{size}x{size}"))
+            .arg("png:-")
+            .output();
+        if let Ok(output) = output
+            && output.status.success()
+            && !output.stdout.is_empty()
+        {
+            return Ok(output.stdout);
+        }
+    }
+    Err("No RAW image renderer succeeded".to_owned())
+}
+
+fn render_dcraw(path: &Path, size: i32) -> Result<Vec<u8>, String> {
+    for executable in ["dcraw_emu", "dcraw"] {
+        let output = Command::new(executable)
+            .args(["-e", "-c"])
+            .arg(path)
+            .output();
+        let Ok(output) = output else {
+            continue;
+        };
+        if !output.status.success() || output.stdout.is_empty() {
+            continue;
+        }
+        let loader = gdk_pixbuf::PixbufLoader::new();
+        if loader.write(&output.stdout).is_err() || loader.close().is_err() {
+            continue;
+        }
+        let Some(pixbuf) = loader.pixbuf() else {
+            continue;
+        };
+        let width = pixbuf.width().max(1);
+        let height = pixbuf.height().max(1);
+        let scale = (f64::from(size) / f64::from(width))
+            .min(f64::from(size) / f64::from(height))
+            .min(1.0);
+        let Some(scaled) = pixbuf.scale_simple(
+            (f64::from(width) * scale).round().max(1.0) as i32,
+            (f64::from(height) * scale).round().max(1.0) as i32,
+            gdk_pixbuf::InterpType::Bilinear,
+        ) else {
+            continue;
+        };
+        if let Ok(png) = scaled.save_to_bufferv("png", &[]) {
+            return Ok(png);
+        }
+    }
+    Err("No embedded RAW thumbnail could be decoded".to_owned())
+}
+
+fn render_pdf_thumbnail(path: &Path, size: i32) -> Result<Vec<u8>, String> {
+    let uri = gio::File::for_path(path).uri();
+    let document = poppler::Document::from_file(&uri, None).map_err(|error| error.to_string())?;
+    let page = document
+        .page(0)
+        .ok_or_else(|| "This PDF has no pages".to_owned())?;
+    render_pdf_surface(
+        &page,
+        f64::from(size),
+        f64::from(size),
+        f64::from(size * size),
+    )
+}
+
+fn render_pdf_page(path: &Path, requested_page: i32) -> Result<(Vec<u8>, i32, i32), String> {
+    let uri = gio::File::for_path(path).uri();
+    let document = poppler::Document::from_file(&uri, None).map_err(|error| error.to_string())?;
+    let pages = document.n_pages();
+    if pages <= 0 {
+        return Err("This PDF has no pages".to_owned());
+    }
+    let page_index = requested_page.clamp(0, pages - 1);
+    let page = document
+        .page(page_index)
+        .ok_or_else(|| "Unable to load that PDF page".to_owned())?;
+    let png = render_pdf_surface(&page, 1400.0, 1800.0, 2_500_000.0)?;
+    Ok((png, page_index, pages))
+}
+
+fn render_pdf_surface(
+    page: &poppler::Page,
+    max_width: f64,
+    max_height: f64,
+    max_pixels: f64,
+) -> Result<Vec<u8>, String> {
+    let (page_width, page_height) = page.size();
+    if page_width <= 0.0 || page_height <= 0.0 {
+        return Err("The PDF page has invalid dimensions".to_owned());
+    }
+    let scale = (max_width / page_width)
+        .min(max_height / page_height)
+        .min((max_pixels / (page_width * page_height)).sqrt());
+    let width = (page_width * scale).ceil().max(1.0) as i32;
+    let height = (page_height * scale).ceil().max(1.0) as i32;
+    let surface = cairo::ImageSurface::create(cairo::Format::ARgb32, width, height)
+        .map_err(|error| error.to_string())?;
+    let context = cairo::Context::new(&surface).map_err(|error| error.to_string())?;
+    context.set_source_rgb(1.0, 1.0, 1.0);
+    context.paint().map_err(|error| error.to_string())?;
+    context.scale(scale, scale);
+    page.render(&context);
+    surface.flush();
+    let mut png = Vec::new();
+    surface
+        .write_to_png(&mut png)
+        .map_err(|error| error.to_string())?;
+    Ok(png)
+}
+
+fn render_media(path: &Path, size: i32) -> Result<Vec<u8>, String> {
+    let output = Command::new("ffmpegthumbnailer")
+        .arg("-i")
+        .arg(path)
+        .args(["-o", "/dev/stdout", "-s"])
+        .arg(size.to_string())
+        .args(["-q", "8"])
+        .output()
+        .map_err(|error| error.to_string())?;
+    if output.status.success() && !output.stdout.is_empty() {
+        Ok(output.stdout)
+    } else {
+        Err("Unable to render media thumbnail".to_owned())
+    }
+}

--- a/src/sandbox_helper.rs
+++ b/src/sandbox_helper.rs
@@ -25,7 +25,10 @@ pub(crate) fn run(arguments: &[String]) -> Result<(), String> {
             let (png, page, pages) = render_pdf_page(input, value)?;
             (png, Some(format!("{page} {pages}")))
         }
-        "preview-media" => (render_media(input, 1400)?, None),
+        "preview-media" => {
+            render_media_preview(input, output)?;
+            return Ok(());
+        }
         _ => return Err("Unknown preview helper operation".to_owned()),
     };
     fs::write(output, png).map_err(|error| error.to_string())?;
@@ -162,6 +165,52 @@ fn render_pdf_surface(
         .write_to_png(&mut png)
         .map_err(|error| error.to_string())?;
     Ok(png)
+}
+
+fn render_media_preview(path: &Path, output: &Path) -> Result<(), String> {
+    let status = Command::new("ffmpeg")
+        .args(["-nostdin", "-v", "error", "-threads", "2", "-i"])
+        .arg(path)
+        .args([
+            "-map",
+            "0:v:0",
+            "-map",
+            "0:a:0?",
+            "-sn",
+            "-dn",
+            "-t",
+            "30",
+            "-vf",
+            "scale=w='min(1280,iw)':h=-2:force_original_aspect_ratio=decrease",
+            "-c:v",
+            "libvpx",
+            "-threads",
+            "2",
+            "-deadline",
+            "realtime",
+            "-cpu-used",
+            "8",
+            "-b:v",
+            "2M",
+            "-maxrate",
+            "3M",
+            "-bufsize",
+            "4M",
+            "-c:a",
+            "libopus",
+            "-b:a",
+            "96k",
+            "-f",
+            "webm",
+            "-y",
+        ])
+        .arg(output)
+        .status()
+        .map_err(|error| error.to_string())?;
+    status
+        .success()
+        .then_some(())
+        .ok_or_else(|| "Unable to normalize media preview".to_owned())
 }
 
 fn render_media(path: &Path, size: i32) -> Result<Vec<u8>, String> {

--- a/src/services/preview.rs
+++ b/src/services/preview.rs
@@ -22,6 +22,7 @@ pub enum PreviewContent {
     Text { content: String, truncated: bool },
     Image,
     Media,
+    Rasterized { png: Vec<u8> },
     Pdf { png: Vec<u8>, page: i32, pages: i32 },
     Unsupported,
 }

--- a/src/services/preview.rs
+++ b/src/services/preview.rs
@@ -23,6 +23,7 @@ pub enum PreviewContent {
     Image,
     Media,
     Rasterized { png: Vec<u8> },
+    SandboxedMedia { data: Vec<u8> },
     Pdf { png: Vec<u8>, page: i32, pages: i32 },
     Unsupported,
 }

--- a/src/style.css
+++ b/src/style.css
@@ -744,20 +744,39 @@ paned > separator {
   font-weight: 700;
 }
 
-.preview-close {
+.preview-header-action {
   background: transparent;
-  border: none;
+  border: 1px solid transparent;
   border-radius: 5px;
   box-shadow: none;
-  color: @theme_border;
+  color: @theme_accent;
   min-height: 24px;
   min-width: 24px;
   padding: 2px;
 }
 
-.preview-close:hover {
+.preview-header-action:hover {
   background: alpha(@theme_muted, 0.62);
+  border-color: alpha(@theme_border, 0.42);
   color: @theme_accent;
+}
+
+.preview-header-action:active {
+  background: alpha(@theme_muted, 0.82);
+  border-color: @theme_accent;
+  color: @theme_accent;
+}
+
+.preview-header-action:focus-visible {
+  outline: 2px solid alpha(@theme_accent, 0.52);
+  outline-offset: 1px;
+}
+
+.preview-header-action:disabled {
+  background: transparent;
+  border-color: transparent;
+  color: @theme_dim_text;
+  opacity: 0.46;
 }
 
 .preview-metadata {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -5235,7 +5235,7 @@ fn properties_action(icon: &str, label: &str) -> gtk::Button {
     button
 }
 
-fn open_location(location: &Location, parent: &impl IsA<gtk::Widget>) {
+pub(super) fn open_location(location: &Location, parent: &impl IsA<gtk::Widget>) {
     let file = gio_file_for_location(location);
     let uri = file.uri();
     if let Err(error) = gio::AppInfo::launch_default_for_uri(&uri, None::<&gio::AppLaunchContext>) {

--- a/src/ui/preview.rs
+++ b/src/ui/preview.rs
@@ -7,7 +7,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use gtk::{gio, glib, prelude::*};
+use gtk::{glib, prelude::*};
 use sourceview5::prelude::*;
 
 use crate::{
@@ -36,7 +36,6 @@ struct PreviewState {
     modified: gtk::Label,
     content_type: gtk::Label,
     content: gtk::Box,
-    media: RefCell<Option<gtk::Video>>,
     split: RefCell<Option<gtk::Paned>>,
     occupied_width: RefCell<Option<Rc<dyn Fn() -> i32>>>,
     current: RefCell<Option<FileEntry>>,
@@ -116,7 +115,6 @@ impl PreviewDrawer {
             modified,
             content_type,
             content,
-            media: RefCell::new(None),
             split: RefCell::new(None),
             occupied_width: RefCell::new(None),
             current: RefCell::new(None),
@@ -380,27 +378,26 @@ impl PreviewState {
                     self.content.append(&notice);
                 }
             }
-            PreviewContent::Image => {
-                let file = file_for_entry(&preview.entry);
-                let picture = gtk::Picture::for_file(&file);
-                picture.add_css_class("preview-image");
-                picture.set_can_shrink(true);
-                picture.set_content_fit(gtk::ContentFit::Contain);
-                picture.set_hexpand(true);
-                picture.set_vexpand(true);
-                self.content.append(&picture);
+            PreviewContent::Rasterized { png } => {
+                let bytes = glib::Bytes::from_owned(png);
+                match gtk::gdk::Texture::from_bytes(&bytes) {
+                    Ok(texture) => {
+                        let picture = gtk::Picture::for_paintable(&texture);
+                        picture.add_css_class("preview-image");
+                        picture.set_can_shrink(true);
+                        picture.set_content_fit(gtk::ContentFit::Contain);
+                        picture.set_hexpand(true);
+                        picture.set_vexpand(true);
+                        self.content.append(&picture);
+                    }
+                    Err(error) => self.show_message("Preview unavailable", &error.to_string()),
+                }
             }
-            PreviewContent::Media => {
-                let file = file_for_entry(&preview.entry);
-                let video = gtk::Video::new();
-                video.add_css_class("preview-media");
-                video.set_autoplay(false);
-                video.set_loop(false);
-                video.set_file(Some(&file));
-                video.set_hexpand(true);
-                video.set_vexpand(true);
-                self.media.replace(Some(video.clone()));
-                self.content.append(&video);
+            PreviewContent::Image | PreviewContent::Media => {
+                self.show_message(
+                    "Preview unavailable",
+                    "The sandboxed renderer returned no image",
+                );
             }
             PreviewContent::Pdf { png, page, pages } => {
                 self.render_pdf_viewer(preview.entry, png, page, pages);
@@ -681,12 +678,6 @@ impl PreviewState {
     }
 
     fn clear_content(&self) {
-        if let Some(video) = self.media.borrow_mut().take() {
-            if let Some(stream) = video.media_stream() {
-                stream.set_playing(false);
-            }
-            video.set_file(gio::File::NONE);
-        }
         clear_box(&self.content);
     }
 
@@ -822,14 +813,6 @@ fn clear_box(box_: &gtk::Box) {
     while let Some(child) = box_.first_child() {
         box_.remove(&child);
     }
-}
-
-fn file_for_entry(entry: &FileEntry) -> gio::File {
-    entry
-        .location
-        .native_path()
-        .map(gio::File::for_path)
-        .unwrap_or_else(|| gio::File::for_uri(entry.location.uri_value().unwrap_or_default()))
 }
 
 fn metadata_size(entry: &FileEntry) -> String {

--- a/src/ui/preview.rs
+++ b/src/ui/preview.rs
@@ -71,6 +71,15 @@ impl PreviewDrawer {
         title.set_ellipsize(gtk::pango::EllipsizeMode::Middle);
         title.set_hexpand(true);
         title.set_xalign(0.0);
+        let open = gtk::Button::builder()
+            .tooltip_text("Open in default application")
+            .valign(gtk::Align::Center)
+            .build();
+        open.set_child(Some(&crate::assets::primary_icon(
+            crate::assets::icons::EXTERNAL_LINK,
+            16,
+        )));
+        open.add_css_class("preview-header-action");
         let close = gtk::Button::builder()
             .tooltip_text("Close preview (Space)")
             .valign(gtk::Align::Center)
@@ -80,8 +89,10 @@ impl PreviewDrawer {
             16,
         )));
         close.add_css_class("preview-close");
+        close.add_css_class("preview-header-action");
         header.append(&icon);
         header.append(&title);
+        header.append(&open);
         header.append(&close);
         pane.append(&header);
 
@@ -128,6 +139,28 @@ impl PreviewDrawer {
             last_split_width: Cell::new(0),
             animating: Cell::new(false),
             animation_generation: Rc::new(Cell::new(0)),
+        });
+        let weak = Rc::downgrade(&state);
+        open.connect_clicked(move |_| {
+            let Some(state) = weak.upgrade() else {
+                return;
+            };
+            let location = state
+                .current
+                .borrow()
+                .as_ref()
+                .map(|entry| entry.location.clone());
+            if let Some(location) = location {
+                if let Some(stream) = state
+                    .media
+                    .borrow()
+                    .as_ref()
+                    .and_then(gtk::Video::media_stream)
+                {
+                    stream.set_playing(false);
+                }
+                super::browser::open_location(&location, &state.pane);
+            }
         });
         let weak = Rc::downgrade(&state);
         close.connect_clicked(move |_| {
@@ -407,6 +440,13 @@ impl PreviewState {
                 video.set_vexpand(true);
                 self.media.replace(Some(video.clone()));
                 self.content.append(&video);
+                let notice = gtk::Label::new(Some(
+                    "Preview limited to the first 30 seconds. Open the file to play the full video.",
+                ));
+                notice.add_css_class("preview-note");
+                notice.set_wrap(true);
+                notice.set_xalign(0.0);
+                self.content.append(&notice);
             }
             PreviewContent::Image | PreviewContent::Media => {
                 self.show_message(

--- a/src/ui/preview.rs
+++ b/src/ui/preview.rs
@@ -7,7 +7,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use gtk::{glib, prelude::*};
+use gtk::{gio, glib, prelude::*};
 use sourceview5::prelude::*;
 
 use crate::{
@@ -36,6 +36,7 @@ struct PreviewState {
     modified: gtk::Label,
     content_type: gtk::Label,
     content: gtk::Box,
+    media: RefCell<Option<gtk::Video>>,
     split: RefCell<Option<gtk::Paned>>,
     occupied_width: RefCell<Option<Rc<dyn Fn() -> i32>>>,
     current: RefCell<Option<FileEntry>>,
@@ -115,6 +116,7 @@ impl PreviewDrawer {
             modified,
             content_type,
             content,
+            media: RefCell::new(None),
             split: RefCell::new(None),
             occupied_width: RefCell::new(None),
             current: RefCell::new(None),
@@ -393,10 +395,23 @@ impl PreviewState {
                     Err(error) => self.show_message("Preview unavailable", &error.to_string()),
                 }
             }
+            PreviewContent::SandboxedMedia { data } => {
+                let bytes = glib::Bytes::from_owned(data);
+                let stream = gio::MemoryInputStream::from_bytes(&bytes);
+                let media = gtk::MediaFile::for_input_stream(&stream);
+                let video = gtk::Video::for_media_stream(Some(&media));
+                video.add_css_class("preview-media");
+                video.set_autoplay(false);
+                video.set_loop(false);
+                video.set_hexpand(true);
+                video.set_vexpand(true);
+                self.media.replace(Some(video.clone()));
+                self.content.append(&video);
+            }
             PreviewContent::Image | PreviewContent::Media => {
                 self.show_message(
                     "Preview unavailable",
-                    "The sandboxed renderer returned no image",
+                    "The sandboxed renderer returned no preview",
                 );
             }
             PreviewContent::Pdf { png, page, pages } => {
@@ -678,6 +693,11 @@ impl PreviewState {
     }
 
     fn clear_content(&self) {
+        if let Some(video) = self.media.borrow_mut().take()
+            && let Some(stream) = video.media_stream()
+        {
+            stream.set_playing(false);
+        }
         clear_box(&self.content);
     }
 

--- a/src/ui/preview.rs
+++ b/src/ui/preview.rs
@@ -444,8 +444,9 @@ impl PreviewState {
                     "Preview limited to the first 30 seconds. Open the file to play the full video.",
                 ));
                 notice.add_css_class("preview-note");
+                notice.set_justify(gtk::Justification::Center);
                 notice.set_wrap(true);
-                notice.set_xalign(0.0);
+                notice.set_xalign(0.5);
                 self.content.append(&notice);
             }
             PreviewContent::Image | PreviewContent::Media => {

--- a/src/ui/thumbnail.rs
+++ b/src/ui/thumbnail.rs
@@ -4,23 +4,30 @@ use std::{
     cell::RefCell,
     collections::{HashMap, VecDeque},
     path::{Path, PathBuf},
-    process::Command,
     sync::atomic::{AtomicU64, Ordering},
 };
 
-use gdk_pixbuf::prelude::*;
 use gtk::{gdk, gio, glib, prelude::*};
 
-use crate::model::{FileEntry, MetadataValue};
+use crate::{
+    model::{FileEntry, MetadataValue},
+    sandbox::{Cancellation, ParseOperation},
+};
 
 static NEXT_REQUEST: AtomicU64 = AtomicU64::new(1);
 const MAX_CACHE_ENTRIES: usize = 256;
 const MAX_CACHE_BYTES: usize = 64 * 1024 * 1024;
 
 thread_local! {
-    static ACTIVE_REQUESTS: RefCell<HashMap<usize, (u64, glib::WeakRef<gtk::Image>)>> =
+    static ACTIVE_REQUESTS: RefCell<HashMap<usize, ActiveRequest>> =
         RefCell::new(HashMap::new());
     static THUMBNAIL_CACHE: RefCell<ThumbnailCache> = RefCell::new(ThumbnailCache::default());
+}
+
+struct ActiveRequest {
+    id: u64,
+    image: glib::WeakRef<gtk::Image>,
+    cancellation: Cancellation,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -80,7 +87,7 @@ pub(super) fn set_thumbnail_or_icon(
     icon_size: i32,
     thumbnail_size: i32,
 ) {
-    let (image_id, request) = set_fallback_icon(image, fallback_icon, icon_size);
+    let (image_id, request, cancellation) = set_fallback_icon(image, fallback_icon, icon_size);
 
     let Some(path) = entry.location.native_path().map(Path::to_path_buf) else {
         return;
@@ -103,9 +110,11 @@ pub(super) fn set_thumbnail_or_icon(
     let weak_image = glib::WeakRef::new();
     weak_image.set(Some(image));
     glib::MainContext::default().spawn_local(async move {
-        let result =
-            gio::spawn_blocking(move || render_thumbnail(&path, kind, thumbnail_size)).await;
-        let Ok(Some(png)) = result else {
+        let result = gio::spawn_blocking(move || {
+            render_thumbnail(&path, kind, thumbnail_size, &cancellation)
+        })
+        .await;
+        let Ok(Ok(png)) = result else {
             return;
         };
         let bytes = glib::Bytes::from_owned(png);
@@ -114,7 +123,7 @@ pub(super) fn set_thumbnail_or_icon(
             requests
                 .borrow()
                 .get(&image_id)
-                .is_some_and(|active| active.0 == request)
+                .is_some_and(|active| active.id == request)
         });
         if !is_current {
             return;
@@ -150,20 +159,30 @@ pub(super) fn show_fallback_icon(image: &gtk::Image, icon: &str, size: i32) {
     set_fallback_icon(image, icon, size);
 }
 
-fn set_fallback_icon(image: &gtk::Image, icon: &str, size: i32) -> (usize, u64) {
+fn set_fallback_icon(image: &gtk::Image, icon: &str, size: i32) -> (usize, u64, Cancellation) {
     let request = NEXT_REQUEST.fetch_add(1, Ordering::Relaxed);
     let image_id = image.as_ptr() as usize;
     let weak_image = glib::WeakRef::new();
     weak_image.set(Some(image));
+    let cancellation = Cancellation::default();
     ACTIVE_REQUESTS.with(|requests| {
         let mut requests = requests.borrow_mut();
-        requests.retain(|_, (_, image)| image.upgrade().is_some());
-        requests.insert(image_id, (request, weak_image));
+        requests.retain(|_, active| active.image.upgrade().is_some());
+        if let Some(previous) = requests.insert(
+            image_id,
+            ActiveRequest {
+                id: request,
+                image: weak_image,
+                cancellation: cancellation.clone(),
+            },
+        ) {
+            previous.cancellation.cancel();
+        }
     });
     image.set_pixel_size(size);
     image.set_size_request(size, size);
     crate::assets::set_primary_icon(image, icon);
-    (image_id, request)
+    (image_id, request, cancellation)
 }
 
 fn thumbnail_kind(path: &Path) -> Option<ThumbnailKind> {
@@ -183,112 +202,20 @@ fn thumbnail_kind(path: &Path) -> Option<ThumbnailKind> {
     }
 }
 
-fn render_thumbnail(path: &Path, kind: ThumbnailKind, size: i32) -> Option<Vec<u8>> {
-    let render_size = size.clamp(16, 256);
-    match kind {
-        ThumbnailKind::Image => render_pixbuf_thumbnail(path, render_size),
-        ThumbnailKind::RawImage => render_pixbuf_thumbnail(path, render_size)
-            .or_else(|| render_imagemagick_thumbnail(path, render_size))
-            .or_else(|| render_dcraw_thumbnail(path, render_size)),
-        ThumbnailKind::Pdf => render_pdf_thumbnail(path, render_size),
-        ThumbnailKind::Video => render_video_thumbnail(path, render_size),
-    }
-}
-
-fn render_pixbuf_thumbnail(path: &Path, size: i32) -> Option<Vec<u8>> {
-    gdk_pixbuf::Pixbuf::from_file_at_scale(path, size, size, true)
-        .ok()?
-        .save_to_bufferv("png", &[])
-        .ok()
-}
-
-fn render_imagemagick_thumbnail(path: &Path, size: i32) -> Option<Vec<u8>> {
-    for executable in ["magick", "convert"] {
-        let output = Command::new(executable)
-            .arg(path)
-            .args(["-auto-orient", "-thumbnail"])
-            .arg(format!("{size}x{size}"))
-            .arg("png:-")
-            .output();
-        if let Ok(output) = output
-            && output.status.success()
-            && !output.stdout.is_empty()
-        {
-            return Some(output.stdout);
-        }
-    }
-    None
-}
-
-fn render_dcraw_thumbnail(path: &Path, size: i32) -> Option<Vec<u8>> {
-    for executable in ["dcraw_emu", "dcraw"] {
-        let output = Command::new(executable)
-            .args(["-e", "-c"])
-            .arg(path)
-            .output();
-        let Ok(output) = output else {
-            continue;
-        };
-        if !output.status.success() || output.stdout.is_empty() {
-            continue;
-        }
-        let loader = gdk_pixbuf::PixbufLoader::new();
-        if loader.write(&output.stdout).is_err() || loader.close().is_err() {
-            continue;
-        }
-        let Some(pixbuf) = loader.pixbuf() else {
-            continue;
-        };
-        let width = pixbuf.width().max(1);
-        let height = pixbuf.height().max(1);
-        let scale = (f64::from(size) / f64::from(width))
-            .min(f64::from(size) / f64::from(height))
-            .min(1.0);
-        let scaled = pixbuf.scale_simple(
-            (f64::from(width) * scale).round().max(1.0) as i32,
-            (f64::from(height) * scale).round().max(1.0) as i32,
-            gdk_pixbuf::InterpType::Bilinear,
-        )?;
-        if let Ok(png) = scaled.save_to_bufferv("png", &[]) {
-            return Some(png);
-        }
-    }
-    None
-}
-
-fn render_pdf_thumbnail(path: &Path, size: i32) -> Option<Vec<u8>> {
-    let uri = gio::File::for_path(path).uri();
-    let document = poppler::Document::from_file(&uri, None).ok()?;
-    let page = document.page(0)?;
-    let (page_width, page_height) = page.size();
-    if page_width <= 0.0 || page_height <= 0.0 {
-        return None;
-    }
-    let scale = (f64::from(size) / page_width).min(f64::from(size) / page_height);
-    let width = (page_width * scale).ceil().max(1.0) as i32;
-    let height = (page_height * scale).ceil().max(1.0) as i32;
-    let surface = cairo::ImageSurface::create(cairo::Format::ARgb32, width, height).ok()?;
-    let context = cairo::Context::new(&surface).ok()?;
-    context.set_source_rgb(1.0, 1.0, 1.0);
-    context.paint().ok()?;
-    context.scale(scale, scale);
-    page.render(&context);
-    surface.flush();
-    let mut png = Vec::new();
-    surface.write_to_png(&mut png).ok()?;
-    Some(png)
-}
-
-fn render_video_thumbnail(path: &Path, size: i32) -> Option<Vec<u8>> {
-    let output = Command::new("ffmpegthumbnailer")
-        .arg("-i")
-        .arg(path)
-        .args(["-o", "/dev/stdout", "-s"])
-        .arg(size.to_string())
-        .args(["-q", "8"])
-        .output()
-        .ok()?;
-    (output.status.success() && !output.stdout.is_empty()).then_some(output.stdout)
+fn render_thumbnail(
+    path: &Path,
+    kind: ThumbnailKind,
+    size: i32,
+    cancellation: &Cancellation,
+) -> Result<Vec<u8>, String> {
+    let operation = match kind {
+        ThumbnailKind::Image => ParseOperation::ThumbnailImage,
+        ThumbnailKind::RawImage => ParseOperation::ThumbnailRaw,
+        ThumbnailKind::Pdf => ParseOperation::ThumbnailPdf,
+        ThumbnailKind::Video => ParseOperation::ThumbnailVideo,
+    };
+    crate::sandbox::parse(path, operation, size.clamp(16, 256), cancellation)
+        .map(|output| output.png)
 }
 
 #[cfg(test)]

--- a/src/ui/thumbnail.rs
+++ b/src/ui/thumbnail.rs
@@ -215,7 +215,7 @@ fn render_thumbnail(
         ThumbnailKind::Video => ParseOperation::ThumbnailVideo,
     };
     crate::sandbox::parse(path, operation, size.clamp(16, 256), cancellation)
-        .map(|output| output.png)
+        .map(|output| output.data)
 }
 
 #[cfg(test)]

--- a/src/ui/thumbnail/tests.rs
+++ b/src/ui/thumbnail/tests.rs
@@ -1,16 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 use gtk::glib;
 
-use super::{
-    MAX_CACHE_ENTRIES, ThumbnailCache, ThumbnailKey, ThumbnailKind, render_pdf_thumbnail,
-    thumbnail_kind,
-};
+use super::{MAX_CACHE_ENTRIES, ThumbnailCache, ThumbnailKey, ThumbnailKind, thumbnail_kind};
 
 #[test]
 fn recognizes_mainstream_image_and_video_formats() {
@@ -42,27 +36,6 @@ fn recognizes_mainstream_image_and_video_formats() {
         thumbnail_kind(Path::new("clip.ogv")),
         Some(ThumbnailKind::Video)
     );
-}
-
-#[test]
-fn renders_the_first_pdf_page_as_a_bounded_thumbnail() {
-    let path = std::env::temp_dir().join(format!(
-        "strata-thumbnail-{}-{}.pdf",
-        std::process::id(),
-        std::thread::current().name().unwrap_or("test")
-    ));
-    let surface = cairo::PdfSurface::new(612.0, 792.0, &path).expect("create PDF surface");
-    let context = cairo::Context::new(&surface).expect("create PDF context");
-    context.set_source_rgb(0.2, 0.4, 0.8);
-    context.paint().expect("paint PDF page");
-    context.show_page().expect("finish PDF page");
-    drop(context);
-    surface.finish();
-
-    let png = render_pdf_thumbnail(&path, 64).expect("render PDF thumbnail");
-    let _removed = fs::remove_file(path);
-
-    assert!(png.starts_with(b"\x89PNG\r\n\x1a\n"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- move image, RAW, PDF, and media parsing into a short-lived helper process
- isolate each helper with bubblewrap, one read-only input, private output, no network/home access, and CPU/memory/file/wall-clock limits
- cancel the complete sandbox on stale thumbnail or preview requests and fail closed to existing fallback UI
- replace in-process GStreamer media previews with sandboxed static previews
- document sandboxed providers, runtime requirements, and the project Git workflow

## Testing

- `./scripts/check.sh`
- manually rendered an image through the exact bubblewrap/prlimit command used by Strata

Closes #6

Supersedes #16, which GitHub closed when its branch was renamed to follow the new convention.
