### PR TITLE
feat(browser): show thumbnails and avoid premature filename truncation

### DIFF
--- a/docs/preview-sandbox.md
+++ b/docs/preview-sandbox.md
@@ -21,7 +21,7 @@ Strata starts its own executable in a bubblewrap sandbox. The sandbox has:
 - read-only access to `/usr`, required runtime libraries and font/ImageMagick configuration, the Strata executable, and exactly one canonicalized input file;
 - writable access only to private mode-0700 output and temporary directories;
 - an empty environment with a nonexistent home directory;
-- 1.25 GB address-space and 32 MB file-size limits;
+- a 2 GB address-space limit, allowing modern image loaders to start their isolated worker threads, and a 32 MB file-size limit;
 - a 12-second wall-clock limit for image, PDF, and thumbnail rendering, plus a 10-second CPU limit; and
 - a 30-second wall-clock limit for media previews, which have no cumulative CPU limit because FFmpeg uses multiple threads.
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -14,6 +14,7 @@ use std::{
 
 const WALL_TIME_LIMIT: Duration = Duration::from_secs(12);
 const MEDIA_WALL_TIME_LIMIT: Duration = Duration::from_secs(30);
+const ADDRESS_SPACE_LIMIT_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 const MAX_OUTPUT_BYTES: u64 = 32 * 1024 * 1024;
 static NEXT_DIRECTORY: AtomicU64 = AtomicU64::new(1);
 
@@ -198,7 +199,11 @@ fn sandbox_command(
     command.arg(executable).arg("/app/strata");
     command.arg("--ro-bind").arg(input).arg("/input");
     command.arg("--bind").arg(output).arg("/output");
-    command.args(["--", "/usr/bin/prlimit", "--as=1342177280"]);
+    command.args([
+        "--",
+        "/usr/bin/prlimit",
+        &format!("--as={ADDRESS_SPACE_LIMIT_BYTES}"),
+    ]);
     if operation != ParseOperation::PreviewMedia {
         command.arg("--cpu=10");
     }

--- a/src/sandbox/tests.rs
+++ b/src/sandbox/tests.rs
@@ -25,7 +25,7 @@ fn sandbox_exposes_only_runtime_input_and_private_output() {
     assert!(joined.contains("--clearenv"));
     assert!(joined.contains("--ro-bind /home/alice/Downloads/untrusted.pdf /input"));
     assert!(joined.contains("--bind /tmp/private-output /output"));
-    assert!(joined.contains("--as=1342177280"));
+    assert!(joined.contains("--as=2147483648"));
     assert!(joined.contains("--cpu=10"));
     assert!(joined.contains("--fsize=33554432"));
     // RLIMIT_NPROC counts every process owned by the host user, not just the

--- a/src/style.css
+++ b/src/style.css
@@ -325,6 +325,11 @@ headerbar menubutton.header-action > button:focus-visible image {
   outline-offset: -1px;
 }
 
+.search-result-thumbnail {
+  min-height: 32px;
+  min-width: 32px;
+}
+
 .search-result-name {
   color: @theme_text;
   font-weight: 650;

--- a/src/style.css
+++ b/src/style.css
@@ -1928,17 +1928,25 @@ menubutton.column-header-action > button:focus-visible image {
 }
 
 .file-size {
+  background: @theme_bg;
   color: @theme_dim_text;
   font-size: 0.9em;
   opacity: 0;
+  padding-left: 10px;
 }
 
 .file-list row:hover .file-size {
+  background: alpha(@theme_muted, 0.65);
   opacity: 1;
 }
 
-.file-list row:selected .file-size,
+.file-list row:selected .file-size {
+  background: alpha(@theme_muted, 0.65);
+  color: @theme_dim_text;
+}
+
 .file-list .file-row.active-path .file-size {
+  background: @theme_highlight;
   color: @theme_dim_text;
 }
 

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -2732,8 +2732,7 @@ impl ViewState {
             let label = gtk::Label::builder()
                 .halign(gtk::Align::Fill)
                 .xalign(0.0)
-                .hexpand(false)
-                .max_width_chars(24)
+                .hexpand(true)
                 .ellipsize(gtk::pango::EllipsizeMode::End)
                 .build();
             let rename = gtk::Entry::new();
@@ -2751,7 +2750,6 @@ impl ViewState {
             });
             let spacer = gtk::Box::new(gtk::Orientation::Horizontal, 0);
             spacer.add_css_class("file-row-spacer");
-            spacer.set_hexpand(true);
             let size = gtk::Label::new(None);
             size.add_css_class("file-size");
             size.set_xalign(1.0);

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -92,6 +92,7 @@ struct PeekView {
     location: Location,
     presentation: LoadPresentation,
     model: gtk::StringList,
+    entries: Rc<RefCell<Vec<FileEntry>>>,
     entry_count: Rc<Cell<usize>>,
     spinner: gtk::Spinner,
 }
@@ -2405,12 +2406,7 @@ impl ViewState {
                     if !entries.is_empty() {
                         peek.presentation.show_content();
                     }
-                    append_entries(
-                        &peek.model,
-                        &peek.entry_count,
-                        entries,
-                        Some(self.peek_behavior.item_limit),
-                    );
+                    append_peek_entries(peek, entries, self.peek_behavior.item_limit);
                 }
             }
             BrowserEvent::PeekFinished => {
@@ -3468,9 +3464,10 @@ impl ViewState {
         content.append(&header);
 
         let entry_count = Rc::new(Cell::new(0));
+        let entries = Rc::new(RefCell::new(Vec::new()));
         let model = gtk::StringList::new(&[]);
         let selection = gtk::NoSelection::new(Some(model.clone()));
-        let factory = basic_label_factory();
+        let factory = peek_label_factory(entries.clone());
         let list = gtk::ListView::new(Some(selection), Some(factory));
         list.add_css_class("file-list");
         let weak_browser = Rc::downgrade(&self.browser);
@@ -3547,6 +3544,7 @@ impl ViewState {
             location: location.clone(),
             presentation,
             model,
+            entries,
             entry_count,
             spinner,
         }));
@@ -3596,7 +3594,7 @@ impl ViewState {
     }
 }
 
-fn basic_label_factory() -> gtk::SignalListItemFactory {
+fn peek_label_factory(entries: Rc<RefCell<Vec<FileEntry>>>) -> gtk::SignalListItemFactory {
     let factory = gtk::SignalListItemFactory::new();
     factory.connect_setup(|_, item| {
         let Some(item) = item.downcast_ref::<gtk::ListItem>() else {
@@ -3618,7 +3616,7 @@ fn basic_label_factory() -> gtk::SignalListItemFactory {
         row.append(&chevron);
         item.set_child(Some(&row));
     });
-    factory.connect_bind(|_, item| {
+    factory.connect_bind(move |_, item| {
         let Some(item) = item.downcast_ref::<gtk::ListItem>() else {
             return;
         };
@@ -3641,15 +3639,12 @@ fn basic_label_factory() -> gtk::SignalListItemFactory {
         let name = model_display_name(&value);
         let directory = model_is_directory(&value);
         label.set_label(name);
-        crate::assets::set_primary_icon(
-            &icon,
-            if directory {
-                crate::assets::icons::FOLDER
-            } else {
-                icon_for_name(name)
-            },
-        );
-        icon.set_opacity(if directory { 1.0 } else { 0.72 });
+        if let Some(entry) = entries.borrow().get(item.position() as usize) {
+            super::thumbnail::set_thumbnail_or_icon(&icon, entry, entry_icon(entry), 17, 24);
+        } else {
+            super::thumbnail::show_fallback_icon(&icon, icon_for_name(name), 17);
+        }
+        icon.set_opacity(if directory { 1.0 } else { 0.82 });
         chevron.set_visible(directory);
     });
     factory
@@ -5003,21 +4998,15 @@ fn icon_for_name(name: &str) -> &'static str {
     }
 }
 
-fn append_entries(
-    model: &gtk::StringList,
-    stored_count: &Rc<Cell<usize>>,
-    entries: Vec<FileEntry>,
-    limit: Option<usize>,
-) {
-    let remaining = limit
-        .map(|limit| limit.max(1).saturating_sub(stored_count.get()))
-        .unwrap_or(entries.len());
-    let mut appended = 0;
-    for entry in entries.into_iter().take(remaining) {
-        model.append(&entry_model_value(&entry));
-        appended += 1;
+fn append_peek_entries(peek: &PeekView, entries: Vec<FileEntry>, limit: usize) {
+    let remaining = limit.max(1).saturating_sub(peek.entry_count.get());
+    let entries = entries.into_iter().take(remaining).collect::<Vec<_>>();
+    let values = entries.iter().map(entry_model_value).collect::<Vec<_>>();
+    peek.entry_count.set(peek.entry_count.get() + entries.len());
+    peek.entries.borrow_mut().extend(entries);
+    for value in values {
+        peek.model.append(&value);
     }
-    stored_count.set(stored_count.get() + appended);
 }
 
 fn cancel_source(source: &RefCell<Option<glib::SourceId>>) {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -2072,7 +2072,13 @@ impl ViewState {
         let Some(icon) = row.first_child() else {
             return false;
         };
-        let Some(label) = icon.next_sibling().and_downcast::<gtk::Label>() else {
+        let Some(middle) = icon.next_sibling().and_downcast::<gtk::Overlay>() else {
+            return false;
+        };
+        let Some(editor) = middle.child().and_downcast::<gtk::Box>() else {
+            return false;
+        };
+        let Some(label) = editor.first_child().and_downcast::<gtk::Label>() else {
             return false;
         };
         let Some(field) = label.next_sibling().and_downcast::<gtk::Entry>() else {
@@ -2750,16 +2756,23 @@ impl ViewState {
             });
             let spacer = gtk::Box::new(gtk::Orientation::Horizontal, 0);
             spacer.add_css_class("file-row-spacer");
+            let editor = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+            editor.append(&label);
+            editor.append(&rename);
+            editor.append(&spacer);
             let size = gtk::Label::new(None);
             size.add_css_class("file-size");
+            size.set_halign(gtk::Align::End);
+            size.set_valign(gtk::Align::Center);
             size.set_xalign(1.0);
+            let middle = gtk::Overlay::new();
+            middle.set_hexpand(true);
+            middle.set_child(Some(&editor));
+            middle.add_overlay(&size);
             let chevron = crate::assets::primary_icon(crate::assets::icons::CHEVRON_RIGHT, 15);
             chevron.add_css_class("file-chevron");
             row.append(&icon);
-            row.append(&label);
-            row.append(&rename);
-            row.append(&spacer);
-            row.append(&size);
+            row.append(&middle);
             row.append(&chevron);
             let motion = gtk::EventControllerMotion::new();
             let list_item = item.clone();
@@ -2969,7 +2982,13 @@ impl ViewState {
             let Some(icon) = row.first_child().and_downcast::<gtk::Image>() else {
                 return;
             };
-            let Some(label) = icon.next_sibling().and_downcast::<gtk::Label>() else {
+            let Some(middle) = icon.next_sibling().and_downcast::<gtk::Overlay>() else {
+                return;
+            };
+            let Some(editor) = middle.child().and_downcast::<gtk::Box>() else {
+                return;
+            };
+            let Some(label) = editor.first_child().and_downcast::<gtk::Label>() else {
                 return;
             };
             let Some(rename) = label.next_sibling().and_downcast::<gtk::Entry>() else {
@@ -2978,10 +2997,10 @@ impl ViewState {
             let Some(spacer) = rename.next_sibling().and_downcast::<gtk::Box>() else {
                 return;
             };
-            let Some(size) = spacer.next_sibling().and_downcast::<gtk::Label>() else {
+            let Some(size) = middle.last_child().and_downcast::<gtk::Label>() else {
                 return;
             };
-            let Some(chevron) = size.next_sibling().and_downcast::<gtk::Image>() else {
+            let Some(chevron) = middle.next_sibling().and_downcast::<gtk::Image>() else {
                 return;
             };
             label.set_label(model_display_name(&value.string()));

--- a/src/ui/preview.rs
+++ b/src/ui/preview.rs
@@ -179,6 +179,9 @@ impl PreviewDrawer {
     pub fn attach_split(&self, split: &gtk::Paned, occupied_width: Rc<dyn Fn() -> i32>) {
         self.state.split.replace(Some(split.clone()));
         self.state.occupied_width.replace(Some(occupied_width));
+        if !self.state.opened.get() {
+            split.set_end_child(None::<&gtk::Widget>);
+        }
         let weak = Rc::downgrade(&self.state);
         split.add_tick_callback(move |split, _| {
             let Some(state) = weak.upgrade() else {
@@ -227,6 +230,7 @@ impl PreviewState {
             self.pane.set_size_request(0, -1);
             self.revealer.set_reveal_child(true);
             if let Some(split) = self.split.borrow().as_ref() {
+                split.set_end_child(Some(&self.revealer));
                 self.animate_open(split);
             }
         }
@@ -307,6 +311,7 @@ impl PreviewState {
         self.revealer.set_reveal_child(false);
         if let Some(split) = self.split.borrow().as_ref() {
             split.set_position(split.width());
+            split.set_end_child(None::<&gtk::Widget>);
         }
         self.pane.set_size_request(MIN_WIDTH, -1);
     }

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -270,14 +270,22 @@ fn result_row(item: &SearchItem, root: &Path) -> gtk::ListBoxRow {
     let row = gtk::ListBoxRow::new();
     row.add_css_class("search-result");
     let content = gtk::Box::new(gtk::Orientation::Horizontal, 12);
-    content.append(&crate::assets::primary_icon(
-        if item.is_directory {
-            crate::assets::icons::FOLDER
-        } else {
-            crate::assets::icons::DOCUMENTS
-        },
-        19,
-    ));
+    let icon = gtk::Image::new();
+    icon.add_css_class("search-result-thumbnail");
+    if item.is_directory {
+        crate::assets::set_primary_icon(&icon, crate::assets::icons::FOLDER);
+        icon.set_pixel_size(19);
+        icon.set_size_request(32, 32);
+    } else {
+        super::thumbnail::set_thumbnail_or_icon_for_path(
+            &icon,
+            &item.path,
+            crate::assets::icons::DOCUMENTS,
+            19,
+            32,
+        );
+    }
+    content.append(&icon);
     let labels = gtk::Box::new(gtk::Orientation::Vertical, 2);
     labels.set_hexpand(true);
     let name = gtk::Label::new(Some(&item.name));

--- a/src/ui/thumbnail.rs
+++ b/src/ui/thumbnail.rs
@@ -87,19 +87,58 @@ pub(super) fn set_thumbnail_or_icon(
     icon_size: i32,
     thumbnail_size: i32,
 ) {
-    let (image_id, request, cancellation) = set_fallback_icon(image, fallback_icon, icon_size);
-
-    let Some(path) = entry.location.native_path().map(Path::to_path_buf) else {
+    let Some(path) = entry.location.native_path() else {
+        show_fallback_icon(image, fallback_icon, icon_size);
         return;
     };
+    set_thumbnail_for_path(
+        image,
+        path,
+        known_metadata(&entry.modified_unix_seconds),
+        known_metadata(&entry.size),
+        fallback_icon,
+        icon_size,
+        thumbnail_size,
+    );
+}
+
+pub(super) fn set_thumbnail_or_icon_for_path(
+    image: &gtk::Image,
+    path: &Path,
+    fallback_icon: &str,
+    icon_size: i32,
+    thumbnail_size: i32,
+) {
+    set_thumbnail_for_path(
+        image,
+        path,
+        None,
+        None,
+        fallback_icon,
+        icon_size,
+        thumbnail_size,
+    );
+}
+
+fn set_thumbnail_for_path(
+    image: &gtk::Image,
+    path: &Path,
+    modified: Option<i64>,
+    file_size: Option<u64>,
+    fallback_icon: &str,
+    icon_size: i32,
+    thumbnail_size: i32,
+) {
+    let (image_id, request, cancellation) = set_fallback_icon(image, fallback_icon, icon_size);
+    let path = path.to_path_buf();
     let Some(kind) = thumbnail_kind(&path) else {
         return;
     };
     let thumbnail_size = thumbnail_size.clamp(16, 256);
     let key = ThumbnailKey {
         path: path.clone(),
-        modified: known_metadata(&entry.modified_unix_seconds),
-        file_size: known_metadata(&entry.size),
+        modified,
+        file_size,
         thumbnail_size,
     };
     if let Some(bytes) = THUMBNAIL_CACHE.with(|cache| cache.borrow_mut().get(&key)) {

--- a/src/ui/thumbnail.rs
+++ b/src/ui/thumbnail.rs
@@ -21,13 +21,20 @@ const MAX_CACHE_BYTES: usize = 64 * 1024 * 1024;
 thread_local! {
     static ACTIVE_REQUESTS: RefCell<HashMap<usize, ActiveRequest>> =
         RefCell::new(HashMap::new());
+    static PENDING_THUMBNAILS: RefCell<HashMap<ThumbnailKey, Vec<PendingTarget>>> =
+        RefCell::new(HashMap::new());
     static THUMBNAIL_CACHE: RefCell<ThumbnailCache> = RefCell::new(ThumbnailCache::default());
 }
 
 struct ActiveRequest {
     id: u64,
     image: glib::WeakRef<gtk::Image>,
-    cancellation: Cancellation,
+}
+
+struct PendingTarget {
+    image_id: usize,
+    request: u64,
+    image: glib::WeakRef<gtk::Image>,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -129,7 +136,7 @@ fn set_thumbnail_for_path(
     icon_size: i32,
     thumbnail_size: i32,
 ) {
-    let (image_id, request, cancellation) = set_fallback_icon(image, fallback_icon, icon_size);
+    let (image_id, request) = set_fallback_icon(image, fallback_icon, icon_size);
     let path = path.to_path_buf();
     let Some(kind) = thumbnail_kind(&path) else {
         return;
@@ -148,32 +155,56 @@ fn set_thumbnail_for_path(
 
     let weak_image = glib::WeakRef::new();
     weak_image.set(Some(image));
+    let target = PendingTarget {
+        image_id,
+        request,
+        image: weak_image,
+    };
+    let should_render = PENDING_THUMBNAILS.with(|pending| {
+        let mut pending = pending.borrow_mut();
+        if let Some(targets) = pending.get_mut(&key) {
+            targets.push(target);
+            false
+        } else {
+            pending.insert(key.clone(), vec![target]);
+            true
+        }
+    });
+    if !should_render {
+        return;
+    }
+
     glib::MainContext::default().spawn_local(async move {
+        let cancellation = Cancellation::default();
         let result = gio::spawn_blocking(move || {
             render_thumbnail(&path, kind, thumbnail_size, &cancellation)
         })
         .await;
+        let targets = PENDING_THUMBNAILS
+            .with(|pending| pending.borrow_mut().remove(&key).unwrap_or_default());
         let Ok(Ok(png)) = result else {
             return;
         };
         let bytes = glib::Bytes::from_owned(png);
         THUMBNAIL_CACHE.with(|cache| cache.borrow_mut().insert(key, bytes.clone()));
-        let is_current = ACTIVE_REQUESTS.with(|requests| {
-            requests
-                .borrow()
-                .get(&image_id)
-                .is_some_and(|active| active.id == request)
-        });
-        if !is_current {
-            return;
-        }
-        let Some(image) = weak_image.upgrade() else {
-            ACTIVE_REQUESTS.with(|requests| {
-                requests.borrow_mut().remove(&image_id);
+        for target in targets {
+            let is_current = ACTIVE_REQUESTS.with(|requests| {
+                requests
+                    .borrow()
+                    .get(&target.image_id)
+                    .is_some_and(|active| active.id == target.request)
             });
-            return;
-        };
-        apply_thumbnail(&image, &bytes, thumbnail_size);
+            if !is_current {
+                continue;
+            }
+            let Some(image) = target.image.upgrade() else {
+                ACTIVE_REQUESTS.with(|requests| {
+                    requests.borrow_mut().remove(&target.image_id);
+                });
+                continue;
+            };
+            apply_thumbnail(&image, &bytes, thumbnail_size);
+        }
     });
 }
 
@@ -198,30 +229,26 @@ pub(super) fn show_fallback_icon(image: &gtk::Image, icon: &str, size: i32) {
     set_fallback_icon(image, icon, size);
 }
 
-fn set_fallback_icon(image: &gtk::Image, icon: &str, size: i32) -> (usize, u64, Cancellation) {
+fn set_fallback_icon(image: &gtk::Image, icon: &str, size: i32) -> (usize, u64) {
     let request = NEXT_REQUEST.fetch_add(1, Ordering::Relaxed);
     let image_id = image.as_ptr() as usize;
     let weak_image = glib::WeakRef::new();
     weak_image.set(Some(image));
-    let cancellation = Cancellation::default();
     ACTIVE_REQUESTS.with(|requests| {
         let mut requests = requests.borrow_mut();
         requests.retain(|_, active| active.image.upgrade().is_some());
-        if let Some(previous) = requests.insert(
+        requests.insert(
             image_id,
             ActiveRequest {
                 id: request,
                 image: weak_image,
-                cancellation: cancellation.clone(),
             },
-        ) {
-            previous.cancellation.cancel();
-        }
+        );
     });
     image.set_pixel_size(size);
     image.set_size_request(size, size);
     crate::assets::set_primary_icon(image, icon);
-    (image_id, request, cancellation)
+    (image_id, request)
 }
 
 fn thumbnail_kind(path: &Path) -> Option<ThumbnailKind> {


### PR DESCRIPTION
## Summary
- render asynchronous cached thumbnails in folder-peek rows
- render thumbnails alongside search result names and paths
- retain themed file and folder icons while thumbnails load or fail
- reuse the existing sandboxed thumbnail pipeline and cache

Closes #41

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features`

## Screenshots
Thumbnails in peeking:
<img width="1278" height="635" alt="image" src="https://github.com/user-attachments/assets/9770b8c7-86c8-4782-90d2-b7f144e19626" />

Thumbnails in search:
<img width="1278" height="1401" alt="image" src="https://github.com/user-attachments/assets/100914e4-562f-45d6-ae27-0ae517b3b931" />

