### PR TITLE
fix(operations): report partial cancellation results

### DIFF
--- a/src/adapters/local_files.rs
+++ b/src/adapters/local_files.rs
@@ -4,7 +4,7 @@ use std::{
     cell::{Cell, RefCell},
     collections::HashMap,
     io::ErrorKind,
-    path::PathBuf,
+    path::{Path, PathBuf},
     rc::Rc,
     time::{Duration, Instant},
 };
@@ -20,6 +20,7 @@ use crate::{
 };
 
 const ATTRIBUTES: &str = "standard::display-name,standard::name,standard::type,standard::is-hidden,standard::is-symlink,standard::size,time::modified";
+const MAX_PENDING_MONITOR_CHANGES: usize = 256;
 
 #[derive(Default)]
 pub struct LocalFileSource;
@@ -308,6 +309,9 @@ impl FileSource for LocalFileSource {
         let timeout_for_change = timeout.clone();
         let cancelled_for_change = cancelled.clone();
         monitor.connect_changed(move |_, file, other_file, event| {
+            if pending_for_change.borrow().contains_key(Path::new("")) {
+                return;
+            }
             let path = file.path();
             let other_path = other_file.and_then(gio::File::path);
             let change = match event {
@@ -341,13 +345,9 @@ impl FileSource for LocalFileSource {
                 PendingMonitorChange::Move { to, .. } => to.clone(),
                 PendingMonitorChange::Rescan => PathBuf::new(),
             };
-            pending_for_change
-                .borrow_mut()
-                .entry(key)
-                .and_modify(|pending| {
-                    *pending = merge_pending_change(pending.clone(), change.clone());
-                })
-                .or_insert(change);
+            if !queue_monitor_change(&mut pending_for_change.borrow_mut(), key, change) {
+                return;
+            }
 
             if let Some(source) = timeout_for_change.take() {
                 source.remove();
@@ -385,6 +385,27 @@ fn log_directory_load_started(request_id: RequestId, location: &Location) {
         location = %location.diagnostic_path(),
         "directory load location"
     );
+}
+
+fn queue_monitor_change(
+    pending: &mut HashMap<PathBuf, PendingMonitorChange>,
+    key: PathBuf,
+    change: PendingMonitorChange,
+) -> bool {
+    if pending.contains_key(Path::new("")) {
+        return false;
+    }
+    pending
+        .entry(key)
+        .and_modify(|pending| {
+            *pending = merge_pending_change(pending.clone(), change.clone());
+        })
+        .or_insert(change);
+    if pending.len() > MAX_PENDING_MONITOR_CHANGES {
+        pending.clear();
+        pending.insert(PathBuf::new(), PendingMonitorChange::Rescan);
+    }
+    true
 }
 
 fn merge_pending_change(

--- a/src/adapters/local_files/tests.rs
+++ b/src/adapters/local_files/tests.rs
@@ -257,6 +257,30 @@ fn coalescing_preserves_a_move_when_metadata_follows_it() {
 }
 
 #[test]
+fn large_monitor_bursts_collapse_to_one_rescan() {
+    let mut pending = HashMap::new();
+    for index in 0..=MAX_PENDING_MONITOR_CHANGES {
+        let path = PathBuf::from(format!("/fixture/{index}"));
+        assert!(queue_monitor_change(
+            &mut pending,
+            path.clone(),
+            PendingMonitorChange::Upsert(path),
+        ));
+    }
+
+    assert_eq!(pending.len(), 1);
+    assert!(matches!(
+        pending.get(Path::new("")),
+        Some(PendingMonitorChange::Rescan)
+    ));
+    assert!(!queue_monitor_change(
+        &mut pending,
+        "/fixture/ignored".into(),
+        PendingMonitorChange::Remove("/fixture/ignored".into()),
+    ));
+}
+
+#[test]
 fn conflicting_move_events_fall_back_to_a_rescan() {
     let change = merge_pending_change(
         PendingMonitorChange::Move {

--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -4,6 +4,8 @@
 mod tests;
 
 use std::{
+    cell::Cell,
+    collections::HashSet,
     ffi::{OsStr, OsString},
     future::Future,
     io,
@@ -23,13 +25,32 @@ use std::{
 use gtk::{gio, glib, prelude::*};
 
 use crate::{
+    adapters::location_for_file,
     model::Location,
     services::{
-        ArchiveFormat, CompressRequest, CreateDirectoryRequest, CreateFileRequest, DeleteRequest,
-        ExtractRequest, LoadHandle, OperationEvent, OperationProvider, OperationRequestId,
-        PasteRequest, RenameRequest, RestoreRequest, TransferConflict, validate_basename,
+        ArchiveFormat, CancelledOperation, CompressRequest, CreateDirectoryRequest,
+        CreateFileRequest, DeleteRequest, ExtractRequest, LoadHandle, OperationEvent,
+        OperationProvider, OperationRequestId, PasteRequest, RenameRequest, RestoreRequest,
+        TransferConflict, validate_basename,
     },
 };
+
+async fn await_cancellable<O, T>(
+    object: &O,
+    cancellable: &gio::Cancellable,
+    start: impl FnOnce(&O, &gio::Cancellable, gio::GioFutureResult<Result<T, glib::Error>>) + 'static,
+) -> Result<T, glib::Error>
+where
+    O: Clone + 'static,
+    T: 'static,
+{
+    // The backend's callback is authoritative: cancellation can race with a successful result.
+    let cancellable = cancellable.clone();
+    gio::GioFuture::new(object, move |object, _, result| {
+        start(object, &cancellable, result);
+    })
+    .await
+}
 
 fn gio_file(location: &Location) -> gio::File {
     location
@@ -47,36 +68,67 @@ fn transfer_is_noop(source: &gio::File, destination: &gio::File, target: &gio::F
     source.equal(target) || source.equal(destination) || destination.has_prefix(source)
 }
 
+fn was_cancelled(error: &glib::Error) -> bool {
+    error.matches(gio::IOErrorEnum::Cancelled)
+}
+
 fn copy_recursively(
     source: gio::File,
     target: gio::File,
     overwrite_existing: bool,
+    cancellable: gio::Cancellable,
+    created_root: Option<Rc<Cell<bool>>>,
 ) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>> {
     Box::pin(async move {
-        let info = source
-            .query_info_future(
+        let info = await_cancellable(&source, &cancellable, |source, cancellable, result| {
+            source.query_info_async(
                 "standard::type",
                 gio::FileQueryInfoFlags::NOFOLLOW_SYMLINKS,
                 glib::Priority::DEFAULT,
-            )
-            .await?;
+                Some(cancellable),
+                move |output| result.resolve(output),
+            );
+        })
+        .await?;
         if info.file_type() == gio::FileType::Directory {
-            if !overwrite_existing || !target.query_exists(None::<&gio::Cancellable>) {
-                target
-                    .make_directory_future(glib::Priority::DEFAULT)
-                    .await?;
+            if !overwrite_existing || !target.query_exists(Some(&cancellable)) {
+                await_cancellable(&target, &cancellable, |target, cancellable, result| {
+                    target.make_directory_async(
+                        glib::Priority::DEFAULT,
+                        Some(cancellable),
+                        move |output| result.resolve(output),
+                    );
+                })
+                .await?;
+                if let Some(created_root) = &created_root {
+                    created_root.set(true);
+                }
             }
-            let enumerator = source
-                .enumerate_children_future(
-                    "standard::name",
-                    gio::FileQueryInfoFlags::NOFOLLOW_SYMLINKS,
-                    glib::Priority::DEFAULT,
-                )
+            let enumerator =
+                await_cancellable(&source, &cancellable, |source, cancellable, result| {
+                    source.enumerate_children_async(
+                        "standard::name",
+                        gio::FileQueryInfoFlags::NOFOLLOW_SYMLINKS,
+                        glib::Priority::DEFAULT,
+                        Some(cancellable),
+                        move |output| result.resolve(output),
+                    );
+                })
                 .await?;
             loop {
-                let children = enumerator
-                    .next_files_future(64, glib::Priority::DEFAULT)
-                    .await?;
+                let children = await_cancellable(
+                    &enumerator,
+                    &cancellable,
+                    |enumerator, cancellable, result| {
+                        enumerator.next_files_async(
+                            64,
+                            glib::Priority::DEFAULT,
+                            Some(cancellable),
+                            move |output| result.resolve(output),
+                        );
+                    },
+                )
+                .await?;
                 if children.is_empty() {
                     break;
                 }
@@ -85,6 +137,8 @@ fn copy_recursively(
                         source.child(child.name()),
                         target.child(child.name()),
                         overwrite_existing,
+                        cancellable.clone(),
+                        None,
                     )
                     .await?;
                 }
@@ -98,10 +152,105 @@ fn copy_recursively(
                 } else {
                     gio::FileCopyFlags::NONE
                 };
-            let (copy, _progress) = source.copy_future(&target, flags, glib::Priority::DEFAULT);
-            copy.await
+            await_cancellable(&source, &cancellable, move |source, cancellable, result| {
+                source.copy_async(
+                    &target,
+                    flags,
+                    glib::Priority::DEFAULT,
+                    Some(cancellable),
+                    None,
+                    move |output| result.resolve(output),
+                );
+            })
+            .await
         }
     })
+}
+
+async fn copy_new_recursively(
+    source: gio::File,
+    target: gio::File,
+    cancellable: gio::Cancellable,
+) -> Result<(), glib::Error> {
+    if source.is_native()
+        && target.is_native()
+        && let Some(target_path) = target.path()
+    {
+        let source_type =
+            await_cancellable(&source, &cancellable, |source, cancellable, result| {
+                source.query_info_async(
+                    "standard::type",
+                    gio::FileQueryInfoFlags::NOFOLLOW_SYMLINKS,
+                    glib::Priority::DEFAULT,
+                    Some(cancellable),
+                    move |output| result.resolve(output),
+                );
+            })
+            .await?
+            .file_type();
+        if source_type == gio::FileType::Directory {
+            let parent = target_path
+                .parent()
+                .ok_or_else(|| io_error("The destination has no parent directory"))?;
+            let staged = StagedSibling::create(parent, true).map_err(io_error)?;
+            if let Err(error) = copy_recursively(
+                source,
+                gio::File::for_path(staged.path()),
+                true,
+                cancellable.clone(),
+                None,
+            )
+            .await
+            {
+                discard_staged(staged).await;
+                return Err(error);
+            }
+            if let Err(error) = cancellable.set_error_if_cancelled() {
+                discard_staged(staged).await;
+                return Err(error);
+            }
+
+            let staged_path = staged.path().to_owned();
+            let committed = gio::spawn_blocking(move || {
+                rustix::fs::renameat_with(
+                    rustix::fs::CWD,
+                    &staged_path,
+                    rustix::fs::CWD,
+                    &target_path,
+                    rustix::fs::RenameFlags::NOREPLACE,
+                )
+            })
+            .await
+            .map_err(|_| io_error("The copy worker stopped unexpectedly"));
+            let committed = match committed {
+                Ok(Ok(())) => Ok(()),
+                Ok(Err(error)) => Err(io_error(format!(
+                    "Could not finish copying the item: {error}"
+                ))),
+                Err(error) => Err(error),
+            };
+            if let Err(error) = committed {
+                discard_staged(staged).await;
+                return Err(error);
+            }
+            return Ok(());
+        }
+    }
+
+    let created_root = Rc::new(Cell::new(false));
+    let result = copy_recursively(
+        source,
+        target.clone(),
+        false,
+        cancellable.clone(),
+        Some(created_root.clone()),
+    )
+    .await;
+    if result.as_ref().is_err_and(was_cancelled) && created_root.get() {
+        let cleanup = gio::Cancellable::new();
+        let _cleanup_result = permanently_delete(target, true, cleanup).await;
+    }
+    result
 }
 
 enum StagedSibling {
@@ -131,20 +280,35 @@ impl StagedSibling {
     }
 }
 
+async fn discard_staged(staged: StagedSibling) {
+    let _discarded = gio::spawn_blocking(move || drop(staged)).await;
+}
+
 fn io_error(error: impl std::fmt::Display) -> glib::Error {
     glib::Error::new(gio::IOErrorEnum::Failed, &error.to_string())
 }
 
 type StageCopy = Rc<
-    dyn Fn(gio::File, gio::File, bool) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>>,
+    dyn Fn(
+        gio::File,
+        gio::File,
+        bool,
+        gio::Cancellable,
+    ) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>>,
 >;
 
 async fn replace_local_with(
     source: gio::File,
     target: gio::File,
     move_source: bool,
+    cancellable: gio::Cancellable,
+    affected_locations: Option<&mut HashSet<Location>>,
     copy_to_stage: StageCopy,
 ) -> Result<(), glib::Error> {
+    if let Some(locations) = affected_locations {
+        locations.insert(location_for_file(&source));
+        locations.insert(location_for_file(&target));
+    }
     if source.path().is_none() {
         return Err(glib::Error::new(
             gio::IOErrorEnum::NotSupported,
@@ -160,22 +324,28 @@ async fn replace_local_with(
     let parent = target_path
         .parent()
         .ok_or_else(|| io_error("The destination has no parent directory"))?;
-    let source_type = source
-        .query_info_future(
+    let source_type = await_cancellable(&source, &cancellable, |source, cancellable, result| {
+        source.query_info_async(
             "standard::type",
             gio::FileQueryInfoFlags::NOFOLLOW_SYMLINKS,
             glib::Priority::DEFAULT,
-        )
-        .await?
-        .file_type();
-    let target_type = target
-        .query_info_future(
+            Some(cancellable),
+            move |output| result.resolve(output),
+        );
+    })
+    .await?
+    .file_type();
+    let target_type = await_cancellable(&target, &cancellable, |target, cancellable, result| {
+        target.query_info_async(
             "standard::type",
             gio::FileQueryInfoFlags::NOFOLLOW_SYMLINKS,
             glib::Priority::DEFAULT,
-        )
-        .await?
-        .file_type();
+            Some(cancellable),
+            move |output| result.resolve(output),
+        );
+    })
+    .await?
+    .file_type();
     let source_is_directory = source_type == gio::FileType::Directory;
     let target_is_directory = target_type == gio::FileType::Directory;
     if source_is_directory != target_is_directory {
@@ -187,7 +357,21 @@ async fn replace_local_with(
 
     let staged = StagedSibling::create(parent, source_is_directory).map_err(io_error)?;
     let staged_file = gio::File::for_path(staged.path());
-    copy_to_stage(source.clone(), staged_file.clone(), source_is_directory).await?;
+    if let Err(error) = copy_to_stage(
+        source.clone(),
+        staged_file.clone(),
+        source_is_directory,
+        cancellable.clone(),
+    )
+    .await
+    {
+        discard_staged(staged).await;
+        return Err(error);
+    }
+    if let Err(error) = cancellable.set_error_if_cancelled() {
+        discard_staged(staged).await;
+        return Err(error);
+    }
 
     let staged_path = staged.path().to_owned();
     let exchanged = gio::spawn_blocking(move || {
@@ -200,12 +384,27 @@ async fn replace_local_with(
         )
     })
     .await
-    .map_err(|_| io_error("The replacement worker stopped unexpectedly"))?;
-    exchanged.map_err(|error| io_error(format!("Could not safely replace the item: {error}")))?;
+    .map_err(|_| io_error("The replacement worker stopped unexpectedly"));
+    let exchanged = match exchanged {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(error)) => Err(io_error(format!(
+            "Could not safely replace the item: {error}"
+        ))),
+        Err(error) => Err(error),
+    };
+    if let Err(error) = exchanged {
+        discard_staged(staged).await;
+        return Err(error);
+    }
 
-    permanently_delete(staged_file, target_is_directory).await?;
+    if let Err(error) =
+        permanently_delete(staged_file, target_is_directory, gio::Cancellable::new()).await
+    {
+        discard_staged(staged).await;
+        return Err(error);
+    }
     if move_source {
-        permanently_delete(source, source_is_directory).await?;
+        permanently_delete(source, source_is_directory, cancellable).await?;
     }
     Ok(())
 }
@@ -214,22 +413,34 @@ async fn replace_local(
     source: gio::File,
     target: gio::File,
     move_source: bool,
+    cancellable: gio::Cancellable,
+    affected_locations: Option<&mut HashSet<Location>>,
 ) -> Result<(), glib::Error> {
     replace_local_with(
         source,
         target,
         move_source,
-        Rc::new(|source, staged, directory| {
+        cancellable,
+        affected_locations,
+        Rc::new(|source, staged, directory, cancellable| {
             Box::pin(async move {
                 if directory {
-                    copy_recursively(source, staged, true).await
+                    copy_recursively(source, staged, true, cancellable, None).await
                 } else {
                     let flags = gio::FileCopyFlags::ALL_METADATA
                         | gio::FileCopyFlags::NOFOLLOW_SYMLINKS
                         | gio::FileCopyFlags::OVERWRITE;
-                    let (copy, _progress) =
-                        source.copy_future(&staged, flags, glib::Priority::DEFAULT);
-                    copy.await
+                    await_cancellable(&source, &cancellable, move |source, cancellable, result| {
+                        source.copy_async(
+                            &staged,
+                            flags,
+                            glib::Priority::DEFAULT,
+                            Some(cancellable),
+                            None,
+                            move |output| result.resolve(output),
+                        );
+                    })
+                    .await
                 }
             })
         }),
@@ -240,20 +451,34 @@ async fn replace_local(
 fn permanently_delete(
     file: gio::File,
     directory: bool,
+    cancellable: gio::Cancellable,
 ) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>> {
     Box::pin(async move {
         if directory {
-            let enumerator = file
-                .enumerate_children_future(
+            let enumerator = await_cancellable(&file, &cancellable, |file, cancellable, result| {
+                file.enumerate_children_async(
                     "standard::name,standard::type",
                     gio::FileQueryInfoFlags::NOFOLLOW_SYMLINKS,
                     glib::Priority::DEFAULT,
+                    Some(cancellable),
+                    move |output| result.resolve(output),
+                );
+            })
+            .await?;
+            loop {
+                let children = await_cancellable(
+                    &enumerator,
+                    &cancellable,
+                    |enumerator, cancellable, result| {
+                        enumerator.next_files_async(
+                            64,
+                            glib::Priority::DEFAULT,
+                            Some(cancellable),
+                            move |output| result.resolve(output),
+                        );
+                    },
                 )
                 .await?;
-            loop {
-                let children = enumerator
-                    .next_files_future(64, glib::Priority::DEFAULT)
-                    .await?;
                 if children.is_empty() {
                     break;
                 }
@@ -261,12 +486,18 @@ fn permanently_delete(
                     permanently_delete(
                         file.child(child.name()),
                         child.file_type() == gio::FileType::Directory,
+                        cancellable.clone(),
                     )
                     .await?;
                 }
             }
         }
-        file.delete_future(glib::Priority::DEFAULT).await
+        await_cancellable(&file, &cancellable, |file, cancellable, result| {
+            file.delete_async(glib::Priority::DEFAULT, Some(cancellable), move |output| {
+                result.resolve(output)
+            });
+        })
+        .await
     })
 }
 
@@ -304,12 +535,36 @@ fn deletion_error_message(name: &str, permanent: bool, error: &glib::Error) -> S
     }
 }
 
+fn cancellation_handle(cancellable: gio::Cancellable) -> LoadHandle {
+    LoadHandle::new(move || cancellable.cancel())
+}
+
+fn cancelled_event(
+    request_id: crate::services::OperationRequestId,
+    completed: Vec<Location>,
+    failed: Vec<Location>,
+    not_attempted: Vec<Location>,
+    affected_locations: HashSet<Location>,
+) -> OperationEvent {
+    OperationEvent::Cancelled {
+        request_id,
+        result: CancelledOperation {
+            completed,
+            failed,
+            not_attempted,
+            affected_locations,
+        },
+    }
+}
+
 #[derive(Default)]
 pub struct LocalOperationProvider;
 
 impl OperationProvider for LocalOperationProvider {
     fn rename(&self, request: RenameRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle {
-        let task = glib::MainContext::default().spawn_local(async move {
+        let cancellable = gio::Cancellable::new();
+        let operation_cancellable = cancellable.clone();
+        let _task = glib::MainContext::default().spawn_local(async move {
             if let Err(message) = validate_basename(&request.new_name) {
                 emit(OperationEvent::Failed {
                     request_id: request.id,
@@ -325,20 +580,51 @@ impl OperationProvider for LocalOperationProvider {
                 .unwrap_or_else(|| {
                     gio::File::for_uri(request.entry.location.uri_value().unwrap_or_default())
                 });
-            match file
-                .set_display_name_future(&request.new_name, glib::Priority::DEFAULT)
-                .await
+            let item = request.entry.location.clone();
+            let affected_locations = item.parent().into_iter().collect();
+            if operation_cancellable.is_cancelled() {
+                emit(cancelled_event(
+                    request.id,
+                    Vec::new(),
+                    Vec::new(),
+                    vec![item],
+                    affected_locations,
+                ));
+                return;
+            }
+            match await_cancellable(
+                &file,
+                &operation_cancellable,
+                move |file, cancellable, result| {
+                    file.set_display_name_async(
+                        &request.new_name,
+                        glib::Priority::DEFAULT,
+                        Some(cancellable),
+                        move |output| result.resolve(output),
+                    );
+                },
+            )
+            .await
             {
                 Ok(_) => emit(OperationEvent::Renamed {
                     request_id: request.id,
                 }),
+                Err(error) if was_cancelled(&error) => {
+                    emit(cancelled_event(
+                        request.id,
+                        Vec::new(),
+                        vec![item],
+                        Vec::new(),
+                        affected_locations,
+                    ));
+                }
                 Err(error) => emit(OperationEvent::Failed {
                     request_id: request.id,
                     message: error.to_string(),
                 }),
             }
         });
-        LoadHandle::new(move || task.abort())
+        cancellation_handle(cancellable)
     }
 
     fn create_directory(
@@ -346,7 +632,9 @@ impl OperationProvider for LocalOperationProvider {
         request: CreateDirectoryRequest,
         emit: Rc<dyn Fn(OperationEvent)>,
     ) -> LoadHandle {
-        let task = glib::MainContext::default().spawn_local(async move {
+        let cancellable = gio::Cancellable::new();
+        let operation_cancellable = cancellable.clone();
+        let _task = glib::MainContext::default().spawn_local(async move {
             let parent = gio_file(&request.parent);
             let folder = match validated_child(&parent, &request.name) {
                 Ok(folder) => folder,
@@ -358,17 +646,50 @@ impl OperationProvider for LocalOperationProvider {
                     return;
                 }
             };
-            match folder.make_directory_future(glib::Priority::DEFAULT).await {
+            let item = location_for_file(&folder);
+            let affected_locations = HashSet::from([request.parent.clone()]);
+            if operation_cancellable.is_cancelled() {
+                emit(cancelled_event(
+                    request.id,
+                    Vec::new(),
+                    Vec::new(),
+                    vec![item],
+                    affected_locations,
+                ));
+                return;
+            }
+            match await_cancellable(
+                &folder,
+                &operation_cancellable,
+                |folder, cancellable, result| {
+                    folder.make_directory_async(
+                        glib::Priority::DEFAULT,
+                        Some(cancellable),
+                        move |output| result.resolve(output),
+                    );
+                },
+            )
+            .await
+            {
                 Ok(()) => emit(OperationEvent::Created {
                     request_id: request.id,
                 }),
+                Err(error) if was_cancelled(&error) => {
+                    emit(cancelled_event(
+                        request.id,
+                        Vec::new(),
+                        vec![item],
+                        Vec::new(),
+                        affected_locations,
+                    ));
+                }
                 Err(error) => emit(OperationEvent::Failed {
                     request_id: request.id,
                     message: error.to_string(),
                 }),
             }
         });
-        LoadHandle::new(move || task.abort())
+        cancellation_handle(cancellable)
     }
 
     fn create_file(
@@ -376,7 +697,9 @@ impl OperationProvider for LocalOperationProvider {
         request: CreateFileRequest,
         emit: Rc<dyn Fn(OperationEvent)>,
     ) -> LoadHandle {
-        let task = glib::MainContext::default().spawn_local(async move {
+        let cancellable = gio::Cancellable::new();
+        let operation_cancellable = cancellable.clone();
+        let _task = glib::MainContext::default().spawn_local(async move {
             let parent = gio_file(&request.parent);
             let file = match validated_child(&parent, &request.name) {
                 Ok(file) => file,
@@ -388,26 +711,78 @@ impl OperationProvider for LocalOperationProvider {
                     return;
                 }
             };
-            match file
-                .create_future(gio::FileCreateFlags::NONE, glib::Priority::DEFAULT)
-                .await
+            let item = location_for_file(&file);
+            let affected_locations = HashSet::from([request.parent.clone()]);
+            if operation_cancellable.is_cancelled() {
+                emit(cancelled_event(
+                    request.id,
+                    Vec::new(),
+                    Vec::new(),
+                    vec![item],
+                    affected_locations,
+                ));
+                return;
+            }
+            match await_cancellable(
+                &file,
+                &operation_cancellable,
+                |file, cancellable, result| {
+                    file.create_async(
+                        gio::FileCreateFlags::NONE,
+                        glib::Priority::DEFAULT,
+                        Some(cancellable),
+                        move |output| result.resolve(output),
+                    );
+                },
+            )
+            .await
             {
                 Ok(_) => emit(OperationEvent::Created {
                     request_id: request.id,
                 }),
+                Err(error) if was_cancelled(&error) => {
+                    emit(cancelled_event(
+                        request.id,
+                        Vec::new(),
+                        vec![item],
+                        Vec::new(),
+                        affected_locations,
+                    ));
+                }
                 Err(error) => emit(OperationEvent::Failed {
                     request_id: request.id,
                     message: error.to_string(),
                 }),
             }
         });
-        LoadHandle::new(move || task.abort())
+        cancellation_handle(cancellable)
     }
 
     fn paste(&self, request: PasteRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle {
-        let task = glib::MainContext::default().spawn_local(async move {
+        let cancellable = gio::Cancellable::new();
+        let operation_cancellable = cancellable.clone();
+        let _task = glib::MainContext::default().spawn_local(async move {
             let destination = gio_file(&request.destination);
-            for item in &request.items {
+            let mut affected_locations = HashSet::from([request.destination.clone()]);
+            for parent in request.items.iter().filter_map(|item| item.source.parent()) {
+                affected_locations.insert(parent);
+            }
+            let total = request.items.len();
+            let mut completed = Vec::new();
+            for (index, item) in request.items.iter().enumerate() {
+                if operation_cancellable.is_cancelled() {
+                    emit(cancelled_event(
+                        request.id,
+                        completed,
+                        Vec::new(),
+                        request.items[index..]
+                            .iter()
+                            .map(|item| item.source.clone())
+                            .collect(),
+                        affected_locations,
+                    ));
+                    return;
+                }
                 let source = gio_file(&item.source);
                 let Some(name) = source.basename() else {
                     emit(OperationEvent::Failed {
@@ -418,40 +793,116 @@ impl OperationProvider for LocalOperationProvider {
                 };
                 let target = destination.child(name);
                 if transfer_is_noop(&source, &destination, &target) {
+                    completed.push(item.source.clone());
+                    emit(OperationEvent::TransferProgress {
+                        request_id: request.id,
+                        completed: completed.len(),
+                        total,
+                    });
                     continue;
                 }
+                affected_locations.insert(item.source.clone());
+                affected_locations.insert(location_for_file(&target));
                 let result = if item.conflict == TransferConflict::ReplaceExisting {
-                    replace_local(source, target, request.move_sources).await
+                    replace_local(
+                        source,
+                        target,
+                        request.move_sources,
+                        operation_cancellable.clone(),
+                        Some(&mut affected_locations),
+                    )
+                    .await
                 } else if request.move_sources {
                     let flags =
                         gio::FileCopyFlags::ALL_METADATA | gio::FileCopyFlags::NOFOLLOW_SYMLINKS;
-                    let (transfer, _progress) =
-                        source.move_future(&target, flags, glib::Priority::DEFAULT);
-                    transfer.await
+                    await_cancellable(
+                        &source,
+                        &operation_cancellable,
+                        move |source, cancellable, result| {
+                            source.move_async(
+                                &target,
+                                flags,
+                                glib::Priority::DEFAULT,
+                                Some(cancellable),
+                                None,
+                                move |output| result.resolve(output),
+                            );
+                        },
+                    )
+                    .await
                 } else {
-                    copy_recursively(source, target, false).await
+                    copy_new_recursively(source, target, operation_cancellable.clone()).await
                 };
                 if let Err(error) = result {
-                    emit(OperationEvent::Failed {
+                    if was_cancelled(&error) {
+                        emit(cancelled_event(
+                            request.id,
+                            completed,
+                            vec![item.source.clone()],
+                            request.items[index + 1..]
+                                .iter()
+                                .map(|item| item.source.clone())
+                                .collect(),
+                            affected_locations,
+                        ));
+                        return;
+                    }
+                    emit(OperationEvent::TransferFailed {
                         request_id: request.id,
+                        completed_locations: completed,
                         message: error.to_string(),
                     });
                     return;
                 }
+                completed.push(item.source.clone());
+                emit(OperationEvent::TransferProgress {
+                    request_id: request.id,
+                    completed: completed.len(),
+                    total,
+                });
             }
             emit(OperationEvent::Pasted {
                 request_id: request.id,
+                locations: completed,
             });
         });
-        LoadHandle::new(move || task.abort())
+        cancellation_handle(cancellable)
     }
 
     fn delete(&self, request: DeleteRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle {
-        let task = glib::MainContext::default().spawn_local(async move {
+        let cancellable = gio::Cancellable::new();
+        let operation_cancellable = cancellable.clone();
+        let _task = glib::MainContext::default().spawn_local(async move {
             let mut errors = Vec::new();
             let mut deleted_locations = Vec::new();
+            let mut failed_locations = Vec::new();
+            let mut affected_locations = HashSet::new();
+            for entry in &request.entries {
+                if let Some(parent) = entry.location.parent() {
+                    affected_locations.insert(parent);
+                }
+                if entry.is_directory() {
+                    affected_locations.insert(entry.location.clone());
+                }
+            }
+            if !request.permanent {
+                affected_locations.insert(Location::uri("trash:///"));
+            }
             let total = request.entries.len();
             for (index, entry) in request.entries.iter().enumerate() {
+                if operation_cancellable.is_cancelled() {
+                    emit(cancelled_event(
+                        request.id,
+                        deleted_locations,
+                        failed_locations,
+                        request.entries[index..]
+                            .iter()
+                            .map(|entry| entry.location.clone())
+                            .collect(),
+                        affected_locations,
+                    ));
+                    return;
+                }
                 let file = gio_file(&entry.location);
                 let result = if request.permanent {
                     if entry
@@ -459,19 +910,61 @@ impl OperationProvider for LocalOperationProvider {
                         .uri_value()
                         .is_some_and(|uri| uri.starts_with("trash:"))
                     {
-                        file.delete_future(glib::Priority::DEFAULT).await
+                        await_cancellable(
+                            &file,
+                            &operation_cancellable,
+                            |file, cancellable, result| {
+                                file.delete_async(
+                                    glib::Priority::DEFAULT,
+                                    Some(cancellable),
+                                    move |output| result.resolve(output),
+                                );
+                            },
+                        )
+                        .await
                     } else {
-                        permanently_delete(file, entry.is_directory()).await
+                        permanently_delete(
+                            file,
+                            entry.is_directory(),
+                            operation_cancellable.clone(),
+                        )
+                        .await
                     }
                 } else {
-                    file.trash_future(glib::Priority::DEFAULT).await
+                    await_cancellable(
+                        &file,
+                        &operation_cancellable,
+                        |file, cancellable, result| {
+                            file.trash_async(
+                                glib::Priority::DEFAULT,
+                                Some(cancellable),
+                                move |output| result.resolve(output),
+                            );
+                        },
+                    )
+                    .await
                 };
                 let deleted_location = if let Err(error) = result {
+                    if was_cancelled(&error) {
+                        failed_locations.push(entry.location.clone());
+                        emit(cancelled_event(
+                            request.id,
+                            deleted_locations,
+                            failed_locations,
+                            request.entries[index + 1..]
+                                .iter()
+                                .map(|entry| entry.location.clone())
+                                .collect(),
+                            affected_locations,
+                        ));
+                        return;
+                    }
                     errors.push(deletion_error_message(
                         &entry.display_name,
                         request.permanent,
                         &error,
                     ));
+                    failed_locations.push(entry.location.clone());
                     None
                 } else {
                     deleted_locations.push(entry.location.clone());
@@ -497,35 +990,71 @@ impl OperationProvider for LocalOperationProvider {
                 });
             }
         });
-        LoadHandle::new(move || task.abort())
+        cancellation_handle(cancellable)
     }
 
     fn restore(&self, request: RestoreRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle {
-        let task = glib::MainContext::default().spawn_local(async move {
+        let cancellable = gio::Cancellable::new();
+        let operation_cancellable = cancellable.clone();
+        let _task = glib::MainContext::default().spawn_local(async move {
             let total = request.entries.len();
             let mut errors = Vec::new();
             let mut restored_locations = Vec::new();
+            let mut failed_locations = Vec::new();
+            let mut affected_locations = HashSet::from([Location::uri("trash:///")]);
             for (index, entry) in request.entries.iter().enumerate() {
+                if operation_cancellable.is_cancelled() {
+                    emit(cancelled_event(
+                        request.id,
+                        restored_locations,
+                        failed_locations,
+                        request.entries[index..]
+                            .iter()
+                            .map(|entry| entry.location.clone())
+                            .collect(),
+                        affected_locations,
+                    ));
+                    return;
+                }
                 let source = gio_file(&entry.location);
-                let result = match source
-                    .query_info_future(
-                        "trash::orig-path",
-                        gio::FileQueryInfoFlags::NONE,
-                        glib::Priority::DEFAULT,
-                    )
-                    .await
+                let result = match await_cancellable(
+                    &source,
+                    &operation_cancellable,
+                    |source, cancellable, result| {
+                        source.query_info_async(
+                            "trash::orig-path",
+                            gio::FileQueryInfoFlags::NONE,
+                            glib::Priority::DEFAULT,
+                            Some(cancellable),
+                            move |output| result.resolve(output),
+                        );
+                    },
+                )
+                .await
                 {
                     Ok(info) => match info.attribute_byte_string("trash::orig-path") {
                         Some(original_path) => {
                             let target =
                                 gio::File::for_path(std::path::Path::new(original_path.as_str()));
-                            let (restore, _progress) = source.move_future(
-                                &target,
-                                gio::FileCopyFlags::ALL_METADATA
-                                    | gio::FileCopyFlags::NOFOLLOW_SYMLINKS,
-                                glib::Priority::DEFAULT,
-                            );
-                            restore.await
+                            if let Some(parent) = location_for_file(&target).parent() {
+                                affected_locations.insert(parent);
+                            }
+                            await_cancellable(
+                                &source,
+                                &operation_cancellable,
+                                move |source, cancellable, result| {
+                                    source.move_async(
+                                        &target,
+                                        gio::FileCopyFlags::ALL_METADATA
+                                            | gio::FileCopyFlags::NOFOLLOW_SYMLINKS,
+                                        glib::Priority::DEFAULT,
+                                        Some(cancellable),
+                                        None,
+                                        move |output| result.resolve(output),
+                                    );
+                                },
+                            )
+                            .await
                         }
                         None => Err(glib::Error::new(
                             gio::IOErrorEnum::NotFound,
@@ -535,7 +1064,22 @@ impl OperationProvider for LocalOperationProvider {
                     Err(error) => Err(error),
                 };
                 let restored_location = if let Err(error) = result {
+                    if was_cancelled(&error) {
+                        failed_locations.push(entry.location.clone());
+                        emit(cancelled_event(
+                            request.id,
+                            restored_locations,
+                            failed_locations,
+                            request.entries[index + 1..]
+                                .iter()
+                                .map(|entry| entry.location.clone())
+                                .collect(),
+                            affected_locations,
+                        ));
+                        return;
+                    }
                     errors.push(format!("{}: {error}", entry.display_name));
+                    failed_locations.push(entry.location.clone());
                     None
                 } else {
                     restored_locations.push(entry.location.clone());
@@ -561,7 +1105,7 @@ impl OperationProvider for LocalOperationProvider {
                 });
             }
         });
-        LoadHandle::new(move || task.abort())
+        cancellation_handle(cancellable)
     }
 
     fn compress(&self, request: CompressRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle {

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -2,13 +2,14 @@
 
 use std::{
     cell::{Cell, RefCell},
+    collections::HashSet,
     error::Error,
     fs,
     io::{Cursor, Write},
     path::Path,
     rc::Rc,
     sync::{Arc, Mutex, atomic::AtomicUsize},
-    time::SystemTime,
+    time::{Duration, SystemTime},
 };
 
 use gtk::{gio, glib, prelude::*};
@@ -16,17 +17,47 @@ use gtk::{gio, glib, prelude::*};
 static ASYNC_FILE_TEST: Mutex<()> = Mutex::new(());
 
 use super::{
-    LocalOperationProvider, copy_recursively, deletion_error_message, deletion_error_summary,
-    extract_7z_from_reader, extract_tar, extract_zip_from_archive, operation_error_summary,
-    replace_local, replace_local_with, transfer_is_noop, validated_archive_path, validated_child,
+    LocalOperationProvider, await_cancellable, copy_new_recursively, copy_recursively,
+    deletion_error_message, deletion_error_summary, extract_7z_from_reader, extract_tar,
+    extract_zip_from_archive, operation_error_summary, replace_local, replace_local_with,
+    transfer_is_noop, validated_archive_path, validated_child,
 };
 use crate::{
-    model::Location,
+    model::{EntryKind, FileEntry, Location, MetadataValue},
     services::{
-        OperationEvent, OperationProvider, OperationRequestId, PasteItem, PasteRequest,
-        TransferConflict,
+        DeleteRequest, LoadHandle, OperationEvent, OperationProvider, OperationRequestId,
+        PasteItem, PasteRequest, RestoreRequest, TransferConflict,
     },
 };
+
+fn file_entry(path: &std::path::Path) -> FileEntry {
+    FileEntry {
+        location: Location::local(path),
+        native_name: path.file_name().unwrap_or_default().to_owned(),
+        display_name: path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned(),
+        kind: EntryKind::File,
+        size: MetadataValue::Unknown,
+        modified_unix_seconds: MetadataValue::Unknown,
+    }
+}
+
+fn directory_entry(path: &std::path::Path) -> FileEntry {
+    FileEntry {
+        kind: EntryKind::Directory,
+        ..file_entry(path)
+    }
+}
+
+fn settle_cancelled_io(context: &glib::MainContext) {
+    context.block_on(glib::timeout_future(Duration::from_millis(25)));
+    while context.pending() {
+        context.iteration(false);
+    }
+}
 
 #[test]
 fn deletion_error_summaries_are_bounded_and_report_the_failure_count() {
@@ -105,6 +136,25 @@ fn transfers_into_the_same_location_or_a_descendant_are_noops() {
 }
 
 #[test]
+fn completed_gio_result_wins_a_cancellation_race() {
+    let context = glib::MainContext::new();
+    let cancellable = gio::Cancellable::new();
+    let cancel_after_result = cancellable.clone();
+    let file = gio::File::for_path("/fixture");
+
+    let result = context.block_on(await_cancellable(
+        &file,
+        &cancellable,
+        move |_, _, result| {
+            result.resolve(Ok::<_, glib::Error>(()));
+            cancel_after_result.cancel();
+        },
+    ));
+
+    assert!(result.is_ok());
+}
+
+#[test]
 fn recursive_copy_preserves_nested_directory_contents() -> Result<(), Box<dyn Error>> {
     let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
     let unique = SystemTime::now()
@@ -121,6 +171,8 @@ fn recursive_copy_preserves_nested_directory_contents() -> Result<(), Box<dyn Er
         gio::File::for_path(&source),
         gio::File::for_path(&target),
         false,
+        gio::Cancellable::new(),
+        None,
     ));
 
     assert!(result.is_ok());
@@ -132,6 +184,8 @@ fn recursive_copy_preserves_nested_directory_contents() -> Result<(), Box<dyn Er
         gio::File::for_path(&source),
         gio::File::for_path(&target),
         true,
+        gio::Cancellable::new(),
+        None,
     ));
     assert!(overwrite.is_ok());
     assert_eq!(fs::read(target.join("top.txt"))?, b"replacement");
@@ -157,7 +211,9 @@ fn staged_file_replacement_preserves_the_destination_on_disk_full() -> Result<()
         gio::File::for_path(source),
         gio::File::for_path(&target),
         false,
-        Rc::new(|_, staged, _| {
+        gio::Cancellable::new(),
+        None,
+        Rc::new(|_, staged, _, _| {
             Box::pin(async move {
                 fs::write(
                     staged
@@ -196,12 +252,15 @@ fn cancelling_staging_preserves_the_destination_and_cleans_the_partial_copy()
     fs::write(&target, b"original")?;
     let staging = Rc::new(Cell::new(false));
     let staging_for_copy = staging.clone();
+    let cancellable = gio::Cancellable::new();
 
     let task = glib::MainContext::default().spawn_local(replace_local_with(
         gio::File::for_path(&source),
         gio::File::for_path(&target),
         false,
-        Rc::new(move |_, staged, _| {
+        cancellable.clone(),
+        None,
+        Rc::new(move |_, staged, _, cancellable| {
             let staging = staging_for_copy.clone();
             Box::pin(async move {
                 fs::write(
@@ -212,7 +271,11 @@ fn cancelling_staging_preserves_the_destination_and_cleans_the_partial_copy()
                 )
                 .map_err(super::io_error)?;
                 staging.set(true);
-                std::future::pending().await
+                cancellable.future().await;
+                Err(glib::Error::new(
+                    gio::IOErrorEnum::Cancelled,
+                    "injected cancellation",
+                ))
             })
         }),
     ));
@@ -220,12 +283,11 @@ fn cancelling_staging_preserves_the_destination_and_cleans_the_partial_copy()
     while !staging.get() {
         context.iteration(true);
     }
-    task.abort();
-    drop(task);
-    while context.pending() {
-        context.iteration(false);
-    }
+    cancellable.cancel();
+    let result = context.block_on(task)?;
+    settle_cancelled_io(&context);
 
+    assert!(result.is_err_and(|error| error.matches(gio::IOErrorEnum::Cancelled)));
     assert_eq!(fs::read(&target)?, b"original");
     assert_eq!(fs::read(&source)?, b"replacement");
     assert_eq!(fs::read_dir(&root)?.count(), 2);
@@ -250,12 +312,62 @@ fn staged_file_replacement_commits_then_removes_a_moved_source() -> Result<(), B
         gio::File::for_path(&source),
         gio::File::for_path(&target),
         true,
+        gio::Cancellable::new(),
+        None,
     ));
 
     assert!(result.is_ok(), "{result:?}");
     assert_eq!(fs::read(&target)?, b"replacement");
     assert!(!source.exists());
     assert_eq!(fs::read_dir(&root)?.count(), 1);
+    fs::remove_dir_all(root)?;
+    Ok(())
+}
+
+#[test]
+fn cancelled_replacement_move_tracks_the_modified_source_and_target_roots()
+-> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("strata-replacement-move-cancel-test-{unique}"));
+    let source = root.join("source");
+    let target = root.join("target");
+    fs::create_dir_all(source.join("new"))?;
+    fs::create_dir_all(target.join("old"))?;
+    fs::write(source.join("new/item.txt"), b"replacement")?;
+    for index in 0..16 {
+        fs::write(target.join(format!("old/item-{index}.txt")), b"old")?;
+    }
+
+    let cancellable = gio::Cancellable::new();
+    let cancel_after_commit = cancellable.clone();
+    let committed_marker = target.join("new/item.txt");
+    let context = glib::MainContext::default();
+    let watcher = context.spawn_local(async move {
+        while !committed_marker.exists() {
+            glib::timeout_future(Duration::from_millis(1)).await;
+        }
+        cancel_after_commit.cancel();
+    });
+    let mut affected_locations = HashSet::new();
+    let result = context.block_on(replace_local(
+        gio::File::for_path(&source),
+        gio::File::for_path(&target),
+        true,
+        cancellable,
+        Some(&mut affected_locations),
+    ));
+    context.block_on(watcher)?;
+    settle_cancelled_io(&context);
+
+    assert!(result.is_err_and(|error| error.matches(gio::IOErrorEnum::Cancelled)));
+    assert!(affected_locations.contains(&Location::local(&source)));
+    assert!(affected_locations.contains(&Location::local(&target)));
+    assert_eq!(fs::read(target.join("new/item.txt"))?, b"replacement");
+    assert!(source.exists());
+
     fs::remove_dir_all(root)?;
     Ok(())
 }
@@ -292,23 +404,36 @@ fn each_transfer_item_keeps_its_own_conflict_decision() -> Result<(), Box<dyn Er
                     conflict: TransferConflict::FailIfExists,
                 },
             ],
-            move_sources: false,
+            move_sources: true,
         },
         Rc::new(move |event| emitted.borrow_mut().push(event)),
     );
-    while events.borrow().is_empty() {
+    while !events.borrow().iter().any(|event| {
+        matches!(
+            event,
+            OperationEvent::Pasted { .. }
+                | OperationEvent::Cancelled { .. }
+                | OperationEvent::TransferFailed { .. }
+                | OperationEvent::Failed { .. }
+        )
+    }) {
         glib::MainContext::default().iteration(true);
     }
 
     assert!(matches!(
-        events.borrow().as_slice(),
-        [OperationEvent::Failed { .. }]
+        events.borrow().last(),
+        Some(OperationEvent::TransferFailed {
+            completed_locations,
+            ..
+        }) if completed_locations == &[Location::local(sources.join("replace.txt"))]
     ));
     assert_eq!(
         fs::read(destination.join("replace.txt"))?,
         b"new replacement"
     );
     assert_eq!(fs::read(destination.join("late.txt"))?, b"late arrival");
+    assert!(!sources.join("replace.txt").exists());
+    assert!(sources.join("late.txt").exists());
     fs::remove_dir_all(root)?;
     Ok(())
 }
@@ -331,6 +456,8 @@ fn staged_directory_replacement_does_not_merge_old_contents() -> Result<(), Box<
         gio::File::for_path(&source),
         gio::File::for_path(&target),
         false,
+        gio::Cancellable::new(),
+        None,
     ));
 
     assert!(result.is_ok(), "{result:?}");
@@ -429,6 +556,65 @@ fn archive_paths_must_be_nonempty_confined_relative_paths() -> Result<(), Box<dy
 }
 
 #[test]
+fn cancelling_between_deletions_reports_completed_and_unattempted_items()
+-> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("strata-delete-cancel-test-{unique}"));
+    let first = root.join("first.txt");
+    let second = root.join("second.txt");
+    fs::create_dir_all(&root)?;
+    fs::write(&first, b"first")?;
+    fs::write(&second, b"second")?;
+
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let operation = Rc::new(RefCell::new(None::<LoadHandle>));
+    let emitted = events.clone();
+    let operation_for_emit = operation.clone();
+    let handle = LocalOperationProvider.delete(
+        DeleteRequest {
+            id: OperationRequestId(7),
+            entries: vec![file_entry(&first), file_entry(&second)],
+            permanent: true,
+        },
+        Rc::new(move |event| {
+            let cancel = matches!(event, OperationEvent::DeleteProgress { completed: 1, .. });
+            emitted.borrow_mut().push(event);
+            if cancel {
+                operation_for_emit.borrow_mut().take();
+            }
+        }),
+    );
+    operation.replace(Some(handle));
+    while !events
+        .borrow()
+        .iter()
+        .any(|event| matches!(event, OperationEvent::Cancelled { .. }))
+    {
+        glib::MainContext::default().iteration(true);
+    }
+
+    let result = events
+        .borrow()
+        .iter()
+        .find_map(|event| match event {
+            OperationEvent::Cancelled { result, .. } => Some(result.clone()),
+            _ => None,
+        })
+        .expect("terminal cancellation result");
+    assert_eq!(result.completed, [Location::local(&first)]);
+    assert!(result.failed.is_empty());
+    assert_eq!(result.not_attempted, [Location::local(&second)]);
+    assert!(!first.exists());
+    assert!(second.exists());
+
+    fs::remove_dir_all(root)?;
+    Ok(())
+}
+
+#[test]
 fn every_archive_format_rejects_parent_traversal() -> Result<(), Box<dyn Error>> {
     let root = tempfile::tempdir()?;
     let destination = root.path().join("destination");
@@ -479,6 +665,176 @@ fn every_archive_format_rejects_parent_traversal() -> Result<(), Box<dyn Error>>
     ] {
         assert!(!root.path().join(marker).exists(), "created {marker}");
     }
+    Ok(())
+}
+
+#[test]
+fn cancelling_recursive_copy_removes_only_its_staging_output() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("strata-copy-cancel-test-{unique}"));
+    let source = root.join("source");
+    let target = root.join("target");
+    fs::create_dir_all(source.join("nested"))?;
+    fs::write(source.join("nested/item.txt"), b"contents")?;
+    fs::write(root.join("pre-existing.txt"), b"keep")?;
+
+    let cancellable = gio::Cancellable::new();
+    let task = glib::MainContext::default().spawn_local(copy_new_recursively(
+        gio::File::for_path(&source),
+        gio::File::for_path(&target),
+        cancellable.clone(),
+    ));
+    let context = glib::MainContext::default();
+    loop {
+        context.iteration(true);
+        if fs::read_dir(&root)?.any(|entry| {
+            entry.is_ok_and(|entry| entry.file_name().to_string_lossy().starts_with(".strata-"))
+        }) {
+            break;
+        }
+    }
+    cancellable.cancel();
+    let result = context.block_on(task)?;
+    settle_cancelled_io(&context);
+
+    assert!(result.is_err_and(|error| error.matches(gio::IOErrorEnum::Cancelled)));
+    assert!(!target.exists());
+    assert_eq!(fs::read(root.join("pre-existing.txt"))?, b"keep");
+    assert_eq!(fs::read_dir(&root)?.count(), 2);
+    fs::remove_dir_all(root)?;
+    Ok(())
+}
+
+#[test]
+fn cancelling_recursive_delete_leaves_the_unfinished_root_in_place() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("strata-recursive-delete-cancel-test-{unique}"));
+    let nested = root.join("nested");
+    fs::create_dir_all(&nested)?;
+    for index in 0..4 {
+        fs::write(nested.join(format!("item-{index}.txt")), b"contents")?;
+    }
+
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let emitted = events.clone();
+    let operation = LocalOperationProvider.delete(
+        DeleteRequest {
+            id: OperationRequestId(10),
+            entries: vec![directory_entry(&root)],
+            permanent: true,
+        },
+        Rc::new(move |event| emitted.borrow_mut().push(event)),
+    );
+    let context = glib::MainContext::default();
+    while fs::read_dir(&nested)?.count() == 4 {
+        context.iteration(true);
+    }
+    drop(operation);
+    while !events
+        .borrow()
+        .iter()
+        .any(|event| matches!(event, OperationEvent::Cancelled { .. }))
+    {
+        context.iteration(true);
+    }
+    settle_cancelled_io(&context);
+
+    let result = events
+        .borrow()
+        .iter()
+        .find_map(|event| match event {
+            OperationEvent::Cancelled { result, .. } => Some(result.clone()),
+            _ => None,
+        })
+        .expect("terminal cancellation result");
+    assert!(result.failed == [Location::local(&root)]);
+    assert!(result.affected_locations.contains(&Location::local(&root)));
+    assert!(
+        !result
+            .affected_locations
+            .contains(&Location::local(&nested))
+    );
+    assert!(root.exists());
+    fs::remove_dir_all(root)?;
+    Ok(())
+}
+
+#[test]
+fn cancelling_between_moves_reports_completed_and_unattempted_sources() -> Result<(), Box<dyn Error>>
+{
+    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("strata-move-cancel-test-{unique}"));
+    let sources = root.join("sources");
+    let destination = root.join("destination");
+    let first = sources.join("first.txt");
+    let second = sources.join("second.txt");
+    fs::create_dir_all(&sources)?;
+    fs::create_dir_all(&destination)?;
+    fs::write(&first, b"first")?;
+    fs::write(&second, b"second")?;
+
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let operation = Rc::new(RefCell::new(None::<LoadHandle>));
+    let emitted = events.clone();
+    let operation_for_emit = operation.clone();
+    let handle = LocalOperationProvider.paste(
+        PasteRequest {
+            id: OperationRequestId(8),
+            destination: Location::local(&destination),
+            items: vec![
+                PasteItem {
+                    source: Location::local(&first),
+                    conflict: TransferConflict::FailIfExists,
+                },
+                PasteItem {
+                    source: Location::local(&second),
+                    conflict: TransferConflict::FailIfExists,
+                },
+            ],
+            move_sources: true,
+        },
+        Rc::new(move |event| {
+            let cancel = matches!(event, OperationEvent::TransferProgress { completed: 1, .. });
+            emitted.borrow_mut().push(event);
+            if cancel {
+                operation_for_emit.borrow_mut().take();
+            }
+        }),
+    );
+    operation.replace(Some(handle));
+    while !events
+        .borrow()
+        .iter()
+        .any(|event| matches!(event, OperationEvent::Cancelled { .. }))
+    {
+        glib::MainContext::default().iteration(true);
+    }
+
+    let result = events
+        .borrow()
+        .iter()
+        .find_map(|event| match event {
+            OperationEvent::Cancelled { result, .. } => Some(result.clone()),
+            _ => None,
+        })
+        .expect("terminal cancellation result");
+    assert_eq!(result.completed, [Location::local(&first)]);
+    assert!(result.failed.is_empty());
+    assert_eq!(result.not_attempted, [Location::local(&second)]);
+    assert!(destination.join("first.txt").exists());
+    assert!(!first.exists());
+    assert!(second.exists());
+
+    fs::remove_dir_all(root)?;
     Ok(())
 }
 
@@ -536,5 +892,34 @@ fn extraction_supports_nesting_and_regular_conflicts() -> Result<(), Box<dyn Err
     );
     assert_eq!(fs::read(destination.join("existing/old.txt"))?, b"old");
     assert_eq!(fs::read(destination.join("existing (2)/new.txt"))?, b"new");
+    Ok(())
+}
+
+#[test]
+fn cancelling_restore_before_io_reports_every_item_as_unattempted() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let emitted = events.clone();
+    let entries = vec![file_entry(std::path::Path::new("/fixture/trashed.txt"))];
+    let operation = LocalOperationProvider.restore(
+        RestoreRequest {
+            id: OperationRequestId(9),
+            entries: entries.clone(),
+        },
+        Rc::new(move |event| emitted.borrow_mut().push(event)),
+    );
+
+    drop(operation);
+    while events.borrow().is_empty() {
+        glib::MainContext::default().iteration(true);
+    }
+
+    assert!(matches!(
+        events.borrow().as_slice(),
+        [OperationEvent::Cancelled { result, .. }]
+            if result.completed.is_empty()
+                && result.failed.is_empty()
+                && result.not_attempted == [entries[0].location.clone()]
+    ));
     Ok(())
 }

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -160,6 +160,8 @@ pub enum BrowserEvent {
 type Observer = Rc<dyn Fn(BrowserEvent)>;
 type PreferencesObserver = Rc<dyn Fn(ViewPreferences)>;
 
+const MAX_INCREMENTAL_OPERATION_UPDATES: usize = 64;
+
 pub struct Browser {
     source: Rc<dyn FileSource>,
     state: RefCell<NavigationState>,
@@ -1060,7 +1062,9 @@ impl Browser {
                 ..
             } = &event
             {
-                if let Some(location) = deleted_location {
+                if *total <= MAX_INCREMENTAL_OPERATION_UPDATES
+                    && let Some(location) = deleted_location
+                {
                     browser.remove_deleted_locations(std::slice::from_ref(location));
                 }
                 browser.emit(BrowserEvent::DeletionProgress {
@@ -1086,7 +1090,9 @@ impl Browser {
                 ..
             } = &event
             {
-                if let Some(location) = restored_location {
+                if *total <= MAX_INCREMENTAL_OPERATION_UPDATES
+                    && let Some(location) = restored_location
+                {
                     browser.remove_deleted_locations(std::slice::from_ref(location));
                 }
                 browser.emit(BrowserEvent::RestorationProgress {
@@ -1170,9 +1176,6 @@ impl Browser {
                     browser.emit(BrowserEvent::OperationCompletedWithErrors { message });
                 }
                 OperationEvent::Cancelled { result, .. } => {
-                    if deleting || restoring {
-                        browser.remove_deleted_locations(&result.completed);
-                    }
                     let mut affected_locations = refresh_locations.clone();
                     affected_locations.extend(result.affected_locations);
                     browser.refresh_columns_at_or_below(&affected_locations);
@@ -1454,6 +1457,16 @@ impl Browser {
     }
 
     fn remove_deleted_locations(self: &Rc<Self>, locations: &[Location]) {
+        if locations.len() > MAX_INCREMENTAL_OPERATION_UPDATES {
+            let parents: HashSet<_> = locations
+                .iter()
+                .filter_map(deletion_parent_location)
+                .collect();
+            for parent in parents {
+                self.refresh_columns_at(&parent);
+            }
+            return;
+        }
         for location in locations {
             let Some(parent) = deletion_parent_location(location) else {
                 continue;

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -135,6 +135,7 @@ pub enum BrowserEvent {
         completed: usize,
         failed: usize,
         not_attempted: usize,
+        affected_locations: HashSet<Location>,
     },
     NavigationRejected {
         parent_depth: usize,
@@ -1178,11 +1179,11 @@ impl Browser {
                 OperationEvent::Cancelled { result, .. } => {
                     let mut affected_locations = refresh_locations.clone();
                     affected_locations.extend(result.affected_locations);
-                    browser.refresh_columns_at_or_below(&affected_locations);
                     browser.emit(BrowserEvent::OperationCancelled {
                         completed: result.completed.len(),
                         failed: result.failed.len(),
                         not_attempted: result.not_attempted.len(),
+                        affected_locations,
                     });
                 }
                 OperationEvent::Renamed { .. } => {
@@ -1436,6 +1437,10 @@ impl Browser {
         for depth in depths {
             self.refresh_column(depth);
         }
+    }
+
+    pub(crate) fn refresh_after_cancellation(self: &Rc<Self>, roots: &HashSet<Location>) {
+        self.refresh_columns_at_or_below(roots);
     }
 
     fn refresh_columns_at_or_below(self: &Rc<Self>, roots: &HashSet<Location>) {

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -2,6 +2,7 @@
 
 use std::{
     cell::{Cell, RefCell},
+    collections::HashSet,
     path::PathBuf,
     rc::{Rc, Weak},
     time::Duration,
@@ -97,6 +98,17 @@ pub enum BrowserEvent {
     RenameFailed {
         message: String,
     },
+    TransferStarted {
+        total: usize,
+        moving: bool,
+    },
+    TransferProgress {
+        completed: usize,
+        total: usize,
+    },
+    TransferFinished {
+        moved_locations: Vec<Location>,
+    },
     DeletionStarted {
         total: usize,
     },
@@ -118,6 +130,11 @@ pub enum BrowserEvent {
     },
     OperationCompletedWithErrors {
         message: String,
+    },
+    OperationCancelled {
+        completed: usize,
+        failed: usize,
+        not_attempted: usize,
     },
     NavigationRejected {
         parent_depth: usize,
@@ -154,6 +171,7 @@ pub struct Browser {
     operation_provider: RefCell<Option<Rc<dyn OperationProvider>>>,
     operation_load: RefCell<Option<LoadHandle>>,
     current_operation: Cell<Option<OperationRequestId>>,
+    transfer_operation: Cell<Option<bool>>,
     deletion_operation: Cell<bool>,
     restoration_operation: Cell<bool>,
     next_request: Cell<u64>,
@@ -181,6 +199,7 @@ impl Browser {
             operation_provider: RefCell::new(None),
             operation_load: RefCell::new(None),
             current_operation: Cell::new(None),
+            transfer_operation: Cell::new(None),
             deletion_operation: Cell::new(false),
             restoration_operation: Cell::new(false),
             next_request: Cell::new(1),
@@ -792,7 +811,7 @@ impl Browser {
                 parent,
                 name,
             },
-            self.operation_callback(request_id, false, vec![refresh_parent]),
+            self.operation_callback(request_id, false, HashSet::from([refresh_parent])),
         );
         self.operation_load.replace(Some(load));
     }
@@ -818,7 +837,7 @@ impl Browser {
                 parent,
                 name,
             },
-            self.operation_callback(request_id, false, vec![refresh_parent]),
+            self.operation_callback(request_id, false, HashSet::from([refresh_parent])),
         );
         self.operation_load.replace(Some(load));
     }
@@ -839,12 +858,15 @@ impl Browser {
             return;
         };
         let request_id = self.begin_operation();
-        let mut refresh_locations = vec![destination.clone()];
+        self.transfer_operation.set(Some(move_sources));
+        self.emit(BrowserEvent::TransferStarted {
+            total: items.len(),
+            moving: move_sources,
+        });
+        let mut refresh_locations = HashSet::from([destination.clone()]);
         if move_sources {
             for parent in items.iter().filter_map(|item| item.source.parent()) {
-                if !refresh_locations.contains(&parent) {
-                    refresh_locations.push(parent);
-                }
+                refresh_locations.insert(parent);
             }
         }
         let load = provider.paste(
@@ -872,16 +894,14 @@ impl Browser {
         let total = entries.len();
         let request_id = self.begin_operation();
         self.deletion_operation.set(true);
-        if total > 1 {
-            self.emit(BrowserEvent::DeletionStarted { total });
-        }
+        self.emit(BrowserEvent::DeletionStarted { total });
         let load = provider.delete(
             DeleteRequest {
                 id: request_id,
                 entries,
                 permanent,
             },
-            self.operation_callback(request_id, false, Vec::new()),
+            self.operation_callback(request_id, false, HashSet::new()),
         );
         self.operation_load.replace(Some(load));
     }
@@ -899,15 +919,13 @@ impl Browser {
         let total = entries.len();
         let request_id = self.begin_operation();
         self.restoration_operation.set(true);
-        if total > 1 {
-            self.emit(BrowserEvent::RestorationStarted { total });
-        }
+        self.emit(BrowserEvent::RestorationStarted { total });
         let load = provider.restore(
             RestoreRequest {
                 id: request_id,
                 entries,
             },
-            self.operation_callback(request_id, false, Vec::new()),
+            self.operation_callback(request_id, false, HashSet::new()),
         );
         self.operation_load.replace(Some(load));
     }
@@ -939,7 +957,7 @@ impl Browser {
                 format,
                 password,
             },
-            self.operation_callback(request_id, false, Vec::new()),
+            self.operation_callback(request_id, false, HashSet::new()),
         );
         self.operation_load.replace(Some(load));
     }
@@ -964,31 +982,31 @@ impl Browser {
                 destination,
                 password,
             },
-            self.operation_callback(request_id, false, Vec::new()),
+            self.operation_callback(request_id, false, HashSet::new()),
         );
         self.operation_load.replace(Some(load));
     }
 
     pub fn cancel_file_operation(&self) {
-        let deleting = self.deletion_operation.replace(false);
-        let restoring = self.restoration_operation.replace(false);
-        let had_operation = self.current_operation.replace(None).is_some();
+        if self.transfer_operation.get().is_none()
+            && !self.deletion_operation.get()
+            && !self.restoration_operation.get()
+        {
+            let had_operation = self.current_operation.replace(None).is_some();
+            self.operation_load.borrow_mut().take();
+            if had_operation {
+                self.emit(BrowserEvent::ArchiveCompleted {
+                    select_name: String::new(),
+                });
+            }
+            return;
+        }
         self.operation_load.borrow_mut().take();
-        if deleting {
-            self.emit(BrowserEvent::DeletionFinished);
-        }
-        if restoring {
-            self.emit(BrowserEvent::RestorationFinished);
-        }
-        if !deleting && !restoring && had_operation {
-            self.emit(BrowserEvent::ArchiveCompleted {
-                select_name: String::new(),
-            });
-        }
     }
 
     fn begin_operation(&self) -> OperationRequestId {
         self.operation_load.borrow_mut().take();
+        self.transfer_operation.set(None);
         self.deletion_operation.set(false);
         self.restoration_operation.set(false);
         let request_id = OperationRequestId(self.next_request.get());
@@ -1002,7 +1020,7 @@ impl Browser {
         self: &Rc<Self>,
         request_id: OperationRequestId,
         rename: bool,
-        refresh_locations: Vec<Location>,
+        refresh_locations: HashSet<Location>,
     ) -> Rc<dyn Fn(OperationEvent)> {
         let weak = Rc::downgrade(self);
         Rc::new(move |event| {
@@ -1012,7 +1030,9 @@ impl Browser {
             let event_id = match &event {
                 OperationEvent::Renamed { request_id }
                 | OperationEvent::Created { request_id }
-                | OperationEvent::Pasted { request_id }
+                | OperationEvent::Pasted { request_id, .. }
+                | OperationEvent::TransferFailed { request_id, .. }
+                | OperationEvent::TransferProgress { request_id, .. }
                 | OperationEvent::DeleteProgress { request_id, .. }
                 | OperationEvent::RestoreProgress { request_id, .. }
                 | OperationEvent::Deleted { request_id, .. }
@@ -1023,6 +1043,7 @@ impl Browser {
                 | OperationEvent::Compressed { request_id, .. }
                 | OperationEvent::Extracted { request_id, .. }
                 | OperationEvent::ArchiveStarted { request_id, .. }
+                | OperationEvent::Cancelled { request_id, .. }
                 | OperationEvent::ArchiveProgress { request_id, .. } => *request_id,
             };
             if event_id != request_id || browser.current_operation.get() != Some(event_id) {
@@ -1038,12 +1059,20 @@ impl Browser {
                 if let Some(location) = deleted_location {
                     browser.remove_deleted_locations(std::slice::from_ref(location));
                 }
-                if *total > 1 {
-                    browser.emit(BrowserEvent::DeletionProgress {
-                        completed: *completed,
-                        total: *total,
-                    });
-                }
+                browser.emit(BrowserEvent::DeletionProgress {
+                    completed: *completed,
+                    total: *total,
+                });
+                return;
+            }
+            if let OperationEvent::TransferProgress {
+                completed, total, ..
+            } = &event
+            {
+                browser.emit(BrowserEvent::TransferProgress {
+                    completed: *completed,
+                    total: *total,
+                });
                 return;
             }
             if let OperationEvent::RestoreProgress {
@@ -1056,12 +1085,10 @@ impl Browser {
                 if let Some(location) = restored_location {
                     browser.remove_deleted_locations(std::slice::from_ref(location));
                 }
-                if *total > 1 {
-                    browser.emit(BrowserEvent::RestorationProgress {
-                        completed: *completed,
-                        total: *total,
-                    });
-                }
+                browser.emit(BrowserEvent::RestorationProgress {
+                    completed: *completed,
+                    total: *total,
+                });
                 return;
             }
             if let OperationEvent::ArchiveStarted { total, .. } = &event {
@@ -1079,10 +1106,29 @@ impl Browser {
                 return;
             }
             browser.current_operation.set(None);
-            if browser.deletion_operation.replace(false) {
+            let moving = browser.transfer_operation.replace(None);
+            let deleting = browser.deletion_operation.replace(false);
+            let restoring = browser.restoration_operation.replace(false);
+            if moving.is_some() {
+                let moved_locations = match &event {
+                    OperationEvent::Pasted { locations, .. } if moving == Some(true) => {
+                        locations.clone()
+                    }
+                    OperationEvent::Cancelled { result, .. } if moving == Some(true) => {
+                        result.completed.clone()
+                    }
+                    OperationEvent::TransferFailed {
+                        completed_locations,
+                        ..
+                    } if moving == Some(true) => completed_locations.clone(),
+                    _ => Vec::new(),
+                };
+                browser.emit(BrowserEvent::TransferFinished { moved_locations });
+            }
+            if deleting {
                 browser.emit(BrowserEvent::DeletionFinished);
             }
-            if browser.restoration_operation.replace(false) {
+            if restoring {
                 browser.emit(BrowserEvent::RestorationFinished);
             }
             browser.operation_load.borrow_mut().take();
@@ -1091,6 +1137,12 @@ impl Browser {
                     browser.emit(BrowserEvent::RenameFailed { message });
                 }
                 OperationEvent::Failed { message, .. } => {
+                    browser.emit(BrowserEvent::OperationFailed { message });
+                }
+                OperationEvent::TransferFailed { message, .. } => {
+                    for location in &refresh_locations {
+                        browser.refresh_columns_at(location);
+                    }
                     browser.emit(BrowserEvent::OperationFailed { message });
                 }
                 OperationEvent::CompletedWithErrors {
@@ -1112,6 +1164,19 @@ impl Browser {
                 } => {
                     browser.remove_deleted_locations(&restored_locations);
                     browser.emit(BrowserEvent::OperationCompletedWithErrors { message });
+                }
+                OperationEvent::Cancelled { result, .. } => {
+                    if deleting || restoring {
+                        browser.remove_deleted_locations(&result.completed);
+                    }
+                    let mut affected_locations = refresh_locations.clone();
+                    affected_locations.extend(result.affected_locations);
+                    browser.refresh_columns_at_or_below(&affected_locations);
+                    browser.emit(BrowserEvent::OperationCancelled {
+                        completed: result.completed.len(),
+                        failed: result.failed.len(),
+                        not_attempted: result.not_attempted.len(),
+                    });
                 }
                 OperationEvent::Renamed { .. } => {
                     browser.emit(BrowserEvent::RenameCompleted);
@@ -1146,7 +1211,8 @@ impl Browser {
                         }
                     }
                 }
-                OperationEvent::DeleteProgress { .. }
+                OperationEvent::TransferProgress { .. }
+                | OperationEvent::DeleteProgress { .. }
                 | OperationEvent::RestoreProgress { .. }
                 | OperationEvent::ArchiveStarted { .. }
                 | OperationEvent::ArchiveProgress { .. } => {}
@@ -1365,6 +1431,24 @@ impl Browser {
         }
     }
 
+    fn refresh_columns_at_or_below(self: &Rc<Self>, roots: &HashSet<Location>) {
+        let open_locations = {
+            let state = self.state.borrow();
+            let mut locations = Vec::new();
+            let mut depth = 0;
+            while let Some(location) = state.location_at(depth) {
+                locations.push((depth, location));
+                depth += 1;
+            }
+            locations
+        };
+        for (depth, location) in open_locations {
+            if location_or_ancestor_is_affected(&location, roots) {
+                self.refresh_column(depth);
+            }
+        }
+    }
+
     fn remove_deleted_locations(self: &Rc<Self>, locations: &[Location]) {
         for location in locations {
             let Some(parent) = deletion_parent_location(location) else {
@@ -1547,6 +1631,17 @@ impl Browser {
         self.next_request.set(id.saturating_add(1));
         RequestId(id)
     }
+}
+
+fn location_or_ancestor_is_affected(location: &Location, roots: &HashSet<Location>) -> bool {
+    let mut current = Some(location.clone());
+    while let Some(location) = current {
+        if roots.contains(&location) {
+            return true;
+        }
+        current = location.parent();
+    }
+    false
 }
 
 fn deletion_parent_location(location: &Location) -> Option<Location> {

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -5,7 +5,7 @@ use std::{cell::Cell, ffi::OsString};
 use super::*;
 use crate::{
     model::{EntryKind, MetadataValue},
-    services::{CompressRequest, ExtractRequest, LoadHandle},
+    services::{CancelledOperation, CompressRequest, ExtractRequest, LoadHandle},
 };
 
 #[test]
@@ -301,6 +301,98 @@ impl FileSource for CountingFileSource {
     }
 }
 
+#[test]
+fn cancellation_refreshes_an_affected_remote_root_and_its_open_descendants() {
+    let enumerate_calls = Rc::new(Cell::new(0));
+    let browser = Browser::new(Rc::new(CountingFileSource {
+        enumerate_calls: enumerate_calls.clone(),
+    }));
+    let root = Location::uri("smb://host/share");
+    browser.navigate(root.clone());
+    browser.descend(0, Location::uri("smb://host/share/child"));
+    assert_eq!(enumerate_calls.get(), 2);
+
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let observed = events.clone();
+    browser.observe(move |event| observed.borrow_mut().push(event));
+    let cancellations = Rc::new(Cell::new(0));
+    let cancellations_for_handle = cancellations.clone();
+    let request_id = browser.begin_operation();
+    browser.deletion_operation.set(true);
+    browser
+        .operation_load
+        .replace(Some(LoadHandle::new(move || {
+            cancellations_for_handle.set(cancellations_for_handle.get() + 1);
+        })));
+    let emit = browser.operation_callback(request_id, false, HashSet::new());
+
+    browser.cancel_file_operation();
+
+    assert_eq!(cancellations.get(), 1);
+    assert_eq!(browser.current_operation.get(), Some(request_id));
+    assert!(
+        !events
+            .borrow()
+            .iter()
+            .any(|event| matches!(event, BrowserEvent::DeletionFinished))
+    );
+
+    emit(OperationEvent::Cancelled {
+        request_id,
+        result: CancelledOperation {
+            completed: vec![Location::uri("smb://host/share/completed")],
+            failed: vec![Location::uri("smb://host/share/interrupted")],
+            not_attempted: vec![Location::uri("smb://host/share/not-attempted")],
+            affected_locations: HashSet::from([root]),
+        },
+    });
+
+    assert_eq!(browser.current_operation.get(), None);
+    assert_eq!(enumerate_calls.get(), 4);
+    assert!(
+        events
+            .borrow()
+            .iter()
+            .any(|event| matches!(event, BrowserEvent::DeletionFinished))
+    );
+    assert!(events.borrow().iter().any(|event| matches!(
+        event,
+        BrowserEvent::OperationCancelled {
+            completed: 1,
+            failed: 1,
+            not_attempted: 1,
+        }
+    )));
+}
+
+#[test]
+fn transfer_failure_reports_moves_completed_before_the_error() {
+    let browser = Browser::new(Rc::new(FakeFileSource));
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let observed = events.clone();
+    browser.observe(move |event| observed.borrow_mut().push(event));
+    let request_id = browser.begin_operation();
+    browser.transfer_operation.set(Some(true));
+    let emit = browser.operation_callback(request_id, false, HashSet::new());
+    let completed = Location::local("/fixture/completed");
+
+    emit(OperationEvent::TransferFailed {
+        request_id,
+        completed_locations: vec![completed.clone()],
+        message: "injected failure".to_owned(),
+    });
+
+    assert!(events.borrow().iter().any(|event| matches!(
+        event,
+        BrowserEvent::TransferFinished { moved_locations }
+            if moved_locations == std::slice::from_ref(&completed)
+    )));
+    assert!(events.borrow().iter().any(|event| matches!(
+        event,
+        BrowserEvent::OperationFailed { message } if message == "injected failure"
+    )));
+}
+
 struct ImmediateOperationProvider;
 
 impl OperationProvider for ImmediateOperationProvider {
@@ -336,6 +428,7 @@ impl OperationProvider for ImmediateOperationProvider {
     fn paste(&self, request: PasteRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle {
         emit(OperationEvent::Pasted {
             request_id: request.id,
+            locations: request.items.into_iter().map(|item| item.source).collect(),
         });
         LoadHandle::new(|| {})
     }

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -283,6 +283,32 @@ impl FileSource for FakeFileSource {
     }
 }
 
+struct TrashFileSource;
+
+impl FileSource for TrashFileSource {
+    fn validate_location(&self, _location: &Location) -> Result<(), LocationValidationError> {
+        Ok(())
+    }
+
+    fn enumerate(&self, request: DirectoryRequest, emit: Rc<dyn Fn(DirectoryEvent)>) -> LoadHandle {
+        emit(DirectoryEvent::Batch {
+            request_id: request.id,
+            entries: vec![FileEntry {
+                location: Location::uri("trash:///item"),
+                native_name: OsString::from("item"),
+                display_name: "item".into(),
+                kind: EntryKind::File,
+                size: MetadataValue::Unknown,
+                modified_unix_seconds: MetadataValue::Unknown,
+            }],
+        });
+        emit(DirectoryEvent::Finished {
+            request_id: request.id,
+        });
+        LoadHandle::new(|| {})
+    }
+}
+
 struct CountingFileSource {
     enumerate_calls: Rc<Cell<usize>>,
 }
@@ -299,6 +325,39 @@ impl FileSource for CountingFileSource {
         });
         LoadHandle::new(|| {})
     }
+}
+
+#[test]
+fn large_restore_progress_defers_model_removal() {
+    let browser = Browser::new(Rc::new(TrashFileSource));
+    browser.navigate(Location::uri("trash:///"));
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let observed = events.clone();
+    browser.observe(move |event| observed.borrow_mut().push(event));
+    let request_id = browser.begin_operation();
+    browser.restoration_operation.set(true);
+    let emit = browser.operation_callback(request_id, false, HashSet::new());
+
+    emit(OperationEvent::RestoreProgress {
+        request_id,
+        completed: 1,
+        total: 3_000,
+        restored_location: Some(Location::uri("trash:///item")),
+    });
+
+    assert!(events.borrow().iter().any(|event| matches!(
+        event,
+        BrowserEvent::RestorationProgress {
+            completed: 1,
+            total: 3_000,
+        }
+    )));
+    assert!(
+        !events
+            .borrow()
+            .iter()
+            .any(|event| matches!(event, BrowserEvent::EntriesSpliced { .. }))
+    );
 }
 
 #[test]

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -407,6 +407,18 @@ fn cancellation_refreshes_an_affected_remote_root_and_its_open_descendants() {
     });
 
     assert_eq!(browser.current_operation.get(), None);
+    assert_eq!(enumerate_calls.get(), 2);
+    let affected_locations = events
+        .borrow()
+        .iter()
+        .find_map(|event| match event {
+            BrowserEvent::OperationCancelled {
+                affected_locations, ..
+            } => Some(affected_locations.clone()),
+            _ => None,
+        })
+        .expect("cancellation event");
+    browser.refresh_after_cancellation(&affected_locations);
     assert_eq!(enumerate_calls.get(), 4);
     assert!(
         events
@@ -420,6 +432,7 @@ fn cancellation_refreshes_an_affected_remote_root_and_its_open_descendants() {
             completed: 1,
             failed: 1,
             not_attempted: 1,
+            ..
         }
     )));
 }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -12,9 +12,9 @@ pub use file_source::{
     LocationValidationError, RequestId, backend_unavailable_message, uri_has_embedded_password,
 };
 pub use operations::{
-    ArchiveFormat, CompressRequest, CreateDirectoryRequest, CreateFileRequest, DeleteRequest,
-    ExtractRequest, OperationEvent, OperationProvider, OperationRequestId, PasteItem, PasteRequest,
-    RenameRequest, RestoreRequest, TransferConflict, validate_basename,
+    ArchiveFormat, CancelledOperation, CompressRequest, CreateDirectoryRequest, CreateFileRequest,
+    DeleteRequest, ExtractRequest, OperationEvent, OperationProvider, OperationRequestId,
+    PasteItem, PasteRequest, RenameRequest, RestoreRequest, TransferConflict, validate_basename,
 };
 pub use preview::{
     Preview, PreviewContent, PreviewEvent, PreviewProvider, PreviewRequest, PreviewRequestId,

--- a/src/services/operations.rs
+++ b/src/services/operations.rs
@@ -3,7 +3,7 @@
 #[cfg(test)]
 mod tests;
 
-use std::rc::Rc;
+use std::{collections::HashSet, rc::Rc};
 
 use crate::model::{FileEntry, Location};
 
@@ -136,6 +136,14 @@ pub struct ExtractRequest {
     pub password: Option<String>,
 }
 
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct CancelledOperation {
+    pub completed: Vec<Location>,
+    pub failed: Vec<Location>,
+    pub not_attempted: Vec<Location>,
+    pub affected_locations: HashSet<Location>,
+}
+
 #[derive(Clone, Debug)]
 pub enum OperationEvent {
     Renamed {
@@ -146,6 +154,17 @@ pub enum OperationEvent {
     },
     Pasted {
         request_id: OperationRequestId,
+        locations: Vec<Location>,
+    },
+    TransferFailed {
+        request_id: OperationRequestId,
+        completed_locations: Vec<Location>,
+        message: String,
+    },
+    TransferProgress {
+        request_id: OperationRequestId,
+        completed: usize,
+        total: usize,
     },
     DeleteProgress {
         request_id: OperationRequestId,
@@ -176,6 +195,10 @@ pub enum OperationEvent {
         request_id: OperationRequestId,
         restored_locations: Vec<Location>,
         message: String,
+    },
+    Cancelled {
+        request_id: OperationRequestId,
+        result: CancelledOperation,
     },
     Failed {
         request_id: OperationRequestId,

--- a/src/style.css
+++ b/src/style.css
@@ -2253,7 +2253,7 @@ menubutton.column-header-action > button:focus-visible image {
 }
 
 .skeleton-row {
-  background: alpha(@theme_border, 0.12);
+  background: alpha(@theme_border, 0.28);
   border-radius: 4px;
   min-height: 10px;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -2249,7 +2249,7 @@ menubutton.column-header-action > button:focus-visible image {
 }
 
 .loading-skeleton {
-  padding: 16px 18px;
+  padding: 8px;
 }
 
 .skeleton-row {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -3461,7 +3461,7 @@ impl ViewState {
                     .map(|insertion| insertion.entries.len())
                     .sum();
                 if let Some(column) = self.columns.borrow().get(depth).cloned() {
-                    if entry_count > 0 {
+                    if entry_count > 0 && !column.spinner.is_spinning() {
                         column.presentation.show_content();
                     }
                     for insertion in insertions {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -3545,9 +3545,8 @@ impl ViewState {
                 if let Some(column) = self.columns.borrow().get(depth) {
                     column.syncing_selection.set(true);
                     column.selection.set_model(None::<&gio::ListModel>);
+                    column.filtered_model.set_model(None::<&gio::ListModel>);
                     column.model.splice(0, column.model.n_items(), &[]);
-                    column.selection.set_model(Some(&column.filtered_model));
-                    column.syncing_selection.set(false);
                     column.entry_count.set(0);
                     set_filter_placeholder(column, 0);
                     column.spinner.set_visible(true);
@@ -3557,6 +3556,11 @@ impl ViewState {
             }
             BrowserEvent::LoadFinished { depth } => {
                 if let Some(column) = self.columns.borrow().get(depth) {
+                    if column.selection.model().is_none() {
+                        column.filtered_model.set_model(Some(&column.model));
+                        column.selection.set_model(Some(&column.filtered_model));
+                        column.syncing_selection.set(false);
+                    }
                     column.spinner.stop();
                     column.spinner.set_visible(false);
                     let count = column.entry_count.get();
@@ -3581,6 +3585,11 @@ impl ViewState {
             }
             BrowserEvent::LoadFailed { depth, message } => {
                 if let Some(column) = self.columns.borrow().get(depth) {
+                    if column.selection.model().is_none() {
+                        column.filtered_model.set_model(Some(&column.model));
+                        column.selection.set_model(Some(&column.filtered_model));
+                        column.syncing_selection.set(false);
+                    }
                     column.spinner.stop();
                     column.spinner.set_visible(false);
                     column

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -3538,7 +3538,10 @@ impl ViewState {
             }
             BrowserEvent::ColumnReloaded { depth } => {
                 if let Some(column) = self.columns.borrow().get(depth) {
+                    column.syncing_selection.set(true);
+                    column.selection.unselect_all();
                     column.model.splice(0, column.model.n_items(), &[]);
+                    column.syncing_selection.set(false);
                     column.entry_count.set(0);
                     set_filter_placeholder(column, 0);
                     column.spinner.set_visible(true);

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -1029,7 +1029,6 @@ impl ViewState {
         sources: Vec<Location>,
         move_sources: bool,
     ) {
-        let clear_cut = move_sources && same_locations(&sources, &self.cut_locations.borrow());
         let mut accepted = Vec::new();
         let mut collisions = Vec::new();
         for source in sources {
@@ -1042,13 +1041,7 @@ impl ViewState {
                 });
             }
         }
-        self.resolve_transfer_collisions(
-            destination,
-            collisions,
-            accepted,
-            move_sources,
-            clear_cut,
-        );
+        self.resolve_transfer_collisions(destination, collisions, accepted, move_sources);
     }
 
     fn resolve_transfer_collisions(
@@ -1057,17 +1050,8 @@ impl ViewState {
         mut collisions: Vec<Location>,
         accepted: Vec<PasteItem>,
         move_sources: bool,
-        clear_cut: bool,
     ) {
         if collisions.is_empty() {
-            if clear_cut {
-                self.complete_cut_transfer(
-                    &accepted
-                        .iter()
-                        .map(|item| item.source.clone())
-                        .collect::<Vec<_>>(),
-                );
-            }
             self.browser.transfer(destination, accepted, move_sources);
             return;
         }
@@ -1139,7 +1123,6 @@ impl ViewState {
                 },
                 skipped_accepted.clone(),
                 move_sources,
-                clear_cut,
             );
         });
 
@@ -1169,7 +1152,6 @@ impl ViewState {
                 remaining,
                 accepted,
                 move_sources,
-                clear_cut,
             );
         });
 
@@ -3330,11 +3312,34 @@ impl ViewState {
                     rename.field.grab_focus();
                 }
             }
+            BrowserEvent::TransferStarted { total, moving } => self.show_file_operation_progress(
+                total,
+                if moving {
+                    crate::assets::icons::FOLDER
+                } else {
+                    crate::assets::icons::COPY
+                },
+                if moving {
+                    "Moving items"
+                } else {
+                    "Copying items"
+                },
+                "Cancelling will not undo completed changes",
+            ),
+            BrowserEvent::TransferProgress { completed, total } => {
+                self.update_delete_progress(completed, total);
+            }
+            BrowserEvent::TransferFinished { moved_locations } => {
+                if !moved_locations.is_empty() {
+                    self.complete_cut_transfer(&moved_locations);
+                }
+                self.dismiss_delete_progress();
+            }
             BrowserEvent::DeletionStarted { total } => self.show_file_operation_progress(
                 total,
                 crate::assets::icons::TRASH,
                 "Deleting items",
-                "This may take a moment",
+                "Cancelling will not undo completed changes",
             ),
             BrowserEvent::DeletionProgress { completed, total } => {
                 self.update_delete_progress(completed, total);
@@ -3344,7 +3349,7 @@ impl ViewState {
                 total,
                 crate::assets::icons::FOLDER,
                 "Restoring items",
-                "Items are being returned to their original locations",
+                "Cancelling will not undo completed changes",
             ),
             BrowserEvent::RestorationProgress { completed, total } => {
                 self.update_delete_progress(completed, total);
@@ -3364,6 +3369,19 @@ impl ViewState {
             }
             BrowserEvent::OperationCompletedWithErrors { message } => {
                 show_error_dialog(&self.overlay, "Completed with errors", &message);
+            }
+            BrowserEvent::OperationCancelled {
+                completed,
+                failed,
+                not_attempted,
+            } => {
+                let message = format!(
+                    "{} completed, {} failed, and {} not attempted.\n\nCompleted changes were not reverted.",
+                    item_count_label(completed),
+                    item_count_label(failed),
+                    item_count_label(not_attempted),
+                );
+                show_error_dialog(&self.overlay, "Operation cancelled", &message);
             }
             BrowserEvent::NavigationRejected {
                 parent_depth,

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -1233,6 +1233,7 @@ impl ViewState {
     fn refresh_cut_rows(&self) {
         let cut = self.cut_locations.borrow();
         self.mode_views.borrow().set_cut_locations(&cut);
+        let cut_lookup: HashSet<_> = cut.iter().collect();
         for (depth, column) in self.columns.borrow().iter().enumerate() {
             column.bound_rows.borrow_mut().retain(|bound| {
                 let (Some(item), Some(row)) = (bound.item.upgrade(), bound.row.upgrade()) else {
@@ -1244,7 +1245,7 @@ impl ViewState {
                     item.position(),
                 )
                 .and_then(|position| self.browser.entry_at(depth, position))
-                .is_some_and(|entry| cut.contains(&entry.location));
+                .is_some_and(|entry| cut_lookup.contains(&entry.location));
                 set_cut_path_style(&row, is_cut);
                 true
             });
@@ -3986,15 +3987,14 @@ impl ViewState {
                 return;
             }
             let filtered_positions = bitset_positions(&selection.selection());
-            let source_positions: Vec<_> = filtered_positions
+            let mapped_positions = source_positions_for_filtered(
+                &source_for_selection,
+                &filtered_for_selection,
+                &filtered_positions,
+            );
+            let source_positions: Vec<_> = mapped_positions
                 .iter()
-                .filter_map(|position| {
-                    source_position_for_filtered(
-                        &source_for_selection,
-                        &filtered_for_selection,
-                        *position,
-                    )
-                })
+                .map(|(_, source_position)| *source_position)
                 .collect();
             let changed_end = position.saturating_add(count);
             let focused = filtered_positions
@@ -4010,11 +4010,9 @@ impl ViewState {
                 .or_else(|| filtered_positions.last().copied());
             focused_filtered_changed.set(focused);
             let focused_source = focused.and_then(|position| {
-                source_position_for_filtered(
-                    &source_for_selection,
-                    &filtered_for_selection,
-                    position,
-                )
+                mapped_positions
+                    .iter()
+                    .find_map(|(filtered, source)| (*filtered == position).then_some(*source))
             });
             if let Some(browser) = weak_browser.upgrade() {
                 browser.set_selection(depth, &source_positions, focused_source);
@@ -5027,14 +5025,34 @@ fn source_position_for_filtered(
     filtered: &gtk::FilterListModel,
     filtered_position: u32,
 ) -> Option<usize> {
-    let item = filtered.item(filtered_position)?;
-    (0..source.n_items())
-        .find(|position| {
-            source
-                .item(*position)
-                .is_some_and(|candidate| candidate == item)
+    source_positions_for_filtered(source, filtered, &[filtered_position])
+        .first()
+        .map(|(_, source)| *source)
+}
+
+fn source_positions_for_filtered(
+    source: &gtk::StringList,
+    filtered: &gtk::FilterListModel,
+    filtered_positions: &[u32],
+) -> Vec<(u32, usize)> {
+    let mut source_position = 0;
+    filtered_positions
+        .iter()
+        .filter_map(|filtered_position| {
+            let item = filtered.item(*filtered_position)?;
+            while source_position < source.n_items() {
+                let candidate_position = source_position;
+                source_position += 1;
+                if source
+                    .item(candidate_position)
+                    .is_some_and(|candidate| candidate == item)
+                {
+                    return Some((*filtered_position, candidate_position as usize));
+                }
+            }
+            None
         })
-        .map(|position| position as usize)
+        .collect()
 }
 
 fn set_column_selection(column: &ColumnView, position: u32) {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -3753,6 +3753,7 @@ impl ViewState {
                 completed,
                 failed,
                 not_attempted,
+                affected_locations,
             } => {
                 let message = format!(
                     "{} completed, {} failed, and {} not attempted.\n\nCompleted changes were not reverted.",
@@ -3760,7 +3761,13 @@ impl ViewState {
                     item_count_label(failed),
                     item_count_label(not_attempted),
                 );
-                show_error_dialog(&self.overlay, "Operation cancelled", &message);
+                let browser = self.browser.clone();
+                show_error_dialog_after_close(
+                    &self.overlay,
+                    "Operation cancelled",
+                    &message,
+                    Rc::new(move || browser.refresh_after_cancellation(&affected_locations)),
+                );
             }
             BrowserEvent::NavigationRejected {
                 parent_depth,
@@ -7646,12 +7653,22 @@ pub(super) fn open_location(location: &Location, parent: &impl IsA<gtk::Widget>)
 }
 
 pub(super) fn show_error_dialog(parent: &impl IsA<gtk::Widget>, message: &str, detail: &str) {
+    show_error_dialog_after_close(parent, message, detail, Rc::new(|| {}));
+}
+
+fn show_error_dialog_after_close(
+    parent: &impl IsA<gtk::Widget>,
+    message: &str,
+    detail: &str,
+    on_close: Rc<dyn Fn()>,
+) {
     let Some(window_overlay) = parent
         .root()
         .and_downcast::<gtk::Window>()
         .and_then(|window| window.child())
         .and_downcast::<gtk::Overlay>()
     else {
+        on_close();
         return;
     };
     let blurred_root = window_overlay.child().and_downcast::<BlurBin>();
@@ -7683,8 +7700,14 @@ pub(super) fn show_error_dialog(parent: &impl IsA<gtk::Widget>, message: &str, d
     let close_layer = layer.clone();
     let close_overlay = window_overlay.clone();
     let close_root = blurred_root.clone();
+    let dismissed = Rc::new(Cell::new(false));
     let dismiss = move || {
+        if dismissed.replace(true) {
+            return;
+        }
         dismiss_modal_layer(&close_layer, &close_overlay, close_root.as_ref());
+        let on_close = on_close.clone();
+        glib::timeout_add_local_once(Duration::from_millis(250), move || on_close());
     };
     let dismiss = Rc::new(dismiss);
     let clicked_dismiss = dismiss.clone();

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -3539,8 +3539,9 @@ impl ViewState {
             BrowserEvent::ColumnReloaded { depth } => {
                 if let Some(column) = self.columns.borrow().get(depth) {
                     column.syncing_selection.set(true);
-                    column.selection.unselect_all();
+                    column.selection.set_model(None::<&gio::ListModel>);
                     column.model.splice(0, column.model.n_items(), &[]);
+                    column.selection.set_model(Some(&column.filtered_model));
                     column.syncing_selection.set(false);
                     column.entry_count.set(0);
                     set_filter_placeholder(column, 0);

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -114,17 +114,22 @@ struct PeekView {
     spinner: gtk::Spinner,
 }
 
+pub(super) fn loading_skeleton() -> gtk::Box {
+    let skeleton = gtk::Box::new(gtk::Orientation::Vertical, 9);
+    skeleton.add_css_class("loading-skeleton");
+    for width in [168, 124, 192, 148, 176, 112] {
+        let row = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+        row.add_css_class("skeleton-row");
+        row.set_size_request(width, 10);
+        row.set_halign(gtk::Align::Start);
+        skeleton.append(&row);
+    }
+    skeleton
+}
+
 impl LoadPresentation {
     fn new(content: &impl IsA<gtk::Widget>, retry: Option<gtk::Button>) -> Self {
-        let skeleton = gtk::Box::new(gtk::Orientation::Vertical, 9);
-        skeleton.add_css_class("loading-skeleton");
-        for width in [168, 124, 192, 148, 176, 112] {
-            let row = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-            row.add_css_class("skeleton-row");
-            row.set_size_request(width, 10);
-            row.set_halign(gtk::Align::Start);
-            skeleton.append(&row);
-        }
+        let skeleton = loading_skeleton();
 
         let feedback = gtk::Box::new(gtk::Orientation::Vertical, 8);
         feedback.add_css_class("directory-feedback");

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -2,6 +2,7 @@
 
 use std::{
     cell::{Cell, RefCell},
+    collections::HashSet,
     future::Future,
     path::Path,
     pin::Pin,
@@ -1215,9 +1216,7 @@ impl ViewState {
     }
 
     fn complete_cut_transfer(&self, transferred: &[Location]) {
-        self.cut_locations
-            .borrow_mut()
-            .retain(|location| !transferred.contains(location));
+        retain_untransferred(&mut self.cut_locations.borrow_mut(), transferred);
         let remaining = self.cut_locations.borrow().clone();
         if remaining.is_empty() {
             if let Some(display) = gtk::gdk::Display::default() {
@@ -6360,9 +6359,17 @@ fn new_folder_destination_depth(
 }
 
 fn same_locations(left: &[Location], right: &[Location]) -> bool {
-    !left.is_empty()
-        && left.len() == right.len()
-        && left.iter().all(|location| right.contains(location))
+    if left.is_empty() || left.len() != right.len() {
+        return false;
+    }
+    let left: HashSet<_> = left.iter().collect();
+    let right: HashSet<_> = right.iter().collect();
+    left.len() == right.len() && left == right
+}
+
+fn retain_untransferred(cut: &mut Vec<Location>, transferred: &[Location]) {
+    let transferred: HashSet<_> = transferred.iter().collect();
+    cut.retain(|location| !transferred.contains(location));
 }
 
 fn item_context_option(icon: &str, label: &str, accelerator: &str) -> gtk::Button {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -5222,6 +5222,8 @@ pub(super) fn install_folder_context_menu(
 pub(super) type ContextPickPosition = Rc<dyn Fn(&gtk::Widget) -> Option<u32>>;
 pub(super) type ContextSourcePosition = Rc<dyn Fn(u32) -> Option<usize>>;
 
+const ITEM_CONTEXT_SUMMARY_MAX_CHARS: i32 = 60;
+
 pub(super) fn install_item_context_menu(
     state: &Rc<ViewState>,
     widget: &gtk::Widget,
@@ -5242,10 +5244,12 @@ pub(super) fn install_item_context_menu(
     let heading = gtk::Label::new(None);
     heading.add_css_class("item-context-title");
     heading.set_ellipsize(gtk::pango::EllipsizeMode::End);
+    heading.set_max_width_chars(ITEM_CONTEXT_SUMMARY_MAX_CHARS);
     heading.set_xalign(0.0);
     let summary = gtk::Label::new(None);
     summary.add_css_class("item-context-summary");
     summary.set_ellipsize(gtk::pango::EllipsizeMode::End);
+    summary.set_max_width_chars(ITEM_CONTEXT_SUMMARY_MAX_CHARS);
     summary.set_xalign(0.0);
     header.append(&heading);
     header.append(&summary);
@@ -5487,13 +5491,6 @@ pub(super) fn install_item_context_menu(
         if !selection.is_selected(filtered_position) {
             selection.select_item(filtered_position, true);
         }
-        let selected_positions = bitset_positions(&selection.selection())
-            .into_iter()
-            .filter_map(|position| source_position(position))
-            .collect::<Vec<_>>();
-        state
-            .browser
-            .set_selection(depth, &selected_positions, Some(resolved_position));
         target.replace(Some((resolved_position, entry.clone())));
         let entries = state.browser.selected_entries();
         preview.set_visible(entry_supports_quick_preview(&entry));
@@ -5815,6 +5812,11 @@ fn selected_items_summary(entries: &[FileEntry]) -> String {
         .join(", ");
     if entries.len() > 3 {
         names.push_str(", …");
+    }
+    let max_chars = ITEM_CONTEXT_SUMMARY_MAX_CHARS as usize;
+    if names.chars().count() > max_chars {
+        names = names.chars().take(max_chars - 1).collect();
+        names.push('…');
     }
     names
 }

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -331,6 +331,15 @@ fn multi_selection_summary_lists_at_most_three_names() {
         selected_items_summary(&[entry("one"), entry("two"), entry("three"), entry("four")]),
         "one, two, three, …"
     );
+    let summary = selected_items_summary(&[
+        entry("a-very-long-file-name-that-would-expand-the-context-menu"),
+        entry("another-very-long-file-name-that-would-expand-the-menu"),
+    ]);
+    assert_eq!(
+        summary.chars().count(),
+        ITEM_CONTEXT_SUMMARY_MAX_CHARS as usize
+    );
+    assert!(summary.ends_with('…'));
 }
 
 #[test]

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -531,6 +531,28 @@ fn cut_clipboard_locations_match_regardless_of_order() {
         &[Location::local("/fixture/first")],
         &[Location::local("/fixture/other")]
     ));
+    assert!(!same_locations(
+        &[
+            Location::local("/fixture/first"),
+            Location::local("/fixture/first")
+        ],
+        &[
+            Location::local("/fixture/first"),
+            Location::local("/fixture/second")
+        ]
+    ));
+}
+
+#[test]
+fn completed_moves_are_removed_from_the_cut_list() {
+    let first = Location::local("/fixture/first");
+    let second = Location::local("/fixture/second");
+    let third = Location::local("/fixture/third");
+    let mut cut = vec![first.clone(), second.clone(), third.clone()];
+
+    retain_untransferred(&mut cut, &[first, third]);
+
+    assert_eq!(cut, vec![second]);
 }
 
 #[test]

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -8,6 +8,7 @@
 
 use std::{
     cell::{Cell, RefCell},
+    collections::HashSet,
     rc::{Rc, Weak},
 };
 
@@ -104,7 +105,7 @@ pub struct ModeViews {
     browser: Rc<Browser>,
     single_click_previews: Rc<Cell<bool>>,
     transfer_handler: TransferHandlerSlot,
-    cut_locations: Rc<RefCell<Vec<Location>>>,
+    cut_locations: Rc<RefCell<HashSet<Location>>>,
     context_state: RefCell<Option<Weak<super::browser::ViewState>>>,
     active_rename: Rc<RefCell<Option<ActiveModeRename>>>,
     active_new_entry: Rc<RefCell<Option<ActiveModeNewEntry>>>,
@@ -162,7 +163,7 @@ impl ModeViews {
             browser,
             single_click_previews: Rc::new(Cell::new(true)),
             transfer_handler: Rc::new(RefCell::new(None)),
-            cut_locations: Rc::new(RefCell::new(Vec::new())),
+            cut_locations: Rc::new(RefCell::new(HashSet::new())),
             context_state: RefCell::new(None),
             active_rename: Rc::new(RefCell::new(None)),
             active_new_entry: Rc::new(RefCell::new(None)),
@@ -446,7 +447,8 @@ impl ModeViews {
     }
 
     pub fn set_cut_locations(&self, locations: &[Location]) {
-        self.cut_locations.replace(locations.to_vec());
+        self.cut_locations
+            .replace(locations.iter().cloned().collect());
         for pane in self.grid_panes.iter().chain(self.explorer_pane.iter()) {
             refresh_cut_pane(pane, &self.browser, locations);
         }
@@ -960,7 +962,7 @@ fn build_grid_pane(
     browser: Rc<Browser>,
     single_click_previews: Rc<Cell<bool>>,
     transfer_handler: TransferHandlerSlot,
-    cut_locations: Rc<RefCell<Vec<Location>>>,
+    cut_locations: Rc<RefCell<HashSet<Location>>>,
     options: GridOptions,
     depth: usize,
     title: &str,
@@ -1545,7 +1547,7 @@ fn build_explorer_pane(
     browser: Rc<Browser>,
     single_click_previews: Rc<Cell<bool>>,
     transfer_handler: TransferHandlerSlot,
-    cut_locations: Rc<RefCell<Vec<Location>>>,
+    cut_locations: Rc<RefCell<HashSet<Location>>>,
     active_new_entry: Rc<RefCell<Option<ActiveModeNewEntry>>>,
     depth: usize,
     title: &str,

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -577,7 +577,10 @@ impl ModeViews {
             }
             BrowserEvent::ColumnReloaded { depth } => {
                 for pane in self.panes_at(*depth) {
+                    pane.syncing_selection.set(true);
+                    pane.selection.unselect_all();
                     pane.model.splice(0, pane.model.n_items(), &[]);
+                    pane.syncing_selection.set(false);
                     pane.spinner.set_visible(true);
                     pane.spinner.start();
                     pane.stack.set_visible_child_name("loading");

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -578,8 +578,13 @@ impl ModeViews {
             BrowserEvent::ColumnReloaded { depth } => {
                 for pane in self.panes_at(*depth) {
                     pane.syncing_selection.set(true);
-                    pane.selection.unselect_all();
+                    pane.selection.set_model(None::<&gio::ListModel>);
                     pane.model.splice(0, pane.model.n_items(), &[]);
+                    if let Some(filtered) = pane.filtered_model.as_ref() {
+                        pane.selection.set_model(Some(filtered));
+                    } else {
+                        pane.selection.set_model(Some(&pane.model));
+                    }
                     pane.syncing_selection.set(false);
                     pane.spinner.set_visible(true);
                     pane.spinner.start();

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -83,6 +83,7 @@ struct Pane {
     model: gtk::StringList,
     selection: gtk::MultiSelection,
     filtered_model: Option<gio::ListModel>,
+    filter_model: Option<gtk::FilterListModel>,
     syncing_selection: Rc<Cell<bool>>,
     stack: gtk::Stack,
     status: gtk::Label,
@@ -581,13 +582,10 @@ impl ModeViews {
                 for pane in self.panes_at(*depth) {
                     pane.syncing_selection.set(true);
                     pane.selection.set_model(None::<&gio::ListModel>);
-                    pane.model.splice(0, pane.model.n_items(), &[]);
-                    if let Some(filtered) = pane.filtered_model.as_ref() {
-                        pane.selection.set_model(Some(filtered));
-                    } else {
-                        pane.selection.set_model(Some(&pane.model));
+                    if let Some(filtered) = pane.filter_model.as_ref() {
+                        filtered.set_model(None::<&gio::ListModel>);
                     }
-                    pane.syncing_selection.set(false);
+                    pane.model.splice(0, pane.model.n_items(), &[]);
                     pane.spinner.set_visible(true);
                     pane.spinner.start();
                     pane.stack.set_visible_child_name("loading");
@@ -595,6 +593,7 @@ impl ModeViews {
             }
             BrowserEvent::LoadFinished { depth } => {
                 for pane in self.panes_at(*depth) {
+                    reconnect_pane_model(pane);
                     pane.spinner.stop();
                     pane.spinner.set_visible(false);
                     show_count(pane);
@@ -602,6 +601,7 @@ impl ModeViews {
             }
             BrowserEvent::LoadFailed { depth, message } => {
                 for pane in self.panes_at(*depth) {
+                    reconnect_pane_model(pane);
                     pane.spinner.stop();
                     pane.status
                         .set_label(&format!("Unable to read this directory\n{message}"));
@@ -1259,6 +1259,7 @@ fn build_grid_pane(
         model,
         selection,
         filtered_model: Some(view_model.upcast()),
+        filter_model: Some(filtered_model),
         syncing_selection,
         stack,
         status,
@@ -1603,7 +1604,7 @@ fn build_explorer_pane(
     let new_entry_is_directory = Rc::new(Cell::new(true));
     let flattened_models = gio::ListStore::new::<gio::ListModel>();
     flattened_models.append(&new_entry_placeholder.clone().upcast::<gio::ListModel>());
-    flattened_models.append(&filtered_model.upcast::<gio::ListModel>());
+    flattened_models.append(&filtered_model.clone().upcast::<gio::ListModel>());
     let view_model = gtk::FlattenListModel::new(Some(flattened_models));
     let view_model_object = view_model.clone().upcast::<gio::ListModel>();
     let selection = gtk::MultiSelection::new(Some(view_model.clone()));
@@ -1846,6 +1847,7 @@ fn build_explorer_pane(
         model,
         selection,
         filtered_model: Some(view_model_object),
+        filter_model: Some(filtered_model),
         syncing_selection,
         stack,
         status,
@@ -2462,6 +2464,21 @@ fn replace_entries(pane: &Pane, entries: &[FileEntry]) {
         .collect();
     pane.model.splice(0, pane.model.n_items(), &values);
     show_count(pane);
+}
+
+fn reconnect_pane_model(pane: &Pane) {
+    if pane.selection.model().is_some() {
+        return;
+    }
+    if let Some(filtered) = pane.filter_model.as_ref() {
+        filtered.set_model(Some(&pane.model));
+    }
+    if let Some(filtered) = pane.filtered_model.as_ref() {
+        pane.selection.set_model(Some(filtered));
+    } else {
+        pane.selection.set_model(Some(&pane.model));
+    }
+    pane.syncing_selection.set(false);
 }
 
 fn show_count(pane: &Pane) {

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -1895,9 +1895,7 @@ fn pane_base(
     let content = gtk::Box::new(gtk::Orientation::Vertical, 0);
     content.set_hexpand(true);
     content.set_vexpand(true);
-    let loading = gtk::Box::new(gtk::Orientation::Vertical, 0);
-    loading.set_valign(gtk::Align::Center);
-    loading.append(&gtk::Label::new(Some("Loading…")));
+    let loading = super::browser::loading_skeleton();
     let status = gtk::Label::new(Some("This directory is empty"));
     status.add_css_class("status-message");
     status.set_wrap(true);

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -539,7 +539,9 @@ impl ModeViews {
                             .collect();
                         pane.model.splice(insertion.position as u32, 0, &values);
                     }
-                    show_count(pane);
+                    if !pane.spinner.is_spinning() {
+                        show_count(pane);
+                    }
                 }
             }
             BrowserEvent::EntriesReplaced { depth, entries } => {


### PR DESCRIPTION
Closes #11

## Summary

- replace task abortion with explicit GIO cancellation
- report completed, failed, and unattempted items after cancellation
- refresh affected roots and open descendants, including remote locations
- preserve completed move results and cut-clipboard state
- safely stage recursive copies and replacements
- move staging cleanup off the GTK main thread
- provide cancellable progress for transfers, deletion, and restoration

## Safety

- completed operations are not misreported as cancelled
- cancellation cleanup removes only Strata-owned staging data
- existing destinations are never removed during staging cleanup
- affected-location tracking remains linear for large directory trees

## Testing

- cancellation between items and during recursive operations
- cancellation/completion race handling
- partial move failures and clipboard preservation
- replacement source and target refresh
- remote descendant refresh
- `./scripts/check.sh` — 214 tests passed