### PR TITLE
fix(operations): make replacement transfers failure-safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "field-offset"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +384,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
 ]
 
 [[package]]
@@ -770,6 +797,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,6 +978,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "regex-automata"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,7 +1008,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -982,6 +1021,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1171,8 +1223,10 @@ dependencies = [
  "gtk4",
  "ignore",
  "poppler-rs",
+ "rustix",
  "serde",
  "sourceview5",
+ "tempfile",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
@@ -1237,6 +1291,19 @@ name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "thread_local"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,10 @@ gio = { version = "0.21.5", features = ["v2_72"] }
 gtk = { package = "gtk4", version = "0.10.3", features = ["v4_12"] }
 ignore = "0.4.23"
 poppler = { package = "poppler-rs", version = "0.25.0" }
+rustix = { version = "1.1.4", features = ["fs"] }
 serde = { version = "1.0", features = ["derive"] }
 sourceview5 = { version = "0.10.0", features = ["gtk_v4_12"] }
+tempfile = "3.27.0"
 toml = "0.9"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.20"

--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -3,7 +3,7 @@
 #[cfg(test)]
 mod tests;
 
-use std::{future::Future, pin::Pin, rc::Rc};
+use std::{future::Future, io, path::Path, pin::Pin, rc::Rc};
 
 use gtk::{gio, glib, prelude::*};
 
@@ -11,7 +11,7 @@ use crate::{
     model::Location,
     services::{
         CreateDirectoryRequest, DeleteRequest, LoadHandle, OperationEvent, OperationProvider,
-        PasteRequest, RenameRequest, RestoreRequest, validate_basename,
+        PasteRequest, RenameRequest, RestoreRequest, TransferConflict, validate_basename,
     },
 };
 
@@ -86,6 +86,139 @@ fn copy_recursively(
             copy.await
         }
     })
+}
+
+enum StagedSibling {
+    File(tempfile::TempPath),
+    Directory(tempfile::TempDir),
+}
+
+impl StagedSibling {
+    fn create(parent: &Path, directory: bool) -> io::Result<Self> {
+        let mut builder = tempfile::Builder::new();
+        builder.prefix(".strata-replacement-");
+        if directory {
+            builder.tempdir_in(parent).map(Self::Directory)
+        } else {
+            builder
+                .tempfile_in(parent)
+                .map(tempfile::NamedTempFile::into_temp_path)
+                .map(Self::File)
+        }
+    }
+
+    fn path(&self) -> &Path {
+        match self {
+            Self::File(path) => path,
+            Self::Directory(directory) => directory.path(),
+        }
+    }
+}
+
+fn io_error(error: impl std::fmt::Display) -> glib::Error {
+    glib::Error::new(gio::IOErrorEnum::Failed, &error.to_string())
+}
+
+type StageCopy = Rc<
+    dyn Fn(gio::File, gio::File, bool) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>>,
+>;
+
+async fn replace_local_with(
+    source: gio::File,
+    target: gio::File,
+    move_source: bool,
+    copy_to_stage: StageCopy,
+) -> Result<(), glib::Error> {
+    if source.path().is_none() {
+        return Err(glib::Error::new(
+            gio::IOErrorEnum::NotSupported,
+            "Safe replacement is unavailable for this source",
+        ));
+    }
+    let target_path = target.path().ok_or_else(|| {
+        glib::Error::new(
+            gio::IOErrorEnum::NotSupported,
+            "Safe replacement is unavailable at this destination",
+        )
+    })?;
+    let parent = target_path
+        .parent()
+        .ok_or_else(|| io_error("The destination has no parent directory"))?;
+    let source_type = source
+        .query_info_future(
+            "standard::type",
+            gio::FileQueryInfoFlags::NOFOLLOW_SYMLINKS,
+            glib::Priority::DEFAULT,
+        )
+        .await?
+        .file_type();
+    let target_type = target
+        .query_info_future(
+            "standard::type",
+            gio::FileQueryInfoFlags::NOFOLLOW_SYMLINKS,
+            glib::Priority::DEFAULT,
+        )
+        .await?
+        .file_type();
+    let source_is_directory = source_type == gio::FileType::Directory;
+    let target_is_directory = target_type == gio::FileType::Directory;
+    if source_is_directory != target_is_directory {
+        return Err(glib::Error::new(
+            gio::IOErrorEnum::NotSupported,
+            "A file and a folder cannot safely replace one another",
+        ));
+    }
+
+    let staged = StagedSibling::create(parent, source_is_directory).map_err(io_error)?;
+    let staged_file = gio::File::for_path(staged.path());
+    copy_to_stage(source.clone(), staged_file.clone(), source_is_directory).await?;
+
+    let staged_path = staged.path().to_owned();
+    let exchanged = gio::spawn_blocking(move || {
+        rustix::fs::renameat_with(
+            rustix::fs::CWD,
+            &staged_path,
+            rustix::fs::CWD,
+            &target_path,
+            rustix::fs::RenameFlags::EXCHANGE,
+        )
+    })
+    .await
+    .map_err(|_| io_error("The replacement worker stopped unexpectedly"))?;
+    exchanged.map_err(|error| io_error(format!("Could not safely replace the item: {error}")))?;
+
+    permanently_delete(staged_file, target_is_directory).await?;
+    if move_source {
+        permanently_delete(source, source_is_directory).await?;
+    }
+    Ok(())
+}
+
+async fn replace_local(
+    source: gio::File,
+    target: gio::File,
+    move_source: bool,
+) -> Result<(), glib::Error> {
+    replace_local_with(
+        source,
+        target,
+        move_source,
+        Rc::new(|source, staged, directory| {
+            Box::pin(async move {
+                if directory {
+                    copy_recursively(source, staged, true).await
+                } else {
+                    let flags = gio::FileCopyFlags::ALL_METADATA
+                        | gio::FileCopyFlags::NOFOLLOW_SYMLINKS
+                        | gio::FileCopyFlags::OVERWRITE;
+                    let (copy, _progress) =
+                        source.copy_future(&staged, flags, glib::Priority::DEFAULT);
+                    copy.await
+                }
+            })
+        }),
+    )
+    .await
 }
 
 fn permanently_delete(
@@ -214,8 +347,8 @@ impl OperationProvider for LocalOperationProvider {
     fn paste(&self, request: PasteRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle {
         let task = glib::MainContext::default().spawn_local(async move {
             let destination = gio_file(&request.destination);
-            for source in &request.sources {
-                let source = gio_file(source);
+            for item in &request.items {
+                let source = gio_file(&item.source);
                 let Some(name) = source.basename() else {
                     emit(OperationEvent::Failed {
                         request_id: request.id,
@@ -227,46 +360,16 @@ impl OperationProvider for LocalOperationProvider {
                 if transfer_is_noop(&source, &destination, &target) {
                     continue;
                 }
-                if request.overwrite_existing && target.query_exists(None::<&gio::Cancellable>) {
-                    let target_type = target
-                        .query_info_future(
-                            "standard::type",
-                            gio::FileQueryInfoFlags::NOFOLLOW_SYMLINKS,
-                            glib::Priority::DEFAULT,
-                        )
-                        .await
-                        .map(|info| info.file_type());
-                    let result = match target_type {
-                        Ok(file_type) => {
-                            permanently_delete(
-                                target.clone(),
-                                file_type == gio::FileType::Directory,
-                            )
-                            .await
-                        }
-                        Err(error) => Err(error),
-                    };
-                    if let Err(error) = result {
-                        emit(OperationEvent::Failed {
-                            request_id: request.id,
-                            message: error.to_string(),
-                        });
-                        return;
-                    }
-                }
-                let flags = gio::FileCopyFlags::ALL_METADATA
-                    | gio::FileCopyFlags::NOFOLLOW_SYMLINKS
-                    | if request.overwrite_existing {
-                        gio::FileCopyFlags::OVERWRITE
-                    } else {
-                        gio::FileCopyFlags::NONE
-                    };
-                let result = if request.move_sources {
+                let result = if item.conflict == TransferConflict::ReplaceExisting {
+                    replace_local(source, target, request.move_sources).await
+                } else if request.move_sources {
+                    let flags =
+                        gio::FileCopyFlags::ALL_METADATA | gio::FileCopyFlags::NOFOLLOW_SYMLINKS;
                     let (transfer, _progress) =
                         source.move_future(&target, flags, glib::Priority::DEFAULT);
                     transfer.await
                 } else {
-                    copy_recursively(source, target, request.overwrite_existing).await
+                    copy_recursively(source, target, false).await
                 };
                 if let Err(error) = result {
                     emit(OperationEvent::Failed {

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -1,12 +1,28 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use std::{error::Error, fs, time::SystemTime};
+use std::{
+    cell::{Cell, RefCell},
+    error::Error,
+    fs,
+    rc::Rc,
+    sync::Mutex,
+    time::SystemTime,
+};
 
 use gtk::{gio, glib, prelude::*};
 
+static ASYNC_FILE_TEST: Mutex<()> = Mutex::new(());
+
 use super::{
-    copy_recursively, deletion_error_summary, operation_error_summary, transfer_is_noop,
-    validated_child,
+    LocalOperationProvider, copy_recursively, deletion_error_summary, operation_error_summary,
+    replace_local, replace_local_with, transfer_is_noop, validated_child,
+};
+use crate::{
+    model::Location,
+    services::{
+        OperationEvent, OperationProvider, OperationRequestId, PasteItem, PasteRequest,
+        TransferConflict,
+    },
 };
 
 #[test]
@@ -65,6 +81,7 @@ fn transfers_into_the_same_location_or_a_descendant_are_noops() {
 
 #[test]
 fn recursive_copy_preserves_nested_directory_contents() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
     let unique = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)?
         .as_nanos();
@@ -94,6 +111,207 @@ fn recursive_copy_preserves_nested_directory_contents() -> Result<(), Box<dyn Er
     assert!(overwrite.is_ok());
     assert_eq!(fs::read(target.join("top.txt"))?, b"replacement");
 
+    fs::remove_dir_all(root)?;
+    Ok(())
+}
+
+#[test]
+fn staged_file_replacement_preserves_the_destination_on_disk_full() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("strata-replacement-failure-test-{unique}"));
+    let source = root.join("source.txt");
+    let target = root.join("target.txt");
+    fs::create_dir_all(&root)?;
+    fs::write(&source, b"replacement")?;
+    fs::write(&target, b"original")?;
+
+    let result = glib::MainContext::default().block_on(replace_local_with(
+        gio::File::for_path(source),
+        gio::File::for_path(&target),
+        false,
+        Rc::new(|_, staged, _| {
+            Box::pin(async move {
+                fs::write(
+                    staged
+                        .path()
+                        .ok_or_else(|| super::io_error("missing stage"))?,
+                    b"partial",
+                )
+                .map_err(super::io_error)?;
+                Err(glib::Error::new(
+                    gio::IOErrorEnum::NoSpace,
+                    "injected disk-full failure",
+                ))
+            })
+        }),
+    ));
+
+    assert!(result.is_err());
+    assert_eq!(fs::read(&target)?, b"original");
+    assert_eq!(fs::read_dir(&root)?.count(), 2);
+    fs::remove_dir_all(root)?;
+    Ok(())
+}
+
+#[test]
+fn cancelling_staging_preserves_the_destination_and_cleans_the_partial_copy()
+-> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("strata-replacement-cancel-test-{unique}"));
+    let source = root.join("source.txt");
+    let target = root.join("target.txt");
+    fs::create_dir_all(&root)?;
+    fs::write(&source, b"replacement")?;
+    fs::write(&target, b"original")?;
+    let staging = Rc::new(Cell::new(false));
+    let staging_for_copy = staging.clone();
+
+    let task = glib::MainContext::default().spawn_local(replace_local_with(
+        gio::File::for_path(&source),
+        gio::File::for_path(&target),
+        false,
+        Rc::new(move |_, staged, _| {
+            let staging = staging_for_copy.clone();
+            Box::pin(async move {
+                fs::write(
+                    staged
+                        .path()
+                        .ok_or_else(|| super::io_error("missing stage"))?,
+                    b"partial",
+                )
+                .map_err(super::io_error)?;
+                staging.set(true);
+                std::future::pending().await
+            })
+        }),
+    ));
+    let context = glib::MainContext::default();
+    while !staging.get() {
+        context.iteration(true);
+    }
+    task.abort();
+    drop(task);
+    while context.pending() {
+        context.iteration(false);
+    }
+
+    assert_eq!(fs::read(&target)?, b"original");
+    assert_eq!(fs::read(&source)?, b"replacement");
+    assert_eq!(fs::read_dir(&root)?.count(), 2);
+    fs::remove_dir_all(root)?;
+    Ok(())
+}
+
+#[test]
+fn staged_file_replacement_commits_then_removes_a_moved_source() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("strata-replacement-success-test-{unique}"));
+    let source = root.join("source.txt");
+    let target = root.join("target.txt");
+    fs::create_dir_all(&root)?;
+    fs::write(&source, b"replacement")?;
+    fs::write(&target, b"original")?;
+
+    let result = glib::MainContext::default().block_on(replace_local(
+        gio::File::for_path(&source),
+        gio::File::for_path(&target),
+        true,
+    ));
+
+    assert!(result.is_ok(), "{result:?}");
+    assert_eq!(fs::read(&target)?, b"replacement");
+    assert!(!source.exists());
+    assert_eq!(fs::read_dir(&root)?.count(), 1);
+    fs::remove_dir_all(root)?;
+    Ok(())
+}
+
+#[test]
+fn each_transfer_item_keeps_its_own_conflict_decision() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("strata-conflict-decisions-test-{unique}"));
+    let sources = root.join("sources");
+    let destination = root.join("destination");
+    fs::create_dir_all(&sources)?;
+    fs::create_dir_all(&destination)?;
+    fs::write(sources.join("replace.txt"), b"new replacement")?;
+    fs::write(sources.join("late.txt"), b"new late item")?;
+    fs::write(destination.join("replace.txt"), b"old replacement")?;
+    fs::write(destination.join("late.txt"), b"late arrival")?;
+
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let emitted = events.clone();
+    let _operation = LocalOperationProvider.paste(
+        PasteRequest {
+            id: OperationRequestId(1),
+            destination: Location::local(&destination),
+            items: vec![
+                PasteItem {
+                    source: Location::local(sources.join("replace.txt")),
+                    conflict: TransferConflict::ReplaceExisting,
+                },
+                PasteItem {
+                    source: Location::local(sources.join("late.txt")),
+                    conflict: TransferConflict::FailIfExists,
+                },
+            ],
+            move_sources: false,
+        },
+        Rc::new(move |event| emitted.borrow_mut().push(event)),
+    );
+    while events.borrow().is_empty() {
+        glib::MainContext::default().iteration(true);
+    }
+
+    assert!(matches!(
+        events.borrow().as_slice(),
+        [OperationEvent::Failed { .. }]
+    ));
+    assert_eq!(
+        fs::read(destination.join("replace.txt"))?,
+        b"new replacement"
+    );
+    assert_eq!(fs::read(destination.join("late.txt"))?, b"late arrival");
+    fs::remove_dir_all(root)?;
+    Ok(())
+}
+
+#[test]
+fn staged_directory_replacement_does_not_merge_old_contents() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("strata-directory-replacement-test-{unique}"));
+    let source = root.join("source");
+    let target = root.join("target");
+    fs::create_dir_all(source.join("new"))?;
+    fs::create_dir_all(target.join("old"))?;
+    fs::write(source.join("new/item.txt"), b"new")?;
+    fs::write(target.join("old/item.txt"), b"old")?;
+
+    let result = glib::MainContext::default().block_on(replace_local(
+        gio::File::for_path(&source),
+        gio::File::for_path(&target),
+        false,
+    ));
+
+    assert!(result.is_ok(), "{result:?}");
+    assert_eq!(fs::read(target.join("new/item.txt"))?, b"new");
+    assert!(!target.join("old").exists());
+    assert!(source.exists());
     fs::remove_dir_all(root)?;
     Ok(())
 }

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -13,7 +13,7 @@ use crate::{
     services::{
         CreateDirectoryRequest, DeleteRequest, DirectoryChange, DirectoryEvent, DirectoryRequest,
         FileSource, LoadHandle, LocationValidationError, OperationEvent, OperationProvider,
-        OperationRequestId, PasteRequest, RenameRequest, RequestId, RestoreRequest,
+        OperationRequestId, PasteItem, PasteRequest, RenameRequest, RequestId, RestoreRequest,
         validate_basename,
     },
 };
@@ -634,11 +634,10 @@ impl Browser {
     pub fn transfer(
         self: &Rc<Self>,
         destination: Location,
-        sources: Vec<Location>,
+        items: Vec<PasteItem>,
         move_sources: bool,
-        overwrite_existing: bool,
     ) {
-        if sources.is_empty() {
+        if items.is_empty() {
             return;
         }
         let Some(provider) = self.operation_provider.borrow().clone() else {
@@ -652,9 +651,8 @@ impl Browser {
             PasteRequest {
                 id: request_id,
                 destination,
-                sources,
+                items,
                 move_sources,
-                overwrite_existing,
             },
             self.operation_callback(request_id, false),
         );

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -12,7 +12,7 @@ pub use file_source::{
 };
 pub use operations::{
     CreateDirectoryRequest, DeleteRequest, OperationEvent, OperationProvider, OperationRequestId,
-    PasteRequest, RenameRequest, RestoreRequest, validate_basename,
+    PasteItem, PasteRequest, RenameRequest, RestoreRequest, TransferConflict, validate_basename,
 };
 pub use preview::{
     Preview, PreviewContent, PreviewEvent, PreviewProvider, PreviewRequest, PreviewRequestId,

--- a/src/services/operations.rs
+++ b/src/services/operations.rs
@@ -40,13 +40,24 @@ pub struct CreateDirectoryRequest {
     pub name: String,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TransferConflict {
+    FailIfExists,
+    ReplaceExisting,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PasteItem {
+    pub source: Location,
+    pub conflict: TransferConflict,
+}
+
 #[derive(Clone, Debug)]
 pub struct PasteRequest {
     pub id: OperationRequestId,
     pub destination: Location,
-    pub sources: Vec<Location>,
+    pub items: Vec<PasteItem>,
     pub move_sources: bool,
-    pub overwrite_existing: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -15,8 +15,8 @@ use crate::{
     app::{Browser, BrowserEvent},
     model::{EntryKind, FileEntry, Location, SortDirection, SortKey},
     services::{
-        FileSource, OperationProvider, PreviewContent, content_family, has_plain_text_extension,
-        validate_basename,
+        FileSource, OperationProvider, PasteItem, PreviewContent, TransferConflict, content_family,
+        has_plain_text_extension, validate_basename,
     },
 };
 
@@ -758,7 +758,10 @@ impl ViewState {
             if transfer_has_collision(&source, &destination) {
                 collisions.push(source);
             } else {
-                accepted.push(source);
+                accepted.push(PasteItem {
+                    source,
+                    conflict: TransferConflict::FailIfExists,
+                });
             }
         }
         self.resolve_transfer_collisions(
@@ -766,7 +769,6 @@ impl ViewState {
             collisions,
             accepted,
             move_sources,
-            false,
             clear_cut,
         );
     }
@@ -775,17 +777,20 @@ impl ViewState {
         self: &Rc<Self>,
         destination: Location,
         mut collisions: Vec<Location>,
-        accepted: Vec<Location>,
+        accepted: Vec<PasteItem>,
         move_sources: bool,
-        overwrite_existing: bool,
         clear_cut: bool,
     ) {
         if collisions.is_empty() {
             if clear_cut {
-                self.complete_cut_transfer(&accepted);
+                self.complete_cut_transfer(
+                    &accepted
+                        .iter()
+                        .map(|item| item.source.clone())
+                        .collect::<Vec<_>>(),
+                );
             }
-            self.browser
-                .transfer(destination, accepted, move_sources, overwrite_existing);
+            self.browser.transfer(destination, accepted, move_sources);
             return;
         }
         let source = collisions.remove(0);
@@ -895,7 +900,6 @@ impl ViewState {
                 },
                 skipped_accepted.clone(),
                 move_sources,
-                overwrite_existing,
                 clear_cut,
             );
         });
@@ -908,9 +912,15 @@ impl ViewState {
         replace.connect_clicked(move |_| {
             dismiss_modal_layer(&replaced_layer, &replaced_overlay, replaced_root.as_ref());
             let mut accepted = accepted.clone();
-            accepted.push(source.clone());
+            accepted.push(PasteItem {
+                source: source.clone(),
+                conflict: TransferConflict::ReplaceExisting,
+            });
             let remaining = if replace_all.is_active() {
-                accepted.extend(collisions.clone());
+                accepted.extend(collisions.iter().cloned().map(|source| PasteItem {
+                    source,
+                    conflict: TransferConflict::ReplaceExisting,
+                }));
                 Vec::new()
             } else {
                 collisions.clone()
@@ -920,7 +930,6 @@ impl ViewState {
                 remaining,
                 accepted,
                 move_sources,
-                true,
                 clear_cut,
             );
         });


### PR DESCRIPTION
## Summary
- track replace/fail-if-exists decisions per transfer item
- stage local replacements in unique sibling paths and atomically exchange them with destinations
- preserve existing destinations when staging, cancellation, remote backends, or atomic exchange cannot complete safely
- replace directories without merging and clean staged files after failures

## Testing
- `./scripts/check.sh`
- injected disk-full and cancellation coverage verifies destination preservation and staging cleanup
- multi-item conflict coverage verifies late destinations are not overwritten

Closes #7