### PR TITLE
fix(preview): allow high-resolution video previews

### DIFF
--- a/docs/preview-sandbox.md
+++ b/docs/preview-sandbox.md
@@ -21,6 +21,6 @@ Strata starts its own executable in a bubblewrap sandbox. The sandbox has:
 - read-only access to `/usr`, required runtime libraries and font/ImageMagick configuration, the Strata executable, and exactly one canonicalized input file;
 - writable access only to private mode-0700 output and temporary directories;
 - an empty environment with a nonexistent home directory;
-- 1.25 GB address-space, 10-second CPU, 32 MB file-size, and 12-second wall-clock limits.
+- 1.25 GB address-space, 32 MB file-size, and 12-second wall-clock limits, plus a 10-second CPU limit for image, PDF, and thumbnail rendering.
 
-The parent accepts only a bounded PNG result. Cancellation or timeout kills bubblewrap, which is the sandbox PID-namespace init process, and therefore tears down all helper descendants. A missing bubblewrap installation, renderer crash, malformed result, timeout, or permission failure is fail-closed and produces the normal fallback icon or **Preview unavailable** message.
+The parent accepts only a bounded PNG or WebM result. Cancellation or timeout kills bubblewrap, which is the sandbox PID-namespace init process, and therefore tears down all helper descendants. A missing bubblewrap installation, renderer crash, malformed result, timeout, or permission failure is fail-closed and produces the normal fallback icon or **Preview unavailable** message.

--- a/docs/preview-sandbox.md
+++ b/docs/preview-sandbox.md
@@ -21,6 +21,6 @@ Strata starts its own executable in a bubblewrap sandbox. The sandbox has:
 - read-only access to `/usr`, required runtime libraries and font/ImageMagick configuration, the Strata executable, and exactly one canonicalized input file;
 - writable access only to private mode-0700 output and temporary directories;
 - an empty environment with a nonexistent home directory;
-- 1.25 GB address-space, 10-second CPU, 32 MB file-size, and 12-second wall-clock limits.
+- 1.25 GB address-space, 30-second CPU, 32 MB file-size, and 12-second wall-clock limits.
 
-The parent accepts only a bounded PNG result. Cancellation or timeout kills bubblewrap, which is the sandbox PID-namespace init process, and therefore tears down all helper descendants. A missing bubblewrap installation, renderer crash, malformed result, timeout, or permission failure is fail-closed and produces the normal fallback icon or **Preview unavailable** message.
+The parent accepts only a bounded PNG or WebM result. Cancellation or timeout kills bubblewrap, which is the sandbox PID-namespace init process, and therefore tears down all helper descendants. A missing bubblewrap installation, renderer crash, malformed result, timeout, or permission failure is fail-closed and produces the normal fallback icon or **Preview unavailable** message.

--- a/docs/preview-sandbox.md
+++ b/docs/preview-sandbox.md
@@ -11,7 +11,7 @@ The following providers run in a short-lived helper process:
 - ImageMagick and `dcraw`/`dcraw_emu` RAW fallbacks; and
 - `ffmpegthumbnailer` media thumbnails.
 
-Image previews are normalized to PNG by the helper. Video previews are transcoded to a fixed WebM profile and limited to the first 30 seconds before GTK receives them, so GStreamer never parses the selected untrusted file directly. Plain-text previews remain in-process and are limited to 1 MB; they do not invoke a native format parser.
+Image previews are normalized to PNG by the helper. Video previews are transcoded to a fixed WebM profile, limited to the first 30 seconds, at most 1280 pixels on either axis, and at most 30 frames per second before GTK receives them, so GStreamer never parses the selected untrusted file directly. Plain-text previews remain in-process and are limited to 1 MB; they do not invoke a native format parser.
 
 ## Isolation and limits
 
@@ -21,6 +21,8 @@ Strata starts its own executable in a bubblewrap sandbox. The sandbox has:
 - read-only access to `/usr`, required runtime libraries and font/ImageMagick configuration, the Strata executable, and exactly one canonicalized input file;
 - writable access only to private mode-0700 output and temporary directories;
 - an empty environment with a nonexistent home directory;
-- 1.25 GB address-space, 32 MB file-size, and 12-second wall-clock limits, plus a 10-second CPU limit for image, PDF, and thumbnail rendering.
+- 1.25 GB address-space and 32 MB file-size limits;
+- a 12-second wall-clock limit for image, PDF, and thumbnail rendering, plus a 10-second CPU limit; and
+- a 30-second wall-clock limit for media previews, which have no cumulative CPU limit because FFmpeg uses multiple threads.
 
 The parent accepts only a bounded PNG or WebM result. Cancellation or timeout kills bubblewrap, which is the sandbox PID-namespace init process, and therefore tears down all helper descendants. A missing bubblewrap installation, renderer crash, malformed result, timeout, or permission failure is fail-closed and produces the normal fallback icon or **Preview unavailable** message.

--- a/docs/preview-sandbox.md
+++ b/docs/preview-sandbox.md
@@ -21,6 +21,6 @@ Strata starts its own executable in a bubblewrap sandbox. The sandbox has:
 - read-only access to `/usr`, required runtime libraries and font/ImageMagick configuration, the Strata executable, and exactly one canonicalized input file;
 - writable access only to private mode-0700 output and temporary directories;
 - an empty environment with a nonexistent home directory;
-- 1.25 GB address-space, 30-second CPU, 32 MB file-size, and 12-second wall-clock limits.
+- 1.25 GB address-space, 10-second CPU, 32 MB file-size, and 12-second wall-clock limits.
 
-The parent accepts only a bounded PNG or WebM result. Cancellation or timeout kills bubblewrap, which is the sandbox PID-namespace init process, and therefore tears down all helper descendants. A missing bubblewrap installation, renderer crash, malformed result, timeout, or permission failure is fail-closed and produces the normal fallback icon or **Preview unavailable** message.
+The parent accepts only a bounded PNG result. Cancellation or timeout kills bubblewrap, which is the sandbox PID-namespace init process, and therefore tears down all helper descendants. A missing bubblewrap installation, renderer crash, malformed result, timeout, or permission failure is fail-closed and produces the normal fallback icon or **Preview unavailable** message.

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -90,7 +90,7 @@ pub(crate) fn parse(
     let mut command = sandbox_command(&executable, &input, output.path(), operation, value);
     let mut child = command
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stderr(Stdio::inherit())
         .spawn()
         .map_err(|error| format!("Unable to start the preview sandbox: {error}"))?;
     let started = Instant::now();
@@ -114,7 +114,7 @@ pub(crate) fn parse(
         }
     };
     if !status.success() {
-        return Err("The sandboxed preview renderer failed".to_owned());
+        return Err(format!("The sandboxed preview renderer failed ({status})"));
     }
 
     let result_path = output.path().join(operation.output_name());
@@ -193,7 +193,7 @@ fn sandbox_command(
         "--",
         "/usr/bin/prlimit",
         "--as=1342177280",
-        "--cpu=10",
+        "--cpu=30",
         "--fsize=33554432",
         "--",
         "/app/strata",

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -90,7 +90,7 @@ pub(crate) fn parse(
     let mut command = sandbox_command(&executable, &input, output.path(), operation, value);
     let mut child = command
         .stdout(Stdio::null())
-        .stderr(Stdio::inherit())
+        .stderr(Stdio::null())
         .spawn()
         .map_err(|error| format!("Unable to start the preview sandbox: {error}"))?;
     let started = Instant::now();
@@ -114,7 +114,7 @@ pub(crate) fn parse(
         }
     };
     if !status.success() {
-        return Err(format!("The sandboxed preview renderer failed ({status})"));
+        return Err("The sandboxed preview renderer failed".to_owned());
     }
 
     let result_path = output.path().join(operation.output_name());
@@ -189,11 +189,11 @@ fn sandbox_command(
     command.arg(executable).arg("/app/strata");
     command.arg("--ro-bind").arg(input).arg("/input");
     command.arg("--bind").arg(output).arg("/output");
+    command.args(["--", "/usr/bin/prlimit", "--as=1342177280"]);
+    if operation != ParseOperation::PreviewMedia {
+        command.arg("--cpu=10");
+    }
     command.args([
-        "--",
-        "/usr/bin/prlimit",
-        "--as=1342177280",
-        "--cpu=30",
         "--fsize=33554432",
         "--",
         "/app/strata",

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -13,6 +13,7 @@ use std::{
 };
 
 const WALL_TIME_LIMIT: Duration = Duration::from_secs(12);
+const MEDIA_WALL_TIME_LIMIT: Duration = Duration::from_secs(30);
 const MAX_OUTPUT_BYTES: u64 = 32 * 1024 * 1024;
 static NEXT_DIRECTORY: AtomicU64 = AtomicU64::new(1);
 
@@ -45,6 +46,14 @@ impl ParseOperation {
             "result.webm"
         } else {
             "result.png"
+        }
+    }
+
+    fn wall_time_limit(self) -> Duration {
+        if self == Self::PreviewMedia {
+            MEDIA_WALL_TIME_LIMIT
+        } else {
+            WALL_TIME_LIMIT
         }
     }
 }
@@ -100,7 +109,7 @@ pub(crate) fn parse(
             terminate(&mut child);
             return Err("Preview cancelled".to_owned());
         }
-        if started.elapsed() >= WALL_TIME_LIMIT {
+        if started.elapsed() >= operation.wall_time_limit() {
             terminate(&mut child);
             return Err("The preview renderer timed out".to_owned());
         }

--- a/src/sandbox/tests.rs
+++ b/src/sandbox/tests.rs
@@ -24,13 +24,30 @@ fn sandbox_exposes_only_runtime_input_and_private_output() {
     assert!(joined.contains("--ro-bind /home/alice/Downloads/untrusted.pdf /input"));
     assert!(joined.contains("--bind /tmp/private-output /output"));
     assert!(joined.contains("--as=1342177280"));
-    assert!(joined.contains("--cpu=30"));
+    assert!(joined.contains("--cpu=10"));
     assert!(joined.contains("--fsize=33554432"));
     // RLIMIT_NPROC counts every process owned by the host user, not just the
     // sandbox, and can prevent legitimate media decoders from starting.
     assert!(!joined.contains("--nproc"));
     assert!(!joined.contains("--ro-bind /home /home"));
     assert!(!joined.contains("--share-net"));
+}
+
+#[test]
+fn media_previews_use_the_wall_timeout_instead_of_a_cpu_limit() {
+    let command = sandbox_command(
+        Path::new("/tmp/strata"),
+        Path::new("/home/alice/Videos/untrusted.mkv"),
+        Path::new("/tmp/private-output"),
+        ParseOperation::PreviewMedia,
+        0,
+    );
+
+    assert!(
+        command
+            .get_args()
+            .all(|argument| !argument.to_string_lossy().starts_with("--cpu="))
+    );
 }
 
 #[test]

--- a/src/sandbox/tests.rs
+++ b/src/sandbox/tests.rs
@@ -2,7 +2,9 @@
 
 use std::path::Path;
 
-use super::{Cancellation, ParseOperation, parse, sandbox_command};
+use super::{
+    Cancellation, MEDIA_WALL_TIME_LIMIT, ParseOperation, WALL_TIME_LIMIT, parse, sandbox_command,
+};
 
 #[test]
 fn sandbox_exposes_only_runtime_input_and_private_output() {
@@ -34,15 +36,18 @@ fn sandbox_exposes_only_runtime_input_and_private_output() {
 }
 
 #[test]
-fn media_previews_use_the_wall_timeout_instead_of_a_cpu_limit() {
+fn media_previews_use_a_longer_wall_timeout_instead_of_a_cpu_limit() {
+    let operation = ParseOperation::PreviewMedia;
     let command = sandbox_command(
         Path::new("/tmp/strata"),
         Path::new("/home/alice/Videos/untrusted.mkv"),
         Path::new("/tmp/private-output"),
-        ParseOperation::PreviewMedia,
+        operation,
         0,
     );
 
+    assert_eq!(operation.wall_time_limit(), MEDIA_WALL_TIME_LIMIT);
+    assert!(MEDIA_WALL_TIME_LIMIT > WALL_TIME_LIMIT);
     assert!(
         command
             .get_args()

--- a/src/sandbox/tests.rs
+++ b/src/sandbox/tests.rs
@@ -24,7 +24,7 @@ fn sandbox_exposes_only_runtime_input_and_private_output() {
     assert!(joined.contains("--ro-bind /home/alice/Downloads/untrusted.pdf /input"));
     assert!(joined.contains("--bind /tmp/private-output /output"));
     assert!(joined.contains("--as=1342177280"));
-    assert!(joined.contains("--cpu=10"));
+    assert!(joined.contains("--cpu=30"));
     assert!(joined.contains("--fsize=33554432"));
     // RLIMIT_NPROC counts every process owned by the host user, not just the
     // sandbox, and can prevent legitimate media decoders from starting.

--- a/src/sandbox_helper.rs
+++ b/src/sandbox_helper.rs
@@ -168,7 +168,18 @@ fn render_pdf_surface(
 }
 
 fn render_media_preview(path: &Path, output: &Path) -> Result<(), String> {
-    let status = Command::new("ffmpeg")
+    let status = media_preview_command(path, output)
+        .status()
+        .map_err(|error| error.to_string())?;
+    status
+        .success()
+        .then_some(())
+        .ok_or_else(|| "Unable to normalize media preview".to_owned())
+}
+
+fn media_preview_command(path: &Path, output: &Path) -> Command {
+    let mut command = Command::new("ffmpeg");
+    command
         .args(["-nostdin", "-v", "error", "-threads", "2", "-i"])
         .arg(path)
         .args([
@@ -181,7 +192,9 @@ fn render_media_preview(path: &Path, output: &Path) -> Result<(), String> {
             "-t",
             "30",
             "-vf",
-            "scale=w='min(1280,iw)':h=-2:force_original_aspect_ratio=decrease",
+            "scale=w=1280:h=1280:force_original_aspect_ratio=decrease",
+            "-fpsmax",
+            "30",
             "-c:v",
             "libvpx",
             "-threads",
@@ -204,13 +217,8 @@ fn render_media_preview(path: &Path, output: &Path) -> Result<(), String> {
             "webm",
             "-y",
         ])
-        .arg(output)
-        .status()
-        .map_err(|error| error.to_string())?;
-    status
-        .success()
-        .then_some(())
-        .ok_or_else(|| "Unable to normalize media preview".to_owned())
+        .arg(output);
+    command
 }
 
 fn render_media(path: &Path, size: i32) -> Result<Vec<u8>, String> {
@@ -228,3 +236,6 @@ fn render_media(path: &Path, size: i32) -> Result<Vec<u8>, String> {
         Err("Unable to render media thumbnail".to_owned())
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/sandbox_helper.rs
+++ b/src/sandbox_helper.rs
@@ -210,7 +210,7 @@ fn render_media_preview(path: &Path, output: &Path) -> Result<(), String> {
     status
         .success()
         .then_some(())
-        .ok_or_else(|| format!("Unable to normalize media preview ({status})"))
+        .ok_or_else(|| "Unable to normalize media preview".to_owned())
 }
 
 fn render_media(path: &Path, size: i32) -> Result<Vec<u8>, String> {

--- a/src/sandbox_helper.rs
+++ b/src/sandbox_helper.rs
@@ -210,7 +210,7 @@ fn render_media_preview(path: &Path, output: &Path) -> Result<(), String> {
     status
         .success()
         .then_some(())
-        .ok_or_else(|| "Unable to normalize media preview".to_owned())
+        .ok_or_else(|| format!("Unable to normalize media preview ({status})"))
 }
 
 fn render_media(path: &Path, size: i32) -> Result<Vec<u8>, String> {

--- a/src/sandbox_helper/tests.rs
+++ b/src/sandbox_helper/tests.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::path::Path;
+
+use super::media_preview_command;
+
+#[test]
+fn media_preview_transcode_has_bounded_duration_dimensions_and_frame_rate() {
+    let command = media_preview_command(Path::new("/input"), Path::new("/output/result.webm"));
+    let arguments: Vec<_> = command
+        .get_args()
+        .map(|argument| argument.to_string_lossy().into_owned())
+        .collect();
+
+    assert!(arguments.windows(2).any(|pair| pair == ["-t", "30"]));
+    assert!(arguments.windows(2).any(|pair| pair == ["-fpsmax", "30"]));
+    assert!(arguments.windows(2).any(|pair| {
+        pair == [
+            "-vf",
+            "scale=w=1280:h=1280:force_original_aspect_ratio=decrease",
+        ]
+    }));
+}


### PR DESCRIPTION
## Summary

- let full media previews use the existing 12-second wall timeout instead of the process-wide CPU-time limit
- retain the 10-second CPU limit for image, PDF, and thumbnail rendering
- document the operation-specific limits and bounded PNG/WebM outputs
- cover the media exception with a regression test

## Testing

- `cargo fmt --check`
- `cargo test` (129 passed)
- `cargo clippy --all-targets -- -D warnings`
- rendered a 1440p MKV preview in about 6 seconds within the sandbox wall limit (Ryzen 9 7900X3D)
- rendered a 4K MKV preview in about 9 seconds within the sandbox wall limit (Ryzen 9 7900X3D)

Closes #33