### PR TITLE
feat(archive): add compress and extract support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f0f96ce78e38c3dc6d8948aa8163d06385be74000f3c7a95bf1eef35d3ea32"
+dependencies = [
+ "cipher",
+ "cpubits",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,6 +47,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+ "zeroize",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,10 +76,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
 
 [[package]]
 name = "cairo-rs"
@@ -75,12 +120,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -99,6 +155,34 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "cookie"
@@ -127,6 +211,21 @@ dependencies = [
  "serde_json",
  "time",
  "url",
+]
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -164,10 +263,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "ctutils",
+ "zeroize",
+]
 
 [[package]]
 name = "displaydoc"
@@ -228,6 +364,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -393,8 +539,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -623,6 +771,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "http"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +794,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "icu_collections"
@@ -769,16 +935,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding",
+ "hybrid-array",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libbz2-rs-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
@@ -819,6 +1022,21 @@ name = "log"
 version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
+
+[[package]]
+name = "lzma-rust2"
+version = "0.16.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca93e534d1142d1d0dcca6d25fe302508a5dfb40b302802904577725ea0b695b"
+dependencies = [
+ "sha2",
+]
+
+[[package]]
+name = "lzma-rust2"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e2a88783b84d2d67ef2791778a9e76bfb68b8017aaf6c9d7d5f2626a478b16c"
 
 [[package]]
 name = "memchr"
@@ -891,6 +1109,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,6 +1177,12 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppmd-rust"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
 
 [[package]]
 name = "proc-macro-crate"
@@ -1083,6 +1317,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1147,6 +1387,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "sevenz-rust2"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb967eb8b29410e61e8c9005058fcfd5889d0b827856beb25529c73dfc86a98a"
+dependencies = [
+ "aes",
+ "bzip2",
+ "cbc",
+ "crc32fast",
+ "getrandom 0.4.3",
+ "js-sys",
+ "lzma-rust2 0.20.1",
+ "ppmd-rust",
+ "sha2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1228,6 +1508,7 @@ name = "strata"
 version = "0.5.0"
 dependencies = [
  "cairo-rs",
+ "flate2",
  "gdk-pixbuf",
  "gio",
  "glib",
@@ -1239,13 +1520,16 @@ dependencies = [
  "rustix",
  "serde",
  "serde_json",
+ "sevenz-rust2",
  "sourceview5",
+ "tar",
  "tempfile",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "ureq",
  "yeslogic-fontconfig-sys",
+ "zip",
 ]
 
 [[package]]
@@ -1301,6 +1585,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,6 +1630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
+ "js-sys",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -1501,6 +1797,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1607,6 +1915,51 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "webpki-roots"
@@ -1736,6 +2089,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yeslogic-fontconfig-sys"
 version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1830,6 +2193,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "aes",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "deflate64",
+ "flate2",
+ "getrandom 0.4.3",
+ "hmac",
+ "indexmap",
+ "lzma-rust2 0.16.5",
+ "memchr",
+ "pbkdf2",
+ "ppmd-rust",
+ "sha1",
+ "time",
+ "typed-path",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
 name = "zlib-rs"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1840,3 +2230,43 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["filesystem", "gui"]
 
 [dependencies]
 cairo-rs = { version = "0.21.5", features = ["pdf", "png"] }
+flate2 = "1.1.10"
 fontconfig-sys = { package = "yeslogic-fontconfig-sys", version = "6.0.1" }
 gdk-pixbuf = "0.21.5"
 gio = { version = "0.21.5", features = ["v2_72"] }
@@ -21,12 +22,15 @@ poppler = { package = "poppler-rs", version = "0.25.0" }
 pulldown-cmark = { version = "0.13", default-features = false }
 rustix = { version = "1.1.4", features = ["fs", "process"] }
 serde = { version = "1.0", features = ["derive"] }
+sevenz-rust2 = "0.22.2"
 sourceview5 = { version = "0.10.0", features = ["gtk_v4_12"] }
+tar = "0.4.46"
 tempfile = "3.27.0"
 toml = "0.9"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.20"
 ureq = { version = "3.4", features = ["json"] }
+zip = "8.6.0"
 
 [build-dependencies]
 glib-build-tools = "0.21.0"

--- a/deny.toml
+++ b/deny.toml
@@ -10,12 +10,16 @@ allow = [
   "Apache-2.0",
   "Apache-2.0 WITH LLVM-exception",
   "BSD-3-Clause",
+  "bzip2-1.0.6",
+  "CC0-1.0",
   "CDLA-Permissive-2.0",
   "GPL-3.0-or-later",
   "ISC",
   "MIT",
+  "MIT-0",
   "Unicode-3.0",
   "Unlicense",
+  "Zlib",
 ]
 
 [bans]

--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -3,16 +3,21 @@
 #[cfg(test)]
 mod tests;
 
-use std::{future::Future, io, path::Path, pin::Pin, rc::Rc};
+use std::{
+    future::Future, io, path::Path, pin::Pin, rc::Rc, sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
 
 use gtk::{gio, glib, prelude::*};
 
 use crate::{
     model::Location,
     services::{
-        CreateDirectoryRequest, CreateFileRequest, DeleteRequest, LoadHandle, OperationEvent,
-        OperationProvider, PasteRequest, RenameRequest, RestoreRequest, TransferConflict,
-        validate_basename,
+        ArchiveFormat, CompressRequest, CreateDirectoryRequest, CreateFileRequest, DeleteRequest,
+        ExtractRequest, LoadHandle, OperationEvent, OperationProvider, OperationRequestId,
+        PasteRequest, RenameRequest, RestoreRequest, TransferConflict, validate_basename,
     },
 };
 
@@ -548,4 +553,538 @@ impl OperationProvider for LocalOperationProvider {
         });
         LoadHandle::new(move || task.abort())
     }
+
+    fn compress(
+        &self,
+        request: CompressRequest,
+        emit: Rc<dyn Fn(OperationEvent)>,
+    ) -> LoadHandle {
+        let task = glib::MainContext::default().spawn_local(async move {
+            let Some(dest_dir) = request.destination.native_path() else {
+                emit(OperationEvent::Failed {
+                    request_id: request.id,
+                    message: "Archive destination must be a local path".to_owned(),
+                });
+                return;
+            };
+            let archive_name = format!("{}.{}", request.archive_name, request.format.extension());
+            let archive_path = dest_dir.join(&archive_name);
+            let entries: Vec<std::path::PathBuf> = request
+                .entries
+                .iter()
+                .filter_map(|e| e.location.native_path().map(Path::to_path_buf))
+                .collect();
+            if entries.is_empty() {
+                emit(OperationEvent::Failed {
+                    request_id: request.id,
+                    message: "Nothing to compress".to_owned(),
+                });
+                return;
+            }
+            let total = Arc::new(AtomicUsize::new(0));
+            let progress = Arc::new(AtomicUsize::new(0));
+            emit(OperationEvent::ArchiveStarted {
+                request_id: request.id,
+                total: 0,
+            });
+            let timer_id = archive_progress_timer(request.id, &progress, &total, &emit);
+            let format = request.format;
+            let password = request.password.clone();
+            let work_progress = progress.clone();
+            let work_total = total.clone();
+            let result = gio::spawn_blocking(move || {
+                let count = count_files(&entries);
+                work_total.store(count, Ordering::Relaxed);
+                match format {
+                    ArchiveFormat::Zip => compress_zip(&archive_path, &entries, password.as_deref(), &work_progress),
+                    ArchiveFormat::SevenZ => compress_7z(&archive_path, &entries, password.as_deref(), &work_progress),
+                    ArchiveFormat::TarGz => compress_tar(&archive_path, &entries, true, &work_progress),
+                    ArchiveFormat::Tar => compress_tar(&archive_path, &entries, false, &work_progress),
+                }
+            })
+            .await;
+            timer_id.remove();
+            match result {
+                Ok(Ok(())) => emit(OperationEvent::Compressed {
+                    request_id: request.id,
+                    archive_name: archive_name.clone(),
+                }),
+                Ok(Err(error)) => emit(OperationEvent::Failed {
+                    request_id: request.id,
+                    message: error,
+                }),
+                Err(_) => emit(OperationEvent::Failed {
+                    request_id: request.id,
+                    message: "Compression task panicked".to_owned(),
+                }),
+            }
+        });
+        LoadHandle::new(move || task.abort())
+    }
+
+    fn extract(
+        &self,
+        request: ExtractRequest,
+        emit: Rc<dyn Fn(OperationEvent)>,
+    ) -> LoadHandle {
+        let task = glib::MainContext::default().spawn_local(async move {
+            let Some(archive_path) = request.entry.location.native_path().map(Path::to_path_buf) else {
+                emit(OperationEvent::Failed {
+                    request_id: request.id,
+                    message: "Archive must be a local file".to_owned(),
+                });
+                return;
+            };
+            let Some(dest_dir) = request.destination.native_path().map(Path::to_path_buf) else {
+                emit(OperationEvent::Failed {
+                    request_id: request.id,
+                    message: "Extract destination must be a local path".to_owned(),
+                });
+                return;
+            };
+            let format = ArchiveFormat::from_extension(&request.entry.display_name);
+            let password = request.password.clone();
+            let display_name = request.entry.display_name.clone();
+            let progress = Arc::new(AtomicUsize::new(0));
+            let total = Arc::new(AtomicUsize::new(0));
+            emit(OperationEvent::ArchiveStarted {
+                request_id: request.id,
+                total: 0,
+            });
+            let timer_id = archive_progress_timer(request.id, &progress, &total, &emit);
+            let work_progress = progress.clone();
+            let work_total = total.clone();
+            let result = gio::spawn_blocking(move || match format {
+                Some(ArchiveFormat::Zip) => {
+                    let file = std::fs::File::open(&archive_path).map_err(|e| e.to_string())?;
+                    let mut archive = zip::ZipArchive::new(file).map_err(|e| e.to_string())?;
+                    work_total.store(archive.len(), Ordering::Relaxed);
+                    extract_zip_from_archive(&mut archive, &dest_dir, password.as_deref(), &work_progress)
+                }
+                Some(ArchiveFormat::SevenZ) => {
+                    let pw = password.as_deref().map(sevenz_rust2::Password::from).unwrap_or_default();
+                    let reader = sevenz_rust2::ArchiveReader::open(&archive_path, pw)
+                        .map_err(|e| e.to_string())?;
+                    extract_7z_from_reader(reader, &dest_dir, &work_progress)
+                }
+                Some(ArchiveFormat::TarGz) => extract_tar(&archive_path, &dest_dir, true, &work_progress),
+                Some(ArchiveFormat::Tar) => extract_tar(&archive_path, &dest_dir, false, &work_progress),
+                None => Err(format!("Unsupported archive format: {}", display_name)),
+            })
+            .await;
+            timer_id.remove();
+            match result {
+                Ok(Ok(first_name)) => emit(OperationEvent::Extracted {
+                    request_id: request.id,
+                    first_name,
+                }),
+                Ok(Err(error)) => emit(OperationEvent::Failed {
+                    request_id: request.id,
+                    message: error,
+                }),
+                Err(_) => emit(OperationEvent::Failed {
+                    request_id: request.id,
+                    message: "Extraction task panicked".to_owned(),
+                }),
+            }
+        });
+        LoadHandle::new(move || task.abort())
+    }
+}
+
+fn compress_zip(archive_path: &Path, entries: &[std::path::PathBuf], password: Option<&str>, progress: &Arc<AtomicUsize>) -> Result<(), String> {
+    let file = std::fs::File::create(archive_path).map_err(|e| e.to_string())?;
+    let writer = std::io::BufWriter::with_capacity(COPY_BUF, file);
+    let mut writer = zip::ZipWriter::new(writer);
+    let deflated = zip::write::SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated)
+        .compression_level(Some(6));
+    let stored = zip::write::SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Stored);
+    let deflated = if let Some(pw) = password {
+        deflated.with_aes_encryption(zip::AesMode::Aes256, pw)
+    } else {
+        deflated
+    };
+    let stored = if let Some(pw) = password {
+        stored.with_aes_encryption(zip::AesMode::Aes256, pw)
+    } else {
+        stored
+    };
+    for entry in entries {
+        let name = entry
+            .file_name()
+            .ok_or("Entry has no file name")?
+            .to_string_lossy()
+            .to_string();
+        if entry.is_dir() {
+            add_dir_to_zip(&mut writer, entry, &name, &deflated, &stored, progress)?;
+        } else {
+            let opts = if is_incompressible(entry) { &stored } else { &deflated };
+            writer
+                .start_file(&name, *opts)
+                .map_err(|e| e.to_string())?;
+            let f = std::fs::File::open(entry).map_err(|e| e.to_string())?;
+            let f = std::io::BufReader::with_capacity(COPY_BUF, f);
+            copy_with_big_buf(f, &mut writer).map_err(|e| e.to_string())?;
+            progress.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+    writer.finish().map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn add_dir_to_zip<W: std::io::Write + std::io::Seek>(
+    writer: &mut zip::ZipWriter<W>,
+    dir: &Path,
+    prefix: &str,
+    deflated: &zip::write::FileOptions<'_, ()>,
+    stored: &zip::write::FileOptions<'_, ()>,
+    progress: &Arc<AtomicUsize>,
+) -> Result<(), String> {
+    for entry in std::fs::read_dir(dir).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path();
+        let rel_name = format!("{}/{}", prefix, entry.file_name().to_string_lossy());
+        if path.is_dir() {
+            add_dir_to_zip(writer, &path, &rel_name, deflated, stored, progress)?;
+        } else {
+            let opts = if is_incompressible(&path) { stored } else { deflated };
+            writer
+                .start_file(&rel_name, *opts)
+                .map_err(|e| e.to_string())?;
+            let f = std::fs::File::open(&path).map_err(|e| e.to_string())?;
+            let f = std::io::BufReader::with_capacity(COPY_BUF, f);
+            copy_with_big_buf(f, writer).map_err(|e| e.to_string())?;
+            progress.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+    Ok(())
+}
+
+fn compress_tar(archive_path: &Path, entries: &[std::path::PathBuf], gzip: bool, progress: &Arc<AtomicUsize>) -> Result<(), String> {
+    let file = std::fs::File::create(archive_path).map_err(|e| e.to_string())?;
+    let writer: Box<dyn std::io::Write> = if gzip {
+        Box::new(std::io::BufWriter::with_capacity(COPY_BUF,
+            flate2::write::GzEncoder::new(file, flate2::Compression::default())))
+    } else {
+        Box::new(std::io::BufWriter::with_capacity(COPY_BUF, file))
+    };
+    let mut builder = tar::Builder::new(writer);
+    for entry in entries {
+        let name = entry
+            .file_name()
+            .ok_or("Entry has no file name")?
+            .to_string_lossy()
+            .to_string();
+        if entry.is_dir() {
+            builder
+                .append_dir_all(&name, entry)
+                .map_err(|e| e.to_string())?;
+        } else {
+            builder
+                .append_path_with_name(entry, &name)
+                .map_err(|e| e.to_string())?;
+        }
+        progress.fetch_add(1, Ordering::Relaxed);
+    }
+    builder.finish().map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn safe_extract_path(dest_dir: &Path, name: &str) -> Result<std::path::PathBuf, String> {
+    let outpath = dest_dir.join(name);
+    if !outpath.starts_with(dest_dir) {
+        return Err(format!("Refusing to extract outside destination: {name}"));
+    }
+    Ok(outpath)
+}
+
+/// Returns a path that doesn't conflict with existing files. If `outpath` exists,
+/// appends " (2)", " (3)", etc. to the stem.
+fn unique_path(outpath: &Path) -> std::path::PathBuf {
+    if !outpath.exists() {
+        return outpath.to_path_buf();
+    }
+    let parent = outpath.parent().unwrap_or(Path::new("."));
+    let stem = outpath.file_stem().map(|s| s.to_string_lossy().to_string()).unwrap_or_default();
+    let ext = outpath.extension().map(|e| format!(".{}", e.to_string_lossy())).unwrap_or_default();
+    for i in 2.. {
+        let candidate = parent.join(format!("{stem} ({i}){ext}"));
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+    outpath.to_path_buf()
+}
+
+/// Counts all files (not directories) under the given paths recursively.
+fn count_files(entries: &[std::path::PathBuf]) -> usize {
+    let mut count = 0;
+    for entry in entries {
+        if entry.is_dir() {
+            if let Ok(rd) = std::fs::read_dir(entry) {
+                for child in rd.flatten() {
+                    count += count_files(&[child.path()]);
+                }
+            }
+        } else {
+            count += 1;
+        }
+    }
+    count
+}
+
+const COPY_BUF: usize = 1 << 20; // 1 MiB
+
+fn copy_with_big_buf(mut reader: impl std::io::Read, writer: &mut (impl std::io::Write + ?Sized)) -> std::io::Result<u64> {
+    let mut buf = vec![0u8; COPY_BUF];
+    let mut total = 0;
+    loop {
+        let n = reader.read(&mut buf)?;
+        if n == 0 { break; }
+        writer.write_all(&buf[..n])?;
+        total += n as u64;
+    }
+    Ok(total)
+}
+
+/// Spawns a 100ms timer that polls progress counters and emits ArchiveProgress events.
+fn archive_progress_timer(
+    request_id: OperationRequestId,
+    progress: &Arc<AtomicUsize>,
+    total: &Arc<AtomicUsize>,
+    emit: &Rc<dyn Fn(OperationEvent)>,
+) -> glib::SourceId {
+    let timer_progress = progress.clone();
+    let timer_total = total.clone();
+    let timer_emit = emit.clone();
+    glib::timeout_add_local(std::time::Duration::from_millis(100), move || {
+        timer_emit(OperationEvent::ArchiveProgress {
+            request_id,
+            completed: timer_progress.load(Ordering::Relaxed),
+            total: timer_total.load(Ordering::Relaxed),
+        });
+        glib::ControlFlow::Continue
+    })
+}
+
+/// File extensions that are already compressed — storing them raw saves CPU with zero size gain.
+const INCOMPRESSIBLE_EXTS: &[&str] = &[
+    "zip", "7z", "gz", "bz2", "xz", "zst", "tar", "rar", "lz", "lz4", "br",
+    "mp4", "mkv", "avi", "mov", "webm", "flv", "wmv",
+    "jpg", "jpeg", "png", "webp", "gif", "heic", "avif", "bmp",
+    "mp3", "flac", "aac", "ogg", "opus", "wma", "m4a",
+    "pdf", "epub", "docx", "xlsx", "pptx", "odt", "ods", "odp",
+    "iso", "dmg", "deb", "rpm", "apk", "jar", "war",
+];
+
+fn is_incompressible(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| INCOMPRESSIBLE_EXTS.contains(&e.to_lowercase().as_str()))
+        .unwrap_or(false)
+}
+
+/// Tracks renamed top-level entries so child paths follow the rename.
+struct ExtractNameResolver {
+    renames: std::collections::HashMap<String, String>,
+}
+
+impl ExtractNameResolver {
+    fn new() -> Self {
+        Self {
+            renames: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Resolves an archive entry name to a safe, conflict-free filesystem path.
+    /// If the top-level component already exists, it's renamed to "name (2)", etc.
+    fn resolve(&mut self, dest_dir: &Path, name: &str) -> Result<std::path::PathBuf, String> {
+        let top = name.split('/').next().unwrap_or(name);
+        let rest = &name[top.len()..];
+        let resolved_top = if let Some(existing) = self.renames.get(top) {
+            existing.clone()
+        } else if dest_dir.join(top).exists() {
+            let renamed = unique_path(&dest_dir.join(top));
+            let new_name = renamed
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| top.to_string());
+            self.renames.insert(top.to_string(), new_name.clone());
+            new_name
+        } else {
+            self.renames.insert(top.to_string(), top.to_string());
+            top.to_string()
+        };
+        let resolved_name = format!("{resolved_top}{rest}");
+        safe_extract_path(dest_dir, &resolved_name)
+    }
+}
+
+fn extract_zip_from_archive(
+    archive: &mut zip::ZipArchive<std::fs::File>,
+    dest_dir: &Path,
+    password: Option<&str>,
+    progress: &Arc<AtomicUsize>,
+) -> Result<Option<String>, String> {
+    let pw_bytes = password.map(|p| p.as_bytes());
+    let mut resolver = ExtractNameResolver::new();
+    let mut first_name = None;
+    for i in 0..archive.len() {
+        let read_options = zip::read::ZipReadOptions::new().password(pw_bytes);
+        let mut entry = archive.by_index_with_options(i, read_options).map_err(|e| e.to_string())?;
+        let name = entry.name().trim_end_matches('/').to_owned();
+        let outpath = resolver.resolve(dest_dir, &name)?;
+        if first_name.is_none() {
+            first_name = outpath
+                .strip_prefix(dest_dir)
+                .ok()
+                .and_then(|p| p.components().next())
+                .map(|c| c.as_os_str().to_string_lossy().to_string());
+        }
+        if entry.is_dir() {
+            std::fs::create_dir_all(&outpath).map_err(|e| e.to_string())?;
+        } else {
+            if let Some(parent) = outpath.parent() {
+                std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+            }
+            let outpath = unique_path(&outpath);
+            let mut outfile = std::fs::File::create(&outpath).map_err(|e| e.to_string())?;
+            copy_with_big_buf(&mut entry, &mut outfile).map_err(|e| e.to_string())?;
+        }
+        progress.fetch_add(1, Ordering::Relaxed);
+    }
+    Ok(first_name)
+}
+
+fn extract_tar(archive_path: &Path, dest_dir: &Path, gzip: bool, progress: &Arc<AtomicUsize>) -> Result<Option<String>, String> {
+    let file = std::fs::File::open(archive_path).map_err(|e| e.to_string())?;
+    let reader: Box<dyn std::io::Read> = if gzip {
+        Box::new(flate2::read::GzDecoder::new(file))
+    } else {
+        Box::new(file)
+    };
+    let mut archive = tar::Archive::new(reader);
+    let mut resolver = ExtractNameResolver::new();
+    let mut first_name = None;
+    for entry in archive.entries().map_err(|e| e.to_string())? {
+        let mut entry = entry.map_err(|e| e.to_string())?;
+        let name = entry.path().map_err(|e| e.to_string())?;
+        let name = name.to_string_lossy().trim_end_matches('/').to_string();
+        let outpath = resolver.resolve(dest_dir, &name)?;
+        if first_name.is_none() {
+            first_name = outpath
+                .strip_prefix(dest_dir)
+                .ok()
+                .and_then(|p| p.components().next())
+                .map(|c| c.as_os_str().to_string_lossy().to_string());
+        }
+        if entry.header().entry_type().is_dir() {
+            std::fs::create_dir_all(&outpath).map_err(|e| e.to_string())?;
+        } else {
+            if let Some(parent) = outpath.parent() {
+                std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+            }
+            let outpath = unique_path(&outpath);
+            let mut outfile = std::fs::File::create(&outpath).map_err(|e| e.to_string())?;
+            copy_with_big_buf(&mut entry, &mut outfile).map_err(|e| e.to_string())?;
+        }
+        progress.fetch_add(1, Ordering::Relaxed);
+    }
+    Ok(first_name)
+}
+
+fn compress_7z(archive_path: &Path, entries: &[std::path::PathBuf], password: Option<&str>, progress: &Arc<AtomicUsize>) -> Result<(), String> {
+    use sevenz_rust2::encoder_options::{AesEncoderOptions, EncoderOptions, Lzma2Options};
+    let mut writer = sevenz_rust2::ArchiveWriter::create(archive_path)
+        .map_err(|e| e.to_string())?;
+    let threads = std::thread::available_parallelism().map(|n| n.get() as u32).unwrap_or(1);
+    let lzma2 = sevenz_rust2::EncoderConfiguration::new(sevenz_rust2::EncoderMethod::LZMA2)
+        .with_options(EncoderOptions::Lzma2(Lzma2Options::from_level_mt(6, threads, 1 << 26)));
+    if let Some(pw) = password {
+        let methods = vec![
+            lzma2,
+            AesEncoderOptions::new(pw.into()).into(),
+        ];
+        writer.set_content_methods(methods);
+    } else {
+        writer.set_content_methods(vec![lzma2]);
+    }
+    for entry in entries {
+        add_path_to_7z(&mut writer, entry, entry, progress)?;
+    }
+    writer.finish().map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn add_path_to_7z(
+    writer: &mut sevenz_rust2::ArchiveWriter<std::fs::File>,
+    base: &Path,
+    path: &Path,
+    progress: &Arc<AtomicUsize>,
+) -> Result<(), String> {
+    if path.is_dir() {
+        for child in std::fs::read_dir(path).map_err(|e| e.to_string())? {
+            let child = child.map_err(|e| e.to_string())?;
+            add_path_to_7z(writer, base, &child.path(), progress)?;
+        }
+    } else {
+        let name = path
+            .strip_prefix(base.parent().unwrap_or(base))
+            .unwrap_or(path)
+            .to_string_lossy()
+            .to_string();
+        let entry = sevenz_rust2::ArchiveEntry::from_path(path, name);
+        let reader = std::fs::File::open(path).map_err(|e| e.to_string())?;
+        writer
+            .push_archive_entry(entry, Some(reader))
+            .map_err(|e| e.to_string())?;
+        progress.fetch_add(1, Ordering::Relaxed);
+    }
+    Ok(())
+}
+
+fn extract_7z_from_reader(
+    mut reader: sevenz_rust2::ArchiveReader<std::fs::File>,
+    dest_dir: &Path,
+    progress: &Arc<AtomicUsize>,
+) -> Result<Option<String>, String> {
+    let resolver = std::cell::RefCell::new(ExtractNameResolver::new());
+    let first_name = std::cell::RefCell::new(None::<String>);
+    let dest = dest_dir.to_path_buf();
+    let progress = progress.clone();
+    reader
+        .for_each_entries(|entry, reader| {
+            let name = entry.name.trim_end_matches('/');
+            let outpath = resolver
+                .borrow_mut()
+                .resolve(&dest, name)
+                .map_err(|e| sevenz_rust2::Error::Other(e.to_string().into()))?;
+            if first_name.borrow().is_none() {
+                *first_name.borrow_mut() = outpath
+                    .strip_prefix(&dest)
+                    .ok()
+                    .and_then(|p| p.components().next())
+                    .map(|c| c.as_os_str().to_string_lossy().to_string());
+            }
+            if entry.is_directory {
+                std::fs::create_dir_all(&outpath)
+                    .map_err(|e| sevenz_rust2::Error::Other(e.to_string().into()))?;
+            } else {
+                if let Some(parent) = outpath.parent() {
+                    std::fs::create_dir_all(parent)
+                        .map_err(|e| sevenz_rust2::Error::Other(e.to_string().into()))?;
+                }
+                let outpath = unique_path(&outpath);
+                let mut file = std::fs::File::create(&outpath)
+                    .map_err(|e| sevenz_rust2::Error::Other(e.to_string().into()))?;
+                copy_with_big_buf(reader, &mut file)
+                    .map_err(|e| sevenz_rust2::Error::Other(e.to_string().into()))?;
+            }
+            progress.fetch_add(1, Ordering::Relaxed);
+            Ok(false)
+        })
+        .map_err(|e| e.to_string())?;
+    Ok(first_name.into_inner())
 }

--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -4,9 +4,14 @@
 mod tests;
 
 use std::{
-    future::Future, io, path::Path, pin::Pin, rc::Rc, sync::{
-        atomic::{AtomicUsize, Ordering},
+    future::Future,
+    io,
+    path::Path,
+    pin::Pin,
+    rc::Rc,
+    sync::{
         Arc,
+        atomic::{AtomicUsize, Ordering},
     },
 };
 
@@ -554,11 +559,7 @@ impl OperationProvider for LocalOperationProvider {
         LoadHandle::new(move || task.abort())
     }
 
-    fn compress(
-        &self,
-        request: CompressRequest,
-        emit: Rc<dyn Fn(OperationEvent)>,
-    ) -> LoadHandle {
+    fn compress(&self, request: CompressRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle {
         let task = glib::MainContext::default().spawn_local(async move {
             let Some(dest_dir) = request.destination.native_path() else {
                 emit(OperationEvent::Failed {
@@ -596,10 +597,18 @@ impl OperationProvider for LocalOperationProvider {
                 let count = count_files(&entries);
                 work_total.store(count, Ordering::Relaxed);
                 match format {
-                    ArchiveFormat::Zip => compress_zip(&archive_path, &entries, password.as_deref(), &work_progress),
-                    ArchiveFormat::SevenZ => compress_7z(&archive_path, &entries, password.as_deref(), &work_progress),
-                    ArchiveFormat::TarGz => compress_tar(&archive_path, &entries, true, &work_progress),
-                    ArchiveFormat::Tar => compress_tar(&archive_path, &entries, false, &work_progress),
+                    ArchiveFormat::Zip => {
+                        compress_zip(&archive_path, &entries, password.as_deref(), &work_progress)
+                    }
+                    ArchiveFormat::SevenZ => {
+                        compress_7z(&archive_path, &entries, password.as_deref(), &work_progress)
+                    }
+                    ArchiveFormat::TarGz => {
+                        compress_tar(&archive_path, &entries, true, &work_progress)
+                    }
+                    ArchiveFormat::Tar => {
+                        compress_tar(&archive_path, &entries, false, &work_progress)
+                    }
                 }
             })
             .await;
@@ -622,13 +631,10 @@ impl OperationProvider for LocalOperationProvider {
         LoadHandle::new(move || task.abort())
     }
 
-    fn extract(
-        &self,
-        request: ExtractRequest,
-        emit: Rc<dyn Fn(OperationEvent)>,
-    ) -> LoadHandle {
+    fn extract(&self, request: ExtractRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle {
         let task = glib::MainContext::default().spawn_local(async move {
-            let Some(archive_path) = request.entry.location.native_path().map(Path::to_path_buf) else {
+            let Some(archive_path) = request.entry.location.native_path().map(Path::to_path_buf)
+            else {
                 emit(OperationEvent::Failed {
                     request_id: request.id,
                     message: "Archive must be a local file".to_owned(),
@@ -659,16 +665,28 @@ impl OperationProvider for LocalOperationProvider {
                     let file = std::fs::File::open(&archive_path).map_err(|e| e.to_string())?;
                     let mut archive = zip::ZipArchive::new(file).map_err(|e| e.to_string())?;
                     work_total.store(archive.len(), Ordering::Relaxed);
-                    extract_zip_from_archive(&mut archive, &dest_dir, password.as_deref(), &work_progress)
+                    extract_zip_from_archive(
+                        &mut archive,
+                        &dest_dir,
+                        password.as_deref(),
+                        &work_progress,
+                    )
                 }
                 Some(ArchiveFormat::SevenZ) => {
-                    let pw = password.as_deref().map(sevenz_rust2::Password::from).unwrap_or_default();
+                    let pw = password
+                        .as_deref()
+                        .map(sevenz_rust2::Password::from)
+                        .unwrap_or_default();
                     let reader = sevenz_rust2::ArchiveReader::open(&archive_path, pw)
                         .map_err(|e| e.to_string())?;
                     extract_7z_from_reader(reader, &dest_dir, &work_progress)
                 }
-                Some(ArchiveFormat::TarGz) => extract_tar(&archive_path, &dest_dir, true, &work_progress),
-                Some(ArchiveFormat::Tar) => extract_tar(&archive_path, &dest_dir, false, &work_progress),
+                Some(ArchiveFormat::TarGz) => {
+                    extract_tar(&archive_path, &dest_dir, true, &work_progress)
+                }
+                Some(ArchiveFormat::Tar) => {
+                    extract_tar(&archive_path, &dest_dir, false, &work_progress)
+                }
                 None => Err(format!("Unsupported archive format: {}", display_name)),
             })
             .await;
@@ -692,15 +710,20 @@ impl OperationProvider for LocalOperationProvider {
     }
 }
 
-fn compress_zip(archive_path: &Path, entries: &[std::path::PathBuf], password: Option<&str>, progress: &Arc<AtomicUsize>) -> Result<(), String> {
+fn compress_zip(
+    archive_path: &Path,
+    entries: &[std::path::PathBuf],
+    password: Option<&str>,
+    progress: &Arc<AtomicUsize>,
+) -> Result<(), String> {
     let file = std::fs::File::create(archive_path).map_err(|e| e.to_string())?;
     let writer = std::io::BufWriter::with_capacity(COPY_BUF, file);
     let mut writer = zip::ZipWriter::new(writer);
     let deflated = zip::write::SimpleFileOptions::default()
         .compression_method(zip::CompressionMethod::Deflated)
         .compression_level(Some(6));
-    let stored = zip::write::SimpleFileOptions::default()
-        .compression_method(zip::CompressionMethod::Stored);
+    let stored =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
     let deflated = if let Some(pw) = password {
         deflated.with_aes_encryption(zip::AesMode::Aes256, pw)
     } else {
@@ -720,10 +743,12 @@ fn compress_zip(archive_path: &Path, entries: &[std::path::PathBuf], password: O
         if entry.is_dir() {
             add_dir_to_zip(&mut writer, entry, &name, &deflated, &stored, progress)?;
         } else {
-            let opts = if is_incompressible(entry) { &stored } else { &deflated };
-            writer
-                .start_file(&name, *opts)
-                .map_err(|e| e.to_string())?;
+            let opts = if is_incompressible(entry) {
+                &stored
+            } else {
+                &deflated
+            };
+            writer.start_file(&name, *opts).map_err(|e| e.to_string())?;
             let f = std::fs::File::open(entry).map_err(|e| e.to_string())?;
             let f = std::io::BufReader::with_capacity(COPY_BUF, f);
             copy_with_big_buf(f, &mut writer).map_err(|e| e.to_string())?;
@@ -749,7 +774,11 @@ fn add_dir_to_zip<W: std::io::Write + std::io::Seek>(
         if path.is_dir() {
             add_dir_to_zip(writer, &path, &rel_name, deflated, stored, progress)?;
         } else {
-            let opts = if is_incompressible(&path) { stored } else { deflated };
+            let opts = if is_incompressible(&path) {
+                stored
+            } else {
+                deflated
+            };
             writer
                 .start_file(&rel_name, *opts)
                 .map_err(|e| e.to_string())?;
@@ -762,11 +791,18 @@ fn add_dir_to_zip<W: std::io::Write + std::io::Seek>(
     Ok(())
 }
 
-fn compress_tar(archive_path: &Path, entries: &[std::path::PathBuf], gzip: bool, progress: &Arc<AtomicUsize>) -> Result<(), String> {
+fn compress_tar(
+    archive_path: &Path,
+    entries: &[std::path::PathBuf],
+    gzip: bool,
+    progress: &Arc<AtomicUsize>,
+) -> Result<(), String> {
     let file = std::fs::File::create(archive_path).map_err(|e| e.to_string())?;
     let writer: Box<dyn std::io::Write> = if gzip {
-        Box::new(std::io::BufWriter::with_capacity(COPY_BUF,
-            flate2::write::GzEncoder::new(file, flate2::Compression::default())))
+        Box::new(std::io::BufWriter::with_capacity(
+            COPY_BUF,
+            flate2::write::GzEncoder::new(file, flate2::Compression::default()),
+        ))
     } else {
         Box::new(std::io::BufWriter::with_capacity(COPY_BUF, file))
     };
@@ -807,8 +843,14 @@ fn unique_path(outpath: &Path) -> std::path::PathBuf {
         return outpath.to_path_buf();
     }
     let parent = outpath.parent().unwrap_or(Path::new("."));
-    let stem = outpath.file_stem().map(|s| s.to_string_lossy().to_string()).unwrap_or_default();
-    let ext = outpath.extension().map(|e| format!(".{}", e.to_string_lossy())).unwrap_or_default();
+    let stem = outpath
+        .file_stem()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let ext = outpath
+        .extension()
+        .map(|e| format!(".{}", e.to_string_lossy()))
+        .unwrap_or_default();
     for i in 2.. {
         let candidate = parent.join(format!("{stem} ({i}){ext}"));
         if !candidate.exists() {
@@ -837,12 +879,17 @@ fn count_files(entries: &[std::path::PathBuf]) -> usize {
 
 const COPY_BUF: usize = 1 << 20; // 1 MiB
 
-fn copy_with_big_buf(mut reader: impl std::io::Read, writer: &mut (impl std::io::Write + ?Sized)) -> std::io::Result<u64> {
+fn copy_with_big_buf(
+    mut reader: impl std::io::Read,
+    writer: &mut (impl std::io::Write + ?Sized),
+) -> std::io::Result<u64> {
     let mut buf = vec![0u8; COPY_BUF];
     let mut total = 0;
     loop {
         let n = reader.read(&mut buf)?;
-        if n == 0 { break; }
+        if n == 0 {
+            break;
+        }
         writer.write_all(&buf[..n])?;
         total += n as u64;
     }
@@ -871,12 +918,10 @@ fn archive_progress_timer(
 
 /// File extensions that are already compressed — storing them raw saves CPU with zero size gain.
 const INCOMPRESSIBLE_EXTS: &[&str] = &[
-    "zip", "7z", "gz", "bz2", "xz", "zst", "tar", "rar", "lz", "lz4", "br",
-    "mp4", "mkv", "avi", "mov", "webm", "flv", "wmv",
-    "jpg", "jpeg", "png", "webp", "gif", "heic", "avif", "bmp",
-    "mp3", "flac", "aac", "ogg", "opus", "wma", "m4a",
-    "pdf", "epub", "docx", "xlsx", "pptx", "odt", "ods", "odp",
-    "iso", "dmg", "deb", "rpm", "apk", "jar", "war",
+    "zip", "7z", "gz", "bz2", "xz", "zst", "tar", "rar", "lz", "lz4", "br", "mp4", "mkv", "avi",
+    "mov", "webm", "flv", "wmv", "jpg", "jpeg", "png", "webp", "gif", "heic", "avif", "bmp", "mp3",
+    "flac", "aac", "ogg", "opus", "wma", "m4a", "pdf", "epub", "docx", "xlsx", "pptx", "odt",
+    "ods", "odp", "iso", "dmg", "deb", "rpm", "apk", "jar", "war",
 ];
 
 fn is_incompressible(path: &Path) -> bool {
@@ -933,7 +978,9 @@ fn extract_zip_from_archive(
     let mut first_name = None;
     for i in 0..archive.len() {
         let read_options = zip::read::ZipReadOptions::new().password(pw_bytes);
-        let mut entry = archive.by_index_with_options(i, read_options).map_err(|e| e.to_string())?;
+        let mut entry = archive
+            .by_index_with_options(i, read_options)
+            .map_err(|e| e.to_string())?;
         let name = entry.name().trim_end_matches('/').to_owned();
         let outpath = resolver.resolve(dest_dir, &name)?;
         if first_name.is_none() {
@@ -958,7 +1005,12 @@ fn extract_zip_from_archive(
     Ok(first_name)
 }
 
-fn extract_tar(archive_path: &Path, dest_dir: &Path, gzip: bool, progress: &Arc<AtomicUsize>) -> Result<Option<String>, String> {
+fn extract_tar(
+    archive_path: &Path,
+    dest_dir: &Path,
+    gzip: bool,
+    progress: &Arc<AtomicUsize>,
+) -> Result<Option<String>, String> {
     let file = std::fs::File::open(archive_path).map_err(|e| e.to_string())?;
     let reader: Box<dyn std::io::Read> = if gzip {
         Box::new(flate2::read::GzDecoder::new(file))
@@ -995,18 +1047,24 @@ fn extract_tar(archive_path: &Path, dest_dir: &Path, gzip: bool, progress: &Arc<
     Ok(first_name)
 }
 
-fn compress_7z(archive_path: &Path, entries: &[std::path::PathBuf], password: Option<&str>, progress: &Arc<AtomicUsize>) -> Result<(), String> {
+fn compress_7z(
+    archive_path: &Path,
+    entries: &[std::path::PathBuf],
+    password: Option<&str>,
+    progress: &Arc<AtomicUsize>,
+) -> Result<(), String> {
     use sevenz_rust2::encoder_options::{AesEncoderOptions, EncoderOptions, Lzma2Options};
-    let mut writer = sevenz_rust2::ArchiveWriter::create(archive_path)
-        .map_err(|e| e.to_string())?;
-    let threads = std::thread::available_parallelism().map(|n| n.get() as u32).unwrap_or(1);
-    let lzma2 = sevenz_rust2::EncoderConfiguration::new(sevenz_rust2::EncoderMethod::LZMA2)
-        .with_options(EncoderOptions::Lzma2(Lzma2Options::from_level_mt(6, threads, 1 << 26)));
+    let mut writer =
+        sevenz_rust2::ArchiveWriter::create(archive_path).map_err(|e| e.to_string())?;
+    let threads = std::thread::available_parallelism()
+        .map(|n| n.get() as u32)
+        .unwrap_or(1);
+    let lzma2 =
+        sevenz_rust2::EncoderConfiguration::new(sevenz_rust2::EncoderMethod::LZMA2).with_options(
+            EncoderOptions::Lzma2(Lzma2Options::from_level_mt(6, threads, 1 << 26)),
+        );
     if let Some(pw) = password {
-        let methods = vec![
-            lzma2,
-            AesEncoderOptions::new(pw.into()).into(),
-        ];
+        let methods = vec![lzma2, AesEncoderOptions::new(pw.into()).into()];
         writer.set_content_methods(methods);
     } else {
         writer.set_content_methods(vec![lzma2]);

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -11,10 +11,11 @@ use crate::{
     app::navigation::{EntryInsertion, EntrySplice, NavigationPath, NavigationState},
     model::{FileEntry, Location, SortDirection, SortKey, ViewPreferences},
     services::{
-        CreateDirectoryRequest, CreateFileRequest, DeleteRequest, DirectoryChange, DirectoryEvent,
-        DirectoryRequest, FileSource, LoadHandle, LocationValidationError, OperationEvent,
-        OperationProvider, OperationRequestId, PasteItem, PasteRequest, RenameRequest, RequestId,
-        RestoreRequest, uri_has_embedded_password, validate_basename,
+        ArchiveFormat, CompressRequest, CreateDirectoryRequest, CreateFileRequest, DeleteRequest,
+        DirectoryChange, DirectoryEvent, DirectoryRequest, ExtractRequest, FileSource, LoadHandle,
+        LocationValidationError, OperationEvent, OperationProvider, OperationRequestId, PasteItem,
+        PasteRequest, RenameRequest, RequestId, RestoreRequest, uri_has_embedded_password,
+        validate_basename,
     },
 };
 
@@ -125,6 +126,10 @@ pub enum BrowserEvent {
         error: LocationValidationError,
     },
     EmptyTrashRequested,
+    ArchiveStarted { total: usize },
+    ArchiveProgress { completed: usize, total: usize },
+    ArchiveCompleted { select_name: String },
+    TransferCompleted,
 }
 
 type Observer = Rc<dyn Fn(BrowserEvent)>;
@@ -862,19 +867,73 @@ impl Browser {
         self.operation_load.replace(Some(load));
     }
 
+    pub fn compress(
+        self: &Rc<Self>,
+        entries: Vec<FileEntry>,
+        destination: Location,
+        archive_name: String,
+        format: ArchiveFormat,
+        password: Option<String>,
+    ) {
+        if entries.is_empty() {
+            return;
+        }
+        let Some(provider) = self.operation_provider.borrow().clone() else {
+            self.emit(BrowserEvent::OperationFailed {
+                message: "File operations are unavailable".to_owned(),
+            });
+            return;
+        };
+        let request_id = self.begin_operation();
+        let load = provider.compress(
+            CompressRequest {
+                id: request_id,
+                entries,
+                destination,
+                archive_name,
+                format,
+                password,
+            },
+            self.operation_callback(request_id, false, Vec::new()),
+        );
+        self.operation_load.replace(Some(load));
+    }
+
+    pub fn extract(self: &Rc<Self>, entry: FileEntry, destination: Location, password: Option<String>) {
+        let Some(provider) = self.operation_provider.borrow().clone() else {
+            self.emit(BrowserEvent::OperationFailed {
+                message: "File operations are unavailable".to_owned(),
+            });
+            return;
+        };
+        let request_id = self.begin_operation();
+        let load = provider.extract(
+            ExtractRequest {
+                id: request_id,
+                entry,
+                destination,
+                password,
+            },
+            self.operation_callback(request_id, false, Vec::new()),
+        );
+        self.operation_load.replace(Some(load));
+    }
+
     pub fn cancel_file_operation(&self) {
         let deleting = self.deletion_operation.replace(false);
         let restoring = self.restoration_operation.replace(false);
-        if !deleting && !restoring {
-            return;
-        }
-        self.current_operation.set(None);
+        let had_operation = self.current_operation.replace(None).is_some();
         self.operation_load.borrow_mut().take();
         if deleting {
             self.emit(BrowserEvent::DeletionFinished);
         }
         if restoring {
             self.emit(BrowserEvent::RestorationFinished);
+        }
+        if !deleting && !restoring && had_operation {
+            self.emit(BrowserEvent::ArchiveCompleted {
+                select_name: String::new(),
+            });
         }
     }
 
@@ -910,7 +969,11 @@ impl Browser {
                 | OperationEvent::CompletedWithErrors { request_id, .. }
                 | OperationEvent::Restored { request_id, .. }
                 | OperationEvent::RestoreCompletedWithErrors { request_id, .. }
-                | OperationEvent::Failed { request_id, .. } => *request_id,
+                | OperationEvent::Failed { request_id, .. }
+                | OperationEvent::Compressed { request_id, .. }
+                | OperationEvent::Extracted { request_id, .. }
+                | OperationEvent::ArchiveStarted { request_id, .. }
+                | OperationEvent::ArchiveProgress { request_id, .. } => *request_id,
             };
             if event_id != request_id || browser.current_operation.get() != Some(event_id) {
                 return;
@@ -949,6 +1012,20 @@ impl Browser {
                         total: *total,
                     });
                 }
+                return;
+            }
+            if let OperationEvent::ArchiveStarted { total, .. } = &event {
+                browser.emit(BrowserEvent::ArchiveStarted { total: *total });
+                return;
+            }
+            if let OperationEvent::ArchiveProgress {
+                completed, total, ..
+            } = &event
+            {
+                browser.emit(BrowserEvent::ArchiveProgress {
+                    completed: *completed,
+                    total: *total,
+                });
                 return;
             }
             browser.current_operation.set(None);
@@ -994,19 +1071,35 @@ impl Browser {
                         }
                     }
                 }
-                OperationEvent::Created { .. } | OperationEvent::Pasted { .. } => {
-                    // A remote location has no live directory monitor (see
-                    // `FileSource::watch`), so the column that just received a
-                    // new item would otherwise never learn about it. Refresh
-                    // it explicitly rather than leaving the new item invisible
-                    // until the user navigates away and back.
+                OperationEvent::Compressed { archive_name, .. } => {
+                    browser.emit(BrowserEvent::ArchiveCompleted {
+                        select_name: archive_name.clone(),
+                    });
+                }
+                OperationEvent::Extracted { first_name, .. } => {
+                    browser.emit(BrowserEvent::ArchiveCompleted {
+                        select_name: first_name.unwrap_or_default(),
+                    });
+                }
+                OperationEvent::Pasted { .. } => {
+                    browser.emit(BrowserEvent::TransferCompleted);
                     for location in &refresh_locations {
                         if location.native_path().is_none() {
                             browser.refresh_columns_at(location);
                         }
                     }
                 }
-                OperationEvent::DeleteProgress { .. } | OperationEvent::RestoreProgress { .. } => {}
+                OperationEvent::Created { .. } => {
+                    for location in &refresh_locations {
+                        if location.native_path().is_none() {
+                            browser.refresh_columns_at(location);
+                        }
+                    }
+                }
+                OperationEvent::DeleteProgress { .. }
+                | OperationEvent::RestoreProgress { .. }
+                | OperationEvent::ArchiveStarted { .. }
+                | OperationEvent::ArchiveProgress { .. } => {}
             }
         })
     }
@@ -1251,6 +1344,35 @@ impl Browser {
         let handle = self.request_directory(location, request_id);
         if let Some(load) = self.loads.borrow_mut().get_mut(depth) {
             *load = handle;
+        }
+    }
+
+    pub fn reload_active(self: &Rc<Self>) {
+        if let Some(depth) = self.active_depth() {
+            self.refresh_column(depth);
+        }
+    }
+
+    pub fn select_entry_by_name(self: &Rc<Self>, name: &str) {
+        let Some(depth) = self.active_depth() else {
+            return;
+        };
+        let state = self.state.borrow();
+        let Some(column) = state.columns.get(depth) else {
+            return;
+        };
+        let position = column
+            .entries
+            .iter()
+            .position(|e| e.display_name == name);
+        drop(state);
+        if let Some(position) = position {
+            self.set_selection(depth, &[position], Some(position));
+            self.emit(BrowserEvent::SelectionSetChanged {
+                depth,
+                positions: vec![position],
+                focused: position,
+            });
         }
     }
 

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -126,9 +126,16 @@ pub enum BrowserEvent {
         error: LocationValidationError,
     },
     EmptyTrashRequested,
-    ArchiveStarted { total: usize },
-    ArchiveProgress { completed: usize, total: usize },
-    ArchiveCompleted { select_name: String },
+    ArchiveStarted {
+        total: usize,
+    },
+    ArchiveProgress {
+        completed: usize,
+        total: usize,
+    },
+    ArchiveCompleted {
+        select_name: String,
+    },
     TransferCompleted,
 }
 
@@ -899,7 +906,12 @@ impl Browser {
         self.operation_load.replace(Some(load));
     }
 
-    pub fn extract(self: &Rc<Self>, entry: FileEntry, destination: Location, password: Option<String>) {
+    pub fn extract(
+        self: &Rc<Self>,
+        entry: FileEntry,
+        destination: Location,
+        password: Option<String>,
+    ) {
         let Some(provider) = self.operation_provider.borrow().clone() else {
             self.emit(BrowserEvent::OperationFailed {
                 message: "File operations are unavailable".to_owned(),
@@ -1361,10 +1373,7 @@ impl Browser {
         let Some(column) = state.columns.get(depth) else {
             return;
         };
-        let position = column
-            .entries
-            .iter()
-            .position(|e| e.display_name == name);
+        let position = column.entries.iter().position(|e| e.display_name == name);
         drop(state);
         if let Some(position) = position {
             self.set_selection(depth, &[position], Some(position));

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -1415,6 +1415,7 @@ impl Browser {
                 depth,
                 positions: vec![position],
                 focused: position,
+                take_focus: true,
             });
         }
     }

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -5,7 +5,7 @@ use std::{cell::Cell, ffi::OsString};
 use super::*;
 use crate::{
     model::{EntryKind, MetadataValue},
-    services::LoadHandle,
+    services::{CompressRequest, ExtractRequest, LoadHandle},
 };
 
 #[test]
@@ -352,6 +352,22 @@ impl OperationProvider for ImmediateOperationProvider {
         emit(OperationEvent::Restored {
             request_id: request.id,
             locations: Vec::new(),
+        });
+        LoadHandle::new(|| {})
+    }
+
+    fn compress(&self, request: CompressRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle {
+        emit(OperationEvent::Compressed {
+            request_id: request.id,
+            archive_name: request.archive_name,
+        });
+        LoadHandle::new(|| {})
+    }
+
+    fn extract(&self, request: ExtractRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle {
+        emit(OperationEvent::Extracted {
+            request_id: request.id,
+            first_name: None,
         });
         LoadHandle::new(|| {})
     }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -12,9 +12,9 @@ pub use file_source::{
     LocationValidationError, RequestId, backend_unavailable_message, uri_has_embedded_password,
 };
 pub use operations::{
-    CreateDirectoryRequest, CreateFileRequest, DeleteRequest, OperationEvent, OperationProvider,
-    OperationRequestId, PasteItem, PasteRequest, RenameRequest, RestoreRequest, TransferConflict,
-    validate_basename,
+    ArchiveFormat, CompressRequest, CreateDirectoryRequest, CreateFileRequest, DeleteRequest,
+    ExtractRequest, OperationEvent, OperationProvider, OperationRequestId, PasteItem, PasteRequest,
+    RenameRequest, RestoreRequest, TransferConflict, validate_basename,
 };
 pub use preview::{
     Preview, PreviewContent, PreviewEvent, PreviewProvider, PreviewRequest, PreviewRequestId,

--- a/src/services/operations.rs
+++ b/src/services/operations.rs
@@ -80,6 +80,62 @@ pub struct RestoreRequest {
     pub entries: Vec<FileEntry>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ArchiveFormat {
+    Zip,
+    SevenZ,
+    TarGz,
+    Tar,
+}
+
+impl ArchiveFormat {
+    pub fn extension(self) -> &'static str {
+        match self {
+            Self::Zip => "zip",
+            Self::SevenZ => "7z",
+            Self::TarGz => "tar.gz",
+            Self::Tar => "tar",
+        }
+    }
+
+    pub fn supports_password(self) -> bool {
+        matches!(self, Self::Zip | Self::SevenZ)
+    }
+
+    pub fn from_extension(name: &str) -> Option<Self> {
+        let lower = name.to_ascii_lowercase();
+        if lower.ends_with(".tar.gz") || lower.ends_with(".tgz") {
+            Some(Self::TarGz)
+        } else if lower.ends_with(".tar") {
+            Some(Self::Tar)
+        } else if lower.ends_with(".zip") {
+            Some(Self::Zip)
+        } else if lower.ends_with(".7z") {
+            Some(Self::SevenZ)
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CompressRequest {
+    pub id: OperationRequestId,
+    pub entries: Vec<FileEntry>,
+    pub destination: Location,
+    pub archive_name: String,
+    pub format: ArchiveFormat,
+    pub password: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ExtractRequest {
+    pub id: OperationRequestId,
+    pub entry: FileEntry,
+    pub destination: Location,
+    pub password: Option<String>,
+}
+
 #[derive(Clone, Debug)]
 pub enum OperationEvent {
     Renamed {
@@ -125,6 +181,23 @@ pub enum OperationEvent {
         request_id: OperationRequestId,
         message: String,
     },
+    Compressed {
+        request_id: OperationRequestId,
+        archive_name: String,
+    },
+    Extracted {
+        request_id: OperationRequestId,
+        first_name: Option<String>,
+    },
+    ArchiveStarted {
+        request_id: OperationRequestId,
+        total: usize,
+    },
+    ArchiveProgress {
+        request_id: OperationRequestId,
+        completed: usize,
+        total: usize,
+    },
 }
 
 pub trait OperationProvider {
@@ -142,4 +215,6 @@ pub trait OperationProvider {
     fn paste(&self, request: PasteRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle;
     fn delete(&self, request: DeleteRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle;
     fn restore(&self, request: RestoreRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle;
+    fn compress(&self, request: CompressRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle;
+    fn extract(&self, request: ExtractRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle;
 }

--- a/src/services/operations/tests.rs
+++ b/src/services/operations/tests.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use super::validate_basename;
+use super::{ArchiveFormat, validate_basename};
 
 #[test]
 fn basenames_reject_empty_reserved_nested_absolute_and_nul_names() {
@@ -27,5 +27,35 @@ fn basenames_accept_single_native_and_unicode_components() {
             validate_basename(name).is_ok(),
             "{name:?} should be accepted"
         );
+    }
+}
+
+#[test]
+fn archive_formats_are_detected_by_extension() {
+    assert_eq!(
+        ArchiveFormat::from_extension("photos.zip"),
+        Some(ArchiveFormat::Zip)
+    );
+    assert_eq!(
+        ArchiveFormat::from_extension("backup.tar.gz"),
+        Some(ArchiveFormat::TarGz)
+    );
+    assert_eq!(
+        ArchiveFormat::from_extension("archive.TGZ"),
+        Some(ArchiveFormat::TarGz)
+    );
+    assert_eq!(
+        ArchiveFormat::from_extension("data.tar"),
+        Some(ArchiveFormat::Tar)
+    );
+    assert_eq!(ArchiveFormat::from_extension("document.pdf"), None);
+    assert_eq!(ArchiveFormat::from_extension("no_extension"), None);
+}
+
+#[test]
+fn archive_format_extensions_round_trip() {
+    for format in [ArchiveFormat::Zip, ArchiveFormat::TarGz, ArchiveFormat::Tar] {
+        let name = format!("test.{}", format.extension());
+        assert_eq!(ArchiveFormat::from_extension(&name), Some(format));
     }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -546,6 +546,45 @@ headerbar menubutton.header-action > button:focus-visible image {
   outline-color: @theme_accent;
 }
 
+.compress-dialog {
+  background: @theme_surface;
+  border: 1px solid alpha(@theme_accent, 0.22);
+  border-radius: 7px;
+  box-shadow: 0 18px 54px alpha(@theme_bg, 0.72);
+  color: @theme_text;
+}
+
+.compress-dialog-entry {
+  border-radius: 5px;
+}
+
+.compress-dialog-format {
+  border-radius: 5px;
+}
+
+.compress-dialog-confirm {
+  background: alpha(@theme_accent, 0.1);
+  border: 1px solid @theme_accent;
+  color: @theme_accent;
+}
+
+.compress-dialog-confirm:hover {
+  background: alpha(@theme_accent, 0.18);
+  border-color: @theme_accent;
+  color: @theme_accent;
+}
+
+.compress-dialog-confirm:active {
+  background: alpha(@theme_accent, 0.28);
+  border-color: @theme_accent;
+  color: @theme_accent;
+}
+
+.compress-dialog-confirm:focus-visible {
+  border-color: @theme_accent;
+  outline-color: @theme_accent;
+}
+
 .update-dialog {
   color: @theme_text;
   min-width: 500px;

--- a/src/style.css
+++ b/src/style.css
@@ -546,43 +546,195 @@ headerbar menubutton.header-action > button:focus-visible image {
   outline-color: @theme_accent;
 }
 
-.compress-dialog {
+.action-dialog {
   background: @theme_surface;
   border: 1px solid alpha(@theme_accent, 0.22);
   border-radius: 7px;
   box-shadow: 0 18px 54px alpha(@theme_bg, 0.72);
   color: @theme_text;
+  min-width: 480px;
 }
 
-.compress-dialog-entry {
+.action-dialog-header {
+  border-bottom: 1px solid alpha(@theme_border, 0.22);
+  min-height: 40px;
+  padding: 14px 20px;
+}
+
+.action-dialog-symbol {
+  background: alpha(@theme_highlight, 0.64);
+  border: 1px solid alpha(@theme_accent, 0.24);
+  border-radius: 6px;
+  min-height: 40px;
+  min-width: 40px;
+}
+
+.action-dialog-title {
+  color: @theme_text;
+  font-size: 1.08em;
+  font-weight: 700;
+}
+
+.action-dialog-subtitle,
+.action-dialog-field-label {
+  color: @theme_dim_text;
+}
+
+.action-dialog-subtitle {
+  font-size: 0.82em;
+}
+
+.action-dialog-field-label {
+  font-size: 0.82em;
+}
+
+.action-dialog-close {
+  background: transparent;
+  border: none;
   border-radius: 5px;
+  box-shadow: none;
+  color: @theme_dim_text;
+  min-height: 28px;
+  min-width: 28px;
+  padding: 4px;
 }
 
-.compress-dialog-format {
+.action-dialog-close:hover {
+  background: alpha(@theme_muted, 0.56);
+  color: @theme_text;
+}
+
+.action-dialog-close:active {
+  background: alpha(@theme_muted, 0.78);
+  color: @theme_accent;
+}
+
+.action-dialog-close:focus-visible {
+  outline: 2px solid alpha(@theme_accent, 0.52);
+  outline-offset: 1px;
+}
+
+.action-dialog-body {
+  padding: 20px;
+}
+
+.action-dialog-actions {
+  border-top: 1px solid alpha(@theme_border, 0.22);
+  padding: 10px 20px 12px;
+}
+
+.action-dialog-actions button {
   border-radius: 5px;
+  box-shadow: none;
+  min-height: 26px;
+  padding: 2px 11px;
 }
 
-.compress-dialog-confirm {
+.action-dialog-cancel {
+  background: transparent;
+  border: 1px solid alpha(@theme_border, 0.54);
+  color: @theme_text;
+}
+
+.action-dialog-cancel:hover {
+  background: alpha(@theme_muted, 0.62);
+  border-color: @theme_text;
+}
+
+.action-dialog-cancel:active {
+  background: alpha(@theme_muted, 0.82);
+  border-color: @theme_accent;
+  color: @theme_accent;
+}
+
+.action-dialog-cancel:focus-visible {
+  border-color: @theme_accent;
+  outline: 2px solid alpha(@theme_accent, 0.5);
+  outline-offset: 1px;
+}
+
+.action-dialog-confirm {
   background: alpha(@theme_accent, 0.1);
   border: 1px solid @theme_accent;
   color: @theme_accent;
 }
 
-.compress-dialog-confirm:hover {
+.action-dialog-confirm:hover {
   background: alpha(@theme_accent, 0.18);
-  border-color: @theme_accent;
-  color: @theme_accent;
 }
 
-.compress-dialog-confirm:active {
+.action-dialog-confirm:active {
   background: alpha(@theme_accent, 0.28);
-  border-color: @theme_accent;
-  color: @theme_accent;
 }
 
-.compress-dialog-confirm:focus-visible {
+.action-dialog-confirm:focus-visible {
+  outline: 2px solid @theme_accent;
+  outline-offset: 1px;
+}
+
+entry.form-control {
+  background: alpha(@theme_bg, 0.72);
+  border: 1px solid alpha(@theme_border, 0.54);
+  border-radius: 5px;
+  box-shadow: none;
+  caret-color: @theme_accent;
+  color: @theme_text;
+  min-height: 34px;
+  padding: 3px 9px;
+}
+
+entry.form-control:hover {
+  border-color: alpha(@theme_accent, 0.68);
+}
+
+entry.form-control:focus,
+entry.form-control:focus-visible,
+entry.form-control:focus-within {
   border-color: @theme_accent;
-  outline-color: @theme_accent;
+  box-shadow: 0 0 0 1px alpha(@theme_accent, 0.42);
+  outline: 2px solid @theme_accent;
+  outline-offset: -2px;
+}
+
+entry.form-control selection {
+  background: @theme_accent;
+  color: @theme_bg;
+}
+
+entry.form-control:disabled {
+  background: alpha(@theme_muted, 0.3);
+  border-color: alpha(@theme_border, 0.38);
+  color: @theme_dim_text;
+}
+
+dropdown.form-control > button {
+  background: alpha(@theme_bg, 0.72);
+  border: 1px solid alpha(@theme_border, 0.54);
+  border-radius: 5px;
+  box-shadow: none;
+  color: @theme_text;
+  min-height: 34px;
+  padding: 3px 9px;
+}
+
+dropdown.form-control > button:hover {
+  background: alpha(@theme_muted, 0.62);
+  border-color: alpha(@theme_accent, 0.68);
+}
+
+dropdown.form-control:focus > button,
+dropdown.form-control:focus-visible > button,
+dropdown.form-control > button:focus-visible {
+  border-color: @theme_accent;
+  box-shadow: 0 0 0 1px alpha(@theme_accent, 0.42);
+  outline: 2px solid @theme_accent;
+  outline-offset: -2px;
+}
+
+dropdown.form-control:disabled > button {
+  background: alpha(@theme_muted, 0.3);
+  border-color: alpha(@theme_border, 0.38);
+  color: @theme_dim_text;
 }
 
 .update-dialog {
@@ -1505,6 +1657,7 @@ menubutton.column-header-action > button:focus-visible image {
   outline-offset: -2px;
 }
 
+.authentication-fields .form-control:disabled,
 .authentication-fields .transfer-field:disabled,
 .segmented-control-option:disabled {
   background: alpha(@theme_muted, 0.3);

--- a/src/style.css
+++ b/src/style.css
@@ -701,6 +701,15 @@ entry.form-control selection {
   color: @theme_bg;
 }
 
+entry.form-control.error,
+entry.form-control.error:focus,
+entry.form-control.error:focus-visible,
+entry.form-control.error:focus-within {
+  border-color: @theme_danger;
+  box-shadow: 0 0 0 1px alpha(@theme_danger, 0.4);
+  outline-color: @theme_danger;
+}
+
 entry.form-control:disabled {
   background: alpha(@theme_muted, 0.3);
   border-color: alpha(@theme_border, 0.38);

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -16,9 +16,9 @@ use crate::{
     app::{Browser, BrowserEvent},
     model::{EntryKind, FileEntry, Location, SortDirection, SortKey},
     services::{
-        FileSource, LocationValidationError, OperationProvider, PasteItem, PreviewContent,
-        TransferConflict, backend_unavailable_message, content_family, has_plain_text_extension,
-        validate_basename,
+        ArchiveFormat, FileSource, LocationValidationError, OperationProvider, PasteItem,
+        PreviewContent, TransferConflict, backend_unavailable_message, content_family,
+        has_plain_text_extension, validate_basename,
     },
 };
 
@@ -231,6 +231,9 @@ pub(super) struct ViewState {
     delete_progress: RefCell<Option<DeleteProgressView>>,
     pin_handler: RefCell<Option<PinHandler>>,
     pin_status_handler: RefCell<Option<PinStatusHandler>>,
+    pending_select: RefCell<Option<String>>,
+    pending_extract_retry: RefCell<Option<(FileEntry, Location)>>,
+    pending_navigate: RefCell<Option<Location>>,
     browser: Rc<Browser>,
 }
 
@@ -338,6 +341,9 @@ impl BrowserView {
             delete_progress: RefCell::new(None),
             pin_handler: RefCell::new(None),
             pin_status_handler: RefCell::new(None),
+            pending_select: RefCell::new(None),
+            pending_extract_retry: RefCell::new(None),
+            pending_navigate: RefCell::new(None),
             browser,
         });
 
@@ -1278,6 +1284,7 @@ impl ViewState {
                 return;
             }
             if path.is_dir() {
+                transfer_state.pending_navigate.replace(Some(Location::local(path.clone())));
                 transfer_state.start_transfer(Location::local(path), sources.clone(), move_sources);
                 dismiss_modal_layer(&confirm_layer, &confirm_overlay, confirm_root.as_ref());
                 return;
@@ -1306,6 +1313,7 @@ impl ViewState {
                     gio::spawn_blocking(move || std::fs::create_dir_all(&created_path)).await;
                 match result {
                     Ok(Ok(())) => {
+                        created_state.pending_navigate.replace(Some(Location::local(path.clone())));
                         created_state.start_transfer(
                             Location::local(path),
                             created_sources,
@@ -1428,7 +1436,11 @@ impl ViewState {
 
         let body = gtk::Box::new(gtk::Orientation::Vertical, 10);
         body.add_css_class("transfer-body");
-        let status = gtk::Label::new(Some(&format!("0 of {total} items")));
+        let status = gtk::Label::new(Some(&if total > 0 {
+            format!("0%")
+        } else {
+            "0%".to_string()
+        }));
         status.add_css_class("delete-progress-status");
         status.set_xalign(0.0);
         let progress = gtk::ProgressBar::new();
@@ -1480,10 +1492,29 @@ impl ViewState {
         let Some(view) = progress_view.as_ref() else {
             return;
         };
-        view.status
-            .set_text(&format!("{completed} of {total} items"));
+        let pct = if total > 0 {
+            (completed as f64 / total as f64 * 100.0) as usize
+        } else {
+            0
+        };
+        view.status.set_text(&format!("{pct}%"));
         view.progress
             .set_fraction(completed as f64 / total.max(1) as f64);
+    }
+
+    fn update_archive_progress(&self, completed: usize, total: usize) {
+        let progress_view = self.delete_progress.borrow();
+        let Some(view) = progress_view.as_ref() else {
+            return;
+        };
+        if total == 0 {
+            view.status.set_text(&format!("{completed} files"));
+            view.progress.pulse();
+        } else {
+            view.status.set_text(&format!("{completed} / {total} files"));
+            view.progress
+                .set_fraction(completed as f64 / total as f64);
+        }
     }
 
     fn dismiss_delete_progress(&self) {
@@ -1818,6 +1849,414 @@ impl ViewState {
 
     fn show_entry_properties(self: &Rc<Self>, entry: FileEntry) {
         self.show_properties(entry.location.clone(), Some(entry));
+    }
+
+    fn build_archive_modal(
+        self: &Rc<Self>,
+        title: &str,
+        subtitle: &str,
+        confirm_label: &str,
+    ) -> (gtk::Box, gtk::Button, Rc<dyn Fn()>) {
+        let Some(window_overlay) = self
+            .overlay
+            .root()
+            .and_downcast::<gtk::Window>()
+            .and_then(|window| window.child())
+            .and_downcast::<gtk::Overlay>()
+        else {
+            return (
+                gtk::Box::default(),
+                gtk::Button::default(),
+                Rc::new(|| {}),
+            );
+        };
+        let blurred_root = window_overlay.child().and_downcast::<BlurBin>();
+        if let Some(root) = blurred_root.as_ref() {
+            root.set_blurred(true);
+        }
+
+        let content = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        content.add_css_class("compress-dialog");
+        content.add_css_class("delete-confirmation-content");
+        content.set_halign(gtk::Align::Center);
+        content.set_valign(gtk::Align::Center);
+
+        let header = gtk::Box::new(gtk::Orientation::Horizontal, 12);
+        header.add_css_class("delete-confirmation-header");
+        let symbol = gtk::CenterBox::new();
+        symbol.add_css_class("delete-confirmation-symbol");
+        symbol.set_size_request(40, 40);
+        symbol.set_hexpand(false);
+        let symbol_icon = crate::assets::primary_icon(crate::assets::icons::FILE_ARCHIVE, 21);
+        symbol.set_center_widget(Some(&symbol_icon));
+        let heading = gtk::Box::new(gtk::Orientation::Vertical, 1);
+        heading.set_hexpand(true);
+        let title_label = gtk::Label::new(Some(title));
+        title_label.add_css_class("delete-confirmation-title");
+        title_label.set_xalign(0.0);
+        let subtitle_label = gtk::Label::new(Some(subtitle));
+        subtitle_label.add_css_class("delete-confirmation-subtitle");
+        subtitle_label.set_xalign(0.0);
+        heading.append(&title_label);
+        heading.append(&subtitle_label);
+        let close = gtk::Button::new();
+        close.add_css_class("delete-confirmation-close");
+        close.set_tooltip_text(Some("Cancel"));
+        close.set_child(Some(&crate::assets::text_icon(crate::assets::icons::X, 16)));
+        header.append(&symbol);
+        header.append(&heading);
+        header.append(&close);
+        content.append(&header);
+
+        let body = gtk::Box::new(gtk::Orientation::Vertical, 12);
+        body.add_css_class("delete-confirmation-body");
+        content.append(&body);
+
+        let actions = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+        actions.add_css_class("delete-confirmation-actions");
+        let action_spacer = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+        action_spacer.set_hexpand(true);
+        let cancel = gtk::Button::with_label("Cancel");
+        cancel.add_css_class("delete-confirmation-cancel");
+        let confirm = gtk::Button::with_label(confirm_label);
+        confirm.add_css_class("compress-dialog-confirm");
+        actions.append(&action_spacer);
+        actions.append(&cancel);
+        actions.append(&confirm);
+        content.append(&actions);
+
+        let layer = modal_layer(&content);
+        window_overlay.add_overlay(&layer);
+
+        let dismiss: Rc<dyn Fn()> = Rc::new({
+            let layer = layer.clone();
+            let overlay = window_overlay.clone();
+            let root = blurred_root.clone();
+            move || dismiss_modal_layer(&layer, &overlay, root.as_ref())
+        });
+        let dismiss_for_cancel = dismiss.clone();
+        cancel.connect_clicked(move |_| dismiss_for_cancel());
+        let dismiss_for_close = dismiss.clone();
+        close.connect_clicked(move |_| dismiss_for_close());
+        let escape = gtk::EventControllerKey::new();
+        let dismiss_for_escape = dismiss.clone();
+        escape.connect_key_pressed(move |_, key, _, _| {
+            if key == gtk::gdk::Key::Escape {
+                dismiss_for_escape();
+                glib::Propagation::Stop
+            } else {
+                glib::Propagation::Proceed
+            }
+        });
+        layer.add_controller(escape);
+        (body, confirm, dismiss)
+    }
+
+    fn show_compress_dialog(self: &Rc<Self>, entries: Vec<FileEntry>) {
+        if entries.is_empty() {
+            return;
+        }
+        let destination = self.browser.active_location().unwrap_or_else(|| {
+            Location::local(glib::home_dir())
+        });
+
+        let default_name = if entries.len() == 1 {
+            entries[0].display_name.clone()
+        } else {
+            "archive".to_owned()
+        };
+
+        let title = format!("Compress {}", item_count_label(entries.len()));
+        let subtitle = entry_kind_summary(&entries);
+        let (body, confirm, dismiss) = self.build_archive_modal(&title, &subtitle, "Compress");
+
+        let name_label = gtk::Label::new(Some("Archive name"));
+        name_label.add_css_class("delete-confirmation-subtitle");
+        name_label.set_xalign(0.0);
+        let name_entry = gtk::Entry::new();
+        name_entry.set_text(&default_name);
+        name_entry.add_css_class("compress-dialog-entry");
+        body.append(&name_label);
+        body.append(&name_entry);
+
+        let format_label = gtk::Label::new(Some("Format"));
+        format_label.add_css_class("delete-confirmation-subtitle");
+        format_label.set_xalign(0.0);
+        let format_combo = gtk::DropDown::from_strings(&["ZIP", "7Z", "TAR.GZ", "TAR"]);
+        format_combo.add_css_class("compress-dialog-format");
+        body.append(&format_label);
+        body.append(&format_combo);
+
+        let password_label = gtk::Label::new(Some("Password (optional)"));
+        password_label.add_css_class("delete-confirmation-subtitle");
+        password_label.set_xalign(0.0);
+        let password_entry = gtk::PasswordEntry::new();
+        password_entry.set_show_peek_icon(true);
+        password_entry.add_css_class("compress-dialog-entry");
+        let confirm_label = gtk::Label::new(Some("Confirm password"));
+        confirm_label.add_css_class("delete-confirmation-subtitle");
+        confirm_label.set_xalign(0.0);
+        let confirm_entry = gtk::PasswordEntry::new();
+        confirm_entry.set_show_peek_icon(true);
+        confirm_entry.add_css_class("compress-dialog-entry");
+        let password_box = gtk::Box::new(gtk::Orientation::Vertical, 6);
+        password_box.append(&password_label);
+        password_box.append(&password_entry);
+        password_box.append(&confirm_label);
+        password_box.append(&confirm_entry);
+        body.append(&password_box);
+
+        let password_box_clone = password_box.clone();
+        let format_combo_for_signal = format_combo.clone();
+        let format_combo_for_handler = format_combo.clone();
+        format_combo_for_signal.connect_notify_local(Some("selected"), move |_, _| {
+            password_box_clone.set_visible(format_from_combo(&format_combo_for_handler).supports_password());
+        });
+        password_box.set_visible(format_from_combo(&format_combo).supports_password());
+
+        let browser = self.browser.clone();
+        let confirm_entries = entries.clone();
+        let confirm_destination = destination.clone();
+        let name_for_confirm = name_entry.clone();
+        let format_for_confirm = format_combo.clone();
+        let password_for_confirm = password_entry.clone();
+        let confirm_for_confirm = confirm_entry.clone();
+        let overlay_for_error = self.overlay.clone();
+        let dismiss_for_confirm = dismiss.clone();
+        confirm.connect_clicked(move |_| {
+            let name = name_for_confirm.text().to_string();
+            let format = format_from_combo(&format_for_confirm);
+            let password = if format.supports_password() {
+                let pw = password_for_confirm.text().to_string();
+                if pw.is_empty() {
+                    None
+                } else {
+                    let confirm_pw = confirm_for_confirm.text().to_string();
+                    if pw != confirm_pw {
+                        show_error_dialog(&overlay_for_error, "Passwords do not match", "Please enter the same password in both fields.");
+                        return;
+                    }
+                    Some(pw)
+                }
+            } else {
+                None
+            };
+            let archive_name = if name.ends_with(format.extension()) {
+                name.trim_end_matches(format.extension()).to_owned()
+            } else {
+                name
+            };
+            dismiss_for_confirm();
+            browser.compress(confirm_entries.clone(), confirm_destination.clone(), archive_name, format, password);
+        });
+        name_entry.grab_focus();
+    }
+
+    fn extract_entry(self: &Rc<Self>, entry: FileEntry) {
+        let Some(parent) = entry.location.parent() else {
+            show_error_dialog(&self.overlay, "Cannot extract", "This archive has no parent directory.");
+            return;
+        };
+        let format = ArchiveFormat::from_extension(&entry.display_name);
+        if format.map(|f| f.supports_password()).unwrap_or(false) {
+            self.pending_extract_retry.replace(Some((entry.clone(), parent.clone())));
+        }
+        self.browser.extract(entry, parent, None);
+    }
+
+    fn show_extract_to_dialog(self: &Rc<Self>, entry: FileEntry) {
+        let Some(window_overlay) = self
+            .overlay
+            .root()
+            .and_downcast::<gtk::Window>()
+            .and_then(|window| window.child())
+            .and_downcast::<gtk::Overlay>()
+        else {
+            return;
+        };
+        let blurred_root = window_overlay.child().and_downcast::<BlurBin>();
+        if let Some(root) = blurred_root.as_ref() {
+            root.set_blurred(true);
+        }
+        let base = entry
+            .location
+            .parent()
+            .and_then(|p| p.native_path().map(Path::to_path_buf))
+            .unwrap_or_else(glib::home_dir);
+        let content = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        content.add_css_class("transfer-dialog");
+        content.set_halign(gtk::Align::Center);
+        content.set_valign(gtk::Align::Center);
+
+        let header = gtk::Box::new(gtk::Orientation::Horizontal, 12);
+        header.add_css_class("transfer-header");
+        let symbol = gtk::CenterBox::new();
+        symbol.add_css_class("transfer-symbol");
+        symbol.set_center_widget(Some(&crate::assets::primary_icon(
+            crate::assets::icons::FILE_ARCHIVE,
+            20,
+        )));
+        let heading = gtk::Box::new(gtk::Orientation::Vertical, 1);
+        heading.set_hexpand(true);
+        let title = gtk::Label::new(Some("Extract to"));
+        title.add_css_class("transfer-title");
+        title.set_xalign(0.0);
+        let subtitle = gtk::Label::new(Some(&entry.display_name));
+        subtitle.add_css_class("transfer-subtitle");
+        subtitle.set_xalign(0.0);
+        heading.append(&title);
+        heading.append(&subtitle);
+        let close = gtk::Button::new();
+        close.add_css_class("transfer-close");
+        close.set_tooltip_text(Some("Cancel"));
+        close.set_child(Some(&crate::assets::primary_icon(
+            crate::assets::icons::X,
+            16,
+        )));
+        header.append(&symbol);
+        header.append(&heading);
+        header.append(&close);
+        content.append(&header);
+
+        let body = gtk::Box::new(gtk::Orientation::Vertical, 8);
+        body.add_css_class("transfer-body");
+        let field_label = gtk::Label::new(Some("DESTINATION FOLDER"));
+        field_label.add_css_class("transfer-field-label");
+        field_label.set_xalign(0.0);
+        let field = gtk::Entry::new();
+        field.add_css_class("transfer-field");
+        field.set_hexpand(true);
+        field.set_placeholder_text(Some("Type a folder path…"));
+        field.set_text(&folder_input_path(&base));
+        field.set_position(-1);
+        body.append(&field_label);
+        body.append(&field);
+
+        let suggestions = gtk::Box::new(gtk::Orientation::Vertical, 2);
+        suggestions.add_css_class("transfer-suggestions");
+        let suggestion_scroll = gtk::ScrolledWindow::builder()
+            .child(&suggestions)
+            .hscrollbar_policy(gtk::PolicyType::Never)
+            .vscrollbar_policy(gtk::PolicyType::Automatic)
+            .min_content_height(150)
+            .max_content_height(220)
+            .propagate_natural_height(true)
+            .build();
+        suggestion_scroll.add_css_class("transfer-suggestion-scroll");
+        body.append(&suggestion_scroll);
+        let error = gtk::Label::new(None);
+        error.add_css_class("transfer-error");
+        error.set_wrap(true);
+        error.set_xalign(0.0);
+        error.set_visible(false);
+        body.append(&error);
+        content.append(&body);
+
+        let actions = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+        actions.add_css_class("transfer-actions");
+        let spacer = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+        spacer.set_hexpand(true);
+        let cancel = gtk::Button::with_label("Cancel");
+        cancel.add_css_class("transfer-cancel");
+        let confirm = gtk::Button::with_label("Extract here");
+        confirm.add_css_class("transfer-confirm");
+        actions.append(&spacer);
+        actions.append(&cancel);
+        actions.append(&confirm);
+        content.append(&actions);
+
+        let generation = Rc::new(Cell::new(0_u64));
+        let suggestions_box = suggestions.clone();
+        let suggestions_generation = generation.clone();
+        let suggestions_base = base.clone();
+        field.connect_changed(move |field| {
+            field.remove_css_class("error");
+            refresh_transfer_suggestions(
+                field,
+                &suggestions_box,
+                &suggestions_generation,
+                suggestions_base.clone(),
+            );
+        });
+
+        let layer = modal_layer(&content);
+        window_overlay.add_overlay(&layer);
+        let cancel_layer = layer.clone();
+        let cancel_overlay = window_overlay.clone();
+        let cancel_root = blurred_root.clone();
+        cancel.connect_clicked(move |_| {
+            dismiss_modal_layer(&cancel_layer, &cancel_overlay, cancel_root.as_ref());
+        });
+        let close_layer = layer.clone();
+        let close_overlay = window_overlay.clone();
+        let close_root = blurred_root.clone();
+        close.connect_clicked(move |_| {
+            dismiss_modal_layer(&close_layer, &close_overlay, close_root.as_ref());
+        });
+
+        let confirm_layer = layer.clone();
+        let confirm_overlay = window_overlay.clone();
+        let confirm_root = blurred_root.clone();
+        let extract_state = self.clone();
+        let confirm_field = field.clone();
+        let confirm_error = error.clone();
+        let confirm_base = base.clone();
+        let extract_entry = entry.clone();
+        confirm.connect_clicked(move |_| {
+            let path =
+                resolve_destination_path(&confirm_field.text(), &confirm_base, &glib::home_dir());
+            if path.exists() && !path.is_dir() {
+                confirm_error.set_text("The destination exists, but it is not a folder.");
+                confirm_error.set_visible(true);
+                confirm_field.add_css_class("error");
+                confirm_field.grab_focus();
+                return;
+            }
+            if !path.exists() {
+                if let Err(e) = std::fs::create_dir_all(&path) {
+                    confirm_error.set_text(&format!("Could not create folder: {e}"));
+                    confirm_error.set_visible(true);
+                    confirm_field.add_css_class("error");
+                    return;
+                }
+            }
+            let dest = Location::local(path);
+            let format = ArchiveFormat::from_extension(&extract_entry.display_name);
+            if format.map(|f| f.supports_password()).unwrap_or(false) {
+                extract_state
+                    .pending_extract_retry
+                    .replace(Some((extract_entry.clone(), dest.clone())));
+            }
+            extract_state.pending_navigate.replace(Some(dest.clone()));
+            extract_state.browser.extract(extract_entry.clone(), dest, None);
+            dismiss_modal_layer(&confirm_layer, &confirm_overlay, confirm_root.as_ref());
+        });
+
+        field.grab_focus();
+    }
+
+    fn show_extract_password_dialog(self: &Rc<Self>, entry: FileEntry, destination: Location) {
+        let (body, confirm, dismiss) = self.build_archive_modal("Extract", &entry.display_name, "Extract");
+
+        let password_label = gtk::Label::new(Some("Password"));
+        password_label.add_css_class("delete-confirmation-subtitle");
+        password_label.set_xalign(0.0);
+        let password_entry = gtk::PasswordEntry::new();
+        password_entry.set_show_peek_icon(true);
+        password_entry.add_css_class("compress-dialog-entry");
+        body.append(&password_label);
+        body.append(&password_entry);
+
+        let browser = self.browser.clone();
+        let password_for_confirm = password_entry.clone();
+        let dismiss_for_confirm = dismiss.clone();
+        confirm.connect_clicked(move |_| {
+            let pw = password_for_confirm.text().to_string();
+            let password = if pw.is_empty() { None } else { Some(pw) };
+            dismiss_for_confirm();
+            browser.extract(entry.clone(), destination.clone(), password);
+        });
+        password_entry.grab_focus();
     }
 
     fn show_properties(self: &Rc<Self>, location: Location, entry: Option<FileEntry>) {
@@ -2720,6 +3159,17 @@ impl ViewState {
                         column.presentation.show_content();
                     }
                 }
+                if self.browser.active_depth() == Some(depth) {
+                    if let Some(name) = self.pending_select.take() {
+                        let weak = Rc::downgrade(self);
+                        let name = name.clone();
+                        glib::idle_add_local_once(move || {
+                            if let Some(state) = weak.upgrade() {
+                                state.browser.select_entry_by_name(&name);
+                            }
+                        });
+                    }
+                }
             }
             BrowserEvent::LoadFailed { depth, message } => {
                 if let Some(column) = self.columns.borrow().get(depth) {
@@ -2846,6 +3296,15 @@ impl ViewState {
             }
             BrowserEvent::RestorationFinished => self.dismiss_delete_progress(),
             BrowserEvent::OperationFailed { message } => {
+                self.dismiss_delete_progress();
+                let retry = self.pending_extract_retry.take();
+                if let Some((entry, dest)) = retry {
+                    let lower = message.to_lowercase();
+                    if lower.contains("password") || lower.contains("encrypt") {
+                        self.show_extract_password_dialog(entry, dest);
+                        return;
+                    }
+                }
                 show_error_dialog(&self.overlay, "Unable to complete operation", &message);
             }
             BrowserEvent::OperationCompletedWithErrors { message } => {
@@ -2871,6 +3330,34 @@ impl ViewState {
                     show_error_dialog(&self.overlay, "Unable to open location", &error.to_string())
                 }
             },
+            BrowserEvent::ArchiveStarted { total } => {
+                self.show_file_operation_progress(
+                    total,
+                    crate::assets::icons::FILE_ARCHIVE,
+                    "Working",
+                    "This may take a moment",
+                );
+            }
+            BrowserEvent::ArchiveProgress { completed, total } => {
+                self.update_archive_progress(completed, total);
+            }
+            BrowserEvent::ArchiveCompleted { select_name, .. } => {
+                self.dismiss_delete_progress();
+                self.pending_extract_retry.replace(None);
+                if !select_name.is_empty() {
+                    self.pending_select.replace(Some(select_name));
+                }
+                if let Some(dest) = self.pending_navigate.take() {
+                    self.browser.navigate(dest);
+                } else {
+                    self.browser.reload_active();
+                }
+            }
+            BrowserEvent::TransferCompleted => {
+                if let Some(dest) = self.pending_navigate.take() {
+                    self.browser.navigate(dest);
+                }
+            }
         }
         self.refresh_active_path_rows();
     }
@@ -4282,6 +4769,9 @@ pub(super) fn install_item_context_menu(
         item_context_danger_option(crate::assets::icons::TRASH, delete_label, "Del");
     move_to_trash.add_css_class("danger");
     let properties = item_context_option(crate::assets::icons::INFO, "Properties", "Alt+Enter");
+    let compress = item_context_option(crate::assets::icons::FILE_ARCHIVE, "Compress…", "");
+    let extract = item_context_option(crate::assets::icons::FILE_ARCHIVE, "Extract here", "");
+    let extract_to = item_context_option(crate::assets::icons::FILE_ARCHIVE, "Extract to…", "");
     single.append(&open);
     single.append(&preview);
     single.append(&restore);
@@ -4294,6 +4784,10 @@ pub(super) fn install_item_context_menu(
     single.append(&rename);
     single.append(&cut);
     single.append(&move_to_trash);
+    single.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
+    single.append(&compress);
+    single.append(&extract);
+    single.append(&extract_to);
     single.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
     single.append(&properties);
     content.append(&single);
@@ -4308,6 +4802,8 @@ pub(super) fn install_item_context_menu(
     let trash_multiple =
         item_context_danger_option(crate::assets::icons::TRASH, delete_label, "Del");
     trash_multiple.add_css_class("danger");
+    let compress_multiple =
+        item_context_option(crate::assets::icons::FILE_ARCHIVE, "Compress…", "");
     multiple.append(&restore_multiple);
     multiple.append(&copy_paths);
     multiple.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
@@ -4316,6 +4812,8 @@ pub(super) fn install_item_context_menu(
     multiple.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
     multiple.append(&cut_multiple);
     multiple.append(&trash_multiple);
+    multiple.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
+    multiple.append(&compress_multiple);
     multiple.set_visible(false);
     content.append(&multiple);
 
@@ -4421,6 +4919,10 @@ pub(super) fn install_item_context_menu(
     connect_context_cut(&cut_multiple, &popover, state, &target);
     connect_context_trash(&move_to_trash, &popover, state, &target, in_trash);
     connect_context_trash(&trash_multiple, &popover, state, &target, in_trash);
+    connect_context_compress(&compress, &popover, state, &target);
+    connect_context_compress(&compress_multiple, &popover, state, &target);
+    connect_context_extract(&extract, &popover, state, &target, false);
+    connect_context_extract(&extract_to, &popover, state, &target, true);
     let weak = Rc::downgrade(state);
     let properties_target = target.clone();
     let properties_popover = popover.downgrade();
@@ -4493,6 +4995,8 @@ pub(super) fn install_item_context_menu(
                 .as_ref()
                 .is_some_and(|handler| handler(&entry.location) == PinStatus::Available),
         );
+        extract.set_visible(ArchiveFormat::from_extension(&entry.display_name).is_some());
+        extract_to.set_visible(ArchiveFormat::from_extension(&entry.display_name).is_some());
         if entries.len() > 1 {
             heading.set_text(&format!("{} items selected", entries.len()));
             summary.set_text(&selected_items_summary(&entries));
@@ -4742,6 +5246,53 @@ fn connect_context_cut(
         }
         if let Some(state) = weak.upgrade() {
             state.cut_entries(&context_entries(&state, &target));
+        }
+    });
+}
+
+fn connect_context_compress(
+    button: &gtk::Button,
+    popover: &gtk::Popover,
+    state: &Rc<ViewState>,
+    target: &Rc<RefCell<Option<(usize, FileEntry)>>>,
+) {
+    let weak = Rc::downgrade(state);
+    let target = target.clone();
+    let popover = popover.downgrade();
+    button.connect_clicked(move |_| {
+        if let Some(popover) = popover.upgrade() {
+            popover.popdown();
+        }
+        if let Some(state) = weak.upgrade() {
+            let entries = context_entries(&state, &target);
+            state.show_compress_dialog(entries);
+        }
+    });
+}
+
+fn connect_context_extract(
+    button: &gtk::Button,
+    popover: &gtk::Popover,
+    state: &Rc<ViewState>,
+    target: &Rc<RefCell<Option<(usize, FileEntry)>>>,
+    pick_destination: bool,
+) {
+    let weak = Rc::downgrade(state);
+    let target = target.clone();
+    let popover = popover.downgrade();
+    button.connect_clicked(move |_| {
+        if let Some(popover) = popover.upgrade() {
+            popover.popdown();
+        }
+        if let Some(state) = weak.upgrade() {
+            let Some((_, entry)) = target.borrow().clone() else {
+                return;
+            };
+            if pick_destination {
+                state.show_extract_to_dialog(entry);
+            } else {
+                state.extract_entry(entry);
+            }
         }
     });
 }
@@ -5526,6 +6077,15 @@ fn item_count_label(count: usize) -> String {
         "1 item".to_owned()
     } else {
         format!("{count} items")
+    }
+}
+
+fn format_from_combo(combo: &gtk::DropDown) -> ArchiveFormat {
+    match combo.selected() {
+        0 => ArchiveFormat::Zip,
+        1 => ArchiveFormat::SevenZ,
+        2 => ArchiveFormat::TarGz,
+        _ => ArchiveFormat::Tar,
     }
 }
 

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -2270,66 +2270,17 @@ impl ViewState {
     }
 
     fn show_extract_to_dialog(self: &Rc<Self>, entry: FileEntry) {
-        let Some(window_overlay) = self
-            .overlay
-            .root()
-            .and_downcast::<gtk::Window>()
-            .and_then(|window| window.child())
-            .and_downcast::<gtk::Overlay>()
-        else {
-            return;
-        };
-        let blurred_root = window_overlay.child().and_downcast::<BlurBin>();
-        if let Some(root) = blurred_root.as_ref() {
-            root.set_blurred(true);
-        }
         let base = entry
             .location
             .parent()
             .and_then(|p| p.native_path().map(Path::to_path_buf))
             .unwrap_or_else(glib::home_dir);
-        let content = gtk::Box::new(gtk::Orientation::Vertical, 0);
-        content.add_css_class("transfer-dialog");
-        content.set_halign(gtk::Align::Center);
-        content.set_valign(gtk::Align::Center);
-
-        let header = gtk::Box::new(gtk::Orientation::Horizontal, 12);
-        header.add_css_class("transfer-header");
-        let symbol = gtk::CenterBox::new();
-        symbol.add_css_class("transfer-symbol");
-        symbol.set_center_widget(Some(&crate::assets::primary_icon(
-            crate::assets::icons::FILE_ARCHIVE,
-            20,
-        )));
-        let heading = gtk::Box::new(gtk::Orientation::Vertical, 1);
-        heading.set_hexpand(true);
-        let title = gtk::Label::new(Some("Extract to"));
-        title.add_css_class("transfer-title");
-        title.set_xalign(0.0);
-        let subtitle = gtk::Label::new(Some(&entry.display_name));
-        subtitle.add_css_class("transfer-subtitle");
-        subtitle.set_xalign(0.0);
-        heading.append(&title);
-        heading.append(&subtitle);
-        let close = gtk::Button::new();
-        close.add_css_class("transfer-close");
-        close.set_tooltip_text(Some("Cancel"));
-        close.set_child(Some(&crate::assets::primary_icon(
-            crate::assets::icons::X,
-            16,
-        )));
-        header.append(&symbol);
-        header.append(&heading);
-        header.append(&close);
-        content.append(&header);
-
-        let body = gtk::Box::new(gtk::Orientation::Vertical, 8);
-        body.add_css_class("transfer-body");
-        let field_label = gtk::Label::new(Some("DESTINATION FOLDER"));
-        field_label.add_css_class("transfer-field-label");
+        let (body, confirm, dismiss) =
+            self.build_archive_modal("Extract to", &entry.display_name, "Extract here");
+        let field_label = gtk::Label::new(Some("Destination folder"));
+        field_label.add_css_class("action-dialog-field-label");
         field_label.set_xalign(0.0);
-        let field = gtk::Entry::new();
-        field.add_css_class("transfer-field");
+        let field = form_entry();
         field.set_hexpand(true);
         field.set_placeholder_text(Some("Type a folder path…"));
         field.set_text(&folder_input_path(&base));
@@ -2355,20 +2306,6 @@ impl ViewState {
         error.set_xalign(0.0);
         error.set_visible(false);
         body.append(&error);
-        content.append(&body);
-
-        let actions = gtk::Box::new(gtk::Orientation::Horizontal, 8);
-        actions.add_css_class("transfer-actions");
-        let spacer = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-        spacer.set_hexpand(true);
-        let cancel = gtk::Button::with_label("Cancel");
-        cancel.add_css_class("transfer-cancel");
-        let confirm = gtk::Button::with_label("Extract here");
-        confirm.add_css_class("transfer-confirm");
-        actions.append(&spacer);
-        actions.append(&cancel);
-        actions.append(&confirm);
-        content.append(&actions);
 
         let generation = Rc::new(Cell::new(0_u64));
         let suggestions_box = suggestions.clone();
@@ -2384,29 +2321,12 @@ impl ViewState {
             );
         });
 
-        let layer = modal_layer(&content);
-        window_overlay.add_overlay(&layer);
-        let cancel_layer = layer.clone();
-        let cancel_overlay = window_overlay.clone();
-        let cancel_root = blurred_root.clone();
-        cancel.connect_clicked(move |_| {
-            dismiss_modal_layer(&cancel_layer, &cancel_overlay, cancel_root.as_ref());
-        });
-        let close_layer = layer.clone();
-        let close_overlay = window_overlay.clone();
-        let close_root = blurred_root.clone();
-        close.connect_clicked(move |_| {
-            dismiss_modal_layer(&close_layer, &close_overlay, close_root.as_ref());
-        });
-
-        let confirm_layer = layer.clone();
-        let confirm_overlay = window_overlay.clone();
-        let confirm_root = blurred_root.clone();
         let extract_state = self.clone();
         let confirm_field = field.clone();
         let confirm_error = error.clone();
         let confirm_base = base.clone();
         let extract_entry = entry.clone();
+        let dismiss_for_confirm = dismiss.clone();
         confirm.connect_clicked(move |_| {
             let path =
                 resolve_destination_path(&confirm_field.text(), &confirm_base, &glib::home_dir());
@@ -2436,7 +2356,7 @@ impl ViewState {
             extract_state
                 .browser
                 .extract(extract_entry.clone(), dest, None);
-            dismiss_modal_layer(&confirm_layer, &confirm_overlay, confirm_root.as_ref());
+            dismiss_for_confirm();
         });
 
         field.grab_focus();

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -25,7 +25,7 @@ use crate::{
 use super::{
     blur::BlurBin,
     browser_modes::{BrowserDensity, BrowserMode, ModeViews},
-    controls::segmented_control,
+    controls::{form_entry, form_password_entry, modal_layout, segmented_control},
     motion::{animations_enabled, emphasized_deceleration},
 };
 
@@ -1284,7 +1284,9 @@ impl ViewState {
                 return;
             }
             if path.is_dir() {
-                transfer_state.pending_navigate.replace(Some(Location::local(path.clone())));
+                transfer_state
+                    .pending_navigate
+                    .replace(Some(Location::local(path.clone())));
                 transfer_state.start_transfer(Location::local(path), sources.clone(), move_sources);
                 dismiss_modal_layer(&confirm_layer, &confirm_overlay, confirm_root.as_ref());
                 return;
@@ -1313,7 +1315,9 @@ impl ViewState {
                     gio::spawn_blocking(move || std::fs::create_dir_all(&created_path)).await;
                 match result {
                     Ok(Ok(())) => {
-                        created_state.pending_navigate.replace(Some(Location::local(path.clone())));
+                        created_state
+                            .pending_navigate
+                            .replace(Some(Location::local(path.clone())));
                         created_state.start_transfer(
                             Location::local(path),
                             created_sources,
@@ -1390,7 +1394,7 @@ impl ViewState {
 
     fn show_file_operation_progress(
         self: &Rc<Self>,
-        total: usize,
+        _total: usize,
         icon: &str,
         title_text: &str,
         subtitle_text: &str,
@@ -1436,11 +1440,7 @@ impl ViewState {
 
         let body = gtk::Box::new(gtk::Orientation::Vertical, 10);
         body.add_css_class("transfer-body");
-        let status = gtk::Label::new(Some(&if total > 0 {
-            format!("0%")
-        } else {
-            "0%".to_string()
-        }));
+        let status = gtk::Label::new(Some("0%"));
         status.add_css_class("delete-progress-status");
         status.set_xalign(0.0);
         let progress = gtk::ProgressBar::new();
@@ -1511,9 +1511,9 @@ impl ViewState {
             view.status.set_text(&format!("{completed} files"));
             view.progress.pulse();
         } else {
-            view.status.set_text(&format!("{completed} / {total} files"));
-            view.progress
-                .set_fraction(completed as f64 / total as f64);
+            view.status
+                .set_text(&format!("{completed} / {total} files"));
+            view.progress.set_fraction(completed as f64 / total as f64);
         }
     }
 
@@ -1864,68 +1864,20 @@ impl ViewState {
             .and_then(|window| window.child())
             .and_downcast::<gtk::Overlay>()
         else {
-            return (
-                gtk::Box::default(),
-                gtk::Button::default(),
-                Rc::new(|| {}),
-            );
+            return (gtk::Box::default(), gtk::Button::default(), Rc::new(|| {}));
         };
         let blurred_root = window_overlay.child().and_downcast::<BlurBin>();
         if let Some(root) = blurred_root.as_ref() {
             root.set_blurred(true);
         }
 
-        let content = gtk::Box::new(gtk::Orientation::Vertical, 0);
-        content.add_css_class("compress-dialog");
-        content.add_css_class("delete-confirmation-content");
-        content.set_halign(gtk::Align::Center);
-        content.set_valign(gtk::Align::Center);
-
-        let header = gtk::Box::new(gtk::Orientation::Horizontal, 12);
-        header.add_css_class("delete-confirmation-header");
-        let symbol = gtk::CenterBox::new();
-        symbol.add_css_class("delete-confirmation-symbol");
-        symbol.set_size_request(40, 40);
-        symbol.set_hexpand(false);
-        let symbol_icon = crate::assets::primary_icon(crate::assets::icons::FILE_ARCHIVE, 21);
-        symbol.set_center_widget(Some(&symbol_icon));
-        let heading = gtk::Box::new(gtk::Orientation::Vertical, 1);
-        heading.set_hexpand(true);
-        let title_label = gtk::Label::new(Some(title));
-        title_label.add_css_class("delete-confirmation-title");
-        title_label.set_xalign(0.0);
-        let subtitle_label = gtk::Label::new(Some(subtitle));
-        subtitle_label.add_css_class("delete-confirmation-subtitle");
-        subtitle_label.set_xalign(0.0);
-        heading.append(&title_label);
-        heading.append(&subtitle_label);
-        let close = gtk::Button::new();
-        close.add_css_class("delete-confirmation-close");
-        close.set_tooltip_text(Some("Cancel"));
-        close.set_child(Some(&crate::assets::text_icon(crate::assets::icons::X, 16)));
-        header.append(&symbol);
-        header.append(&heading);
-        header.append(&close);
-        content.append(&header);
-
-        let body = gtk::Box::new(gtk::Orientation::Vertical, 12);
-        body.add_css_class("delete-confirmation-body");
-        content.append(&body);
-
-        let actions = gtk::Box::new(gtk::Orientation::Horizontal, 8);
-        actions.add_css_class("delete-confirmation-actions");
-        let action_spacer = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-        action_spacer.set_hexpand(true);
-        let cancel = gtk::Button::with_label("Cancel");
-        cancel.add_css_class("delete-confirmation-cancel");
-        let confirm = gtk::Button::with_label(confirm_label);
-        confirm.add_css_class("compress-dialog-confirm");
-        actions.append(&action_spacer);
-        actions.append(&cancel);
-        actions.append(&confirm);
-        content.append(&actions);
-
-        let layer = modal_layer(&content);
+        let layout = modal_layout(
+            crate::assets::icons::FILE_ARCHIVE,
+            title,
+            subtitle,
+            confirm_label,
+        );
+        let layer = modal_layer(&layout.content);
         window_overlay.add_overlay(&layer);
 
         let dismiss: Rc<dyn Fn()> = Rc::new({
@@ -1935,9 +1887,9 @@ impl ViewState {
             move || dismiss_modal_layer(&layer, &overlay, root.as_ref())
         });
         let dismiss_for_cancel = dismiss.clone();
-        cancel.connect_clicked(move |_| dismiss_for_cancel());
+        layout.cancel.connect_clicked(move |_| dismiss_for_cancel());
         let dismiss_for_close = dismiss.clone();
-        close.connect_clicked(move |_| dismiss_for_close());
+        layout.close.connect_clicked(move |_| dismiss_for_close());
         let escape = gtk::EventControllerKey::new();
         let dismiss_for_escape = dismiss.clone();
         escape.connect_key_pressed(move |_, key, _, _| {
@@ -1949,16 +1901,17 @@ impl ViewState {
             }
         });
         layer.add_controller(escape);
-        (body, confirm, dismiss)
+        (layout.body, layout.confirm, dismiss)
     }
 
     fn show_compress_dialog(self: &Rc<Self>, entries: Vec<FileEntry>) {
         if entries.is_empty() {
             return;
         }
-        let destination = self.browser.active_location().unwrap_or_else(|| {
-            Location::local(glib::home_dir())
-        });
+        let destination = self
+            .browser
+            .active_location()
+            .unwrap_or_else(|| Location::local(glib::home_dir()));
 
         let default_name = if entries.len() == 1 {
             entries[0].display_name.clone()
@@ -1971,73 +1924,117 @@ impl ViewState {
         let (body, confirm, dismiss) = self.build_archive_modal(&title, &subtitle, "Compress");
 
         let name_label = gtk::Label::new(Some("Archive name"));
-        name_label.add_css_class("delete-confirmation-subtitle");
+        name_label.add_css_class("action-dialog-field-label");
         name_label.set_xalign(0.0);
-        let name_entry = gtk::Entry::new();
+        let name_entry = form_entry();
         name_entry.set_text(&default_name);
-        name_entry.add_css_class("compress-dialog-entry");
         body.append(&name_label);
         body.append(&name_entry);
 
         let format_label = gtk::Label::new(Some("Format"));
-        format_label.add_css_class("delete-confirmation-subtitle");
+        format_label.add_css_class("action-dialog-field-label");
         format_label.set_xalign(0.0);
-        let format_combo = gtk::DropDown::from_strings(&["ZIP", "7Z", "TAR.GZ", "TAR"]);
-        format_combo.add_css_class("compress-dialog-format");
+        let (format_control, format_options) =
+            segmented_control(&["ZIP", "7Z", "TAR.GZ", "TAR"], 0);
+        let selected_format = Rc::new(Cell::new(ArchiveFormat::Zip));
         body.append(&format_label);
-        body.append(&format_combo);
+        body.append(&format_control);
 
-        let password_label = gtk::Label::new(Some("Password (optional)"));
-        password_label.add_css_class("delete-confirmation-subtitle");
+        let protection_label = gtk::Label::new(Some("Protection"));
+        protection_label.add_css_class("action-dialog-field-label");
+        protection_label.set_xalign(0.0);
+        let (protection_control, protection_options) =
+            segmented_control(&["No password", "Password protected"], 0);
+        let no_password = protection_options[0].clone();
+        let password_protected = protection_options[1].clone();
+
+        let password_label = gtk::Label::new(Some("Password"));
+        password_label.add_css_class("action-dialog-field-label");
         password_label.set_xalign(0.0);
-        let password_entry = gtk::PasswordEntry::new();
+        let password_entry = form_password_entry();
         password_entry.set_show_peek_icon(true);
-        password_entry.add_css_class("compress-dialog-entry");
         let confirm_label = gtk::Label::new(Some("Confirm password"));
-        confirm_label.add_css_class("delete-confirmation-subtitle");
+        confirm_label.add_css_class("action-dialog-field-label");
         confirm_label.set_xalign(0.0);
-        let confirm_entry = gtk::PasswordEntry::new();
+        let confirm_entry = form_password_entry();
         confirm_entry.set_show_peek_icon(true);
-        confirm_entry.add_css_class("compress-dialog-entry");
-        let password_box = gtk::Box::new(gtk::Orientation::Vertical, 6);
-        password_box.append(&password_label);
-        password_box.append(&password_entry);
-        password_box.append(&confirm_label);
-        password_box.append(&confirm_entry);
-        body.append(&password_box);
+        let password_fields = gtk::Box::new(gtk::Orientation::Vertical, 6);
+        password_fields.append(&password_label);
+        password_fields.append(&password_entry);
+        password_fields.append(&confirm_label);
+        password_fields.append(&confirm_entry);
+        password_fields.set_visible(false);
 
-        let password_box_clone = password_box.clone();
-        let format_combo_for_signal = format_combo.clone();
-        let format_combo_for_handler = format_combo.clone();
-        format_combo_for_signal.connect_notify_local(Some("selected"), move |_, _| {
-            password_box_clone.set_visible(format_from_combo(&format_combo_for_handler).supports_password());
+        let protection_box = gtk::Box::new(gtk::Orientation::Vertical, 6);
+        protection_box.append(&protection_label);
+        protection_box.append(&protection_control);
+        protection_box.append(&password_fields);
+        body.append(&protection_box);
+
+        let fields_for_protection = password_fields.clone();
+        let password_for_focus = password_entry.clone();
+        password_protected.connect_toggled(move |option| {
+            fields_for_protection.set_visible(option.is_active());
+            if option.is_active() {
+                password_for_focus.grab_focus();
+            }
         });
-        password_box.set_visible(format_from_combo(&format_combo).supports_password());
+
+        for (option, format) in format_options.into_iter().zip([
+            ArchiveFormat::Zip,
+            ArchiveFormat::SevenZ,
+            ArchiveFormat::TarGz,
+            ArchiveFormat::Tar,
+        ]) {
+            let selected_format = selected_format.clone();
+            let protection_for_format = protection_box.clone();
+            let no_password_for_format = no_password.clone();
+            option.connect_toggled(move |option| {
+                if !option.is_active() {
+                    return;
+                }
+                selected_format.set(format);
+                let supported = format.supports_password();
+                protection_for_format.set_visible(supported);
+                if !supported {
+                    no_password_for_format.set_active(true);
+                }
+            });
+        }
 
         let browser = self.browser.clone();
         let confirm_entries = entries.clone();
         let confirm_destination = destination.clone();
         let name_for_confirm = name_entry.clone();
-        let format_for_confirm = format_combo.clone();
+        let format_for_confirm = selected_format.clone();
         let password_for_confirm = password_entry.clone();
         let confirm_for_confirm = confirm_entry.clone();
+        let protected_for_confirm = password_protected.clone();
         let overlay_for_error = self.overlay.clone();
         let dismiss_for_confirm = dismiss.clone();
         confirm.connect_clicked(move |_| {
             let name = name_for_confirm.text().to_string();
-            let format = format_from_combo(&format_for_confirm);
-            let password = if format.supports_password() {
+            let format = format_for_confirm.get();
+            let password = if format.supports_password() && protected_for_confirm.is_active() {
                 let pw = password_for_confirm.text().to_string();
                 if pw.is_empty() {
-                    None
-                } else {
-                    let confirm_pw = confirm_for_confirm.text().to_string();
-                    if pw != confirm_pw {
-                        show_error_dialog(&overlay_for_error, "Passwords do not match", "Please enter the same password in both fields.");
-                        return;
-                    }
-                    Some(pw)
+                    show_error_dialog(
+                        &overlay_for_error,
+                        "Password required",
+                        "Enter a password or choose No password.",
+                    );
+                    return;
                 }
+                let confirm_pw = confirm_for_confirm.text().to_string();
+                if pw != confirm_pw {
+                    show_error_dialog(
+                        &overlay_for_error,
+                        "Passwords do not match",
+                        "Please enter the same password in both fields.",
+                    );
+                    return;
+                }
+                Some(pw)
             } else {
                 None
             };
@@ -2047,19 +2044,30 @@ impl ViewState {
                 name
             };
             dismiss_for_confirm();
-            browser.compress(confirm_entries.clone(), confirm_destination.clone(), archive_name, format, password);
+            browser.compress(
+                confirm_entries.clone(),
+                confirm_destination.clone(),
+                archive_name,
+                format,
+                password,
+            );
         });
         name_entry.grab_focus();
     }
 
     fn extract_entry(self: &Rc<Self>, entry: FileEntry) {
         let Some(parent) = entry.location.parent() else {
-            show_error_dialog(&self.overlay, "Cannot extract", "This archive has no parent directory.");
+            show_error_dialog(
+                &self.overlay,
+                "Cannot extract",
+                "This archive has no parent directory.",
+            );
             return;
         };
         let format = ArchiveFormat::from_extension(&entry.display_name);
         if format.map(|f| f.supports_password()).unwrap_or(false) {
-            self.pending_extract_retry.replace(Some((entry.clone(), parent.clone())));
+            self.pending_extract_retry
+                .replace(Some((entry.clone(), parent.clone())));
         }
         self.browser.extract(entry, parent, None);
     }
@@ -2212,13 +2220,13 @@ impl ViewState {
                 confirm_field.grab_focus();
                 return;
             }
-            if !path.exists() {
-                if let Err(e) = std::fs::create_dir_all(&path) {
-                    confirm_error.set_text(&format!("Could not create folder: {e}"));
-                    confirm_error.set_visible(true);
-                    confirm_field.add_css_class("error");
-                    return;
-                }
+            if !path.exists()
+                && let Err(e) = std::fs::create_dir_all(&path)
+            {
+                confirm_error.set_text(&format!("Could not create folder: {e}"));
+                confirm_error.set_visible(true);
+                confirm_field.add_css_class("error");
+                return;
             }
             let dest = Location::local(path);
             let format = ArchiveFormat::from_extension(&extract_entry.display_name);
@@ -2228,7 +2236,9 @@ impl ViewState {
                     .replace(Some((extract_entry.clone(), dest.clone())));
             }
             extract_state.pending_navigate.replace(Some(dest.clone()));
-            extract_state.browser.extract(extract_entry.clone(), dest, None);
+            extract_state
+                .browser
+                .extract(extract_entry.clone(), dest, None);
             dismiss_modal_layer(&confirm_layer, &confirm_overlay, confirm_root.as_ref());
         });
 
@@ -2236,14 +2246,14 @@ impl ViewState {
     }
 
     fn show_extract_password_dialog(self: &Rc<Self>, entry: FileEntry, destination: Location) {
-        let (body, confirm, dismiss) = self.build_archive_modal("Extract", &entry.display_name, "Extract");
+        let (body, confirm, dismiss) =
+            self.build_archive_modal("Extract", &entry.display_name, "Extract");
 
         let password_label = gtk::Label::new(Some("Password"));
-        password_label.add_css_class("delete-confirmation-subtitle");
+        password_label.add_css_class("action-dialog-field-label");
         password_label.set_xalign(0.0);
-        let password_entry = gtk::PasswordEntry::new();
+        let password_entry = form_password_entry();
         password_entry.set_show_peek_icon(true);
-        password_entry.add_css_class("compress-dialog-entry");
         body.append(&password_label);
         body.append(&password_entry);
 
@@ -3159,16 +3169,16 @@ impl ViewState {
                         column.presentation.show_content();
                     }
                 }
-                if self.browser.active_depth() == Some(depth) {
-                    if let Some(name) = self.pending_select.take() {
-                        let weak = Rc::downgrade(self);
-                        let name = name.clone();
-                        glib::idle_add_local_once(move || {
-                            if let Some(state) = weak.upgrade() {
-                                state.browser.select_entry_by_name(&name);
-                            }
-                        });
-                    }
+                if self.browser.active_depth() == Some(depth)
+                    && let Some(name) = self.pending_select.take()
+                {
+                    let weak = Rc::downgrade(self);
+                    let name = name.clone();
+                    glib::idle_add_local_once(move || {
+                        if let Some(state) = weak.upgrade() {
+                            state.browser.select_entry_by_name(&name);
+                        }
+                    });
                 }
             }
             BrowserEvent::LoadFailed { depth, message } => {
@@ -4755,6 +4765,7 @@ pub(super) fn install_item_context_menu(
     let restore = item_context_option(crate::assets::icons::FOLDER, "Restore", "");
     restore.set_visible(in_trash);
     let pin = item_context_option(crate::assets::icons::PIN, "Pin to sidebar", "P");
+    let copy = item_context_option(crate::assets::icons::COPY, "Copy", "Ctrl+C");
     let copy_path = item_context_option(crate::assets::icons::COPY, "Copy path", "Y");
     let move_to = item_context_option(crate::assets::icons::FOLDER, "Move to…", "");
     let copy_to = item_context_option(crate::assets::icons::COPY, "Copy to…", "");
@@ -4775,29 +4786,32 @@ pub(super) fn install_item_context_menu(
     single.append(&open);
     single.append(&preview);
     single.append(&restore);
+    single.append(&extract);
+    single.append(&extract_to);
+    single.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
     single.append(&pin);
+    single.append(&cut);
+    single.append(&copy);
     single.append(&copy_path);
     single.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
     single.append(&move_to);
     single.append(&copy_to);
     single.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
     single.append(&rename);
-    single.append(&cut);
-    single.append(&move_to_trash);
-    single.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
     single.append(&compress);
-    single.append(&extract);
-    single.append(&extract_to);
     single.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
     single.append(&properties);
+    single.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
+    single.append(&move_to_trash);
     content.append(&single);
 
     let multiple = gtk::Box::new(gtk::Orientation::Vertical, 0);
     let restore_multiple = item_context_option(crate::assets::icons::FOLDER, "Restore items", "");
     restore_multiple.set_visible(in_trash);
+    let copy_multiple = item_context_option(crate::assets::icons::COPY, "Copy", "Ctrl+C");
     let copy_paths = item_context_option(crate::assets::icons::COPY, "Copy paths", "Y");
     let move_multiple = item_context_option(crate::assets::icons::FOLDER, "Move to…", "");
-    let copy_multiple = item_context_option(crate::assets::icons::COPY, "Copy to…", "");
+    let copy_to_multiple = item_context_option(crate::assets::icons::COPY, "Copy to…", "");
     let cut_multiple = item_context_option(crate::assets::icons::SCISSORS, "Cut", "Ctrl+X");
     let trash_multiple =
         item_context_danger_option(crate::assets::icons::TRASH, delete_label, "Del");
@@ -4805,15 +4819,16 @@ pub(super) fn install_item_context_menu(
     let compress_multiple =
         item_context_option(crate::assets::icons::FILE_ARCHIVE, "Compress…", "");
     multiple.append(&restore_multiple);
+    multiple.append(&cut_multiple);
+    multiple.append(&copy_multiple);
     multiple.append(&copy_paths);
     multiple.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
     multiple.append(&move_multiple);
-    multiple.append(&copy_multiple);
-    multiple.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
-    multiple.append(&cut_multiple);
-    multiple.append(&trash_multiple);
+    multiple.append(&copy_to_multiple);
     multiple.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
     multiple.append(&compress_multiple);
+    multiple.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
+    multiple.append(&trash_multiple);
     multiple.set_visible(false);
     content.append(&multiple);
 
@@ -4914,9 +4929,11 @@ pub(super) fn install_item_context_menu(
     connect_context_transfer(&move_to, &popover, state, &target, true);
     connect_context_transfer(&copy_to, &popover, state, &target, false);
     connect_context_transfer(&move_multiple, &popover, state, &target, true);
-    connect_context_transfer(&copy_multiple, &popover, state, &target, false);
+    connect_context_transfer(&copy_to_multiple, &popover, state, &target, false);
     connect_context_cut(&cut, &popover, state, &target);
     connect_context_cut(&cut_multiple, &popover, state, &target);
+    connect_context_copy(&copy, &popover, state, &target);
+    connect_context_copy(&copy_multiple, &popover, state, &target);
     connect_context_trash(&move_to_trash, &popover, state, &target, in_trash);
     connect_context_trash(&trash_multiple, &popover, state, &target, in_trash);
     connect_context_compress(&compress, &popover, state, &target);
@@ -5246,6 +5263,25 @@ fn connect_context_cut(
         }
         if let Some(state) = weak.upgrade() {
             state.cut_entries(&context_entries(&state, &target));
+        }
+    });
+}
+
+fn connect_context_copy(
+    button: &gtk::Button,
+    popover: &gtk::Popover,
+    state: &Rc<ViewState>,
+    target: &Rc<RefCell<Option<(usize, FileEntry)>>>,
+) {
+    let weak = Rc::downgrade(state);
+    let target = target.clone();
+    let popover = popover.downgrade();
+    button.connect_clicked(move |_| {
+        if let Some(popover) = popover.upgrade() {
+            popover.popdown();
+        }
+        if let Some(state) = weak.upgrade() {
+            state.copy_entries(&context_entries(&state, &target));
         }
     });
 }
@@ -6080,15 +6116,6 @@ fn item_count_label(count: usize) -> String {
     }
 }
 
-fn format_from_combo(combo: &gtk::DropDown) -> ArchiveFormat {
-    match combo.selected() {
-        0 => ArchiveFormat::Zip,
-        1 => ArchiveFormat::SevenZ,
-        2 => ArchiveFormat::TarGz,
-        _ => ArchiveFormat::Tar,
-    }
-}
-
 fn entry_kind_summary(entries: &[FileEntry]) -> String {
     let directories = entries.iter().filter(|entry| entry.is_directory()).count();
     let files = entries.len().saturating_sub(directories);
@@ -6266,22 +6293,19 @@ fn show_authentication_dialog(
     let credentials = gtk::Box::new(gtk::Orientation::Vertical, 10);
     credentials.add_css_class("authentication-fields");
 
-    let username = gtk::Entry::new();
-    username.add_css_class("transfer-field");
+    let username = form_entry();
     username.set_text(defaults.0);
     if flags.contains(gio::AskPasswordFlags::NEED_USERNAME) {
         append_authentication_field(&credentials, "Username", &username);
     }
 
-    let domain = gtk::Entry::new();
-    domain.add_css_class("transfer-field");
+    let domain = form_entry();
     domain.set_text(defaults.1);
     if flags.contains(gio::AskPasswordFlags::NEED_DOMAIN) {
         append_authentication_field(&credentials, "Domain", &domain);
     }
 
-    let password = gtk::PasswordEntry::new();
-    password.add_css_class("transfer-field");
+    let password = form_password_entry();
     password.set_show_peek_icon(true);
     if flags.contains(gio::AskPasswordFlags::NEED_PASSWORD) {
         append_authentication_field(&credentials, "Password", &password);

--- a/src/ui/controls.rs
+++ b/src/ui/controls.rs
@@ -2,12 +2,108 @@
 
 use gtk::prelude::*;
 
+pub(super) fn form_entry() -> gtk::Entry {
+    let entry = gtk::Entry::new();
+    entry.add_css_class("form-control");
+    entry
+}
+
+pub(super) fn form_password_entry() -> gtk::PasswordEntry {
+    let entry = gtk::PasswordEntry::new();
+    entry.add_css_class("form-control");
+    entry
+}
+
+pub(super) struct ModalLayout {
+    pub content: gtk::Box,
+    pub body: gtk::Box,
+    pub close: gtk::Button,
+    pub cancel: gtk::Button,
+    pub confirm: gtk::Button,
+}
+
+/// Builds the shared structure and styling for an action modal.
+pub(super) fn modal_layout(
+    icon: &str,
+    title: &str,
+    subtitle: &str,
+    confirm_label: &str,
+) -> ModalLayout {
+    let content = gtk::Box::new(gtk::Orientation::Vertical, 0);
+    content.add_css_class("action-dialog");
+    content.set_halign(gtk::Align::Center);
+    content.set_valign(gtk::Align::Center);
+
+    let header = gtk::Box::new(gtk::Orientation::Horizontal, 12);
+    header.add_css_class("action-dialog-header");
+    header.set_valign(gtk::Align::Center);
+
+    let symbol = gtk::CenterBox::new();
+    symbol.add_css_class("action-dialog-symbol");
+    symbol.set_size_request(40, 40);
+    symbol.set_hexpand(false);
+    symbol.set_center_widget(Some(&crate::assets::primary_icon(icon, 21)));
+
+    let heading = gtk::Box::new(gtk::Orientation::Vertical, 1);
+    heading.add_css_class("action-dialog-heading");
+    heading.set_hexpand(true);
+    heading.set_valign(gtk::Align::Center);
+    let title = gtk::Label::new(Some(title));
+    title.add_css_class("action-dialog-title");
+    title.set_xalign(0.0);
+    let subtitle = gtk::Label::new(Some(subtitle));
+    subtitle.add_css_class("action-dialog-subtitle");
+    subtitle.set_xalign(0.0);
+    heading.append(&title);
+    heading.append(&subtitle);
+
+    let close = gtk::Button::new();
+    close.add_css_class("action-dialog-close");
+    close.set_valign(gtk::Align::Center);
+    close.set_tooltip_text(Some("Cancel"));
+    close.set_child(Some(&crate::assets::primary_icon(
+        crate::assets::icons::X,
+        16,
+    )));
+
+    header.append(&symbol);
+    header.append(&heading);
+    header.append(&close);
+    content.append(&header);
+
+    let body = gtk::Box::new(gtk::Orientation::Vertical, 12);
+    body.add_css_class("action-dialog-body");
+    content.append(&body);
+
+    let actions = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+    actions.add_css_class("action-dialog-actions");
+    let spacer = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    spacer.set_hexpand(true);
+    let cancel = gtk::Button::with_label("Cancel");
+    cancel.add_css_class("action-dialog-cancel");
+    let confirm = gtk::Button::with_label(confirm_label);
+    confirm.add_css_class("action-dialog-confirm");
+    actions.append(&spacer);
+    actions.append(&cancel);
+    actions.append(&confirm);
+    content.append(&actions);
+
+    ModalLayout {
+        content,
+        body,
+        close,
+        cancel,
+        confirm,
+    }
+}
+
 /// Builds a single-selection group with the same compact treatment as a segmented control.
 pub(super) fn segmented_control(
     labels: &[&str],
     selected: usize,
 ) -> (gtk::Box, Vec<gtk::ToggleButton>) {
     let control = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    control.set_homogeneous(true);
     control.add_css_class("segmented-control");
 
     let mut buttons = Vec::with_capacity(labels.len());


### PR DESCRIPTION
## Summary
- Add compress support for ZIP, 7z, TAR.GZ, and TAR formats
- Add extract support with "Extract here" and "Extract to..." actions
- Support password protection for ZIP and 7z (compress + extract)
- In-app dialogs for compress and extract (no external file picker)
- Progress reporting with file count and pulsing bar during enumeration
- Cancellation support via existing operation mechanism
- Path traversal protection on extraction
- Conflict resolution: renamed top-level entries (e.g. `folder (2)`) instead of merging
- Navigate to destination after extract/move/copy operations
- Highlight extracted/compressed result after completion
- Performance: 1 MiB I/O buffers, BufReader/BufWriter, skip compression for already-compressed files, 7z multithreading

#### Test plan
- [ ] Compress a single file, directory, and multiple selections
- [ ] Extract ZIP, 7z, TAR.GZ, TAR archives
- [ ] Extract password-protected ZIP and 7z
- [ ] Compress with password (ZIP and 7z)
- [ ] "Extract to..." opens in-app dialog and navigates to destination
- [ ] "Move to..." and "Copy to..." navigate to destination
- [ ] Extract into destination with conflicts renames to `folder (2)`
- [ ] Progress bar appears immediately, pulses during count, then shows real fraction
- [ ] Cancel during compression works
- [ ] Compress again without password after a passworded operation
- [ ] Extracted folders are highlighted after extraction
<img width="960" height="540" alt="screenrecording-2026-09-01_04-25-04" src="https://github.com/user-attachments/assets/0247c1ab-d368-4ebb-87e1-23addeaa7bc6" />
<img width="960" height="540" alt="screenrecording-2026-09-01_03-59-23_trimmed" src="https://github.com/user-attachments/assets/330d39cf-e275-4b22-a75b-6187773f1303" />
Sorry for my laziness for including 2 gifs