### PR TITLE
fix(files): guard optional GFileInfo attributes

### DIFF
--- a/src/adapters/local_files.rs
+++ b/src/adapters/local_files.rs
@@ -76,9 +76,17 @@ fn uri_validation_result(
     }
 }
 
+fn info_is_hidden(info: &gio::FileInfo) -> bool {
+    info.has_attribute(gio::FILE_ATTRIBUTE_STANDARD_IS_HIDDEN) && info.is_hidden()
+}
+
+fn info_is_symlink(info: &gio::FileInfo) -> bool {
+    info.has_attribute(gio::FILE_ATTRIBUTE_STANDARD_IS_SYMLINK) && info.is_symlink()
+}
+
 fn entry_from_info(location: Location, info: gio::FileInfo) -> FileEntry {
     let native_name = info.name().into_os_string();
-    let kind = match (info.file_type(), info.is_symlink()) {
+    let kind = match (info.file_type(), info_is_symlink(&info)) {
         (gio::FileType::Directory, true) => EntryKind::DirectorySymbolicLink,
         (gio::FileType::Regular, true) => EntryKind::FileSymbolicLink,
         // GVfs reports unmounted browsable children (an smb:// host's shares, a
@@ -218,7 +226,7 @@ impl FileSource for LocalFileSource {
                     Ok(files) => {
                         let entries: Vec<_> = files
                             .into_iter()
-                            .filter(|info| request.include_hidden || !info.is_hidden())
+                            .filter(|info| request.include_hidden || !info_is_hidden(info))
                             .map(|info| {
                                 let child = directory.child(info.name());
                                 entry_from_info(location_for_file(&child), info)
@@ -456,7 +464,7 @@ fn query_monitored_entry(
             return;
         }
         match result {
-            Ok(info) if include_hidden || !info.is_hidden() => {
+            Ok(info) if include_hidden || !info_is_hidden(&info) => {
                 let entry = entry_from_info(Location::local(path), info);
                 if let Some(from) = moved_from {
                     notify(DirectoryChange::Move {

--- a/src/adapters/local_files/tests.rs
+++ b/src/adapters/local_files/tests.rs
@@ -150,10 +150,23 @@ fn invalid_utf8_names_keep_their_native_bytes() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+fn missing_optional_attributes_use_safe_defaults() {
+    let info = gio::FileInfo::new();
+
+    assert!(!info_is_hidden(&info));
+    assert!(!info_is_symlink(&info));
+
+    info.set_is_hidden(true);
+    info.set_is_symlink(true);
+
+    assert!(info_is_hidden(&info));
+    assert!(info_is_symlink(&info));
+}
+
+#[test]
 fn unmounted_network_shares_are_treated_as_directories() {
     let info = gio::FileInfo::new();
     info.set_file_type(gio::FileType::Mountable);
-    info.set_is_symlink(false);
     info.set_name("share");
     info.set_display_name("share");
 


### PR DESCRIPTION
## Summary

- check whether GVfs supplied hidden and symlink attributes before reading them
- default missing optional boolean metadata to `false`
- cover missing attributes and unmounted SMB share metadata with unit tests

## Testing

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features`
- `G_DEBUG=fatal-criticals cargo test adapters::local_files::tests`

Closes #73