### PR TITLE
fix(storage): make managed writes atomic and symlink-safe

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -246,13 +246,12 @@ fn recolor_icon_source(source: &str, color: &str) -> String {
 }
 
 fn write_if_changed(path: &Path, contents: &[u8]) -> io::Result<()> {
-    let is_current = path
-        .metadata()
-        .map(|metadata| metadata.len() == contents.len() as u64)
+    let is_current = fs::symlink_metadata(path)
+        .map(|metadata| metadata.file_type().is_file() && metadata.len() == contents.len() as u64)
         .unwrap_or(false);
 
     if !is_current {
-        fs::write(path, contents)?;
+        crate::storage::atomic_write(path, contents)?;
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod model;
 mod sandbox;
 mod sandbox_helper;
 mod services;
+mod storage;
 mod ui;
 
 use gtk::{gio, prelude::*};

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::{
+    fs::{self, File, OpenOptions},
+    io::{self, Write},
+    os::unix::fs::OpenOptionsExt,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+static NEXT_TEMP_FILE: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) fn atomic_write(path: &Path, contents: &[u8]) -> io::Result<()> {
+    atomic_write_with(path, |file| file.write_all(contents))
+}
+
+fn atomic_write_with(
+    path: &Path,
+    write: impl FnOnce(&mut File) -> io::Result<()>,
+) -> io::Result<()> {
+    validate_destination(path)?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "destination has no parent"))?;
+    let (temporary_path, mut file) = create_temporary_file(parent)?;
+
+    let result = (|| {
+        write(&mut file)?;
+        file.flush()?;
+        file.sync_all()?;
+        drop(file);
+        validate_destination(path)?;
+        fs::rename(&temporary_path, path)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(temporary_path);
+    }
+    result
+}
+
+fn validate_destination(path: &Path) -> io::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_file() => Ok(()),
+        Ok(_) => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "refusing to replace non-regular destination {}",
+                path.display()
+            ),
+        )),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn create_temporary_file(parent: &Path) -> io::Result<(PathBuf, File)> {
+    loop {
+        let path = parent.join(format!(
+            ".strata-write-{}-{}.tmp",
+            std::process::id(),
+            NEXT_TEMP_FILE.fetch_add(1, Ordering::Relaxed)
+        ));
+        match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&path)
+        {
+            Ok(file) => return Ok((path, file)),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::{
+    fs,
+    io::{self, Write},
+    os::unix::fs::{MetadataExt, symlink},
+    path::PathBuf,
+    sync::atomic::Ordering,
+};
+
+use super::{NEXT_TEMP_FILE, atomic_write, atomic_write_with};
+
+#[test]
+fn write_failure_preserves_destination_and_removes_temporary_file() -> io::Result<()> {
+    let directory = test_directory()?;
+    let destination = directory.join("settings.toml");
+    fs::write(&destination, b"valid")?;
+
+    let result = atomic_write_with(&destination, |file| {
+        file.write_all(b"partial")?;
+        Err(io::Error::other("injected write failure"))
+    });
+
+    assert!(result.is_err());
+    assert_eq!(fs::read(&destination)?, b"valid");
+    assert_eq!(fs::read_dir(&directory)?.count(), 1);
+    fs::remove_dir_all(directory)
+}
+
+#[test]
+fn symlink_destination_is_rejected_without_touching_target() -> io::Result<()> {
+    let directory = test_directory()?;
+    let target = directory.join("target");
+    let destination = directory.join("settings.toml");
+    fs::write(&target, b"valid")?;
+    symlink(&target, &destination)?;
+
+    let result = atomic_write(&destination, b"replacement");
+
+    assert!(result.is_err());
+    assert_eq!(fs::read(&target)?, b"valid");
+    assert!(fs::symlink_metadata(&destination)?.file_type().is_symlink());
+    fs::remove_dir_all(directory)
+}
+
+#[test]
+fn long_destination_name_writes_with_private_permissions() -> io::Result<()> {
+    let directory = test_directory()?;
+    let destination = directory.join(format!("{}.toml", "a".repeat(240)));
+
+    atomic_write(&destination, b"valid")?;
+
+    assert_eq!(fs::metadata(&destination)?.mode() & 0o777, 0o600);
+    fs::remove_dir_all(directory)
+}
+
+#[test]
+fn non_regular_destination_is_rejected() -> io::Result<()> {
+    let directory = test_directory()?;
+    let destination = directory.join("settings.toml");
+    fs::create_dir(&destination)?;
+
+    assert!(atomic_write(&destination, b"replacement").is_err());
+    assert!(destination.is_dir());
+    fs::remove_dir_all(directory)
+}
+
+fn test_directory() -> io::Result<PathBuf> {
+    loop {
+        let path = std::env::temp_dir().join(format!(
+            "strata-storage-{}-{}",
+            std::process::id(),
+            NEXT_TEMP_FILE.fetch_add(1, Ordering::Relaxed)
+        ));
+        match fs::create_dir(&path) {
+            Ok(()) => return Ok(path),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+            Err(error) => return Err(error),
+        }
+    }
+}

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -296,10 +296,9 @@ impl ThemeManager {
             id = format!("{base}-{suffix}");
             suffix += 1;
         }
-        fs::write(
-            directory.join(format!("{id}.toml")),
-            toml::to_string_pretty(&tokens).map_err(io::Error::other)?,
-        )?;
+        let path = directory.join(format!("{id}.toml"));
+        let value = toml::to_string_pretty(&tokens).map_err(io::Error::other)?;
+        crate::storage::atomic_write(&path, value.as_bytes())?;
 
         let mut themes = self.themes.borrow_mut();
         if let Some(theme) = themes
@@ -370,7 +369,7 @@ impl ThemeManager {
             }
             let value =
                 toml::to_string_pretty(&*self.preferences.borrow()).map_err(io::Error::other)?;
-            fs::write(path, value)
+            crate::storage::atomic_write(&path, value.as_bytes())
         })();
         if let Err(error) = result {
             tracing::warn!(%error, "unable to save theme preference");
@@ -563,10 +562,8 @@ pub(super) fn register_source_buffer(buffer: &sourceview5::Buffer) {
 fn install_source_style_scheme(tokens: &ThemeTokens) {
     let directory = glib::user_cache_dir().join("strata").join("source-styles");
     if let Err(error) = fs::create_dir_all(&directory).and_then(|()| {
-        fs::write(
-            directory.join("strata-current.xml"),
-            source_style_scheme_xml(tokens),
-        )
+        let value = source_style_scheme_xml(tokens);
+        crate::storage::atomic_write(&directory.join("strata-current.xml"), value.as_bytes())
     }) {
         tracing::warn!(%error, "unable to write preview syntax style");
         return;

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -1466,7 +1466,7 @@ fn save_pinned_places(places: &[(Location, String)]) {
             contents.push_str(&format!("{uri} {label}\n"));
         }
     }
-    let _result = std::fs::write(path, contents);
+    let _result = crate::storage::atomic_write(&path, contents.as_bytes());
 }
 
 fn home_directory() -> PathBuf {


### PR DESCRIPTION
## Summary

- add a standard-library atomic-write helper using short, unique temporary names in the destination directory
- write, flush, and sync before renaming; use private `0600` permissions and clean up incomplete temporary files
- reject symlink and non-regular final destinations
- migrate settings, custom themes, GTK bookmarks, bundled-font caches, and source-style caches

## Tests

- cover partial-write failure while preserving the previous file
- cover symlink and non-regular destinations
- cover private permissions and long destination filenames

## Verification

- `cargo fmt --all --check`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features` — 149 passed

Closes #15