### PR TITLE
perf(preview): accelerate video previews with GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Strata is not yet available through Arch's package repositories. Download the ar
 Install the runtime libraries and optional video preview tools on Arch or Omarchy:
 
 ```bash
-sudo pacman -S --needed bubblewrap ffmpeg ffmpegthumbnailer fontconfig gtk4 gtksourceview5 poppler-glib
+sudo pacman -S --needed bubblewrap ffmpeg ffmpegthumbnailer fontconfig gst-libav gst-plugins-good gtk4 gtksourceview5 poppler-glib
 ```
 
 Then verify, extract, and install the downloaded archive (replace the filename with the release you downloaded). The `gh attestation` check verifies the archive's signed GitHub Actions provenance:

--- a/docs/preview-sandbox.md
+++ b/docs/preview-sandbox.md
@@ -23,7 +23,7 @@ Strata starts its own executable in a bubblewrap sandbox. The sandbox has:
 - an empty environment with a nonexistent home directory;
 - a 2 GB address-space limit, allowing modern image loaders to start their isolated worker threads, and a 32 MB file-size limit;
 - a 12-second wall-clock limit for image, PDF, and thumbnail rendering, plus a 10-second CPU limit; and
-- a 30-second wall-clock limit for media previews, which have no cumulative CPU limit because FFmpeg uses multiple threads.
+- a 30-second wall-clock limit for media previews, which have no cumulative CPU limit because FFmpeg uses multiple threads. Hardware attempts are limited to 8 seconds each and 12 seconds collectively so the software fallback retains time to run.
 
 Media previews additionally receive only discovered `/dev/dri/renderD<digits>`, `/dev/nvidia<digits>`, and `/dev/nvidiactl` devices plus read-only `/sys` access for driver discovery. Image, PDF, and thumbnail helpers receive none of these mounts. GPU acceleration expands the media helper's attack surface into the installed userspace and kernel GPU drivers; device access remains media-only and the existing namespaces and resource limits still apply.
 

--- a/docs/preview-sandbox.md
+++ b/docs/preview-sandbox.md
@@ -11,7 +11,7 @@ The following providers run in a short-lived helper process:
 - ImageMagick and `dcraw`/`dcraw_emu` RAW fallbacks; and
 - `ffmpegthumbnailer` media thumbnails.
 
-Image previews are normalized to PNG by the helper. Video previews are transcoded to a fixed WebM profile, limited to the first 30 seconds, at most 1280 pixels on either axis, and at most 30 frames per second before GTK receives them, so GStreamer never parses the selected untrusted file directly. Plain-text previews remain in-process and are limited to 1 MB; they do not invoke a native format parser.
+Image previews are normalized to PNG by the helper. Video previews are limited to the first 30 seconds, at most 1280 pixels on either axis, and at most 30 frames per second. They are normalized by VA-API first, Vulkan second, or the software VP8 fallback. Hardware paths produce H.264/AAC MP4; the software path produces VP8/Opus WebM. This keeps GStreamer from parsing the selected untrusted file directly. Plain-text previews remain in-process and are limited to 1 MB; they do not invoke a native format parser.
 
 ## Isolation and limits
 
@@ -25,4 +25,6 @@ Strata starts its own executable in a bubblewrap sandbox. The sandbox has:
 - a 12-second wall-clock limit for image, PDF, and thumbnail rendering, plus a 10-second CPU limit; and
 - a 30-second wall-clock limit for media previews, which have no cumulative CPU limit because FFmpeg uses multiple threads.
 
-The parent accepts only a bounded PNG or WebM result. Cancellation or timeout kills bubblewrap, which is the sandbox PID-namespace init process, and therefore tears down all helper descendants. A missing bubblewrap installation, renderer crash, malformed result, timeout, or permission failure is fail-closed and produces the normal fallback icon or **Preview unavailable** message.
+Media previews additionally receive only discovered `/dev/dri/renderD<digits>`, `/dev/nvidia<digits>`, and `/dev/nvidiactl` devices plus read-only `/sys` access for driver discovery. Image, PDF, and thumbnail helpers receive none of these mounts. GPU acceleration expands the media helper's attack surface into the installed userspace and kernel GPU drivers; device access remains media-only and the existing namespaces and resource limits still apply.
+
+The parent accepts only a bounded PNG, MP4 with an `ftyp` signature, or WebM with an EBML signature. Failed or unavailable hardware attempts advance to the next backend, while a failed final software attempt produces the normal unavailable-preview result. Cancellation or timeout kills bubblewrap, which is the sandbox PID-namespace init process, and therefore tears down all helper descendants. A missing bubblewrap installation, renderer crash, malformed result, timeout, or permission failure is fail-closed and produces the normal fallback icon or **Preview unavailable** message.

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -43,7 +43,7 @@ impl ParseOperation {
 
     fn output_name(self) -> &'static str {
         if self == Self::PreviewMedia {
-            "result.webm"
+            "result.media"
         } else {
             "result.png"
         }
@@ -96,7 +96,19 @@ pub(crate) fn parse(
     let output = PrivateOutput::create().map_err(|error| error.to_string())?;
     let executable = std::env::current_exe()
         .map_err(|error| format!("Unable to locate the Strata executable: {error}"))?;
-    let mut command = sandbox_command(&executable, &input, output.path(), operation, value);
+    let devices = if operation == ParseOperation::PreviewMedia {
+        gpu_devices(Path::new("/dev"))
+    } else {
+        Vec::new()
+    };
+    let mut command = sandbox_command(
+        &executable,
+        &input,
+        output.path(),
+        operation,
+        value,
+        &devices,
+    );
     let mut child = command
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -133,8 +145,12 @@ pub(crate) fn parse(
         return Err("The preview renderer produced an invalid output size".to_owned());
     }
     let data = fs::read(result_path).map_err(|error| error.to_string())?;
-    if operation != ParseOperation::PreviewMedia && !data.starts_with(b"\x89PNG\r\n\x1a\n") {
-        return Err("The preview renderer produced invalid image data".to_owned());
+    if !valid_output(operation, &data) {
+        return Err(if operation == ParseOperation::PreviewMedia {
+            "The preview renderer produced invalid media data".to_owned()
+        } else {
+            "The preview renderer produced invalid image data".to_owned()
+        });
     }
     let (page, pages) = read_metadata(&output.path().join("result.meta"));
     Ok(ParseOutput { data, page, pages })
@@ -146,6 +162,7 @@ fn sandbox_command(
     output: &Path,
     operation: ParseOperation,
     value: i32,
+    devices: &[PathBuf],
 ) -> Command {
     let mut command = Command::new("bwrap");
     command.args([
@@ -198,6 +215,13 @@ fn sandbox_command(
     command.arg(executable).arg("/app/strata");
     command.arg("--ro-bind").arg(input).arg("/input");
     command.arg("--bind").arg(output).arg("/output");
+    if operation == ParseOperation::PreviewMedia {
+        // Hardware media drivers need selected render nodes plus read-only sysfs discovery data.
+        for device in devices {
+            command.arg("--dev-bind-try").arg(device).arg(device);
+        }
+        command.args(["--ro-bind", "/sys", "/sys"]);
+    }
     command.args(["--", "/usr/bin/prlimit", "--as=1342177280"]);
     if operation != ParseOperation::PreviewMedia {
         command.arg("--cpu=10");
@@ -213,6 +237,44 @@ fn sandbox_command(
     command.arg(format!("/output/{}", operation.output_name()));
     command.arg(value.to_string());
     command
+}
+
+pub(crate) fn gpu_devices(dev: &Path) -> Vec<PathBuf> {
+    let mut devices = Vec::new();
+    if let Ok(entries) = fs::read_dir(dev.join("dri")) {
+        for entry in entries.flatten() {
+            if numbered_name(&entry.file_name(), "renderD") {
+                devices.push(entry.path());
+            }
+        }
+    }
+    if let Ok(entries) = fs::read_dir(dev) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            if name == "nvidiactl" || numbered_name(&name, "nvidia") {
+                devices.push(entry.path());
+            }
+        }
+    }
+    devices.sort();
+    devices
+}
+
+pub(crate) fn numbered_name(name: &std::ffi::OsStr, prefix: &str) -> bool {
+    name.to_str()
+        .and_then(|name| name.strip_prefix(prefix))
+        .is_some_and(|suffix| {
+            !suffix.is_empty() && suffix.bytes().all(|byte| byte.is_ascii_digit())
+        })
+}
+
+fn valid_output(operation: ParseOperation, data: &[u8]) -> bool {
+    if operation == ParseOperation::PreviewMedia {
+        data.starts_with(b"\x1a\x45\xdf\xa3")
+            || data.get(4..8).is_some_and(|signature| signature == b"ftyp")
+    } else {
+        data.starts_with(b"\x89PNG\r\n\x1a\n")
+    }
 }
 
 fn terminate(child: &mut std::process::Child) {

--- a/src/sandbox/tests.rs
+++ b/src/sandbox/tests.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use std::path::Path;
+use std::{fs, path::Path};
 
 use super::{
-    Cancellation, MEDIA_WALL_TIME_LIMIT, ParseOperation, WALL_TIME_LIMIT, parse, sandbox_command,
+    Cancellation, MEDIA_WALL_TIME_LIMIT, ParseOperation, PrivateOutput, WALL_TIME_LIMIT,
+    gpu_devices, parse, sandbox_command, valid_output,
 };
 
 #[test]
@@ -14,6 +15,7 @@ fn sandbox_exposes_only_runtime_input_and_private_output() {
         Path::new("/tmp/private-output"),
         ParseOperation::PreviewPdf,
         2,
+        &[],
     );
     let arguments: Vec<_> = command
         .get_args()
@@ -44,6 +46,7 @@ fn media_previews_use_a_longer_wall_timeout_instead_of_a_cpu_limit() {
         Path::new("/tmp/private-output"),
         operation,
         0,
+        &[],
     );
 
     assert_eq!(operation.wall_time_limit(), MEDIA_WALL_TIME_LIMIT);
@@ -53,6 +56,110 @@ fn media_previews_use_a_longer_wall_timeout_instead_of_a_cpu_limit() {
             .get_args()
             .all(|argument| !argument.to_string_lossy().starts_with("--cpu="))
     );
+}
+
+#[test]
+fn discovers_only_supported_gpu_devices_in_stable_order() {
+    let root = PrivateOutput::create().expect("create temporary device tree");
+    let dev = root.path().join("dev");
+    fs::create_dir_all(dev.join("dri")).expect("create DRI directory");
+    for path in [
+        "dri/renderD129",
+        "dri/card0",
+        "dri/renderD128",
+        "dri/renderD",
+        "nvidia1",
+        "nvidiactl",
+        "nvidia0",
+        "nvidia-uvm",
+        "nvidia-modeset",
+        "unrelated",
+    ] {
+        fs::write(dev.join(path), []).expect("create device entry");
+    }
+
+    assert_eq!(
+        gpu_devices(&dev),
+        [
+            dev.join("dri/renderD128"),
+            dev.join("dri/renderD129"),
+            dev.join("nvidia0"),
+            dev.join("nvidia1"),
+            dev.join("nvidiactl"),
+        ]
+    );
+}
+
+#[test]
+fn media_sandbox_exposes_only_supplied_gpu_devices_and_sysfs() {
+    let devices = [
+        "/dev/dri/renderD128".into(),
+        "/dev/nvidia0".into(),
+        "/dev/nvidiactl".into(),
+    ];
+    let command = sandbox_command(
+        Path::new("/tmp/strata"),
+        Path::new("/home/alice/Videos/untrusted.mkv"),
+        Path::new("/tmp/private-output"),
+        ParseOperation::PreviewMedia,
+        0,
+        &devices,
+    );
+    let joined = command
+        .get_args()
+        .map(|argument| argument.to_string_lossy())
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    for device in &devices {
+        let device = device.to_string_lossy();
+        assert!(joined.contains(&format!("--dev-bind-try {device} {device}")));
+    }
+    assert!(joined.contains("--ro-bind /sys /sys"));
+    assert!(!joined.contains("--cpu=10"));
+    assert!(joined.contains("/output/result.media"));
+}
+
+#[test]
+fn non_media_sandboxes_never_expose_gpu_devices_or_sysfs() {
+    let command = sandbox_command(
+        Path::new("/tmp/strata"),
+        Path::new("/home/alice/Videos/untrusted.mkv"),
+        Path::new("/tmp/private-output"),
+        ParseOperation::ThumbnailVideo,
+        128,
+        &["/dev/dri/renderD128".into(), "/dev/nvidia0".into()],
+    );
+    let joined = command
+        .get_args()
+        .map(|argument| argument.to_string_lossy())
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    assert!(!joined.contains("--dev-bind-try"));
+    assert!(!joined.contains("/sys"));
+    assert!(joined.contains("--cpu=10"));
+}
+
+#[test]
+fn accepts_only_png_webm_or_mp4_output_signatures() {
+    assert!(valid_output(
+        ParseOperation::PreviewImage,
+        b"\x89PNG\r\n\x1a\ncontent"
+    ));
+    assert!(valid_output(
+        ParseOperation::PreviewMedia,
+        b"\x1a\x45\xdf\xa3content"
+    ));
+    assert!(valid_output(
+        ParseOperation::PreviewMedia,
+        b"\0\0\0\x18ftypisom"
+    ));
+    assert!(!valid_output(ParseOperation::PreviewMedia, b""));
+    assert!(!valid_output(
+        ParseOperation::PreviewMedia,
+        b"unrelated data"
+    ));
 }
 
 #[test]

--- a/src/sandbox_helper.rs
+++ b/src/sandbox_helper.rs
@@ -1,9 +1,22 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use std::{fs, path::Path, process::Command};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 use gdk_pixbuf::prelude::*;
 use gtk::gio;
+
+use crate::sandbox::{gpu_devices, numbered_name};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum MediaBackend {
+    VaApi(PathBuf),
+    Vulkan(usize),
+    Software,
+}
 
 pub(crate) fn run(arguments: &[String]) -> Result<(), String> {
     let [operation, input, output, value] = arguments else {
@@ -168,57 +181,144 @@ fn render_pdf_surface(
 }
 
 fn render_media_preview(path: &Path, output: &Path) -> Result<(), String> {
-    let status = media_preview_command(path, output)
-        .status()
-        .map_err(|error| error.to_string())?;
-    status
-        .success()
-        .then_some(())
-        .ok_or_else(|| "Unable to normalize media preview".to_owned())
+    let backends = media_backends(&gpu_devices(Path::new("/dev")));
+    run_media_backends(&backends, |backend| {
+        media_command(backend, path, output)
+            .status()
+            .map(|status| status.success())
+    })
 }
 
-fn media_preview_command(path: &Path, output: &Path) -> Command {
+fn media_backends(devices: &[PathBuf]) -> Vec<MediaBackend> {
+    let mut render_nodes: Vec<_> = devices
+        .iter()
+        .filter(|device| {
+            device
+                .file_name()
+                .is_some_and(|name| numbered_name(name, "renderD"))
+        })
+        .cloned()
+        .collect();
+    render_nodes.sort();
+    let nvidia_devices = devices
+        .iter()
+        .filter(|device| {
+            device
+                .file_name()
+                .is_some_and(|name| numbered_name(name, "nvidia"))
+        })
+        .count();
+    let vulkan_devices = render_nodes.len().max(nvidia_devices);
+    let mut backends = render_nodes
+        .into_iter()
+        .map(MediaBackend::VaApi)
+        .collect::<Vec<_>>();
+    backends.extend((0..vulkan_devices).map(MediaBackend::Vulkan));
+    backends.push(MediaBackend::Software);
+    backends
+}
+
+fn media_command(backend: &MediaBackend, path: &Path, output: &Path) -> Command {
     let mut command = Command::new("ffmpeg");
+    command.args(["-nostdin", "-v", "error"]);
+    match backend {
+        MediaBackend::VaApi(device) => {
+            command
+                .env("MALLOC_ARENA_MAX", "1")
+                .args([
+                    "-threads",
+                    "1",
+                    "-filter_threads",
+                    "1",
+                    "-hwaccel",
+                    "vaapi",
+                    "-hwaccel_device",
+                ])
+                .arg(device)
+                .args(["-hwaccel_output_format", "vaapi"]);
+        }
+        MediaBackend::Vulkan(index) => {
+            command
+                .env("MALLOC_ARENA_MAX", "1")
+                .args(["-threads", "1", "-filter_threads", "1", "-init_hw_device"])
+                .arg(format!("vulkan=vk:{index}"))
+                .args([
+                    "-filter_hw_device",
+                    "vk",
+                    "-hwaccel",
+                    "vulkan",
+                    "-hwaccel_device",
+                    "vk",
+                    "-hwaccel_output_format",
+                    "vulkan",
+                ]);
+        }
+        MediaBackend::Software => {
+            command.args(["-threads", "2"]);
+        }
+    }
     command
-        .args(["-nostdin", "-v", "error", "-threads", "2", "-i"])
+        .arg("-i")
         .arg(path)
-        .args([
-            "-map",
-            "0:v:0",
-            "-map",
-            "0:a:0?",
-            "-sn",
-            "-dn",
-            "-t",
-            "30",
-            "-vf",
-            "scale=w=1280:h=1280:force_original_aspect_ratio=decrease",
-            "-fpsmax",
-            "30",
-            "-c:v",
-            "libvpx",
-            "-threads",
-            "2",
-            "-deadline",
-            "realtime",
-            "-cpu-used",
-            "8",
-            "-b:v",
-            "2M",
-            "-maxrate",
-            "3M",
-            "-bufsize",
-            "4M",
-            "-c:a",
-            "libopus",
-            "-b:a",
-            "96k",
-            "-f",
-            "webm",
-            "-y",
-        ])
-        .arg(output);
+        .args(["-map", "0:v:0", "-map", "0:a:0?", "-sn", "-dn", "-t", "30"]);
+    match backend {
+        MediaBackend::VaApi(_) => {
+            command.args([
+                "-vf",
+                "scale_vaapi=w=1280:h=1280:force_original_aspect_ratio=decrease:force_divisible_by=2:format=nv12",
+                "-c:v",
+                "h264_vaapi",
+            ]);
+        }
+        MediaBackend::Vulkan(_) => {
+            command.args([
+                "-vf",
+                "scale_vulkan=w='if(gte(iw,ih),min(1280,trunc(iw/2)*2),-2)':h='if(gte(iw,ih),-2,min(1280,trunc(ih/2)*2))':format=nv12",
+                "-c:v",
+                "h264_vulkan",
+                "-usage",
+                "transcode",
+                "-tune",
+                "ull",
+            ]);
+        }
+        MediaBackend::Software => {
+            command.args([
+                "-vf",
+                "scale=w=1280:h=1280:force_original_aspect_ratio=decrease",
+                "-c:v",
+                "libvpx",
+                "-threads",
+                "2",
+                "-deadline",
+                "realtime",
+                "-cpu-used",
+                "8",
+            ]);
+        }
+    }
+    command.args(["-fpsmax", "30"]);
+    command.args(["-b:v", "2M", "-maxrate", "3M", "-bufsize", "4M"]);
+    match backend {
+        MediaBackend::Software => command.args(["-c:a", "libopus", "-b:a", "96k", "-f", "webm"]),
+        MediaBackend::VaApi(_) | MediaBackend::Vulkan(_) => {
+            command.args(["-c:a", "aac", "-b:a", "96k", "-f", "mp4"])
+        }
+    };
+    command.arg("-y").arg(output);
     command
+}
+
+fn run_media_backends<E>(
+    backends: &[MediaBackend],
+    mut run: impl FnMut(&MediaBackend) -> Result<bool, E>,
+) -> Result<(), String> {
+    for backend in backends {
+        if run(backend).is_ok_and(|success| success) {
+            return Ok(());
+        }
+    }
+    Err("Unable to normalize media preview".to_owned())
 }
 
 fn render_media(path: &Path, size: i32) -> Result<Vec<u8>, String> {

--- a/src/sandbox_helper.rs
+++ b/src/sandbox_helper.rs
@@ -1,15 +1,21 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use std::{
-    fs,
+    fs, io,
     path::{Path, PathBuf},
     process::Command,
+    thread,
+    time::{Duration, Instant},
 };
 
 use gdk_pixbuf::prelude::*;
 use gtk::gio;
 
 use crate::sandbox::{gpu_devices, numbered_name};
+
+const HARDWARE_ATTEMPT_TIME_LIMIT: Duration = Duration::from_secs(8);
+const HARDWARE_TOTAL_TIME_LIMIT: Duration = Duration::from_secs(12);
+const PROCESS_POLL_INTERVAL: Duration = Duration::from_millis(20);
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum MediaBackend {
@@ -182,10 +188,14 @@ fn render_pdf_surface(
 
 fn render_media_preview(path: &Path, output: &Path) -> Result<(), String> {
     let backends = media_backends(&gpu_devices(Path::new("/dev")));
+    let hardware_started = Instant::now();
     run_media_backends(&backends, |backend| {
-        media_command(backend, path, output)
-            .status()
-            .map(|status| status.success())
+        let mut command = media_command(backend, path, output);
+        if *backend == MediaBackend::Software {
+            return command.status().map(|status| status.success());
+        }
+        let remaining = HARDWARE_TOTAL_TIME_LIMIT.saturating_sub(hardware_started.elapsed());
+        run_command_with_timeout(&mut command, HARDWARE_ATTEMPT_TIME_LIMIT.min(remaining))
     })
 }
 
@@ -319,6 +329,26 @@ fn run_media_backends<E>(
         }
     }
     Err("Unable to normalize media preview".to_owned())
+}
+
+fn run_command_with_timeout(command: &mut Command, timeout: Duration) -> io::Result<bool> {
+    if timeout.is_zero() {
+        return Ok(false);
+    }
+    let mut child = command.spawn()?;
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Ok(status.success());
+        }
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Ok(false);
+        }
+        thread::sleep(PROCESS_POLL_INTERVAL.min(remaining));
+    }
 }
 
 fn render_media(path: &Path, size: i32) -> Result<Vec<u8>, String> {

--- a/src/sandbox_helper/tests.rs
+++ b/src/sandbox_helper/tests.rs
@@ -1,8 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+    time::{Duration, Instant},
+};
 
-use super::{MediaBackend, media_backends, media_command, run_media_backends};
+use super::{
+    MediaBackend, media_backends, media_command, run_command_with_timeout, run_media_backends,
+};
 
 fn arguments(backend: &MediaBackend) -> String {
     media_command(
@@ -75,6 +81,20 @@ fn final_software_failure_returns_the_normalization_error() {
     assert_eq!(
         run_media_backends(&[MediaBackend::Software], |_| Ok::<_, ()>(false)),
         Err("Unable to normalize media preview".to_owned())
+    );
+}
+
+#[test]
+fn timed_commands_stop_and_report_failure_at_their_deadline() {
+    let started = Instant::now();
+    let result =
+        run_command_with_timeout(Command::new("sleep").arg("5"), Duration::from_millis(50));
+
+    assert!(!result.expect("run timed command"));
+    assert!(started.elapsed() < Duration::from_secs(2));
+    assert!(
+        run_command_with_timeout(&mut Command::new("true"), Duration::from_secs(1))
+            .expect("run successful command")
     );
 }
 

--- a/src/sandbox_helper/tests.rs
+++ b/src/sandbox_helper/tests.rs
@@ -1,23 +1,129 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-use super::media_preview_command;
+use super::{MediaBackend, media_backends, media_command, run_media_backends};
+
+fn arguments(backend: &MediaBackend) -> String {
+    media_command(
+        backend,
+        Path::new("/input"),
+        Path::new("/output/result.media"),
+    )
+    .get_args()
+    .map(|argument| argument.to_string_lossy())
+    .collect::<Vec<_>>()
+    .join(" ")
+}
 
 #[test]
-fn media_preview_transcode_has_bounded_duration_dimensions_and_frame_rate() {
-    let command = media_preview_command(Path::new("/input"), Path::new("/output/result.webm"));
-    let arguments: Vec<_> = command
-        .get_args()
-        .map(|argument| argument.to_string_lossy().into_owned())
-        .collect();
+fn media_backends_are_deterministic_and_ordered() {
+    let devices = [
+        PathBuf::from("/dev/nvidiactl"),
+        PathBuf::from("/dev/dri/renderD129"),
+        PathBuf::from("/dev/nvidia0"),
+        PathBuf::from("/dev/dri/renderD128"),
+    ];
 
-    assert!(arguments.windows(2).any(|pair| pair == ["-t", "30"]));
-    assert!(arguments.windows(2).any(|pair| pair == ["-fpsmax", "30"]));
-    assert!(arguments.windows(2).any(|pair| {
-        pair == [
-            "-vf",
-            "scale=w=1280:h=1280:force_original_aspect_ratio=decrease",
+    assert_eq!(
+        media_backends(&devices),
+        [
+            MediaBackend::VaApi("/dev/dri/renderD128".into()),
+            MediaBackend::VaApi("/dev/dri/renderD129".into()),
+            MediaBackend::Vulkan(0),
+            MediaBackend::Vulkan(1),
+            MediaBackend::Software,
         ]
-    }));
+    );
+    assert_eq!(
+        media_backends(&["/dev/nvidia0".into(), "/dev/nvidiactl".into()]),
+        [MediaBackend::Vulkan(0), MediaBackend::Software]
+    );
+}
+
+#[test]
+fn hardware_failures_fall_back_and_first_success_stops() {
+    let backends = [
+        MediaBackend::VaApi("/dev/dri/renderD128".into()),
+        MediaBackend::Vulkan(0),
+        MediaBackend::Software,
+    ];
+    let mut attempts = Vec::new();
+    let result = run_media_backends(&backends, |backend| {
+        attempts.push(backend.clone());
+        match backend {
+            MediaBackend::VaApi(_) => Err(()),
+            MediaBackend::Vulkan(_) => Ok(false),
+            MediaBackend::Software => Ok(true),
+        }
+    });
+
+    assert_eq!(result, Ok(()));
+    assert_eq!(attempts, backends);
+
+    attempts.clear();
+    let result = run_media_backends(&backends, |backend| {
+        attempts.push(backend.clone());
+        Ok::<_, ()>(matches!(backend, MediaBackend::Vulkan(_)))
+    });
+    assert_eq!(result, Ok(()));
+    assert_eq!(attempts, &backends[..2]);
+}
+
+#[test]
+fn final_software_failure_returns_the_normalization_error() {
+    assert_eq!(
+        run_media_backends(&[MediaBackend::Software], |_| Ok::<_, ()>(false)),
+        Err("Unable to normalize media preview".to_owned())
+    );
+}
+
+#[test]
+fn media_commands_select_the_backend_and_preserve_limits() {
+    for backend in [
+        MediaBackend::VaApi("/dev/dri/renderD129".into()),
+        MediaBackend::Vulkan(1),
+    ] {
+        assert!(
+            media_command(&backend, Path::new("/input"), Path::new("/output"))
+                .get_envs()
+                .any(|(name, value)| name == "MALLOC_ARENA_MAX" && value == Some("1".as_ref()))
+        );
+    }
+
+    let vaapi = arguments(&MediaBackend::VaApi("/dev/dri/renderD129".into()));
+    assert!(vaapi.contains("-threads 1 -filter_threads 1"));
+    assert!(vaapi.contains("-hwaccel vaapi -hwaccel_device /dev/dri/renderD129"));
+    assert!(vaapi.contains("-hwaccel_output_format vaapi"));
+    assert!(
+        vaapi.contains(
+            "-vf scale_vaapi=w=1280:h=1280:force_original_aspect_ratio=decrease:force_divisible_by=2:format=nv12 -c:v h264_vaapi"
+        )
+    );
+    assert!(vaapi.contains("-c:a aac -b:a 96k -f mp4"));
+
+    let vulkan = arguments(&MediaBackend::Vulkan(1));
+    assert!(vulkan.contains("-threads 1 -filter_threads 1"));
+    assert!(vulkan.contains("-init_hw_device vulkan=vk:1 -filter_hw_device vk"));
+    assert!(vulkan.contains("-hwaccel vulkan -hwaccel_device vk"));
+    assert!(vulkan.contains(
+        "-vf scale_vulkan=w='if(gte(iw,ih),min(1280,trunc(iw/2)*2),-2)':h='if(gte(iw,ih),-2,min(1280,trunc(ih/2)*2))':format=nv12 -c:v h264_vulkan"
+    ));
+    assert!(vulkan.contains("-usage transcode -tune ull"));
+    assert!(vulkan.contains("-c:a aac -b:a 96k -f mp4"));
+
+    let software = arguments(&MediaBackend::Software);
+    assert!(
+        software
+            .contains("-vf scale=w=1280:h=1280:force_original_aspect_ratio=decrease -c:v libvpx")
+    );
+    assert!(software.contains("-threads 2 -deadline realtime -cpu-used 8"));
+    assert!(software.contains("-c:a libopus -b:a 96k -f webm"));
+
+    for command in [vaapi, vulkan, software] {
+        assert!(command.contains("-map 0:v:0 -map 0:a:0? -sn -dn -t 30"));
+        assert!(command.contains("-fpsmax 30"));
+        assert!(command.contains("-b:v 2M -maxrate 3M -bufsize 4M"));
+        assert!(command.ends_with("-y /output/result.media"));
+    }
 }


### PR DESCRIPTION
Closes #38.

## Summary

- attempt VA-API acceleration across discovered render nodes;
- fall back to Vulkan across visible GPU devices;
- retain #37's bounded VP8/WebM software fallback;
- expose selected GPU devices and read-only `/sys` only to media previews;
- produce H.264/AAC MP4 from hardware paths and VP8/Opus WebM from software;
- validate bounded MP4/WebM signatures before passing output to GTK;
- document the sandbox tradeoff and required GStreamer packages.

The backend order is intentionally fixed as:

1. VA-API
2. Vulkan
3. software

Hardware failures and unsupported codecs advance to the next backend. The first successful command stops the sequence.

## Preserved limits

This builds on #37 and preserves:

- first 30 seconds;
- maximum 1280 pixels on either axis;
- maximum 30 fps;
- 30-second media wall limit;
- 1.25 GiB address-space limit;
- 32 MiB output limit;
- cancellation and namespace isolation.

Image, PDF, and thumbnail helpers retain their existing 12-second wall and 10-second CPU limits and receive no GPU or sysfs access.

## Benchmarks

Environment:

- CPU: AMD Ryzen 7 7800X3D
- GPUs: AMD Raphael iGPU and NVIDIA GeForce RTX 4080
- FFmpeg: n9.0.1
- Kernel: Linux 7.1.9-arch1-2
- release build through the actual bubblewrap path
- three-run median wall time

| Input | AMD VA-API | NVIDIA Vulkan | Forced software |
|---|---:|---:|---:|
| 960×400 | 1.784s | 1.000s | 4.239s |
| 2560×1440 | 3.282s | 2.050s | 5.540s |
| 3840×2160 | 4.833s | 3.456s | 10.000s |
| 1080×1920 H.264/60 | 4.252s | 2.584s | 4.486s |

The Vulkan route used a sandbox exposing only the NVIDIA-compatible nodes, so its measurement includes the expected failed NVIDIA VA-API attempt before Vulkan succeeds.

For the 1080×1920 H.264/60 fps reproducer, every route produced the full bounded preview:

- hardware: 720×1280 at 30 fps, H.264/AAC MP4;
- software: 720×1280 at 30 fps, VP8/Opus WebM.

All outputs passed FFprobe and GStreamer discovery.

## Validation

- `cargo fmt --all --check`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features` — 158 passed
- 36 sandboxed benchmark runs across VA-API, Vulkan, and forced software
- GTK media playback verified locally
