### PR TITLE
fix(logging): redact sensitive locations

### DIFF
--- a/docs/performance-baseline.md
+++ b/docs/performance-baseline.md
@@ -21,6 +21,11 @@ cargo build --release
 RUST_LOG=strata=debug target/release/strata target/fixtures/100000
 ```
 
+Default logs contain request IDs, backend names, counts, and timings without browsed locations.
+`RUST_LOG=strata=debug` explicitly enables diagnostic logging and may include full native paths.
+Remote URI user-info, authentication parameters, queries, and fragments remain redacted at every
+level. Review diagnostic logs before sharing them.
+
 Strata accepts a startup directory on the command line. Structured logs report:
 
 - Time until the application window is presented

--- a/src/adapters/local_files.rs
+++ b/src/adapters/local_files.rs
@@ -111,9 +111,17 @@ impl FileSource for LocalFileSource {
     fn enumerate(&self, request: DirectoryRequest, emit: Rc<dyn Fn(DirectoryEvent)>) -> LoadHandle {
         let request_id = request.id;
         let location = request.location.clone();
-        let display_location = location.display_path();
         let started = Instant::now();
-        tracing::info!(request_id = request_id.0, location = %display_location, "directory load started");
+        tracing::info!(
+            request_id = request_id.0,
+            backend = %location.backend_name(),
+            "directory load started"
+        );
+        tracing::debug!(
+            request_id = request_id.0,
+            location = %location.diagnostic_path(),
+            "directory load location"
+        );
 
         let task = glib::MainContext::default().spawn_local(async move {
             let directory = location
@@ -130,7 +138,12 @@ impl FileSource for LocalFileSource {
             {
                 Ok(enumerator) => enumerator,
                 Err(error) => {
-                    tracing::warn!(request_id = request_id.0, error = %error, "directory load failed");
+                    tracing::warn!(
+                        request_id = request_id.0,
+                        error_domain = ?error.domain(),
+                        error_code = error.code(),
+                        "directory load failed"
+                    );
                     emit(DirectoryEvent::Failed {
                         request_id,
                         message: error.to_string(),
@@ -181,7 +194,12 @@ impl FileSource for LocalFileSource {
                         });
                     }
                     Err(error) => {
-                        tracing::warn!(request_id = request_id.0, error = %error, "directory load interrupted");
+                        tracing::warn!(
+                            request_id = request_id.0,
+                            error_domain = ?error.domain(),
+                            error_code = error.code(),
+                            "directory load interrupted"
+                        );
                         emit(DirectoryEvent::Failed {
                             request_id,
                             message: error.to_string(),
@@ -213,9 +231,14 @@ impl FileSource for LocalFileSource {
             Ok(monitor) => monitor,
             Err(error) => {
                 tracing::warn!(
-                    path = %path.display(),
-                    error = %error,
+                    backend = %location.backend_name(),
+                    error_domain = ?error.domain(),
+                    error_code = error.code(),
                     "directory monitoring unavailable"
+                );
+                tracing::debug!(
+                    location = %location.diagnostic_path(),
+                    "directory monitoring location"
                 );
                 return None;
             }

--- a/src/adapters/local_files.rs
+++ b/src/adapters/local_files.rs
@@ -15,7 +15,7 @@ use crate::{
     model::{EntryKind, FileEntry, Location, MetadataValue},
     services::{
         DirectoryChange, DirectoryEvent, DirectoryRequest, FileSource, LoadHandle,
-        LocationValidationError,
+        LocationValidationError, RequestId,
     },
 };
 
@@ -112,16 +112,7 @@ impl FileSource for LocalFileSource {
         let request_id = request.id;
         let location = request.location.clone();
         let started = Instant::now();
-        tracing::info!(
-            request_id = request_id.0,
-            backend = %location.backend_name(),
-            "directory load started"
-        );
-        tracing::debug!(
-            request_id = request_id.0,
-            location = %location.diagnostic_path(),
-            "directory load location"
-        );
+        log_directory_load_started(request_id, &location);
 
         let task = glib::MainContext::default().spawn_local(async move {
             let directory = location
@@ -315,6 +306,19 @@ impl FileSource for LocalFileSource {
             let _cancelled = monitor.cancel();
         }))
     }
+}
+
+fn log_directory_load_started(request_id: RequestId, location: &Location) {
+    tracing::info!(
+        request_id = request_id.0,
+        backend = %location.backend_name(),
+        "directory load started"
+    );
+    tracing::debug!(
+        request_id = request_id.0,
+        location = %location.diagnostic_path(),
+        "directory load location"
+    );
 }
 
 fn merge_pending_change(

--- a/src/adapters/local_files/tests.rs
+++ b/src/adapters/local_files/tests.rs
@@ -4,13 +4,94 @@ use std::{
     error::Error,
     ffi::OsString,
     fs,
-    io::ErrorKind,
+    io::{ErrorKind, Write},
     os::unix::ffi::{OsStrExt, OsStringExt},
+    sync::{Arc, Mutex, MutexGuard},
     time::SystemTime,
 };
 
+use tracing_subscriber::fmt::MakeWriter;
+
 use super::*;
 use crate::model::Location;
+
+#[derive(Clone, Default)]
+struct LogWriter(Arc<Mutex<Vec<u8>>>);
+
+struct LogWriterGuard<'a>(MutexGuard<'a, Vec<u8>>);
+
+impl Write for LogWriterGuard<'_> {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        self.0.write(buffer)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.0.flush()
+    }
+}
+
+impl<'a> MakeWriter<'a> for LogWriter {
+    type Writer = LogWriterGuard<'a>;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        LogWriterGuard(self.0.lock().unwrap_or_else(|error| error.into_inner()))
+    }
+}
+
+impl LogWriter {
+    fn output(&self) -> String {
+        let output = self.0.lock().unwrap_or_else(|error| error.into_inner());
+        String::from_utf8_lossy(&output).into_owned()
+    }
+}
+
+fn capture_directory_start_log(level: tracing::Level, location: &Location) -> String {
+    let writer = LogWriter::default();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_max_level(level)
+        .with_writer(writer.clone())
+        .finish();
+
+    tracing::subscriber::with_default(subscriber, || {
+        log_directory_load_started(RequestId(42), location);
+    });
+    writer.output()
+}
+
+#[test]
+fn directory_logging_respects_default_and_diagnostic_privacy() {
+    let native_path = "/home/alice/sentinel-private-directory";
+    let native = Location::local(native_path);
+
+    let default_log = capture_directory_start_log(tracing::Level::INFO, &native);
+    assert!(default_log.contains("directory load started"));
+    assert!(default_log.contains("backend=native"));
+    assert!(!default_log.contains(native_path));
+
+    let diagnostic_log = capture_directory_start_log(tracing::Level::DEBUG, &native);
+    assert!(diagnostic_log.contains(native_path));
+
+    let remote = Location::uri(
+        "sftp://alice:password;key=secret@example.com/private?token=secret#private-fragment",
+    );
+    let remote_default_log = capture_directory_start_log(tracing::Level::INFO, &remote);
+    assert!(remote_default_log.contains("backend=sftp"));
+    assert!(!remote_default_log.contains("example.com"));
+
+    let remote_log = capture_directory_start_log(tracing::Level::DEBUG, &remote);
+    assert!(remote_log.contains("sftp://example.com/private"));
+    for secret in [
+        "alice",
+        "password",
+        "key=secret",
+        "token=secret",
+        "private-fragment",
+    ] {
+        assert!(!remote_log.contains(secret));
+    }
+}
 
 #[test]
 fn validation_accepts_readable_directories_and_rejects_files_and_missing_paths()

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -1118,7 +1118,7 @@ impl Browser {
                 if let Some((depth, insertions)) = application {
                     tracing::debug!(
                         request_id = request_id.0,
-                        location = %state.columns[depth].location.display_path(),
+                        location = %state.columns[depth].location.diagnostic_path(),
                         entries = entries.len(),
                         "directory batch accepted"
                     );

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -71,6 +71,35 @@ impl Location {
         }
     }
 
+    pub fn backend_name(&self) -> String {
+        match &self.kind {
+            LocationKind::Native(_) => "native".into(),
+            LocationKind::Uri(uri) => gio::glib::Uri::parse_scheme(uri)
+                .map(|scheme| scheme.to_string())
+                .unwrap_or_else(|| "uri".into()),
+        }
+    }
+
+    /// Returns a debug-only location with URI user-info, query, and fragment removed.
+    pub fn diagnostic_path(&self) -> String {
+        match &self.kind {
+            LocationKind::Native(path) => path.to_string_lossy().into_owned(),
+            LocationKind::Uri(uri) => gio::glib::Uri::parse(
+                uri,
+                gio::glib::UriFlags::HAS_PASSWORD | gio::glib::UriFlags::HAS_AUTH_PARAMS,
+            )
+            .map(|uri| {
+                uri.to_string_partial(
+                    gio::glib::UriHideFlags::USERINFO
+                        | gio::glib::UriHideFlags::QUERY
+                        | gio::glib::UriHideFlags::FRAGMENT,
+                )
+                .to_string()
+            })
+            .unwrap_or_else(|_| "<invalid-uri>".into()),
+        }
+    }
+
     /// Returns a UTF-8-safe representation without changing the native path.
     pub fn display_path(&self) -> String {
         match &self.kind {

--- a/src/model/tests.rs
+++ b/src/model/tests.rs
@@ -30,6 +30,38 @@ fn uri_locations_remain_explicit_and_have_one_breadcrumb() {
 }
 
 #[test]
+fn backend_names_distinguish_native_remote_and_malformed_locations() {
+    assert_eq!(
+        Location::local("/home/alice/private").backend_name(),
+        "native"
+    );
+    assert_eq!(
+        Location::uri("sftp://example.com/private").backend_name(),
+        "sftp"
+    );
+    assert_eq!(Location::uri("not a uri").backend_name(), "uri");
+}
+
+#[test]
+fn diagnostic_paths_preserve_native_paths_and_redact_remote_secrets() {
+    assert_eq!(
+        Location::local("/home/alice/private").diagnostic_path(),
+        "/home/alice/private"
+    );
+    assert_eq!(
+        Location::uri(
+            "sftp://alice:password;key=secret@example.com/home/alice?token=secret#private-fragment"
+        )
+        .diagnostic_path(),
+        "sftp://example.com/home/alice"
+    );
+    assert_eq!(
+        Location::uri("not a uri with alice:password@example.com").diagnostic_path(),
+        "<invalid-uri>"
+    );
+}
+
+#[test]
 fn root_has_one_breadcrumb() {
     assert_eq!(
         Location::local("/").breadcrumbs(),

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -5276,7 +5276,16 @@ pub(super) fn open_location(location: &Location, parent: &impl IsA<gtk::Widget>)
     let file = gio_file_for_location(location);
     let uri = file.uri();
     if let Err(error) = gio::AppInfo::launch_default_for_uri(&uri, None::<&gio::AppLaunchContext>) {
-        tracing::warn!(location = %location.display_path(), error = %error, "unable to open file");
+        tracing::warn!(
+            backend = %location.backend_name(),
+            error_domain = ?error.domain(),
+            error_code = error.code(),
+            "unable to open file"
+        );
+        tracing::debug!(
+            location = %location.diagnostic_path(),
+            "file open location"
+        );
         show_error_dialog(parent, "Unable to open file", &error.to_string());
     }
 }


### PR DESCRIPTION
## Summary
- remove browsed paths and raw GIO messages from default logs
- retain opt-in diagnostic locations while redacting remote URI credentials and secret-bearing components
- document the privacy behavior of `RUST_LOG=strata=debug`

## Testing
- `./scripts/check.sh`
- verified an info-level run omits a sentinel native path
- verified a debug-level run includes the sentinel native path

Closes #14