### PR TITLE
Don't flag an empty name field as an error

### DIFF
--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -4925,17 +4925,6 @@ fn set_cut_path_style(row: &gtk::Box, cut: bool) {
     }
 }
 
-/// Validates a name field live as it changes, including the programmatic
-/// clears that happen when a prompt opens, cancels, or succeeds. An empty
-/// field is left unstyled rather than flagged red: it's the normal starting
-/// state, not a mistake the user made, even though it still can't be
-/// submitted (the `false` return still blocks that).
-/// Whether a name currently typed into a field should be visually flagged as
-/// an error. An empty name is left unstyled: it's the normal starting state
-/// (opening, cancelling, or succeeding a prompt all clear the field) rather
-/// than a mistake the user made, even though it still can't be submitted.
-/// Kept separate from `update_basename_validation` so it can be unit tested
-/// without constructing a real GTK widget.
 fn basename_field_error(name: &str) -> Option<&'static str> {
     if name.is_empty() {
         None

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -4925,8 +4925,19 @@ fn set_cut_path_style(row: &gtk::Box, cut: bool) {
     }
 }
 
+/// Validates a name field live as it changes, including the programmatic
+/// clears that happen when a prompt opens, cancels, or succeeds. An empty
+/// field is left unstyled rather than flagged red: it's the normal starting
+/// state, not a mistake the user made, even though it still can't be
+/// submitted (the `false` return still blocks that).
 pub(super) fn update_basename_validation(field: &gtk::Entry) -> bool {
-    match validate_basename(field.text().as_str()) {
+    let text = field.text();
+    if text.is_empty() {
+        field.remove_css_class("error");
+        field.set_tooltip_text(None);
+        return false;
+    }
+    match validate_basename(text.as_str()) {
         Ok(()) => {
             field.remove_css_class("error");
             field.set_tooltip_text(None);

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -4930,20 +4930,29 @@ fn set_cut_path_style(row: &gtk::Box, cut: bool) {
 /// field is left unstyled rather than flagged red: it's the normal starting
 /// state, not a mistake the user made, even though it still can't be
 /// submitted (the `false` return still blocks that).
+/// Whether a name currently typed into a field should be visually flagged as
+/// an error. An empty name is left unstyled: it's the normal starting state
+/// (opening, cancelling, or succeeding a prompt all clear the field) rather
+/// than a mistake the user made, even though it still can't be submitted.
+/// Kept separate from `update_basename_validation` so it can be unit tested
+/// without constructing a real GTK widget.
+fn basename_field_error(name: &str) -> Option<&'static str> {
+    if name.is_empty() {
+        None
+    } else {
+        validate_basename(name).err()
+    }
+}
+
 pub(super) fn update_basename_validation(field: &gtk::Entry) -> bool {
     let text = field.text();
-    if text.is_empty() {
-        field.remove_css_class("error");
-        field.set_tooltip_text(None);
-        return false;
-    }
-    match validate_basename(text.as_str()) {
-        Ok(()) => {
+    match basename_field_error(text.as_str()) {
+        None => {
             field.remove_css_class("error");
             field.set_tooltip_text(None);
-            true
+            !text.is_empty()
         }
-        Err(message) => {
+        Some(message) => {
             field.add_css_class("error");
             field.set_tooltip_text(Some(message));
             false

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -3,17 +3,10 @@
 use super::*;
 
 #[test]
-fn an_empty_name_field_is_not_flagged_as_an_error() {
-    gtk::init().expect("gtk::init");
-    let field = gtk::Entry::new();
-    field.set_text("bad/name");
-    assert!(!update_basename_validation(&field));
-    assert!(field.has_css_class("error"));
-
-    field.set_text("");
-    assert!(!update_basename_validation(&field));
+fn an_empty_name_is_not_flagged_as_an_error() {
+    assert!(basename_field_error("bad/name").is_some());
     assert!(
-        !field.has_css_class("error"),
+        basename_field_error("").is_none(),
         "an empty field is the normal starting state, not a user mistake"
     );
 }

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -3,6 +3,22 @@
 use super::*;
 
 #[test]
+fn an_empty_name_field_is_not_flagged_as_an_error() {
+    gtk::init().expect("gtk::init");
+    let field = gtk::Entry::new();
+    field.set_text("bad/name");
+    assert!(!update_basename_validation(&field));
+    assert!(field.has_css_class("error"));
+
+    field.set_text("");
+    assert!(!update_basename_validation(&field));
+    assert!(
+        !field.has_css_class("error"),
+        "an empty field is the normal starting state, not a user mistake"
+    );
+}
+
+#[test]
 fn file_sizes_use_compact_decimal_units() {
     assert_eq!(format_file_size(999), "999 B");
     assert_eq!(format_file_size(1_200), "1.2 kB");


### PR DESCRIPTION
Found this while testing something else, but it is not specific to that scenario, it reproduces for a plain local New Folder too.

## The bug

`update_basename_validation` runs on every text change, including the programmatic clears that happen when a New Folder/File prompt opens, cancels, or succeeds after creating. Since `validate_basename("")` treats an empty name as invalid, any of those routine clears can leave the field styled red before the user has typed anything wrong, or anything at all.

Repro:
1. Open New Folder, type an invalid name (for example one with a `/`), press Enter. It gets rejected in place, no dialog, field turns red. So far expected.
2. Press Escape, then open New Folder again.
3. The field is already red and empty, nothing has been typed yet.

Confirmed present on the current `main` (v0.4.0).

## The fix

Treat an empty field as the normal, unstyled starting state rather than an error state. Submission is still blocked (the function still returns `false` for an empty name), only the alarming red border for a field nobody has touched yet is gone.

Added a unit test constructing a real `gtk::Entry` and driving `update_basename_validation` directly, `check.sh` passes (142 tests).