### PR TITLE
ci: use Blacksmith runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   quality:
     name: Format, lint, and test
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
       - name: Check out repository
@@ -33,9 +37,6 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all --check
 
-      - name: Check compilation
-        run: cargo check --all-targets --all-features
-
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
@@ -44,7 +45,7 @@ jobs:
 
   dependencies:
     name: Dependency policy
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
       - name: Check out repository
@@ -57,7 +58,7 @@ jobs:
 
   spelling:
     name: Spelling
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
       - name: Check out repository

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   conventional-title:
     name: Conventional Commit format
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       PR_TITLE: ${{ github.event.pull_request.title }}
     steps:


### PR DESCRIPTION
## Description

Move the CI and pull request title jobs to the Blacksmith Ubuntu 24.04 runners already used by `lgse/fieldwrx`. Also cancel superseded runs for the same pull request or branch and remove the standalone `cargo check`, since Clippy already compiles all targets with all features. The separate jobs remain parallel because combining them would increase wall-clock latency.

## Visual evidence

N/A — workflow-only change with no user-visible UI.

## How to test

1. Open or update this pull request and inspect each workflow job’s runner details.
2. Push another update while a run is active and inspect the superseded run.

**Expected result:** CI and title validation run on `blacksmith-4vcpu-ubuntu-2404`, all existing checks still execute, and an older in-progress CI run for the same pull request is cancelled.

## Related issue

Closes #79