### PR TITLE
feat(updates): show release notes before upgrading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,6 +969,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,8 +1234,10 @@ dependencies = [
  "gtk4",
  "ignore",
  "poppler-rs",
+ "pulldown-cmark",
  "rustix",
  "serde",
+ "serde_json",
  "sourceview5",
  "tempfile",
  "toml 0.9.12+spec-1.1.0",
@@ -1485,6 +1498,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1230,6 +1230,7 @@ dependencies = [
  "cairo-rs",
  "gdk-pixbuf",
  "gio",
+ "glib",
  "glib-build-tools",
  "gtk4",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ gio = { version = "0.21.5", features = ["v2_72"] }
 gtk = { package = "gtk4", version = "0.10.3", features = ["v4_12"] }
 ignore = "0.4.23"
 poppler = { package = "poppler-rs", version = "0.25.0" }
+pulldown-cmark = { version = "0.13", default-features = false }
 rustix = { version = "1.1.4", features = ["fs"] }
 serde = { version = "1.0", features = ["derive"] }
 sourceview5 = { version = "0.10.0", features = ["gtk_v4_12"] }
@@ -28,6 +29,9 @@ ureq = { version = "3.4", features = ["json"] }
 
 [build-dependencies]
 glib-build-tools = "0.21.0"
+
+[dev-dependencies]
+serde_json = "1.0"
 
 [lints.rust]
 unsafe_code = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ cairo-rs = { version = "0.21.5", features = ["pdf", "png"] }
 fontconfig-sys = { package = "yeslogic-fontconfig-sys", version = "6.0.1" }
 gdk-pixbuf = "0.21.5"
 gio = { version = "0.21.5", features = ["v2_72"] }
+glib = "0.21.5"
 gtk = { package = "gtk4", version = "0.10.3", features = ["v4_12"] }
 ignore = "0.4.23"
 poppler = { package = "poppler-rs", version = "0.25.0" }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -22,6 +22,7 @@ pub use preview::{
 pub(crate) use preview::{content_family, has_plain_text_extension};
 pub(crate) use search::{SearchEvent, SearchHandle, SearchItem, index_tree};
 pub(crate) use update_check::{
-    ReleaseMetadata, ReleaseNotes, UpdateCheck, check_for_updates, fetch_release_notes,
+    ReleaseMetadata, ReleaseNoteBlock, ReleaseNotes, UpdateCheck, check_for_updates,
+    fetch_release_notes,
 };
 pub(crate) use update_install::{UpdateInstall, install_update};

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -21,5 +21,7 @@ pub use preview::{
 };
 pub(crate) use preview::{content_family, has_plain_text_extension};
 pub(crate) use search::{SearchEvent, SearchHandle, SearchItem, index_tree};
-pub(crate) use update_check::{UpdateCheck, check_for_updates};
+pub(crate) use update_check::{
+    ReleaseMetadata, ReleaseNotes, UpdateCheck, check_for_updates, fetch_release_notes,
+};
 pub(crate) use update_install::{UpdateInstall, install_update};

--- a/src/services/update_check.rs
+++ b/src/services/update_check.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
+use pulldown_cmark::{Event, HeadingLevel, Options, Parser, Tag, TagEnd};
 use serde::Deserialize;
 
 const API_ROOT: &str = "https://api.github.com/repos/lgse/strata/releases";
@@ -13,11 +13,27 @@ const RELEASES_URL: &str = "https://github.com/lgse/strata/releases";
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ReleaseNoteBlock {
+    Heading {
+        level: u8,
+        markup: String,
+    },
+    Paragraph(String),
+    ListItem {
+        marker: String,
+        depth: usize,
+        markup: String,
+    },
+    Code(String),
+    Rule,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ReleaseMetadata {
     pub version: String,
     pub url: String,
     pub notes: String,
-    pub notes_markup: String,
+    pub note_blocks: Vec<ReleaseNoteBlock>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -83,84 +99,204 @@ fn metadata(release: &ReleaseResponse) -> ReleaseMetadata {
     ReleaseMetadata {
         version: release.tag_name.trim_start_matches('v').to_owned(),
         url: release.html_url.clone(),
-        notes_markup: markdown_to_pango(&notes),
+        note_blocks: parse_markdown(&notes),
         notes,
     }
 }
 
-fn escape_markup(text: &str) -> String {
-    let mut escaped = String::with_capacity(text.len());
-    for character in text.chars() {
-        match character {
-            '&' => escaped.push_str("&amp;"),
-            '<' => escaped.push_str("&lt;"),
-            '>' => escaped.push_str("&gt;"),
-            '\"' => escaped.push_str("&quot;"),
-            '\'' => escaped.push_str("&apos;"),
-            _ => escaped.push(character),
-        }
-    }
-    escaped
+#[derive(Debug)]
+enum ActiveBlock {
+    Heading {
+        level: u8,
+        markup: String,
+    },
+    Paragraph(String),
+    ListItem {
+        marker: String,
+        depth: usize,
+        markup: String,
+    },
+    Code(String),
 }
 
-/// Converts the supported GitHub Markdown subset to inert Pango markup. This is
-/// called while release metadata is being processed on a worker thread.
-fn markdown_to_pango(markdown: &str) -> String {
-    let mut output = String::new();
+impl ActiveBlock {
+    fn markup_mut(&mut self) -> &mut String {
+        match self {
+            Self::Heading { markup, .. }
+            | Self::Paragraph(markup)
+            | Self::ListItem { markup, .. }
+            | Self::Code(markup) => markup,
+        }
+    }
+}
+
+fn heading_level(level: HeadingLevel) -> u8 {
+    match level {
+        HeadingLevel::H1 => 1,
+        HeadingLevel::H2 => 2,
+        HeadingLevel::H3 => 3,
+        HeadingLevel::H4 => 4,
+        HeadingLevel::H5 => 5,
+        HeadingLevel::H6 => 6,
+    }
+}
+
+fn finish_block(active: &mut Option<ActiveBlock>, blocks: &mut Vec<ReleaseNoteBlock>) {
+    let Some(active) = active.take() else {
+        return;
+    };
+    let block = match active {
+        ActiveBlock::Heading { level, markup } => ReleaseNoteBlock::Heading { level, markup },
+        ActiveBlock::Paragraph(markup) => ReleaseNoteBlock::Paragraph(markup),
+        ActiveBlock::ListItem {
+            marker,
+            depth,
+            markup,
+        } => ReleaseNoteBlock::ListItem {
+            marker,
+            depth,
+            markup,
+        },
+        ActiveBlock::Code(markup) => ReleaseNoteBlock::Code(markup),
+    };
+    blocks.push(block);
+}
+
+fn append_markup(active: &mut Option<ActiveBlock>, markup: &str) {
+    let block = active.get_or_insert_with(|| ActiveBlock::Paragraph(String::new()));
+    block.markup_mut().push_str(markup);
+}
+
+fn append_escaped(active: &mut Option<ActiveBlock>, text: &str) {
+    append_markup(active, &glib::markup_escape_text(text));
+}
+
+/// Parses the supported GitHub Markdown subset into safe, balanced blocks while
+/// release metadata is processed on a worker thread.
+fn parse_markdown(markdown: &str) -> Vec<ReleaseNoteBlock> {
+    let mut blocks = Vec::new();
+    let mut active = None;
     let mut links = Vec::new();
-    let parser = Parser::new_ext(markdown, Options::ENABLE_STRIKETHROUGH);
-    for event in parser {
+    let mut lists = Vec::<Option<u64>>::new();
+    let options = Options::ENABLE_STRIKETHROUGH | Options::ENABLE_TASKLISTS;
+
+    for event in Parser::new_ext(markdown, options) {
         match event {
-            Event::Start(Tag::Heading { .. }) => output.push_str("<span size=\"large\"><b>"),
-            Event::End(TagEnd::Heading(_)) => output.push_str("</b></span>\n"),
-            Event::Start(Tag::Paragraph) => {}
-            Event::End(TagEnd::Paragraph) => output.push_str("\n\n"),
-            Event::Start(Tag::Item) => output.push_str("•  "),
-            Event::End(TagEnd::Item) => output.push('\n'),
-            Event::Start(Tag::Emphasis) => output.push_str("<i>"),
-            Event::End(TagEnd::Emphasis) => output.push_str("</i>"),
-            Event::Start(Tag::Strong) => output.push_str("<b>"),
-            Event::End(TagEnd::Strong) => output.push_str("</b>"),
-            Event::Start(Tag::Strikethrough) => output.push_str("<s>"),
-            Event::End(TagEnd::Strikethrough) => output.push_str("</s>"),
+            Event::Start(Tag::Heading { level, .. }) => {
+                finish_block(&mut active, &mut blocks);
+                active = Some(ActiveBlock::Heading {
+                    level: heading_level(level),
+                    markup: String::new(),
+                });
+            }
+            Event::End(TagEnd::Heading(_)) => finish_block(&mut active, &mut blocks),
+            Event::Start(Tag::Paragraph) => {
+                if active.is_none() {
+                    active = Some(ActiveBlock::Paragraph(String::new()));
+                }
+            }
+            Event::End(TagEnd::Paragraph) => {
+                if matches!(active, Some(ActiveBlock::Paragraph(_))) {
+                    finish_block(&mut active, &mut blocks);
+                }
+            }
+            Event::Start(Tag::List(start)) => {
+                if matches!(active, Some(ActiveBlock::ListItem { .. })) {
+                    finish_block(&mut active, &mut blocks);
+                }
+                lists.push(start);
+            }
+            Event::End(TagEnd::List(_)) => {
+                if matches!(active, Some(ActiveBlock::ListItem { .. })) {
+                    finish_block(&mut active, &mut blocks);
+                }
+                lists.pop();
+            }
+            Event::Start(Tag::Item) => {
+                finish_block(&mut active, &mut blocks);
+                let marker = match lists.last_mut() {
+                    Some(Some(next)) => {
+                        let marker = format!("{next}.");
+                        *next = next.saturating_add(1);
+                        marker
+                    }
+                    _ => "•".to_owned(),
+                };
+                active = Some(ActiveBlock::ListItem {
+                    marker,
+                    depth: lists.len().saturating_sub(1),
+                    markup: String::new(),
+                });
+            }
+            Event::End(TagEnd::Item) => {
+                if matches!(active, Some(ActiveBlock::ListItem { .. })) {
+                    finish_block(&mut active, &mut blocks);
+                }
+            }
+            Event::Start(Tag::Emphasis) => append_markup(&mut active, "<i>"),
+            Event::End(TagEnd::Emphasis) => append_markup(&mut active, "</i>"),
+            Event::Start(Tag::Strong) => append_markup(&mut active, "<b>"),
+            Event::End(TagEnd::Strong) => append_markup(&mut active, "</b>"),
+            Event::Start(Tag::Strikethrough) => append_markup(&mut active, "<s>"),
+            Event::End(TagEnd::Strikethrough) => append_markup(&mut active, "</s>"),
             Event::Start(Tag::Link { dest_url, .. }) => {
                 let destination = dest_url.as_ref();
                 let external =
                     destination.starts_with("https://") || destination.starts_with("http://");
                 links.push(external);
                 if external {
-                    output.push_str("<a href=\"");
-                    output.push_str(&escape_markup(destination));
-                    output.push_str("\">");
+                    append_markup(&mut active, "<a href=\"");
+                    append_escaped(&mut active, destination);
+                    append_markup(&mut active, "\">");
                 } else {
-                    output.push_str("<u>");
+                    append_markup(&mut active, "<u>");
                 }
             }
-            Event::End(TagEnd::Link) => output.push_str(if links.pop().unwrap_or(false) {
-                "</a>"
-            } else {
-                "</u>"
-            }),
-            Event::Start(Tag::Image { .. }) => output.push_str("[Image: "),
-            Event::End(TagEnd::Image) => output.push(']'),
-            Event::Start(Tag::CodeBlock(_)) => output.push_str("<tt>"),
-            Event::End(TagEnd::CodeBlock) => output.push_str("</tt>\n"),
-            Event::Code(text) => {
-                output.push_str("<tt>");
-                output.push_str(&escape_markup(&text));
-                output.push_str("</tt>");
+            Event::End(TagEnd::Link) => append_markup(
+                &mut active,
+                if links.pop().unwrap_or(false) {
+                    "</a>"
+                } else {
+                    "</u>"
+                },
+            ),
+            Event::Start(Tag::Image { .. }) => append_markup(&mut active, "[Image: "),
+            Event::End(TagEnd::Image) => append_markup(&mut active, "]"),
+            Event::Start(Tag::CodeBlock(_)) => {
+                if matches!(active, Some(ActiveBlock::ListItem { .. })) {
+                    append_markup(&mut active, "<tt>");
+                } else {
+                    finish_block(&mut active, &mut blocks);
+                    active = Some(ActiveBlock::Code(String::new()));
+                }
             }
-            Event::Text(text) => output.push_str(&escape_markup(&text)),
-            Event::SoftBreak | Event::HardBreak => output.push('\n'),
-            Event::Rule => output.push_str("────────\n"),
-            Event::Html(text) | Event::InlineHtml(text) => output.push_str(&escape_markup(&text)),
+            Event::End(TagEnd::CodeBlock) => {
+                if matches!(active, Some(ActiveBlock::Code(_))) {
+                    finish_block(&mut active, &mut blocks);
+                } else {
+                    append_markup(&mut active, "</tt>");
+                }
+            }
+            Event::Code(text) => {
+                append_markup(&mut active, "<tt>");
+                append_escaped(&mut active, &text);
+                append_markup(&mut active, "</tt>");
+            }
+            Event::Text(text) => append_escaped(&mut active, &text),
+            Event::SoftBreak | Event::HardBreak => append_markup(&mut active, "\n"),
+            Event::Rule => {
+                finish_block(&mut active, &mut blocks);
+                blocks.push(ReleaseNoteBlock::Rule);
+            }
+            Event::Html(text) | Event::InlineHtml(text) => append_escaped(&mut active, &text),
             Event::TaskListMarker(checked) => {
-                output.push_str(if checked { "☑ " } else { "☐ " })
+                append_markup(&mut active, if checked { "☑ " } else { "☐ " });
             }
             _ => {}
         }
     }
-    output.trim().to_owned()
+    finish_block(&mut active, &mut blocks);
+    blocks
 }
 
 /// Queries the latest GitHub release off the GTK thread and reports the outcome once.

--- a/src/services/update_check.rs
+++ b/src/services/update_check.rs
@@ -5,26 +5,44 @@ use std::{
     time::Duration,
 };
 
+use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
 use serde::Deserialize;
 
-const RELEASES_URL: &str = "https://api.github.com/repos/lgse/strata/releases/latest";
+const API_ROOT: &str = "https://api.github.com/repos/lgse/strata/releases";
+const RELEASES_URL: &str = "https://github.com/lgse/strata/releases";
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReleaseMetadata {
+    pub version: String,
+    pub url: String,
+    pub notes: String,
+    pub notes_markup: String,
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum UpdateCheck {
     UpToDate,
     Available {
-        version: String,
-        url: String,
+        release: ReleaseMetadata,
         download_url: Option<String>,
     },
     Failed(String),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ReleaseNotes {
+    Found(ReleaseMetadata),
+    Unavailable { url: String },
+    Failed { message: String, url: String },
 }
 
 #[derive(Deserialize)]
 struct ReleaseResponse {
     tag_name: String,
     html_url: String,
+    #[serde(default)]
+    body: Option<String>,
     #[serde(default)]
     assets: Vec<ReleaseAsset>,
 }
@@ -43,6 +61,108 @@ fn archive_name(version: &str) -> String {
     )
 }
 
+fn agent() -> ureq::Agent {
+    ureq::Agent::config_builder()
+        .timeout_global(Some(REQUEST_TIMEOUT))
+        .build()
+        .into()
+}
+
+fn request_release(url: &str) -> Result<ReleaseResponse, ureq::Error> {
+    agent()
+        .get(url)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "strata-file-manager")
+        .call()
+        .and_then(|mut response| response.body_mut().read_json::<ReleaseResponse>())
+}
+
+fn metadata(release: &ReleaseResponse) -> ReleaseMetadata {
+    let notes = release.body.clone().unwrap_or_default();
+    ReleaseMetadata {
+        version: release.tag_name.trim_start_matches('v').to_owned(),
+        url: release.html_url.clone(),
+        notes_markup: markdown_to_pango(&notes),
+        notes,
+    }
+}
+
+fn escape_markup(text: &str) -> String {
+    let mut escaped = String::with_capacity(text.len());
+    for character in text.chars() {
+        match character {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '\"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&apos;"),
+            _ => escaped.push(character),
+        }
+    }
+    escaped
+}
+
+/// Converts the supported GitHub Markdown subset to inert Pango markup. This is
+/// called while release metadata is being processed on a worker thread.
+fn markdown_to_pango(markdown: &str) -> String {
+    let mut output = String::new();
+    let mut links = Vec::new();
+    let parser = Parser::new_ext(markdown, Options::ENABLE_STRIKETHROUGH);
+    for event in parser {
+        match event {
+            Event::Start(Tag::Heading { .. }) => output.push_str("<span size=\"large\"><b>"),
+            Event::End(TagEnd::Heading(_)) => output.push_str("</b></span>\n"),
+            Event::Start(Tag::Paragraph) => {}
+            Event::End(TagEnd::Paragraph) => output.push_str("\n\n"),
+            Event::Start(Tag::Item) => output.push_str("•  "),
+            Event::End(TagEnd::Item) => output.push('\n'),
+            Event::Start(Tag::Emphasis) => output.push_str("<i>"),
+            Event::End(TagEnd::Emphasis) => output.push_str("</i>"),
+            Event::Start(Tag::Strong) => output.push_str("<b>"),
+            Event::End(TagEnd::Strong) => output.push_str("</b>"),
+            Event::Start(Tag::Strikethrough) => output.push_str("<s>"),
+            Event::End(TagEnd::Strikethrough) => output.push_str("</s>"),
+            Event::Start(Tag::Link { dest_url, .. }) => {
+                let destination = dest_url.as_ref();
+                let external =
+                    destination.starts_with("https://") || destination.starts_with("http://");
+                links.push(external);
+                if external {
+                    output.push_str("<a href=\"");
+                    output.push_str(&escape_markup(destination));
+                    output.push_str("\">");
+                } else {
+                    output.push_str("<u>");
+                }
+            }
+            Event::End(TagEnd::Link) => output.push_str(if links.pop().unwrap_or(false) {
+                "</a>"
+            } else {
+                "</u>"
+            }),
+            Event::Start(Tag::Image { .. }) => output.push_str("[Image: "),
+            Event::End(TagEnd::Image) => output.push(']'),
+            Event::Start(Tag::CodeBlock(_)) => output.push_str("<tt>"),
+            Event::End(TagEnd::CodeBlock) => output.push_str("</tt>\n"),
+            Event::Code(text) => {
+                output.push_str("<tt>");
+                output.push_str(&escape_markup(&text));
+                output.push_str("</tt>");
+            }
+            Event::Text(text) => output.push_str(&escape_markup(&text)),
+            Event::SoftBreak | Event::HardBreak => output.push('\n'),
+            Event::Rule => output.push_str("────────\n"),
+            Event::Html(text) | Event::InlineHtml(text) => output.push_str(&escape_markup(&text)),
+            Event::TaskListMarker(checked) => {
+                output.push_str(if checked { "☑ " } else { "☐ " })
+            }
+            _ => {}
+        }
+    }
+    output.trim().to_owned()
+}
+
 /// Queries the latest GitHub release off the GTK thread and reports the outcome once.
 pub fn check_for_updates(current_version: &'static str) -> Receiver<UpdateCheck> {
     let (sender, receiver) = mpsc::channel();
@@ -55,38 +175,63 @@ pub fn check_for_updates(current_version: &'static str) -> Receiver<UpdateCheck>
     receiver
 }
 
+/// Fetches the release whose tag exactly matches the installed package version.
+pub fn fetch_release_notes(version: &'static str) -> Receiver<ReleaseNotes> {
+    let (sender, receiver) = mpsc::channel();
+    let spawned = std::thread::Builder::new()
+        .name("strata-release-notes".into())
+        .spawn(move || {
+            let _sent = sender.send(fetch_exact_release(version));
+        });
+    drop(spawned);
+    receiver
+}
+
 fn fetch_latest_release(current_version: &str) -> UpdateCheck {
-    let config = ureq::Agent::config_builder()
-        .timeout_global(Some(REQUEST_TIMEOUT))
-        .build();
-    let agent: ureq::Agent = config.into();
-    let release = agent
-        .get(RELEASES_URL)
-        .header("Accept", "application/vnd.github+json")
-        .header("User-Agent", "strata-file-manager")
-        .call()
-        .and_then(|mut response| response.body_mut().read_json::<ReleaseResponse>());
-    match release {
+    match request_release(&format!("{API_ROOT}/latest")) {
         Ok(release) => {
-            let latest = release.tag_name.trim_start_matches('v');
-            if is_newer(latest, current_version) {
-                let archive_name = archive_name(latest);
+            let release_metadata = metadata(&release);
+            if is_newer(&release_metadata.version, current_version) {
+                let archive_name = archive_name(&release_metadata.version);
                 let download_url = release
                     .assets
                     .iter()
                     .find(|asset| asset.name == archive_name)
                     .map(|asset| asset.browser_download_url.clone());
                 UpdateCheck::Available {
-                    version: latest.to_owned(),
-                    url: release.html_url,
+                    release: release_metadata,
                     download_url,
                 }
             } else {
                 UpdateCheck::UpToDate
             }
         }
-        Err(error) => UpdateCheck::Failed(error.to_string()),
+        Err(error) => UpdateCheck::Failed(request_error_message(&error)),
     }
+}
+
+fn fetch_exact_release(version: &str) -> ReleaseNotes {
+    let url = release_page_url(version);
+    match request_release(&format!("{API_ROOT}/tags/v{version}")) {
+        Ok(release) => ReleaseNotes::Found(metadata(&release)),
+        Err(ureq::Error::StatusCode(404)) => ReleaseNotes::Unavailable { url },
+        Err(error) => ReleaseNotes::Failed {
+            message: request_error_message(&error),
+            url,
+        },
+    }
+}
+
+fn request_error_message(error: &ureq::Error) -> String {
+    match error {
+        ureq::Error::StatusCode(403 | 429) => "GitHub API rate limit reached".to_owned(),
+        ureq::Error::StatusCode(code) => format!("GitHub API returned HTTP {code}"),
+        _ => format!("Network request failed: {error}"),
+    }
+}
+
+fn release_page_url(version: &str) -> String {
+    format!("{RELEASES_URL}/tag/v{version}")
 }
 
 fn is_newer(candidate: &str, current: &str) -> bool {

--- a/src/services/update_check/tests.rs
+++ b/src/services/update_check/tests.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use super::{
-    ReleaseResponse, is_newer, markdown_to_pango, metadata, release_page_url, request_error_message,
+    ReleaseNoteBlock, ReleaseResponse, is_newer, metadata, parse_markdown, release_page_url,
+    request_error_message,
 };
 
 #[test]
@@ -39,6 +40,7 @@ fn release_body_is_retained() {
     let release = metadata(&response);
     assert_eq!(release.version, "1.2.3");
     assert_eq!(release.notes, "## Changes\n\n- Fast");
+    assert!(!release.note_blocks.is_empty());
 }
 
 #[test]
@@ -75,36 +77,95 @@ fn other_api_failures_include_the_status() {
 }
 
 #[test]
-fn release_markdown_renders_supported_formatting() {
-    let markup =
-        markdown_to_pango("## Changes\n\n- **Fast** and `safe`\n- [Details](https://example.test)");
-    assert!(markup.contains("<span size=\"large\"><b>Changes</b></span>"));
-    assert!(markup.contains("•  <b>Fast</b> and <tt>safe</tt>"));
-    assert!(markup.contains("<a href=\"https://example.test\">Details</a>"));
+fn release_markdown_renders_supported_formatting_as_blocks() {
+    assert_eq!(
+        parse_markdown("## Changes\n\n- **Fast** and `safe`\n- [Details](https://example.test)"),
+        vec![
+            ReleaseNoteBlock::Heading {
+                level: 2,
+                markup: "Changes".to_owned(),
+            },
+            ReleaseNoteBlock::ListItem {
+                marker: "•".to_owned(),
+                depth: 0,
+                markup: "<b>Fast</b> and <tt>safe</tt>".to_owned(),
+            },
+            ReleaseNoteBlock::ListItem {
+                marker: "•".to_owned(),
+                depth: 0,
+                markup: "<a href=\"https://example.test\">Details</a>".to_owned(),
+            },
+        ]
+    );
+}
+
+#[test]
+fn multiline_formatting_and_code_stay_in_balanced_blocks() {
+    assert_eq!(
+        parse_markdown("**first\nsecond**\n\n```text\none < two\n```"),
+        vec![
+            ReleaseNoteBlock::Paragraph("<b>first\nsecond</b>".to_owned()),
+            ReleaseNoteBlock::Code("one &lt; two\n".to_owned()),
+        ]
+    );
+}
+
+#[test]
+fn nested_and_ordered_lists_keep_markers_and_depth() {
+    let blocks = parse_markdown("3. outer\n   - inner\n4. next");
+    assert_eq!(
+        blocks,
+        vec![
+            ReleaseNoteBlock::ListItem {
+                marker: "3.".to_owned(),
+                depth: 0,
+                markup: "outer".to_owned(),
+            },
+            ReleaseNoteBlock::ListItem {
+                marker: "•".to_owned(),
+                depth: 1,
+                markup: "inner".to_owned(),
+            },
+            ReleaseNoteBlock::ListItem {
+                marker: "4.".to_owned(),
+                depth: 0,
+                markup: "next".to_owned(),
+            },
+        ]
+    );
 }
 
 #[test]
 fn release_markdown_keeps_html_inert_and_does_not_load_images() {
-    let markup = markdown_to_pango(
+    let blocks = parse_markdown(
         "<script>alert('no')</script>\n\n![tracking](https://example.test/pixel.png)",
     );
-    assert!(!markup.contains("<script>"));
-    assert!(markup.contains("&lt;script&gt;"));
-    assert!(!markup.contains("href=\"https://example.test/pixel.png"));
-    assert!(markup.contains("[Image: tracking]"));
+    let debug = format!("{blocks:?}");
+    assert!(!debug.contains("<script>"));
+    assert!(debug.contains("&lt;script&gt;"));
+    assert!(!debug.contains("pixel.png"));
+    assert!(debug.contains("[Image: tracking]"));
 }
 
 #[test]
 fn release_markdown_does_not_activate_non_web_links() {
     assert_eq!(
-        markdown_to_pango("[Run](javascript:alert('no'))"),
-        "<u>Run</u>"
+        parse_markdown("[Run](javascript:alert('no'))"),
+        vec![ReleaseNoteBlock::Paragraph("<u>Run</u>".to_owned())]
     );
 }
 
 #[test]
-fn empty_release_markdown_is_empty_markup() {
-    assert!(markdown_to_pango("  \n").is_empty());
+fn malformed_markdown_and_entities_remain_inert() {
+    let blocks = parse_markdown("<broken & **unfinished");
+    let debug = format!("{blocks:?}");
+    assert!(debug.contains("&lt;broken &amp;"));
+    assert!(!debug.contains("<broken"));
+}
+
+#[test]
+fn empty_release_markdown_has_no_blocks() {
+    assert!(parse_markdown("  \n").is_empty());
 }
 
 #[test]

--- a/src/services/update_check/tests.rs
+++ b/src/services/update_check/tests.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use super::is_newer;
+use super::{
+    ReleaseResponse, is_newer, markdown_to_pango, metadata, release_page_url, request_error_message,
+};
 
 #[test]
 fn newer_patch_version_is_detected() {
@@ -26,4 +28,89 @@ fn older_version_is_not_newer() {
 fn missing_or_malformed_segments_fall_back_to_zero() {
     assert!(!is_newer("0.2", "0.2.0"));
     assert!(!is_newer("0.2.x", "0.2.1"));
+}
+
+#[test]
+fn release_body_is_retained() {
+    let response: ReleaseResponse = serde_json::from_str(
+        r###"{"tag_name":"v1.2.3","html_url":"https://example.test/release","body":"## Changes\n\n- Fast"}"###,
+    )
+    .expect("release fixture should deserialize");
+    let release = metadata(&response);
+    assert_eq!(release.version, "1.2.3");
+    assert_eq!(release.notes, "## Changes\n\n- Fast");
+}
+
+#[test]
+fn missing_release_body_becomes_empty_notes() {
+    let response: ReleaseResponse =
+        serde_json::from_str(r#"{"tag_name":"v1.2.3","html_url":"https://example.test/release"}"#)
+            .expect("release fixture should deserialize");
+    assert!(metadata(&response).notes.is_empty());
+}
+
+#[test]
+fn null_release_body_becomes_empty_notes() {
+    let response: ReleaseResponse = serde_json::from_str(
+        r#"{"tag_name":"v1.2.3","html_url":"https://example.test/release","body":null}"#,
+    )
+    .expect("release fixture should deserialize");
+    assert!(metadata(&response).notes.is_empty());
+}
+
+#[test]
+fn rate_limit_failures_have_a_distinct_message() {
+    assert_eq!(
+        request_error_message(&ureq::Error::StatusCode(429)),
+        "GitHub API rate limit reached"
+    );
+}
+
+#[test]
+fn other_api_failures_include_the_status() {
+    assert_eq!(
+        request_error_message(&ureq::Error::StatusCode(500)),
+        "GitHub API returned HTTP 500"
+    );
+}
+
+#[test]
+fn release_markdown_renders_supported_formatting() {
+    let markup =
+        markdown_to_pango("## Changes\n\n- **Fast** and `safe`\n- [Details](https://example.test)");
+    assert!(markup.contains("<span size=\"large\"><b>Changes</b></span>"));
+    assert!(markup.contains("•  <b>Fast</b> and <tt>safe</tt>"));
+    assert!(markup.contains("<a href=\"https://example.test\">Details</a>"));
+}
+
+#[test]
+fn release_markdown_keeps_html_inert_and_does_not_load_images() {
+    let markup = markdown_to_pango(
+        "<script>alert('no')</script>\n\n![tracking](https://example.test/pixel.png)",
+    );
+    assert!(!markup.contains("<script>"));
+    assert!(markup.contains("&lt;script&gt;"));
+    assert!(!markup.contains("href=\"https://example.test/pixel.png"));
+    assert!(markup.contains("[Image: tracking]"));
+}
+
+#[test]
+fn release_markdown_does_not_activate_non_web_links() {
+    assert_eq!(
+        markdown_to_pango("[Run](javascript:alert('no'))"),
+        "<u>Run</u>"
+    );
+}
+
+#[test]
+fn empty_release_markdown_is_empty_markup() {
+    assert!(markdown_to_pango("  \n").is_empty());
+}
+
+#[test]
+fn current_release_fallback_uses_exact_version_tag() {
+    assert_eq!(
+        release_page_url("1.2.3"),
+        "https://github.com/lgse/strata/releases/tag/v1.2.3"
+    );
 }

--- a/src/style.css
+++ b/src/style.css
@@ -784,6 +784,7 @@ headerbar menubutton.header-action > button:focus-visible image {
 .release-notes-bullet {
   color: @theme_accent;
   font-weight: 700;
+  margin-top: 2px;
 }
 
 .release-notes-content link,

--- a/src/style.css
+++ b/src/style.css
@@ -784,7 +784,7 @@ headerbar menubutton.header-action > button:focus-visible image {
 .release-notes-bullet {
   color: @theme_accent;
   font-weight: 700;
-  margin-top: 2px;
+  margin-top: 3px;
 }
 
 .release-notes-content link,

--- a/src/style.css
+++ b/src/style.css
@@ -781,10 +781,35 @@ headerbar menubutton.header-action > button:focus-visible image {
   line-height: 1.3;
 }
 
+.release-notes-heading {
+  color: @theme_dim_text;
+  font-size: 1.08em;
+  font-weight: 700;
+  margin-top: 2px;
+}
+
+.release-notes-heading.level-1 {
+  font-size: 1.18em;
+}
+
 .release-notes-bullet {
   color: @theme_accent;
   font-weight: 700;
   margin-top: 3px;
+}
+
+.release-notes-code {
+  background: alpha(@theme_bg, 0.58);
+  border: 1px solid alpha(@theme_border, 0.24);
+  border-radius: 4px;
+  color: @theme_dim_text;
+  padding: 8px;
+}
+
+.release-notes-rule {
+  background: alpha(@theme_border, 0.4);
+  color: @theme_border;
+  margin: 4px 0;
 }
 
 .release-notes-content link,

--- a/src/style.css
+++ b/src/style.css
@@ -781,6 +781,11 @@ headerbar menubutton.header-action > button:focus-visible image {
   line-height: 1.3;
 }
 
+.release-notes-bullet {
+  color: @theme_accent;
+  font-weight: 700;
+}
+
 .release-notes-content link,
 .release-notes-content link:visited,
 .release-notes-content link:hover,

--- a/src/style.css
+++ b/src/style.css
@@ -589,7 +589,15 @@ headerbar menubutton.header-action > button:focus-visible image {
 
 .update-dialog-body {
   background: alpha(@theme_bg, 0.3);
-  padding: 20px;
+  padding: 16px 20px;
+}
+
+.update-dialog-notes {
+  background: alpha(@theme_bg, 0.55);
+  border: 1px solid alpha(@theme_border, 0.3);
+  border-radius: 5px;
+  color: @theme_text;
+  padding: 10px;
 }
 
 .update-dialog-progress trough {
@@ -744,6 +752,59 @@ headerbar menubutton.header-action > button:focus-visible image {
 .settings-option-description link:hover,
 .settings-option-description link:active {
   color: @theme_accent;
+}
+
+.release-notes-card {
+  background: alpha(@theme_bg, 0.55);
+  border: 1px solid alpha(@theme_border, 0.24);
+  border-radius: 6px;
+  color: @theme_text;
+  padding: 14px;
+}
+
+.release-notes-card.inline {
+  background: transparent;
+  border: none;
+  border-top: 1px solid alpha(@theme_border, 0.24);
+  border-radius: 0;
+  margin-top: 10px;
+  padding: 12px 0 2px;
+}
+
+.release-notes-title {
+  color: @theme_text;
+  font-weight: 700;
+}
+
+.release-notes-content {
+  color: @theme_dim_text;
+  line-height: 1.3;
+}
+
+.release-notes-content link,
+.release-notes-content link:visited,
+.release-notes-content link:hover,
+.release-notes-content link:active {
+  color: @theme_accent;
+}
+
+.release-notes-fallback {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  color: @theme_accent;
+  padding: 2px 0;
+}
+
+.release-notes-fallback:hover,
+.release-notes-fallback:active,
+.release-notes-fallback:visited {
+  color: @theme_accent;
+}
+
+.release-notes-fallback:focus-visible {
+  outline: 2px solid alpha(@theme_accent, 0.5);
+  outline-offset: 1px;
 }
 
 .settings-update-progress {

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -567,6 +567,7 @@ fn update_check_row(
     let row = gtk::Box::new(gtk::Orientation::Vertical, 0);
     row.add_css_class("settings-option");
     let summary = gtk::Box::new(gtk::Orientation::Horizontal, 16);
+    summary.set_vexpand(true);
     let copy = gtk::Box::new(gtk::Orientation::Vertical, 2);
     copy.set_hexpand(true);
     copy.set_valign(gtk::Align::Center);
@@ -587,7 +588,7 @@ fn update_check_row(
     copy.append(&progress);
     let button = gtk::Button::with_label("Check now");
     button.add_css_class("settings-update-check");
-    button.set_valign(gtk::Align::Start);
+    button.set_valign(gtk::Align::Center);
     summary.append(&copy);
     summary.append(&button);
     row.append(&summary);

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -11,7 +11,7 @@ use gtk::{gdk, glib, prelude::*, subclass::prelude::*};
 
 use crate::{
     assets::icons,
-    services::{self, ReleaseMetadata, ReleaseNotes, UpdateCheck, UpdateInstall},
+    services::{self, ReleaseMetadata, ReleaseNoteBlock, ReleaseNotes, UpdateCheck, UpdateInstall},
 };
 
 #[cfg(test)]
@@ -416,24 +416,50 @@ fn set_release_notes_message(notes: &gtk::Box, message: &str) {
     notes.append(&label);
 }
 
-fn set_release_notes_markup(notes: &gtk::Box, markup: &str) {
+fn set_release_note_blocks(notes: &gtk::Box, blocks: &[ReleaseNoteBlock]) {
     clear_release_notes(notes);
-    for line in markup.lines().filter(|line| !line.trim().is_empty()) {
-        if let Some(item) = line.strip_prefix("•  ") {
-            let row = gtk::Box::new(gtk::Orientation::Horizontal, 8);
-            row.set_valign(gtk::Align::Start);
-            let bullet = gtk::Label::new(Some("•"));
-            bullet.add_css_class("release-notes-bullet");
-            bullet.set_valign(gtk::Align::Start);
-            let copy = release_notes_label();
-            copy.set_markup(item);
-            row.append(&bullet);
-            row.append(&copy);
-            notes.append(&row);
-        } else {
-            let label = release_notes_label();
-            label.set_markup(line);
-            notes.append(&label);
+    for block in blocks {
+        match block {
+            ReleaseNoteBlock::Heading { level, markup } => {
+                let label = release_notes_label();
+                label.add_css_class("release-notes-heading");
+                label.add_css_class(&format!("level-{level}"));
+                label.set_markup(markup);
+                notes.append(&label);
+            }
+            ReleaseNoteBlock::Paragraph(markup) => {
+                let label = release_notes_label();
+                label.set_markup(markup);
+                notes.append(&label);
+            }
+            ReleaseNoteBlock::ListItem {
+                marker,
+                depth,
+                markup,
+            } => {
+                let row = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+                row.set_valign(gtk::Align::Start);
+                row.set_margin_start(i32::try_from(depth.saturating_mul(18)).unwrap_or(i32::MAX));
+                let bullet = gtk::Label::new(Some(marker));
+                bullet.add_css_class("release-notes-bullet");
+                bullet.set_valign(gtk::Align::Start);
+                let copy = release_notes_label();
+                copy.set_markup(markup);
+                row.append(&bullet);
+                row.append(&copy);
+                notes.append(&row);
+            }
+            ReleaseNoteBlock::Code(markup) => {
+                let label = release_notes_label();
+                label.add_css_class("release-notes-code");
+                label.set_markup(&format!("<tt>{markup}</tt>"));
+                notes.append(&label);
+            }
+            ReleaseNoteBlock::Rule => {
+                let separator = gtk::Separator::new(gtk::Orientation::Horizontal);
+                separator.add_css_class("release-notes-rule");
+                notes.append(&separator);
+            }
         }
     }
 }
@@ -489,7 +515,7 @@ fn show_release_notes(card: &ReleaseNotesCard, release: &ReleaseMetadata) {
             "No release notes were provided for this release.",
         );
     } else {
-        set_release_notes_markup(&card.notes, &release.notes_markup);
+        set_release_note_blocks(&card.notes, &release.note_blocks);
     }
     card.fallback.set_uri(&release.url);
     card.fallback.set_visible(true);
@@ -833,7 +859,7 @@ pub(super) fn show_update_dialog(
             "No release notes were provided. Review this release on GitHub before continuing.",
         );
     } else {
-        set_release_notes_markup(&notes, &release.notes_markup);
+        set_release_note_blocks(&notes, &release.note_blocks);
     }
     let notes_scroll = gtk::ScrolledWindow::builder()
         .hscrollbar_policy(gtk::PolicyType::Never)

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -472,6 +472,7 @@ fn release_notes_card(title: &str, initial: &str) -> ReleaseNotesCard {
 }
 
 fn show_release_notes(card: &ReleaseNotesCard, release: &ReleaseMetadata) {
+    card.container.set_visible(true);
     card.title.set_text(&format!(
         "{} · v{}",
         card.title
@@ -595,10 +596,8 @@ fn update_check_row(
             progress.set_visible(false);
             progress.remove_css_class("error");
             status.set_text("Checking for updates…");
-            available_notes.title.set_text("Available release");
-            set_release_notes_message(&available_notes.notes, "Checking for a newer release…");
+            available_notes.container.set_visible(false);
             available_notes.fallback.set_visible(false);
-            available_notes.container.set_visible(true);
             button.set_sensitive(false);
             let receiver = services::check_for_updates(env!("CARGO_PKG_VERSION"));
             let checking = checking.clone();
@@ -611,6 +610,9 @@ fn update_check_row(
                 match receiver.try_recv() {
                     Ok(result) => {
                         status.set_markup(&update_check_message(&result));
+                        available_notes
+                            .container
+                            .set_visible(shows_available_release_notes(&result));
                         match &result {
                             UpdateCheck::Available {
                                 release,
@@ -635,27 +637,7 @@ fn update_check_row(
                                     button.set_label("Install update");
                                 }
                             }
-                            UpdateCheck::UpToDate => {
-                                available_notes
-                                    .title
-                                    .set_text("Current release is the latest");
-                                set_release_notes_message(
-                                    &available_notes.notes,
-                                    "There is no newer release available.",
-                                );
-                                available_notes.fallback.set_visible(false);
-                            }
-                            UpdateCheck::Failed(message) => {
-                                available_notes.title.set_text("Available release");
-                                set_release_notes_message(
-                                    &available_notes.notes,
-                                    &format!("Couldn’t check for a newer release: {message}"),
-                                );
-                                available_notes
-                                    .fallback
-                                    .set_uri("https://github.com/lgse/strata/releases/latest");
-                                available_notes.fallback.set_visible(true);
-                            }
+                            UpdateCheck::UpToDate | UpdateCheck::Failed(_) => {}
                         }
                         button.set_sensitive(true);
                         checking.set(false);
@@ -663,15 +645,10 @@ fn update_check_row(
                     }
                     Err(TryRecvError::Empty) => glib::ControlFlow::Continue,
                     Err(TryRecvError::Disconnected) => {
-                        status.set_text("Couldn't check for updates");
-                        set_release_notes_message(
-                            &available_notes.notes,
-                            "Couldn’t check for a newer release because the request ended unexpectedly.",
+                        status.set_markup(
+                            "Couldn't check for updates · <a href=\"https://github.com/lgse/strata/releases/latest\">View releases on GitHub</a>",
                         );
-                        available_notes
-                            .fallback
-                            .set_uri("https://github.com/lgse/strata/releases/latest");
-                        available_notes.fallback.set_visible(true);
+                        available_notes.container.set_visible(false);
                         button.set_sensitive(true);
                         checking.set(false);
                         glib::ControlFlow::Break
@@ -992,6 +969,10 @@ pub(super) fn show_update_dialog(
     });
 }
 
+fn shows_available_release_notes(result: &UpdateCheck) -> bool {
+    matches!(result, UpdateCheck::Available { .. })
+}
+
 fn update_check_message(result: &UpdateCheck) -> String {
     match result {
         UpdateCheck::UpToDate => {
@@ -1002,12 +983,10 @@ fn update_check_message(result: &UpdateCheck) -> String {
             glib::markup_escape_text(&release.url),
             glib::markup_escape_text(&release.version),
         ),
-        UpdateCheck::Failed(message) => {
-            format!(
-                "Couldn't check for updates: {}",
-                glib::markup_escape_text(message)
-            )
-        }
+        UpdateCheck::Failed(message) => format!(
+            "Couldn't check for updates: {} · <a href=\"https://github.com/lgse/strata/releases/latest\">View releases on GitHub</a>",
+            glib::markup_escape_text(message)
+        ),
     }
 }
 

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -390,11 +390,59 @@ fn updates_page(manager: Rc<ThemeManager>, update_notice: UpdateNoticeHandler) -
     scrollable_page(&preferences, None)
 }
 
+fn release_notes_label() -> gtk::Label {
+    let label = gtk::Label::new(None);
+    label.add_css_class("release-notes-content");
+    label.set_xalign(0.0);
+    label.set_yalign(0.0);
+    label.set_hexpand(true);
+    label.set_wrap(true);
+    label.set_wrap_mode(gtk::pango::WrapMode::WordChar);
+    label.set_selectable(true);
+    label.set_use_markup(true);
+    label
+}
+
+fn clear_release_notes(notes: &gtk::Box) {
+    while let Some(child) = notes.first_child() {
+        notes.remove(&child);
+    }
+}
+
+fn set_release_notes_message(notes: &gtk::Box, message: &str) {
+    clear_release_notes(notes);
+    let label = release_notes_label();
+    label.set_text(message);
+    notes.append(&label);
+}
+
+fn set_release_notes_markup(notes: &gtk::Box, markup: &str) {
+    clear_release_notes(notes);
+    for line in markup.lines().filter(|line| !line.trim().is_empty()) {
+        if let Some(item) = line.strip_prefix("•  ") {
+            let row = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+            row.set_valign(gtk::Align::Start);
+            let bullet = gtk::Label::new(Some("•"));
+            bullet.add_css_class("release-notes-bullet");
+            bullet.set_valign(gtk::Align::Start);
+            let copy = release_notes_label();
+            copy.set_markup(item);
+            row.append(&bullet);
+            row.append(&copy);
+            notes.append(&row);
+        } else {
+            let label = release_notes_label();
+            label.set_markup(line);
+            notes.append(&label);
+        }
+    }
+}
+
 #[derive(Clone)]
 struct ReleaseNotesCard {
     container: gtk::Box,
     title: gtk::Label,
-    notes: gtk::Label,
+    notes: gtk::Box,
     fallback: gtk::LinkButton,
 }
 
@@ -405,14 +453,8 @@ fn release_notes_card(title: &str, initial: &str) -> ReleaseNotesCard {
     title_label.add_css_class("release-notes-title");
     title_label.set_xalign(0.0);
     title_label.set_wrap(true);
-    let notes = gtk::Label::new(Some(initial));
-    notes.add_css_class("release-notes-content");
-    notes.set_xalign(0.0);
-    notes.set_yalign(0.0);
-    notes.set_wrap(true);
-    notes.set_wrap_mode(gtk::pango::WrapMode::WordChar);
-    notes.set_selectable(true);
-    notes.set_use_markup(true);
+    let notes = gtk::Box::new(gtk::Orientation::Vertical, 6);
+    set_release_notes_message(&notes, initial);
     let fallback =
         gtk::LinkButton::with_label("https://github.com/lgse/strata/releases", "View on GitHub");
     fallback.add_css_class("release-notes-fallback");
@@ -441,10 +483,12 @@ fn show_release_notes(card: &ReleaseNotesCard, release: &ReleaseMetadata) {
         release.version
     ));
     if release.notes.trim().is_empty() {
-        card.notes
-            .set_text("No release notes were provided for this release.");
+        set_release_notes_message(
+            &card.notes,
+            "No release notes were provided for this release.",
+        );
     } else {
-        card.notes.set_markup(&release.notes_markup);
+        set_release_notes_markup(&card.notes, &release.notes_markup);
     }
     card.fallback.set_uri(&release.url);
     card.fallback.set_visible(true);
@@ -460,7 +504,8 @@ fn load_current_release_notes(card: &ReleaseNotesCard) {
                 glib::ControlFlow::Break
             }
             Ok(ReleaseNotes::Unavailable { url }) => {
-                card.notes.set_text(
+                set_release_notes_message(
+                    &card.notes,
                     "Release notes are unavailable because this version’s tag was not found.",
                 );
                 card.fallback.set_uri(&url);
@@ -468,15 +513,18 @@ fn load_current_release_notes(card: &ReleaseNotesCard) {
                 glib::ControlFlow::Break
             }
             Ok(ReleaseNotes::Failed { message, url }) => {
-                card.notes
-                    .set_text(&format!("Couldn’t load release notes: {message}"));
+                set_release_notes_message(
+                    &card.notes,
+                    &format!("Couldn’t load release notes: {message}"),
+                );
                 card.fallback.set_uri(&url);
                 card.fallback.set_visible(true);
                 glib::ControlFlow::Break
             }
             Err(TryRecvError::Empty) => glib::ControlFlow::Continue,
             Err(TryRecvError::Disconnected) => {
-                card.notes.set_text(
+                set_release_notes_message(
+                    &card.notes,
                     "Couldn’t load release notes because the request ended unexpectedly.",
                 );
                 glib::ControlFlow::Break
@@ -548,9 +596,7 @@ fn update_check_row(
             progress.remove_css_class("error");
             status.set_text("Checking for updates…");
             available_notes.title.set_text("Available release");
-            available_notes
-                .notes
-                .set_text("Checking for a newer release…");
+            set_release_notes_message(&available_notes.notes, "Checking for a newer release…");
             available_notes.fallback.set_visible(false);
             available_notes.container.set_visible(true);
             button.set_sensitive(false);
@@ -593,16 +639,18 @@ fn update_check_row(
                                 available_notes
                                     .title
                                     .set_text("Current release is the latest");
-                                available_notes
-                                    .notes
-                                    .set_text("There is no newer release available.");
+                                set_release_notes_message(
+                                    &available_notes.notes,
+                                    "There is no newer release available.",
+                                );
                                 available_notes.fallback.set_visible(false);
                             }
                             UpdateCheck::Failed(message) => {
                                 available_notes.title.set_text("Available release");
-                                available_notes.notes.set_text(&format!(
-                                    "Couldn’t check for a newer release: {message}"
-                                ));
+                                set_release_notes_message(
+                                    &available_notes.notes,
+                                    &format!("Couldn’t check for a newer release: {message}"),
+                                );
                                 available_notes
                                     .fallback
                                     .set_uri("https://github.com/lgse/strata/releases/latest");
@@ -616,7 +664,10 @@ fn update_check_row(
                     Err(TryRecvError::Empty) => glib::ControlFlow::Continue,
                     Err(TryRecvError::Disconnected) => {
                         status.set_text("Couldn't check for updates");
-                        available_notes.notes.set_text("Couldn’t check for a newer release because the request ended unexpectedly.");
+                        set_release_notes_message(
+                            &available_notes.notes,
+                            "Couldn’t check for a newer release because the request ended unexpectedly.",
+                        );
                         available_notes
                             .fallback
                             .set_uri("https://github.com/lgse/strata/releases/latest");
@@ -798,20 +849,14 @@ pub(super) fn show_update_dialog(
     let notes_heading = gtk::Label::new(Some("What’s new"));
     notes_heading.add_css_class("release-notes-title");
     notes_heading.set_xalign(0.0);
-    let notes = gtk::Label::new(None);
-    notes.add_css_class("release-notes-content");
-    notes.set_xalign(0.0);
-    notes.set_yalign(0.0);
-    notes.set_wrap(true);
-    notes.set_wrap_mode(gtk::pango::WrapMode::WordChar);
-    notes.set_selectable(true);
-    notes.set_use_markup(true);
+    let notes = gtk::Box::new(gtk::Orientation::Vertical, 6);
     if release.notes.trim().is_empty() {
-        notes.set_text(
+        set_release_notes_message(
+            &notes,
             "No release notes were provided. Review this release on GitHub before continuing.",
         );
     } else {
-        notes.set_markup(&release.notes_markup);
+        set_release_notes_markup(&notes, &release.notes_markup);
     }
     let notes_scroll = gtk::ScrolledWindow::builder()
         .hscrollbar_policy(gtk::PolicyType::Never)

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -11,7 +11,7 @@ use gtk::{gdk, glib, prelude::*, subclass::prelude::*};
 
 use crate::{
     assets::icons,
-    services::{self, UpdateCheck, UpdateInstall},
+    services::{self, ReleaseMetadata, ReleaseNotes, UpdateCheck, UpdateInstall},
 };
 
 #[cfg(test)]
@@ -25,7 +25,7 @@ use super::{
 };
 
 type ThemeCards = Rc<RefCell<Vec<(String, gtk::Button, gtk::Image)>>>;
-pub(super) type UpdateNoticeHandler = Rc<dyn Fn(Option<(String, String, String)>)>;
+pub(super) type UpdateNoticeHandler = Rc<dyn Fn(Option<(ReleaseMetadata, String)>)>;
 
 const DIALOG_WIDTH: i32 = 920;
 const DIALOG_HEIGHT: i32 = 620;
@@ -199,9 +199,10 @@ pub fn build_layer(
         .hexpand(true)
         .vexpand(true)
         .build();
+    stack.add_named(&general_page(browser, themes.clone()), Some("general"));
     stack.add_named(
-        &general_page(browser, themes.clone(), update_notice),
-        Some("general"),
+        &updates_page(themes.clone(), update_notice),
+        Some("updates"),
     );
     stack.add_named(&keybindings_page(), Some("keybindings"));
     let (theme_page, responsive_flows) = theme_page(themes);
@@ -217,6 +218,7 @@ pub fn build_layer(
         ("General", icons::SLIDERS, "general"),
         ("Keybindings", icons::KEYBOARD, "keybindings"),
         ("Theme & appearance", icons::PALETTE, "theme"),
+        ("Updates", icons::DOWNLOADS, "updates"),
         ("About", icons::INFO, "about"),
     ] {
         let active = name == "general";
@@ -290,11 +292,7 @@ fn hide(layer: &gtk::Box, button: &gtk::Button, root: &BlurBin) {
     button.remove_css_class("active");
 }
 
-fn general_page(
-    browser: &BrowserView,
-    manager: Rc<ThemeManager>,
-    update_notice: UpdateNoticeHandler,
-) -> gtk::Widget {
+fn general_page(browser: &BrowserView, manager: Rc<ThemeManager>) -> gtk::Widget {
     let preferences = page_content();
     append_heading(&preferences, "BROWSING");
     let (peeking_row, peeking) = settings_option(
@@ -345,16 +343,34 @@ fn general_page(
     reduce_motion.connect_active_notify(|toggle| set_reduce_motion(toggle.is_active()));
     preferences.append(&motion_row);
 
-    append_heading(&preferences, "UPDATES");
+    scrollable_page(&preferences, None)
+}
+
+fn updates_page(manager: Rc<ThemeManager>, update_notice: UpdateNoticeHandler) -> gtk::Widget {
+    let preferences = page_content();
+    append_heading(&preferences, "UPDATE PREFERENCES");
     let auto_check_enabled = manager.checks_for_updates();
     let (auto_check_row, auto_check) = settings_option(
         "Automatically check for updates",
-        "Check GitHub for a newer release each time settings are opened.",
+        "Check GitHub for a newer release when Strata starts.",
         auto_check_enabled,
     );
     preferences.append(&auto_check_row);
-    let (update_row, run_check) = update_check_row(manager.clone(), update_notice.clone());
+
+    let available_notes = release_notes_card(
+        "Available release",
+        "Check for updates to see the latest release notes.",
+    );
+    let (update_row, run_check) = update_check_row(update_notice.clone(), available_notes.clone());
     preferences.append(&update_row);
+
+    append_heading(&preferences, "RELEASE NOTES");
+    let current_notes = release_notes_card(
+        &format!("Current release · v{}", env!("CARGO_PKG_VERSION")),
+        "Loading release notes…",
+    );
+    preferences.append(&current_notes.container);
+    load_current_release_notes(&current_notes);
 
     let manager_for_updates = manager.clone();
     let toggled_check = run_check.clone();
@@ -374,12 +390,108 @@ fn general_page(
     scrollable_page(&preferences, None)
 }
 
+#[derive(Clone)]
+struct ReleaseNotesCard {
+    container: gtk::Box,
+    title: gtk::Label,
+    notes: gtk::Label,
+    fallback: gtk::LinkButton,
+}
+
+fn release_notes_card(title: &str, initial: &str) -> ReleaseNotesCard {
+    let container = gtk::Box::new(gtk::Orientation::Vertical, 8);
+    container.add_css_class("release-notes-card");
+    let title_label = gtk::Label::new(Some(title));
+    title_label.add_css_class("release-notes-title");
+    title_label.set_xalign(0.0);
+    title_label.set_wrap(true);
+    let notes = gtk::Label::new(Some(initial));
+    notes.add_css_class("release-notes-content");
+    notes.set_xalign(0.0);
+    notes.set_yalign(0.0);
+    notes.set_wrap(true);
+    notes.set_wrap_mode(gtk::pango::WrapMode::WordChar);
+    notes.set_selectable(true);
+    notes.set_use_markup(true);
+    let fallback =
+        gtk::LinkButton::with_label("https://github.com/lgse/strata/releases", "View on GitHub");
+    fallback.add_css_class("release-notes-fallback");
+    fallback.set_halign(gtk::Align::Start);
+    fallback.set_visible(false);
+    container.append(&title_label);
+    container.append(&notes);
+    container.append(&fallback);
+    ReleaseNotesCard {
+        container,
+        title: title_label,
+        notes,
+        fallback,
+    }
+}
+
+fn show_release_notes(card: &ReleaseNotesCard, release: &ReleaseMetadata) {
+    card.title.set_text(&format!(
+        "{} · v{}",
+        card.title
+            .text()
+            .split('·')
+            .next()
+            .unwrap_or("Release")
+            .trim(),
+        release.version
+    ));
+    if release.notes.trim().is_empty() {
+        card.notes
+            .set_text("No release notes were provided for this release.");
+    } else {
+        card.notes.set_markup(&release.notes_markup);
+    }
+    card.fallback.set_uri(&release.url);
+    card.fallback.set_visible(true);
+}
+
+fn load_current_release_notes(card: &ReleaseNotesCard) {
+    let receiver = services::fetch_release_notes(env!("CARGO_PKG_VERSION"));
+    let card = card.clone();
+    glib::timeout_add_local(Duration::from_millis(100), move || {
+        match receiver.try_recv() {
+            Ok(ReleaseNotes::Found(release)) => {
+                show_release_notes(&card, &release);
+                glib::ControlFlow::Break
+            }
+            Ok(ReleaseNotes::Unavailable { url }) => {
+                card.notes.set_text(
+                    "Release notes are unavailable because this version’s tag was not found.",
+                );
+                card.fallback.set_uri(&url);
+                card.fallback.set_visible(true);
+                glib::ControlFlow::Break
+            }
+            Ok(ReleaseNotes::Failed { message, url }) => {
+                card.notes
+                    .set_text(&format!("Couldn’t load release notes: {message}"));
+                card.fallback.set_uri(&url);
+                card.fallback.set_visible(true);
+                glib::ControlFlow::Break
+            }
+            Err(TryRecvError::Empty) => glib::ControlFlow::Continue,
+            Err(TryRecvError::Disconnected) => {
+                card.notes.set_text(
+                    "Couldn’t load release notes because the request ended unexpectedly.",
+                );
+                glib::ControlFlow::Break
+            }
+        }
+    });
+}
+
 fn update_check_row(
-    manager: Rc<ThemeManager>,
     update_notice: UpdateNoticeHandler,
+    available_notes: ReleaseNotesCard,
 ) -> (gtk::Box, Rc<dyn Fn()>) {
-    let row = gtk::Box::new(gtk::Orientation::Horizontal, 16);
+    let row = gtk::Box::new(gtk::Orientation::Vertical, 0);
     row.add_css_class("settings-option");
+    let summary = gtk::Box::new(gtk::Orientation::Horizontal, 16);
     let copy = gtk::Box::new(gtk::Orientation::Vertical, 2);
     copy.set_hexpand(true);
     copy.set_valign(gtk::Align::Center);
@@ -400,9 +512,13 @@ fn update_check_row(
     copy.append(&progress);
     let button = gtk::Button::with_label("Check now");
     button.add_css_class("settings-update-check");
-    button.set_valign(gtk::Align::Center);
-    row.append(&copy);
-    row.append(&button);
+    button.set_valign(gtk::Align::Start);
+    summary.append(&copy);
+    summary.append(&button);
+    row.append(&summary);
+    available_notes.container.add_css_class("inline");
+    available_notes.container.set_visible(false);
+    row.append(&available_notes.container);
 
     let checking = Rc::new(Cell::new(false));
     // Set once a check finds an update this platform can install; consumed by the
@@ -415,11 +531,11 @@ fn update_check_row(
         let checking = checking.clone();
         let status = status.clone();
         let button = button.clone();
-        let manager = manager.clone();
         let update_notice = update_notice.clone();
         let pending_download = pending_download.clone();
         let installed = installed.clone();
         let progress = progress.clone();
+        let available_notes = available_notes.clone();
         move || {
             if checking.replace(true) {
                 return;
@@ -431,40 +547,67 @@ fn update_check_row(
             progress.set_visible(false);
             progress.remove_css_class("error");
             status.set_text("Checking for updates…");
+            available_notes.title.set_text("Available release");
+            available_notes
+                .notes
+                .set_text("Checking for a newer release…");
+            available_notes.fallback.set_visible(false);
+            available_notes.container.set_visible(true);
             button.set_sensitive(false);
             let receiver = services::check_for_updates(env!("CARGO_PKG_VERSION"));
             let checking = checking.clone();
             let status = status.clone();
             let button = button.clone();
-            let manager = manager.clone();
             let update_notice = update_notice.clone();
             let pending_download = pending_download.clone();
+            let available_notes = available_notes.clone();
             glib::timeout_add_local(Duration::from_millis(100), move || {
                 match receiver.try_recv() {
                     Ok(result) => {
                         status.set_markup(&update_check_message(&result));
                         match &result {
                             UpdateCheck::Available {
-                                version,
-                                url,
+                                release,
                                 download_url: Some(download_url),
-                            } if manager.checks_for_updates() => {
-                                update_notice(Some((
-                                    version.clone(),
-                                    url.clone(),
-                                    download_url.clone(),
-                                )));
+                            } => {
+                                update_notice(Some((release.clone(), download_url.clone())));
                             }
-                            UpdateCheck::UpToDate => update_notice(None),
-                            UpdateCheck::Available { .. } | UpdateCheck::Failed(_) => {}
+                            UpdateCheck::UpToDate
+                            | UpdateCheck::Available {
+                                download_url: None, ..
+                            } => update_notice(None),
+                            UpdateCheck::Failed(_) => {}
                         }
-                        if let UpdateCheck::Available {
-                            download_url: Some(download_url),
-                            ..
-                        } = &result
-                        {
-                            *pending_download.borrow_mut() = Some(download_url.clone());
-                            button.set_label("Install update");
+                        match &result {
+                            UpdateCheck::Available {
+                                release,
+                                download_url,
+                            } => {
+                                show_release_notes(&available_notes, release);
+                                if let Some(download_url) = download_url {
+                                    *pending_download.borrow_mut() = Some(download_url.clone());
+                                    button.set_label("Install update");
+                                }
+                            }
+                            UpdateCheck::UpToDate => {
+                                available_notes
+                                    .title
+                                    .set_text("Current release is the latest");
+                                available_notes
+                                    .notes
+                                    .set_text("There is no newer release available.");
+                                available_notes.fallback.set_visible(false);
+                            }
+                            UpdateCheck::Failed(message) => {
+                                available_notes.title.set_text("Available release");
+                                available_notes.notes.set_text(&format!(
+                                    "Couldn’t check for a newer release: {message}"
+                                ));
+                                available_notes
+                                    .fallback
+                                    .set_uri("https://github.com/lgse/strata/releases/latest");
+                                available_notes.fallback.set_visible(true);
+                            }
                         }
                         button.set_sensitive(true);
                         checking.set(false);
@@ -473,6 +616,11 @@ fn update_check_row(
                     Err(TryRecvError::Empty) => glib::ControlFlow::Continue,
                     Err(TryRecvError::Disconnected) => {
                         status.set_text("Couldn't check for updates");
+                        available_notes.notes.set_text("Couldn’t check for a newer release because the request ended unexpectedly.");
+                        available_notes
+                            .fallback
+                            .set_uri("https://github.com/lgse/strata/releases/latest");
+                        available_notes.fallback.set_visible(true);
                         button.set_sensitive(true);
                         checking.set(false);
                         glib::ControlFlow::Break
@@ -601,7 +749,11 @@ fn restart(application: Option<&gtk::Application>) {
     }
 }
 
-pub(super) fn show_update_dialog(parent: &gtk::Window, version: &str, download_url: String) {
+pub(super) fn show_update_dialog(
+    parent: &gtk::Window,
+    release: &ReleaseMetadata,
+    download_url: String,
+) {
     let Some(window_overlay) = parent.child().and_downcast::<gtk::Overlay>() else {
         return;
     };
@@ -615,6 +767,7 @@ pub(super) fn show_update_dialog(parent: &gtk::Window, version: &str, download_u
     content.add_css_class("update-dialog");
     content.set_halign(gtk::Align::Center);
     content.set_valign(gtk::Align::Center);
+    content.set_size_request(560, -1);
     let header = gtk::Box::new(gtk::Orientation::Horizontal, 12);
     header.add_css_class("update-dialog-header");
     let symbol = gtk::CenterBox::new();
@@ -623,12 +776,14 @@ pub(super) fn show_update_dialog(parent: &gtk::Window, version: &str, download_u
     symbol.set_valign(gtk::Align::Center);
     symbol.set_center_widget(Some(&crate::assets::primary_icon(icons::DOWNLOADS, 20)));
     let heading = gtk::Box::new(gtk::Orientation::Vertical, 2);
-    let title = gtk::Label::new(Some(&format!("Installing Strata v{version}")));
+    let title = gtk::Label::new(Some(&format!("Strata v{} is available", release.version)));
     title.add_css_class("update-dialog-title");
     title.set_xalign(0.0);
-    let subtitle = gtk::Label::new(Some(
-        "The update is downloaded and verified before installation.",
-    ));
+    let subtitle = gtk::Label::new(Some(&format!(
+        "Installed v{}  →  Available v{}",
+        env!("CARGO_PKG_VERSION"),
+        release.version
+    )));
     subtitle.add_css_class("update-dialog-subtitle");
     subtitle.set_xalign(0.0);
     subtitle.set_wrap(true);
@@ -640,13 +795,49 @@ pub(super) fn show_update_dialog(parent: &gtk::Window, version: &str, download_u
 
     let body = gtk::Box::new(gtk::Orientation::Vertical, 10);
     body.add_css_class("update-dialog-body");
-    let status = gtk::Label::new(Some(&format!("Strata v{version} is ready to download.")));
+    let notes_heading = gtk::Label::new(Some("What’s new"));
+    notes_heading.add_css_class("release-notes-title");
+    notes_heading.set_xalign(0.0);
+    let notes = gtk::Label::new(None);
+    notes.add_css_class("release-notes-content");
+    notes.set_xalign(0.0);
+    notes.set_yalign(0.0);
+    notes.set_wrap(true);
+    notes.set_wrap_mode(gtk::pango::WrapMode::WordChar);
+    notes.set_selectable(true);
+    notes.set_use_markup(true);
+    if release.notes.trim().is_empty() {
+        notes.set_text(
+            "No release notes were provided. Review this release on GitHub before continuing.",
+        );
+    } else {
+        notes.set_markup(&release.notes_markup);
+    }
+    let notes_scroll = gtk::ScrolledWindow::builder()
+        .hscrollbar_policy(gtk::PolicyType::Never)
+        .vscrollbar_policy(gtk::PolicyType::Automatic)
+        .min_content_height(120)
+        .max_content_height(300)
+        .propagate_natural_height(true)
+        .child(&notes)
+        .build();
+    notes_scroll.add_css_class("update-dialog-notes");
+    let fallback = gtk::LinkButton::with_label(&release.url, "View release on GitHub");
+    fallback.add_css_class("release-notes-fallback");
+    fallback.set_halign(gtk::Align::Start);
+    let status = gtk::Label::new(Some(
+        "Review the release notes before downloading the update.",
+    ));
     status.add_css_class("update-dialog-status");
     status.set_xalign(0.0);
+    status.set_wrap(true);
     let progress = gtk::ProgressBar::new();
     progress.add_css_class("update-dialog-progress");
     progress.set_fraction(0.0);
     progress.set_visible(false);
+    body.append(&notes_heading);
+    body.append(&notes_scroll);
+    body.append(&fallback);
     body.append(&status);
     body.append(&progress);
     content.append(&body);
@@ -761,10 +952,10 @@ fn update_check_message(result: &UpdateCheck) -> String {
         UpdateCheck::UpToDate => {
             format!("Up to date — version {}", env!("CARGO_PKG_VERSION"))
         }
-        UpdateCheck::Available { version, url, .. } => format!(
+        UpdateCheck::Available { release, .. } => format!(
             "Update available: <a href=\"{}\">v{}</a>",
-            glib::markup_escape_text(url),
-            glib::markup_escape_text(version),
+            glib::markup_escape_text(&release.url),
+            glib::markup_escape_text(&release.version),
         ),
         UpdateCheck::Failed(message) => {
             format!(

--- a/src/ui/settings/tests.rs
+++ b/src/ui/settings/tests.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+use crate::services::{ReleaseMetadata, UpdateCheck};
+
 use super::{
     COMPACT_NAVIGATION_BREAKPOINT, DIALOG_HEIGHT, DIALOG_MARGIN, DIALOG_WIDTH,
-    responsive_dialog_size, uses_compact_navigation,
+    responsive_dialog_size, shows_available_release_notes, uses_compact_navigation,
 };
 
 #[test]
@@ -30,4 +32,21 @@ fn settings_dialog_size_stays_valid_at_tiny_allocations() {
 fn settings_navigation_compacts_below_the_breakpoint() {
     assert!(uses_compact_navigation(COMPACT_NAVIGATION_BREAKPOINT - 1));
     assert!(!uses_compact_navigation(COMPACT_NAVIGATION_BREAKPOINT));
+}
+
+#[test]
+fn available_notes_are_shown_only_for_a_newer_release() {
+    assert!(!shows_available_release_notes(&UpdateCheck::UpToDate));
+    assert!(!shows_available_release_notes(&UpdateCheck::Failed(
+        "offline".to_owned()
+    )));
+    assert!(shows_available_release_notes(&UpdateCheck::Available {
+        release: ReleaseMetadata {
+            version: "1.0.0".to_owned(),
+            url: "https://example.test/release".to_owned(),
+            notes: "Changes".to_owned(),
+            notes_markup: "Changes".to_owned(),
+        },
+        download_url: None,
+    }));
 }

--- a/src/ui/settings/tests.rs
+++ b/src/ui/settings/tests.rs
@@ -45,7 +45,9 @@ fn available_notes_are_shown_only_for_a_newer_release() {
             version: "1.0.0".to_owned(),
             url: "https://example.test/release".to_owned(),
             notes: "Changes".to_owned(),
-            notes_markup: "Changes".to_owned(),
+            note_blocks: vec![crate::services::ReleaseNoteBlock::Paragraph(
+                "Changes".to_owned(),
+            )],
         },
         download_url: None,
     }));

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -255,21 +255,23 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
     let update_button = sidebar.update_notice.clone();
     let update_area = sidebar.update_area.clone();
     let update_label = sidebar.update_label.clone();
-    let available_update = Rc::new(RefCell::new(None::<(String, String)>));
+    let available_update = Rc::new(RefCell::new(
+        None::<(crate::services::ReleaseMetadata, String)>,
+    ));
     let available_for_click = available_update.clone();
     let update_parent = window.clone().upcast::<gtk::Window>();
     update_button.connect_clicked(move |_| {
-        let Some((version, download_url)) = available_for_click.borrow().clone() else {
+        let Some((release, download_url)) = available_for_click.borrow().clone() else {
             return;
         };
-        super::settings::show_update_dialog(&update_parent, &version, download_url);
+        super::settings::show_update_dialog(&update_parent, &release, download_url);
     });
     let available_for_notice = available_update.clone();
     let update_notice: super::settings::UpdateNoticeHandler = Rc::new(move |release| {
-        if let Some((version, _url, download_url)) = release {
-            update_button.set_tooltip_text(Some(&format!("Install Strata v{version}")));
-            update_label.set_text(&format!("v{version} available"));
-            *available_for_notice.borrow_mut() = Some((version, download_url));
+        if let Some((release, download_url)) = release {
+            update_button.set_tooltip_text(Some(&format!("Install Strata v{}", release.version)));
+            update_label.set_text(&format!("v{} available", release.version));
+            *available_for_notice.borrow_mut() = Some((release, download_url));
             update_area.set_visible(true);
         } else {
             available_for_notice.borrow_mut().take();


### PR DESCRIPTION
## Summary

- retain GitHub release bodies and fetch notes for the exact installed-version tag
- add a dedicated Updates settings page with current and available release notes
- show safe, scrollable release notes before update download and installation
- handle empty notes, unavailable tags, network failures, and API rate limits without blocking eligible updates

## Screenshots

### Updates settings

![Updates settings with available release notes](https://raw.githubusercontent.com/lgse/strata/14cc0fbdb6f71719154808512d2190fd32c5645a/.github/pr-assets/48/updates-settings.png)

### Update confirmation

![Update confirmation with scrollable release notes](https://raw.githubusercontent.com/lgse/strata/14cc0fbdb6f71719154808512d2190fd32c5645a/.github/pr-assets/48/update-dialog.png)

## Testing

- `./scripts/check.sh`
- manually verified the update flow using a locally staged v0.3.0 binary against the v0.4.0 release

Closes #48
