### PR TITLE
ci: standardize contribution workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,105 @@
+name: Bug report
+description: Report broken or unexpected behavior in Strata
+title: ""
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Strata. Please search existing issues before submitting a new report.
+
+  - type: input
+    id: version
+    attributes:
+      label: Strata version
+      description: Find this under Settings → Updates, or provide the commit SHA for a source build.
+      placeholder: e.g. 0.5.0 or commit abc1234
+    validations:
+      required: true
+
+  - type: dropdown
+    id: installation
+    attributes:
+      label: Installation method
+      options:
+        - GitHub release archive
+        - AUR package
+        - Built from source
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Linux distribution and desktop environment
+      placeholder: e.g. Arch Linux, Hyprland 0.49
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Briefly describe the problem and its impact.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide the smallest reliable sequence that triggers the problem.
+      placeholder: |
+        1. Open …
+        2. Select …
+        3. Observe …
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect Strata to do?
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Screenshots or video
+      description: Drag in screenshots or a short recording if they help demonstrate the problem.
+
+  - type: markdown
+    attributes:
+      value: |
+        ### Crash logs
+
+        If Strata crashed, look for its latest systemd-coredump report with:
+
+        ```shell
+        coredumpctl list strata
+        coredumpctl info strata
+        ```
+
+        Additional application messages may be available with:
+
+        ```shell
+        journalctl --user _COMM=strata --since "30 minutes ago"
+        ```
+
+        Paste relevant text below after removing private paths, filenames, hostnames, and secrets. **Do not upload a core dump**: it can contain passwords, tokens, and private document contents.
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste crash details, backtraces, or terminal output here. Leave this empty if no logs are available.
+      render: shell
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Include anything else that may help, such as whether the issue is intermittent or a recent regression.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+name: Feature request
+description: Suggest an improvement or new capability for Strata
+title: ""
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. Please search existing issues before submitting a new request.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What are you trying to accomplish, and why is it important?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Briefly describe how you would like Strata to address the problem.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe any workarounds or alternative designs you considered.
+
+  - type: textarea
+    id: visual-context
+    attributes:
+      label: Visual examples
+      description: Drag in mockups, screenshots, or short videos if they help explain the request.
+
+  - type: input
+    id: version
+    attributes:
+      label: Strata version
+      description: Optional. Find this under Settings → Updates, or provide the commit SHA for a source build.
+      placeholder: e.g. 0.5.0 or commit abc1234
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other details or links that may help evaluate the request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,11 +9,17 @@ For user-visible changes, attach before/after screenshots or a short video.
 For non-visual changes, write "N/A" and briefly explain why.
 -->
 
-## Testing
+## How to test
 
-<!-- List the checks you ran and any important manual test cases. -->
+<!--
+Give reviewers the steps needed to exercise the feature or reproduce the fixed bug.
+Include any setup, the actions to take, and the expected result. Do not list CI checks.
+-->
 
-- [ ] `./scripts/check.sh`
+1.
+2.
+
+**Expected result:**
 
 ## Related issue
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## What and why
+
+<!-- Briefly describe what changed and why it was needed. -->
+
+## Visual evidence
+
+<!--
+For user-visible changes, attach before/after screenshots or a short video.
+For non-visual changes, write "N/A" and briefly explain why.
+-->
+
+## Testing
+
+<!-- List the checks you ran and any important manual test cases. -->
+
+- [ ] `./scripts/check.sh`
+
+## Related issue
+
+Closes #

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-## What and why
+## Description
 
 <!-- Briefly describe what changed and why it was needed. -->
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,31 @@
+name: Pull request title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  conventional-title:
+    name: Conventional Commit format
+    runs-on: ubuntu-24.04
+    env:
+      PR_TITLE: ${{ github.event.pull_request.title }}
+    steps:
+      - name: Validate pull request title
+        shell: bash
+        run: |
+          pattern='^(feat|fix|docs|refactor|test|perf|build|ci|chore)(\([a-z0-9][a-z0-9._/-]*\))?!?: [[:lower:][:digit:]].+$'
+
+          if [[ ! "$PR_TITLE" =~ $pattern ]]; then
+            echo "Pull request titles must use Conventional Commit format:"
+            echo "  <type>(optional-scope): <imperative description>"
+            echo
+            echo "Allowed types: feat, fix, docs, refactor, test, perf, build, ci, chore"
+            echo "Examples:"
+            echo "  feat(preview): add video thumbnails"
+            echo "  fix!: remove legacy configuration support"
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,15 @@
 - Write commits and pull request titles in Conventional Commits format: `<type>(optional-scope): <imperative description>`.
 - Keep commits focused. Use `!` and a `BREAKING CHANGE:` footer for breaking changes, and reference the issue in the pull request body.
 
+## Issues and pull requests
+
+- Automated agents must follow the same issue-first workflow and pull request template as human contributors; do not remove or bypass template sections.
+- Use the bug report form for defects, the feature request form for enhancements, and a blank issue only when neither form fits.
+- Bug reports must include the Strata version, installation method, environment, reproduction steps, expected behavior, and any available sanitized logs. Never ask reporters to upload a core dump because it may contain secrets or private document contents.
+- Keep pull request descriptions concise: explain what changed and why, list testing, and link the issue.
+- Attach before/after screenshots or a short video for user-visible changes. Write `N/A` with a brief reason for non-visual changes.
+- Pull request titles must pass `.github/workflows/pr-title.yml`; do not bypass or weaken the Conventional Commit title check.
+
 ## Test organization
 
 - Do not place test implementations inline with production code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@
 - Automated agents must follow the same issue-first workflow and pull request template as human contributors; do not remove or bypass template sections.
 - Use the bug report form for defects, the feature request form for enhancements, and a blank issue only when neither form fits.
 - Bug reports must include the Strata version, installation method, environment, reproduction steps, expected behavior, and any available sanitized logs. Never ask reporters to upload a core dump because it may contain secrets or private document contents.
-- Keep pull request descriptions concise: explain what changed and why, list testing, and link the issue.
+- Keep pull request descriptions concise: explain what changed and why, provide manual steps to exercise the feature or reproduce the fixed bug, state the expected result, and link the issue. Do not list automated checks that CI already runs.
 - Attach before/after screenshots or a short video for user-visible changes. Write `N/A` with a brief reason for non-visual changes.
 - Pull request titles must pass `.github/workflows/pr-title.yml`; do not bypass or weaken the Conventional Commit title check.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Claude Code instructions
+
+@AGENTS.md
+
+## Code comments
+
+Do not litter code with comments. Comment only when it explains something that is not immediately apparent from the code, and keep every comment short and concise.


### PR DESCRIPTION
## What and why

Standardize issue and pull request submissions so maintainers receive concise, actionable reports and uniform changelog inputs. Add bug and feature Issue Forms, safe crash-log instructions, a focused pull request template, Conventional Commit title validation, and repository guidance for Claude, Codex, and other coding agents.

## Visual evidence

N/A — this changes GitHub contribution workflow files and agent documentation, not the application UI.

## How to test

1. After merge, choose **New issue** and select **Bug report**; verify it requests the Strata version, installation source, Linux environment, reproduction steps, expected behavior, visual evidence, and sanitized crash logs.
2. Select **Feature request**; verify it asks for the use case, proposed solution, alternatives, visual examples, and optional version.
3. Open a pull request; verify the body asks for a concise what/why, reviewer-facing manual test steps and expected result, visual evidence, and a related issue.
4. Give a pull request a non-Conventional title, then a title such as `fix(files): preserve selection`; verify the title check rejects the former and accepts the latter.

**Expected result:** Contributors are routed to an appropriate issue form, reviewers receive reproducible manual verification steps rather than redundant CI output, visual changes include evidence, and non-Conventional pull request titles fail validation.

## Related issue

Closes #77