### PR TITLE
ci: harden release provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install native development libraries
         run: >-
@@ -23,12 +23,12 @@ jobs:
           sudo apt-get install --yes libfontconfig1-dev libgtk-4-dev libgtksourceview-5-dev libpoppler-glib-dev
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: clippy, rustfmt
 
       - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Check formatting
         run: cargo fmt --all --check
@@ -48,10 +48,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check advisories, licenses, bans, and sources
-        uses: EmbarkStudios/cargo-deny-action@v2.1.1
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           command: check
 
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check spelling
-        uses: crate-ci/typos@v1.50.0
+        uses: crate-ci/typos@4d9c206a77c041268485162b8e2579ad7a5cb9a3 # v1.50.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  RELEASE_RUST_VERSION: 1.98.0
+
 jobs:
   prepare:
     name: Determine release version
@@ -40,7 +43,9 @@ jobs:
           fi
 
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Record source commit
         id: source
@@ -92,9 +97,10 @@ jobs:
 
     steps:
       - name: Check out source commit
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.prepare.outputs.source_sha }}
+          persist-credentials: false
 
       - name: Set release version
         env:
@@ -138,12 +144,13 @@ jobs:
           sudo apt-get install --yes libfontconfig1-dev libgtk-4-dev libgtksourceview-5-dev libpoppler-glib-dev
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
+          toolchain: ${{ env.RELEASE_RUST_VERSION }}
           targets: ${{ matrix.target }}
 
       - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           key: release-${{ matrix.target }}
 
@@ -152,18 +159,20 @@ jobs:
 
       - name: Package binary
         env:
+          SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
           TARGET: ${{ matrix.target }}
           VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           package="strata-${VERSION}-${TARGET}"
           mkdir -p "dist/$package"
           install -m 755 "target/$TARGET/release/strata" "dist/$package/strata"
+          printf '%s\n' "$SOURCE_SHA" > "dist/$package/SOURCE_COMMIT"
           cp README.md LICENSE THIRD_PARTY_LICENSES.md "dist/$package/"
           tar -C dist -czf "dist/$package.tar.gz" "$package"
           (cd dist && sha256sum "$package.tar.gz" > "$package.tar.gz.sha256")
 
       - name: Upload release artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: strata-${{ matrix.target }}
           path: |
@@ -175,21 +184,29 @@ jobs:
     name: Tag and publish release
     needs: [prepare, build]
     runs-on: ubuntu-24.04
+    environment: release
     permissions:
+      attestations: write
       contents: write
+      id-token: write
 
     steps:
       - name: Check out source commit
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.prepare.outputs.source_sha }}
           fetch-depth: 0
 
       - name: Download binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: dist
           merge-multiple: true
+
+      - name: Attest release artifacts
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: dist/*
 
       - name: Commit version and push tag
         env:

--- a/README.md
+++ b/README.md
@@ -61,14 +61,17 @@ Install the runtime libraries and optional video preview tools on Arch or Omarch
 sudo pacman -S --needed bubblewrap ffmpeg ffmpegthumbnailer fontconfig gtk4 gtksourceview5 poppler-glib
 ```
 
-Then verify, extract, and install the downloaded archive (replace the filename with the release you downloaded):
+Then verify, extract, and install the downloaded archive (replace the filename with the release you downloaded). The `gh attestation` check verifies the archive's signed GitHub Actions provenance:
 
 ```bash
 cd ~/Downloads
 sha256sum --check strata-<version>-<target>.tar.gz.sha256
+gh attestation verify strata-<version>-<target>.tar.gz --repo LGSE/strata
 tar -xzf strata-<version>-<target>.tar.gz
 install -Dm755 strata-<version>-<target>/strata ~/.local/bin/strata
 ```
+
+Each archive also contains `SOURCE_COMMIT`, which records the exact commit used for the build.
 
 Ensure `~/.local/bin` is on `PATH`, then run `strata`. Image thumbnails work without `ffmpegthumbnailer`; when `ffmpegthumbnailer` or `ffmpeg` is unavailable, video files fall back to their video icon or an unavailable preview. Bubblewrap is required: preview parsing fails closed rather than running untrusted native parsers without a sandbox. See [Preview sandbox](docs/preview-sandbox.md) for the providers, permissions, and resource limits.
 
@@ -218,9 +221,9 @@ Maintainers can run the **Release** workflow from GitHub's Actions tab on the de
 
 - commits the new version to `Cargo.toml` and `Cargo.lock`;
 - creates an annotated `vX.Y.Z` tag; and
-- publishes x86-64 and ARM64 archives, SHA-256 checksum files, and generated release notes.
+- publishes x86-64 and ARM64 archives, SHA-256 checksum files, signed build-provenance attestations, and generated release notes.
 
-The release workflow stops without publishing if the default branch changes while binaries are building. Run it again from the new head in that case.
+The final publishing job uses the protected `release` GitHub environment and is the only job granted write permissions. Repository administrators must configure that environment with required reviewers; prevent self-review when a separate maintainer is available to approve releases. The release workflow stops without publishing if the default branch changes while binaries are building. Run it again from the new head in that case.
 
 ## Bundled assets
 


### PR DESCRIPTION
## Summary

- pin every workflow action to a full commit SHA while retaining version comments
- pin release builds to Rust 1.98.0 and disable persisted checkout credentials in read-only jobs
- gate the only write-enabled job on the protected `release` environment
- generate signed GitHub build-provenance attestations and record the source commit in each archive
- document provenance verification for downloaded releases

The existing Dependabot `github-actions` configuration will continue opening SHA update PRs. The `release` environment has been created with a required reviewer.

## Tests

- `./scripts/check.sh`
- `actionlint`
- verified every workflow `uses:` ref is a 40-character commit SHA
- verified the `release` environment has a required-reviewer protection rule

Closes #12
