### PR TITLE
feat(ui): add keyboard-driven multi-pane layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ strata ~/Documents     # a specific directory
 
 Useful shortcuts include <kbd>Ctrl</kbd>+<kbd>K</kbd> for recursive search, <kbd>Ctrl</kbd>+<kbd>L</kbd> for a path or URI, <kbd>Ctrl</kbd>+<kbd>F</kbd> to filter the current pane, <kbd>Space</kbd> for preview, <kbd>F2</kbd> to rename, and <kbd>Alt</kbd>+arrow keys for history and parent navigation.
 
+Pane commands use a <kbd>Ctrl</kbd>+<kbd>S</kbd> prefix: press <kbd>V</kbd> to split the active pane side by side, <kbd>S</kbd> to split it top and bottom, <kbd>H</kbd>/<kbd>J</kbd>/<kbd>K</kbd>/<kbd>L</kbd> or the arrow keys to move focus, <kbd>W</kbd> to cycle through panes, and <kbd>C</kbd> to close the active pane. You can nest splits up to four panes, or choose the 2 × 2 preset from the pane menu. The prefix expires after 1.5 seconds and <kbd>Escape</kbd> cancels it.
+
 ### Desktop entry
 
 Create a per-user launcher and optionally make Strata the default directory handler:

--- a/data/icons/scalable/actions/strata-columns-2.svg
+++ b/data/icons/scalable/actions/strata-columns-2.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#8bc9eb" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M12 3v18"/></svg>

--- a/data/icons/scalable/actions/strata-grid-2x2.svg
+++ b/data/icons/scalable/actions/strata-grid-2x2.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#8bc9eb" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v18"/><path d="M3 12h18"/><rect x="3" y="3" width="18" height="18" rx="2"/></svg>

--- a/data/icons/scalable/actions/strata-rows-2.svg
+++ b/data/icons/scalable/actions/strata-rows-2.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#8bc9eb" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M3 12h18"/></svg>

--- a/data/icons/scalable/actions/strata-square.svg
+++ b/data/icons/scalable/actions/strata-square.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#8bc9eb" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/></svg>

--- a/data/strata.gresource.xml
+++ b/data/strata.gresource.xml
@@ -11,6 +11,7 @@
     <file>icons/scalable/actions/strata-check-on-primary.svg</file>
     <file>icons/scalable/actions/strata-chevron-right.svg</file>
     <file>icons/scalable/actions/strata-copy.svg</file>
+    <file>icons/scalable/actions/strata-columns-2.svg</file>
     <file>icons/scalable/actions/strata-download.svg</file>
     <file>icons/scalable/actions/strata-eye-off.svg</file>
     <file>icons/scalable/actions/strata-eye.svg</file>
@@ -21,6 +22,7 @@
     <file>icons/scalable/actions/strata-folder.svg</file>
     <file>icons/scalable/actions/strata-funnel.svg</file>
     <file>icons/scalable/actions/strata-grid.svg</file>
+    <file>icons/scalable/actions/strata-grid-2x2.svg</file>
     <file>icons/scalable/actions/strata-hard-drive.svg</file>
     <file>icons/scalable/actions/strata-house.svg</file>
     <file>icons/scalable/actions/strata-image.svg</file>
@@ -37,12 +39,14 @@
     <file>icons/scalable/actions/strata-pin.svg</file>
     <file>icons/scalable/actions/strata-plus.svg</file>
     <file>icons/scalable/actions/strata-rows.svg</file>
+    <file>icons/scalable/actions/strata-rows-2.svg</file>
     <file>icons/scalable/actions/strata-scissors.svg</file>
     <file>icons/scalable/actions/strata-search.svg</file>
     <file>icons/scalable/actions/strata-settings-active.svg</file>
     <file>icons/scalable/actions/strata-settings.svg</file>
     <file>icons/scalable/actions/strata-settings-2.svg</file>
     <file>icons/scalable/actions/strata-sliders-horizontal.svg</file>
+    <file>icons/scalable/actions/strata-square.svg</file>
     <file>icons/scalable/actions/strata-terminal.svg</file>
     <file>icons/scalable/actions/strata-trash.svg</file>
     <file>icons/scalable/actions/strata-unplug.svg</file>

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -119,6 +119,9 @@ pub enum BrowserEvent {
     OperationCompletedWithErrors {
         message: String,
     },
+    LocationsInvalidated {
+        locations: Vec<Location>,
+    },
     NavigationRejected {
         parent_depth: usize,
         error: LocationValidationError,
@@ -930,6 +933,7 @@ impl Browser {
             return;
         };
         let request_id = self.begin_operation();
+        let refresh_destination = destination.clone();
         let load = provider.compress(
             CompressRequest {
                 id: request_id,
@@ -939,7 +943,7 @@ impl Browser {
                 format,
                 password,
             },
-            self.operation_callback(request_id, false, Vec::new()),
+            self.operation_callback(request_id, false, vec![refresh_destination]),
         );
         self.operation_load.replace(Some(load));
     }
@@ -957,6 +961,7 @@ impl Browser {
             return;
         };
         let request_id = self.begin_operation();
+        let refresh_destination = destination.clone();
         let load = provider.extract(
             ExtractRequest {
                 id: request_id,
@@ -964,7 +969,7 @@ impl Browser {
                 destination,
                 password,
             },
-            self.operation_callback(request_id, false, Vec::new()),
+            self.operation_callback(request_id, false, vec![refresh_destination]),
         );
         self.operation_load.replace(Some(load));
     }
@@ -1086,6 +1091,7 @@ impl Browser {
                 browser.emit(BrowserEvent::RestorationFinished);
             }
             browser.operation_load.borrow_mut().take();
+            let invalidated_locations = operation_invalidated_locations(&event, &refresh_locations);
             match event {
                 OperationEvent::Failed { message, .. } if rename => {
                     browser.emit(BrowserEvent::RenameFailed { message });
@@ -1151,7 +1157,18 @@ impl Browser {
                 | OperationEvent::ArchiveStarted { .. }
                 | OperationEvent::ArchiveProgress { .. } => {}
             }
+            if !invalidated_locations.is_empty() {
+                browser.emit(BrowserEvent::LocationsInvalidated {
+                    locations: invalidated_locations,
+                });
+            }
         })
+    }
+
+    pub fn invalidate_locations(self: &Rc<Self>, locations: &[Location]) {
+        for location in locations {
+            self.refresh_columns_at(location);
+        }
     }
 
     pub fn preview(self: &Rc<Self>, depth: usize, position: usize) {
@@ -1558,6 +1575,44 @@ fn deletion_parent_location(location: &Location) -> Option<Location> {
     } else {
         location.parent()
     }
+}
+
+fn operation_invalidated_locations(
+    event: &OperationEvent,
+    requested: &[Location],
+) -> Vec<Location> {
+    let completed = match event {
+        OperationEvent::Renamed { .. }
+        | OperationEvent::Created { .. }
+        | OperationEvent::Pasted { .. }
+        | OperationEvent::Compressed { .. }
+        | OperationEvent::Extracted { .. } => return requested.to_vec(),
+        OperationEvent::Deleted { locations, .. } | OperationEvent::Restored { locations, .. } => {
+            locations
+        }
+        OperationEvent::CompletedWithErrors {
+            deleted_locations: locations,
+            ..
+        }
+        | OperationEvent::RestoreCompletedWithErrors {
+            restored_locations: locations,
+            ..
+        } => locations,
+        OperationEvent::DeleteProgress { .. }
+        | OperationEvent::RestoreProgress { .. }
+        | OperationEvent::ArchiveStarted { .. }
+        | OperationEvent::ArchiveProgress { .. }
+        | OperationEvent::Failed { .. } => return Vec::new(),
+    };
+    let mut parents = Vec::new();
+    for location in completed {
+        if let Some(parent) = deletion_parent_location(location)
+            && !parents.contains(&parent)
+        {
+            parents.push(parent);
+        }
+    }
+    parents
 }
 
 fn location_from_input(input: &str) -> Result<Location, LocationValidationError> {

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -439,6 +439,76 @@ fn creating_a_directory_locally_does_not_trigger_a_redundant_refresh() {
 }
 
 #[test]
+fn split_browsers_keep_independent_history_and_clones_start_fresh() {
+    let first = Browser::new(Rc::new(FakeFileSource));
+    first.navigate(Location::local("/fixture"));
+    first.navigate(Location::local("/other"));
+    let second = Browser::new(Rc::new(FakeFileSource));
+    second.navigate(first.active_location().expect("active location"));
+
+    assert!(first.can_go_back());
+    assert!(!second.can_go_back());
+    first.back();
+    assert_eq!(first.active_location(), Some(Location::local("/fixture")));
+    assert_eq!(second.active_location(), Some(Location::local("/other")));
+}
+
+#[test]
+fn completed_operations_can_invalidate_the_same_location_in_another_browser() {
+    let first_calls = Rc::new(Cell::new(0));
+    let second_calls = Rc::new(Cell::new(0));
+    let first = Browser::new(Rc::new(CountingFileSource {
+        enumerate_calls: first_calls.clone(),
+    }));
+    let second = Browser::new(Rc::new(CountingFileSource {
+        enumerate_calls: second_calls.clone(),
+    }));
+    first.set_operation_provider(Rc::new(ImmediateOperationProvider));
+    let location = Location::uri("smb://host/share");
+    first.navigate(location.clone());
+    second.navigate(location.clone());
+    let weak_second = Rc::downgrade(&second);
+    first.observe(move |event| {
+        if let BrowserEvent::LocationsInvalidated { locations } = event
+            && let Some(second) = weak_second.upgrade()
+        {
+            second.invalidate_locations(&locations);
+        }
+    });
+
+    first.create_directory(location, "New Folder".to_owned());
+
+    assert_eq!(first_calls.get(), 2);
+    assert_eq!(second_calls.get(), 2);
+}
+
+#[test]
+fn completed_archives_invalidate_the_destination_but_progress_does_not() {
+    let destination = Location::local("/fixture");
+    assert_eq!(
+        operation_invalidated_locations(
+            &OperationEvent::Compressed {
+                request_id: OperationRequestId(1),
+                archive_name: "archive.zip".to_owned(),
+            },
+            std::slice::from_ref(&destination),
+        ),
+        vec![destination]
+    );
+    assert!(
+        operation_invalidated_locations(
+            &OperationEvent::ArchiveProgress {
+                request_id: OperationRequestId(1),
+                completed: 1,
+                total: 2,
+            },
+            &[Location::local("/fixture")],
+        )
+        .is_empty()
+    );
+}
+
+#[test]
 fn restored_sorting_applies_to_the_initial_navigation_load() {
     let browser = Browser::with_preferences(
         Rc::new(RestoredSortingSource),

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -23,6 +23,7 @@ pub mod icons {
     pub const CHECK_ON_PRIMARY: &str = "strata-check-on-primary";
     pub const CHEVRON_RIGHT: &str = "strata-chevron-right";
     pub const COPY: &str = "strata-copy";
+    pub const COLUMNS_2: &str = "strata-columns-2";
     pub const DOCUMENTS: &str = "strata-file-text";
     pub const DOWNLOADS: &str = "strata-download";
     pub const EYE: &str = "strata-eye";
@@ -35,6 +36,7 @@ pub mod icons {
     pub const INFO: &str = "strata-info";
     pub const FUNNEL: &str = "strata-funnel";
     pub const GRID: &str = "strata-grid";
+    pub const GRID_2X2: &str = "strata-grid-2x2";
     pub const HOME: &str = "strata-house";
     pub const LIST: &str = "strata-list";
     pub const LIST_ACTIVE: &str = "strata-list-active";
@@ -49,10 +51,12 @@ pub mod icons {
     pub const PLUS: &str = "strata-plus";
     pub const PICTURES: &str = "strata-image";
     pub const ROWS: &str = "strata-rows";
+    pub const ROWS_2: &str = "strata-rows-2";
     pub const SCISSORS: &str = "strata-scissors";
     pub const SEARCH: &str = "strata-search";
     pub const SETTINGS: &str = "strata-settings";
     pub const SETTINGS_2: &str = "strata-settings-2";
+    pub const SQUARE: &str = "strata-square";
     pub const SLIDERS: &str = "strata-sliders-horizontal";
     pub const TERMINAL: &str = "strata-terminal";
     pub const TRASH: &str = "strata-trash";

--- a/src/style.css
+++ b/src/style.css
@@ -241,19 +241,17 @@ headerbar menubutton.header-action > button:focus-visible image {
 }
 
 .pane-workspace paned > separator {
-  background: @theme_border;
-  box-shadow: inset 0 0 0 1px alpha(@theme_bg, 0.62);
-  color: @theme_text;
-  min-height: 5px;
-  min-width: 5px;
+  background: transparent;
+  border: none;
+  box-shadow: none;
 }
 
-.pane-workspace paned > separator:hover,
-.pane-workspace paned > separator:active,
-.pane-workspace paned > separator:focus-visible {
-  background: @theme_accent;
-  box-shadow: inset 0 0 0 1px alpha(@theme_bg, 0.38);
-  color: @theme_accent;
+.pane-workspace paned.horizontal > separator {
+  border-left: 1px solid alpha(@theme_border, 0.6);
+}
+
+.pane-workspace paned.vertical > separator {
+  border-top: 1px solid alpha(@theme_border, 0.6);
 }
 
 .location-entry,

--- a/src/style.css
+++ b/src/style.css
@@ -151,6 +151,111 @@ headerbar menubutton.header-action > button:focus-visible image {
   opacity: 0.42;
 }
 
+.pane-layout-popover contents {
+  background: @theme_surface;
+  border: 1px solid alpha(@theme_accent, 0.22);
+  border-radius: 7px;
+  box-shadow: 0 8px 28px alpha(@theme_bg, 0.72);
+  color: @theme_text;
+  padding: 0;
+}
+
+.pane-layout-menu {
+  min-width: 320px;
+  padding: 9px 8px;
+}
+
+.pane-layout-option {
+  background: alpha(@theme_bg, 0.36);
+  border: 1px solid alpha(@theme_border, 0.28);
+  border-radius: 6px;
+  box-shadow: none;
+  color: @theme_text;
+  min-height: 58px;
+  padding: 8px 10px;
+}
+
+.pane-layout-option:hover {
+  background: alpha(@theme_muted, 0.55);
+  border-color: alpha(@theme_accent, 0.5);
+  color: @theme_text;
+}
+
+.pane-layout-option:active {
+  background: alpha(@theme_highlight, 0.76);
+  border-color: @theme_accent;
+  color: @theme_text;
+}
+
+.pane-layout-option.selected {
+  background: alpha(@theme_highlight, 0.62);
+  border-color: alpha(@theme_accent, 0.72);
+  color: @theme_accent;
+}
+
+.pane-layout-option:focus-visible {
+  border-color: @theme_accent;
+  outline: 2px solid @theme_accent;
+  outline-offset: -2px;
+}
+
+.pane-layout-symbol {
+  background: alpha(@theme_accent, 0.1);
+  border: 1px solid alpha(@theme_accent, 0.28);
+  border-radius: 5px;
+  min-height: 38px;
+  min-width: 38px;
+}
+
+.pane-layout-title {
+  color: @theme_text;
+  font-weight: 700;
+}
+
+.pane-layout-description {
+  color: @theme_dim_text;
+  font-size: 0.84em;
+}
+
+.pane-layout-shortcut {
+  color: @theme_accent;
+  font-size: 0.78em;
+}
+
+.pane-workspace,
+.browser-pane {
+  background: @theme_bg;
+}
+
+.pane-workspace.split .browser-pane {
+  opacity: 0.72;
+}
+
+.pane-workspace.split .browser-pane.active-pane {
+  opacity: 1;
+}
+
+.pane-workspace.split .browser-pane.active-pane .column-header,
+.pane-workspace.split .browser-pane.active-pane .mode-pane-header {
+  box-shadow: inset 0 4px 0 0 @theme_accent;
+}
+
+.pane-workspace paned > separator {
+  background: @theme_border;
+  box-shadow: inset 0 0 0 1px alpha(@theme_bg, 0.62);
+  color: @theme_text;
+  min-height: 5px;
+  min-width: 5px;
+}
+
+.pane-workspace paned > separator:hover,
+.pane-workspace paned > separator:active,
+.pane-workspace paned > separator:focus-visible {
+  background: @theme_accent;
+  box-shadow: inset 0 0 0 1px alpha(@theme_bg, 0.38);
+  color: @theme_accent;
+}
+
 .location-entry,
 .location-entry:focus,
 .location-entry:focus-visible,

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -204,6 +204,55 @@ impl Default for PeekBehavior {
 
 type PinHandler = Rc<dyn Fn(Location, String)>;
 type PinStatusHandler = Rc<dyn Fn(&Location) -> PinStatus>;
+type CutObserver = Rc<dyn Fn(&[Location])>;
+
+#[derive(Default)]
+pub(super) struct SharedCutState {
+    locations: RefCell<Vec<Location>>,
+    observers: RefCell<Vec<CutObserver>>,
+}
+
+impl SharedCutState {
+    fn observe(&self, observer: CutObserver) {
+        self.observers.borrow_mut().push(observer);
+    }
+
+    fn replace(&self, locations: Vec<Location>) {
+        self.locations.replace(locations);
+        self.notify();
+    }
+
+    fn clear(&self) {
+        if self.locations.borrow().is_empty() {
+            return;
+        }
+        self.locations.borrow_mut().clear();
+        self.notify();
+    }
+
+    fn remove(&self, transferred: &[Location]) -> Vec<Location> {
+        self.locations
+            .borrow_mut()
+            .retain(|location| !transferred.contains(location));
+        self.notify();
+        self.locations.borrow().clone()
+    }
+
+    fn matches(&self, locations: &[Location]) -> bool {
+        same_locations(locations, &self.locations.borrow())
+    }
+
+    fn contains(&self, location: &Location) -> bool {
+        self.locations.borrow().contains(location)
+    }
+
+    fn notify(&self) {
+        let locations = self.locations.borrow();
+        for observer in self.observers.borrow().iter() {
+            observer(&locations);
+        }
+    }
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum PinStatus {
@@ -260,7 +309,7 @@ pub(super) struct ViewState {
     mode_views: RefCell<ModeViews>,
     columns: RefCell<Vec<ColumnView>>,
     hovered_column: Cell<Option<usize>>,
-    cut_locations: RefCell<Vec<Location>>,
+    cut_state: Rc<SharedCutState>,
     horizontal_scroll_generation: Rc<Cell<u64>>,
     peek: RefCell<Option<PeekView>>,
     pending_peek: RefCell<Option<glib::SourceId>>,
@@ -305,7 +354,11 @@ pub struct BrowserView {
 }
 
 impl BrowserView {
-    pub fn new(source: Rc<dyn FileSource>, peek_behavior: PeekBehavior) -> Self {
+    pub(super) fn new(
+        source: Rc<dyn FileSource>,
+        peek_behavior: PeekBehavior,
+        cut_state: Rc<SharedCutState>,
+    ) -> Self {
         let columns_widget = gtk::Box::new(gtk::Orientation::Horizontal, 0);
         columns_widget.add_css_class("columns");
         columns_widget.set_halign(gtk::Align::Start);
@@ -402,7 +455,7 @@ impl BrowserView {
             mode_views: RefCell::new(mode_views),
             columns: RefCell::new(Vec::new()),
             hovered_column: Cell::new(None),
-            cut_locations: RefCell::new(Vec::new()),
+            cut_state: cut_state.clone(),
             horizontal_scroll_generation: Rc::new(Cell::new(0)),
             peek: RefCell::new(None),
             pending_peek: RefCell::new(None),
@@ -434,6 +487,12 @@ impl BrowserView {
             .mode_views
             .borrow()
             .set_context_state(Rc::downgrade(&state));
+        let weak_state = Rc::downgrade(&state);
+        cut_state.observe(Rc::new(move |locations| {
+            if let Some(state) = weak_state.upgrade() {
+                state.refresh_cut_rows(locations);
+            }
+        }));
 
         // The observer owns the view state while its window is alive. The window clears
         // the observer on destruction to break this deliberate lifecycle cycle.
@@ -479,12 +538,6 @@ impl BrowserView {
 
     pub fn widget(&self) -> gtk::Widget {
         self.state.overlay.clone().upcast()
-    }
-
-    pub fn navigate(&self, path: impl AsRef<Path>) {
-        self.state
-            .browser
-            .navigate(Location::local(path.as_ref().to_path_buf()));
     }
 
     pub fn browser(&self) -> Rc<Browser> {
@@ -1029,7 +1082,7 @@ impl ViewState {
         sources: Vec<Location>,
         move_sources: bool,
     ) {
-        let clear_cut = move_sources && same_locations(&sources, &self.cut_locations.borrow());
+        let clear_cut = move_sources && self.cut_state.matches(&sources);
         let mut accepted = Vec::new();
         let mut collisions = Vec::new();
         for source in sources {
@@ -1191,31 +1244,19 @@ impl ViewState {
 
     fn copy_entries(&self, entries: &[FileEntry]) {
         if set_files_clipboard(entries) {
-            self.clear_cut();
+            self.cut_state.clear();
         }
     }
 
     fn cut_entries(&self, entries: &[FileEntry]) {
         if set_files_clipboard(entries) {
-            self.cut_locations
+            self.cut_state
                 .replace(entries.iter().map(|entry| entry.location.clone()).collect());
-            self.refresh_cut_rows();
         }
-    }
-
-    fn clear_cut(&self) {
-        if self.cut_locations.borrow().is_empty() {
-            return;
-        }
-        self.cut_locations.borrow_mut().clear();
-        self.refresh_cut_rows();
     }
 
     fn complete_cut_transfer(&self, transferred: &[Location]) {
-        self.cut_locations
-            .borrow_mut()
-            .retain(|location| !transferred.contains(location));
-        let remaining = self.cut_locations.borrow().clone();
+        let remaining = self.cut_state.remove(transferred);
         if remaining.is_empty() {
             if let Some(display) = gtk::gdk::Display::default() {
                 let _result = display
@@ -1225,12 +1266,10 @@ impl ViewState {
         } else {
             let _set = set_location_files_clipboard(&remaining);
         }
-        self.refresh_cut_rows();
     }
 
-    fn refresh_cut_rows(&self) {
-        let cut = self.cut_locations.borrow();
-        self.mode_views.borrow().set_cut_locations(&cut);
+    fn refresh_cut_rows(&self, cut: &[Location]) {
+        self.mode_views.borrow().set_cut_locations(cut);
         for (depth, column) in self.columns.borrow().iter().enumerate() {
             column.bound_rows.borrow_mut().retain(|bound| {
                 let (Some(item), Some(row)) = (bound.item.upgrade(), bound.row.upgrade()) else {
@@ -1271,7 +1310,7 @@ impl ViewState {
                 .map(|file| location_for_file(&file))
                 .collect::<Vec<_>>();
             if let Some(state) = weak.upgrade() {
-                let move_sources = same_locations(&sources, &state.cut_locations.borrow());
+                let move_sources = state.cut_state.matches(&sources);
                 state.start_transfer(destination, sources, move_sources);
             }
         });
@@ -3319,6 +3358,7 @@ impl ViewState {
             BrowserEvent::OperationCompletedWithErrors { message } => {
                 show_error_dialog(&self.overlay, "Completed with errors", &message);
             }
+            BrowserEvent::LocationsInvalidated { .. } => {}
             BrowserEvent::NavigationRejected {
                 parent_depth,
                 error,
@@ -3634,7 +3674,13 @@ impl ViewState {
             let weak_state_for_enter = weak_state.clone();
             let source_for_enter = source_for_hover.clone();
             let filtered_for_enter = filtered_for_hover.clone();
-            motion.connect_enter(move |_, _, _| {
+            motion.connect_enter(move |motion, _, _| {
+                if motion
+                    .current_event_state()
+                    .contains(gtk::gdk::ModifierType::BUTTON1_MASK)
+                {
+                    return;
+                }
                 if let Some(state) = weak_state_for_enter.upgrade() {
                     let source_position = source_position_for_filtered(
                         &source_for_enter,
@@ -3661,6 +3707,7 @@ impl ViewState {
             });
             row.add_controller(motion);
 
+            let pending_click = Rc::new(Cell::new(None::<usize>));
             let drag = gtk::DragSource::builder()
                 .actions(gtk::gdk::DragAction::COPY | gtk::gdk::DragAction::MOVE)
                 .build();
@@ -3689,8 +3736,16 @@ impl ViewState {
                 source.set_icon(Some(&paintable), x.round() as i32, y.round() as i32);
                 file_drag_content(&entries)
             });
+            let pending_for_drag = pending_click.clone();
+            let weak_state_for_drag_begin = weak_state.clone();
             let dragged_row = row.clone();
-            drag.connect_drag_begin(move |_, _| dragged_row.add_css_class("dragging"));
+            drag.connect_drag_begin(move |_, _| {
+                pending_for_drag.set(None);
+                if let Some(state) = weak_state_for_drag_begin.upgrade() {
+                    state.cancel_peek_for_drag();
+                }
+                dragged_row.add_css_class("dragging");
+            });
             let dragged_row = row.clone();
             drag.connect_drag_end(move |_, _, _| dragged_row.remove_css_class("dragging"));
             row.add_controller(drag);
@@ -3754,7 +3809,9 @@ impl ViewState {
             let weak_state_for_click = weak_state.clone();
             let source_for_click = source_for_hover.clone();
             let filtered_for_click = filtered_for_hover.clone();
+            let pending_for_press = pending_click.clone();
             selection_click.connect_pressed(move |gesture, press_count, _, _| {
+                pending_for_press.set(None);
                 let position = clicked_item.position();
                 if position == gtk::INVALID_LIST_POSITION {
                     return;
@@ -3800,14 +3857,28 @@ impl ViewState {
                     // GtkListView owns double-click activation through its `activate`
                     // signal. This gesture only handles selection and single-click previews;
                     // activating here as well would open files twice.
-                    if should_preview_pointer_press(press_count, control, shift, preserve_group) {
-                        let entry = state.browser.entry_at(depth, source_position);
-                        if entry.as_ref().is_some_and(|entry| {
-                            entry_responds_to_single_click(entry, state.single_click_previews.get())
-                        }) {
-                            state.browser.preview(depth, source_position);
-                        }
+                    let entry = state.browser.entry_at(depth, source_position);
+                    if entry.as_ref().is_some_and(|entry| {
+                        queues_single_click_preview(
+                            press_count,
+                            control,
+                            shift,
+                            preserve_group,
+                            entry,
+                            state.single_click_previews.get(),
+                        )
+                    }) {
+                        pending_for_press.set(Some(source_position));
                     }
+                }
+            });
+            let weak_state_for_release = weak_state.clone();
+            selection_click.connect_released(move |_, _, _, _| {
+                let Some(source_position) = pending_click.take() else {
+                    return;
+                };
+                if let Some(state) = weak_state_for_release.upgrade() {
+                    state.browser.preview(depth, source_position);
                 }
             });
             row.add_controller(selection_click);
@@ -3879,7 +3950,7 @@ impl ViewState {
                 entry.as_ref().is_some_and(|entry| {
                     state
                         .as_ref()
-                        .is_some_and(|state| state.cut_locations.borrow().contains(&entry.location))
+                        .is_some_and(|state| state.cut_state.contains(&entry.location))
                 }),
             );
             if let Some(entry) = entry.as_ref() {
@@ -4312,6 +4383,12 @@ impl ViewState {
             }
         });
         self.pending_close.replace(Some(source));
+    }
+
+    pub(super) fn cancel_peek_for_drag(&self) {
+        cancel_source(&self.pending_peek);
+        cancel_source(&self.pending_close);
+        self.browser.close_peek();
     }
 
     fn append_peek(self: &Rc<Self>, location: &Location) {
@@ -5044,6 +5121,21 @@ fn entry_responds_to_single_click(entry: &FileEntry, previews_enabled: bool) -> 
     entry.is_directory() || (previews_enabled && entry_supports_quick_preview(entry))
 }
 
+fn queues_single_click_preview(
+    press_count: i32,
+    control: bool,
+    shift: bool,
+    preserve_drag_group: bool,
+    entry: &FileEntry,
+    previews_enabled: bool,
+) -> bool {
+    press_count == 1
+        && !control
+        && !shift
+        && !preserve_drag_group
+        && entry_responds_to_single_click(entry, previews_enabled)
+}
+
 pub(super) fn entry_supports_quick_preview(entry: &FileEntry) -> bool {
     if !matches!(entry.kind, EntryKind::File | EntryKind::FileSymbolicLink) {
         return false;
@@ -5598,15 +5690,6 @@ fn set_location_files_clipboard(locations: &[Location]) -> bool {
             )))
             .is_ok()
     })
-}
-
-fn should_preview_pointer_press(
-    press_count: i32,
-    control: bool,
-    shift: bool,
-    preserve_group: bool,
-) -> bool {
-    press_count == 1 && !control && !shift && !preserve_group
 }
 
 fn should_preserve_drag_selection(clicked_selected: bool, selected_count: u64) -> bool {

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -16,6 +16,26 @@ fn global_activity_uses_the_latest_active_label() {
 }
 
 #[test]
+fn cut_state_is_shared_and_cleared_after_a_cross_pane_move() {
+    let state = SharedCutState::default();
+    let first_updates = Rc::new(Cell::new(0));
+    let second_updates = Rc::new(Cell::new(0));
+    for updates in [&first_updates, &second_updates] {
+        let updates = updates.clone();
+        state.observe(Rc::new(move |_| updates.set(updates.get() + 1)));
+    }
+    let source = Location::local("/fixture/source");
+
+    state.replace(vec![source.clone()]);
+    assert!(state.matches(std::slice::from_ref(&source)));
+    assert!(state.contains(&source));
+    assert!(state.remove(std::slice::from_ref(&source)).is_empty());
+    assert!(!state.contains(&source));
+    assert_eq!(first_updates.get(), 2);
+    assert_eq!(second_updates.get(), 2);
+}
+
+#[test]
 fn file_sizes_use_compact_decimal_units() {
     assert_eq!(format_file_size(999), "999 B");
     assert_eq!(format_file_size(1_200), "1.2 kB");
@@ -398,20 +418,36 @@ fn file_names_map_to_specific_lucide_icons() {
 }
 
 #[test]
-fn pointer_preview_handler_ignores_double_click_activation() {
-    assert!(should_preview_pointer_press(1, false, false, false));
-    assert!(!should_preview_pointer_press(2, false, false, false));
-    assert!(!should_preview_pointer_press(1, true, false, false));
-    assert!(!should_preview_pointer_press(1, false, true, false));
-    assert!(!should_preview_pointer_press(1, false, false, true));
-}
-
-#[test]
 fn pressing_an_item_in_a_multi_selection_preserves_the_drag_group() {
     assert!(should_preserve_drag_selection(true, 2));
     assert!(should_preserve_drag_selection(true, 8));
     assert!(!should_preserve_drag_selection(true, 1));
     assert!(!should_preserve_drag_selection(false, 4));
+}
+
+#[test]
+fn single_click_preview_waits_for_an_unmodified_release_candidate() {
+    let file = FileEntry {
+        location: Location::local("/fixture/notes.txt"),
+        native_name: "notes.txt".into(),
+        display_name: "notes.txt".into(),
+        kind: EntryKind::File,
+        size: crate::model::MetadataValue::Known(1),
+        modified_unix_seconds: crate::model::MetadataValue::Unknown,
+    };
+
+    assert!(queues_single_click_preview(
+        1, false, false, false, &file, true
+    ));
+    assert!(!queues_single_click_preview(
+        2, false, false, false, &file, true
+    ));
+    assert!(!queues_single_click_preview(
+        1, true, false, false, &file, true
+    ));
+    assert!(!queues_single_click_preview(
+        1, false, false, true, &file, true
+    ));
 }
 
 #[test]

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -41,6 +41,11 @@ impl ExplorerColumnLayout {
 type TransferHandler = Rc<dyn Fn(Location, Vec<Location>, bool)>;
 type TransferHandlerSlot = Rc<RefCell<Option<TransferHandler>>>;
 
+struct DragInteraction {
+    pending_click: Rc<Cell<bool>>,
+    peek_state: Option<Weak<super::browser::ViewState>>,
+}
+
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum BrowserMode {
     #[default]
@@ -1073,6 +1078,10 @@ fn build_grid_pane(
         item_content.append(&field);
         centered.set_center_widget(Some(&item_content));
         card.append(&centered);
+        let interaction = DragInteraction {
+            pending_click: Rc::new(Cell::new(false)),
+            peek_state: peek_for_setup.clone(),
+        };
         install_preview_click(
             &card,
             item,
@@ -1080,6 +1089,7 @@ fn build_grid_pane(
             previews_for_setup.clone(),
             depth,
             Some((source_for_setup.clone(), filtered_for_setup.clone())),
+            interaction.pending_click.clone(),
         );
         install_modified_selection_click(
             &card,
@@ -1103,6 +1113,7 @@ fn build_grid_pane(
             transfers_for_setup.clone(),
             depth,
             Some((source_for_setup.clone(), filtered_for_setup.clone())),
+            interaction,
         );
         item.set_child(Some(&card));
         register_bound_mode_item(&bound_items_for_setup, item, &card);
@@ -1658,6 +1669,10 @@ fn build_explorer_pane(
         row.append(&size);
         row.append(&kind);
         row.append(&modified);
+        let interaction = DragInteraction {
+            pending_click: Rc::new(Cell::new(false)),
+            peek_state: None,
+        };
         install_preview_click(
             &row,
             item,
@@ -1665,6 +1680,7 @@ fn build_explorer_pane(
             previews_for_setup.clone(),
             depth,
             Some((source_for_setup.clone(), view_model_for_setup.clone())),
+            interaction.pending_click.clone(),
         );
         install_modified_selection_click(
             &row,
@@ -1679,6 +1695,7 @@ fn build_explorer_pane(
             transfers_for_setup.clone(),
             depth,
             Some((source_for_setup.clone(), view_model_for_setup.clone())),
+            interaction,
         );
         item.set_child(Some(&row));
         register_bound_mode_item(&bound_items_for_setup, item, &row);
@@ -2077,7 +2094,13 @@ fn install_grid_peek(
     let entered_item = item.clone();
     let entered_card: gtk::Widget = card.clone().upcast();
     let state_for_enter = state.clone();
-    motion.connect_enter(move |_, _, _| {
+    motion.connect_enter(move |motion, _, _| {
+        if motion
+            .current_event_state()
+            .contains(gtk::gdk::ModifierType::BUTTON1_MASK)
+        {
+            return;
+        }
         let position = entered_item.position();
         if position == gtk::INVALID_LIST_POSITION {
             return;
@@ -2136,6 +2159,7 @@ fn install_explorer_drag_drop(
     transfer_handler: TransferHandlerSlot,
     depth: usize,
     position_map: Option<(gtk::StringList, gio::ListModel)>,
+    interaction: DragInteraction,
 ) {
     let drag = gtk::DragSource::builder()
         .actions(gtk::gdk::DragAction::COPY | gtk::gdk::DragAction::MOVE)
@@ -2170,7 +2194,13 @@ fn install_explorer_drag_drop(
         super::browser::file_drag_content(&entries)
     });
     let dragged_row = row.clone();
-    drag.connect_drag_begin(move |_, _| dragged_row.add_css_class("dragging"));
+    drag.connect_drag_begin(move |_, _| {
+        interaction.pending_click.set(false);
+        if let Some(state) = interaction.peek_state.as_ref().and_then(Weak::upgrade) {
+            state.cancel_peek_for_drag();
+        }
+        dragged_row.add_css_class("dragging");
+    });
     let dragged_row = row.clone();
     drag.connect_drag_end(move |_, _, _| dragged_row.remove_css_class("dragging"));
     row.add_controller(drag);
@@ -2321,12 +2351,17 @@ fn install_preview_click(
     enabled: Rc<Cell<bool>>,
     depth: usize,
     position_map: Option<(gtk::StringList, gio::ListModel)>,
+    pending: Rc<Cell<bool>>,
 ) {
     let click = gtk::GestureClick::new();
     click.set_button(1);
+    let pending_for_press = pending.clone();
+    click.connect_pressed(move |_, press_count, _, _| {
+        pending_for_press.set(press_count == 1);
+    });
     let item = item.clone();
     click.connect_released(move |gesture, press_count, _, _| {
-        if press_count != 1 || !enabled.get() {
+        if !pending.replace(false) || press_count != 1 || !enabled.get() {
             return;
         }
         let modifiers = gesture.current_event_state();

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -5,6 +5,7 @@ mod browser;
 mod browser_modes;
 mod controls;
 mod motion;
+mod panes;
 mod preview;
 mod search;
 mod settings;

--- a/src/ui/panes.rs
+++ b/src/ui/panes.rs
@@ -1,0 +1,1055 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::{
+    cell::{Cell, RefCell},
+    rc::Rc,
+    time::{Duration, Instant},
+};
+
+use gtk::{glib, prelude::*};
+
+use crate::{
+    app::{Browser, BrowserEvent},
+    model::Location,
+    services::{FileSource, OperationProvider},
+};
+
+use super::{
+    browser::{BrowserView, PeekBehavior, PinStatus, SharedCutState},
+    browser_modes::{BrowserDensity, BrowserMode},
+    preview::PreviewDrawer,
+    theme::ThemeManager,
+};
+
+pub(super) const PANE_PREFIX_TIMEOUT: Duration = Duration::from_millis(1_500);
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(super) enum PaneLayout {
+    #[default]
+    Single,
+    SideBySide,
+    Stacked,
+    Grid,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum PaneDirection {
+    Left,
+    Down,
+    Up,
+    Right,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum PaneCommand {
+    Layout(PaneLayout),
+    Focus(PaneDirection),
+    Toggle,
+    Close,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SplitAxis {
+    Horizontal,
+    Vertical,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum PaneNode {
+    Leaf(u64),
+    Split {
+        axis: SplitAxis,
+        first: Box<Self>,
+        second: Box<Self>,
+    },
+}
+
+impl PaneNode {
+    fn pane_ids(&self, ids: &mut Vec<u64>) {
+        match self {
+            Self::Leaf(id) => ids.push(*id),
+            Self::Split { first, second, .. } => {
+                first.pane_ids(ids);
+                second.pane_ids(ids);
+            }
+        }
+    }
+
+    fn contains(&self, target: u64) -> bool {
+        match self {
+            Self::Leaf(id) => *id == target,
+            Self::Split { first, second, .. } => first.contains(target) || second.contains(target),
+        }
+    }
+
+    fn first_leaf(&self) -> u64 {
+        match self {
+            Self::Leaf(id) => *id,
+            Self::Split { first, .. } => first.first_leaf(),
+        }
+    }
+
+    fn split(&mut self, target: u64, axis: SplitAxis, new_id: u64) -> bool {
+        match self {
+            Self::Leaf(id) if *id == target => {
+                *self = Self::Split {
+                    axis,
+                    first: Box::new(Self::Leaf(*id)),
+                    second: Box::new(Self::Leaf(new_id)),
+                };
+                true
+            }
+            Self::Leaf(_) => false,
+            Self::Split { first, second, .. } => {
+                first.split(target, axis, new_id) || second.split(target, axis, new_id)
+            }
+        }
+    }
+
+    fn remove(&mut self, target: u64) -> Option<u64> {
+        let Self::Split { first, second, .. } = self else {
+            return None;
+        };
+        if matches!(first.as_ref(), Self::Leaf(id) if *id == target) {
+            let replacement = second.as_ref().clone();
+            let next = replacement.first_leaf();
+            *self = replacement;
+            return Some(next);
+        }
+        if matches!(second.as_ref(), Self::Leaf(id) if *id == target) {
+            let replacement = first.as_ref().clone();
+            let next = replacement.first_leaf();
+            *self = replacement;
+            return Some(next);
+        }
+        if first.contains(target) {
+            first.remove(target)
+        } else {
+            second.remove(target)
+        }
+    }
+
+    fn rectangles(&self, area: PaneRect, panes: &mut Vec<(u64, PaneRect)>) {
+        match self {
+            Self::Leaf(id) => panes.push((*id, area)),
+            Self::Split {
+                axis: SplitAxis::Horizontal,
+                first,
+                second,
+            } => {
+                let middle = (area.left + area.right) / 2;
+                first.rectangles(
+                    PaneRect {
+                        right: middle,
+                        ..area
+                    },
+                    panes,
+                );
+                second.rectangles(
+                    PaneRect {
+                        left: middle,
+                        ..area
+                    },
+                    panes,
+                );
+            }
+            Self::Split {
+                axis: SplitAxis::Vertical,
+                first,
+                second,
+            } => {
+                let middle = (area.top + area.bottom) / 2;
+                first.rectangles(
+                    PaneRect {
+                        bottom: middle,
+                        ..area
+                    },
+                    panes,
+                );
+                second.rectangles(
+                    PaneRect {
+                        top: middle,
+                        ..area
+                    },
+                    panes,
+                );
+            }
+        }
+    }
+
+    fn is_grid(&self) -> bool {
+        let Self::Split {
+            axis: SplitAxis::Horizontal,
+            first,
+            second,
+        } = self
+        else {
+            return false;
+        };
+        [first.as_ref(), second.as_ref()].into_iter().all(|node| {
+            matches!(
+                node,
+                Self::Split {
+                    axis: SplitAxis::Vertical,
+                    first,
+                    second,
+                } if matches!(first.as_ref(), Self::Leaf(_))
+                    && matches!(second.as_ref(), Self::Leaf(_))
+            )
+        })
+    }
+}
+
+#[derive(Clone, Copy)]
+struct PaneRect {
+    left: i32,
+    top: i32,
+    right: i32,
+    bottom: i32,
+}
+
+impl PaneRect {
+    fn center(self) -> (i32, i32) {
+        (self.left + self.right, self.top + self.bottom)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct PaneState {
+    root: PaneNode,
+    active: u64,
+}
+
+impl Default for PaneState {
+    fn default() -> Self {
+        Self {
+            active: 0,
+            root: PaneNode::Leaf(0),
+        }
+    }
+}
+
+impl PaneState {
+    fn pane_ids(&self) -> Vec<u64> {
+        let mut ids = Vec::with_capacity(4);
+        self.root.pane_ids(&mut ids);
+        ids
+    }
+
+    fn pane_count(&self) -> usize {
+        self.pane_ids().len()
+    }
+
+    fn layout(&self) -> PaneLayout {
+        match &self.root {
+            PaneNode::Leaf(_) => PaneLayout::Single,
+            _ if self.root.is_grid() => PaneLayout::Grid,
+            PaneNode::Split {
+                axis: SplitAxis::Horizontal,
+                ..
+            } => PaneLayout::SideBySide,
+            PaneNode::Split {
+                axis: SplitAxis::Vertical,
+                ..
+            } => PaneLayout::Stacked,
+        }
+    }
+
+    fn split(&mut self, layout: PaneLayout, new_id: u64) -> bool {
+        if self.pane_count() == 4 {
+            return false;
+        }
+        let axis = match layout {
+            PaneLayout::SideBySide => SplitAxis::Horizontal,
+            PaneLayout::Stacked => SplitAxis::Vertical,
+            PaneLayout::Single | PaneLayout::Grid => return false,
+        };
+        if !self.root.split(self.active, axis, new_id) {
+            return false;
+        }
+        self.active = new_id;
+        true
+    }
+
+    fn keep_active(&mut self) -> Vec<u64> {
+        let removed = self
+            .pane_ids()
+            .into_iter()
+            .filter(|id| *id != self.active)
+            .collect();
+        self.root = PaneNode::Leaf(self.active);
+        removed
+    }
+
+    fn keep_pair(&mut self, layout: PaneLayout) -> Vec<u64> {
+        let (axis, directions) = match layout {
+            PaneLayout::SideBySide => (
+                SplitAxis::Horizontal,
+                [(PaneDirection::Left, true), (PaneDirection::Right, false)],
+            ),
+            PaneLayout::Stacked => (
+                SplitAxis::Vertical,
+                [(PaneDirection::Up, true), (PaneDirection::Down, false)],
+            ),
+            PaneLayout::Single | PaneLayout::Grid => return Vec::new(),
+        };
+        let Some((partner, partner_first)) =
+            directions.into_iter().find_map(|(direction, first)| {
+                let mut candidate = self.clone();
+                candidate
+                    .focus(direction)
+                    .then_some((candidate.active, first))
+            })
+        else {
+            return Vec::new();
+        };
+        let removed = self
+            .pane_ids()
+            .into_iter()
+            .filter(|id| *id != self.active && *id != partner)
+            .collect();
+        let active = Box::new(PaneNode::Leaf(self.active));
+        let partner = Box::new(PaneNode::Leaf(partner));
+        let (first, second) = if partner_first {
+            (partner, active)
+        } else {
+            (active, partner)
+        };
+        self.root = PaneNode::Split {
+            axis,
+            first,
+            second,
+        };
+        removed
+    }
+
+    fn set_grid(&mut self, ids: [u64; 4]) {
+        let column = |top, bottom| PaneNode::Split {
+            axis: SplitAxis::Vertical,
+            first: Box::new(PaneNode::Leaf(top)),
+            second: Box::new(PaneNode::Leaf(bottom)),
+        };
+        self.root = PaneNode::Split {
+            axis: SplitAxis::Horizontal,
+            first: Box::new(column(ids[0], ids[1])),
+            second: Box::new(column(ids[2], ids[3])),
+        };
+    }
+
+    fn close_active(&mut self) -> Option<u64> {
+        if self.pane_count() == 1 {
+            return None;
+        }
+        let removed = self.active;
+        self.active = self.root.remove(removed)?;
+        Some(removed)
+    }
+
+    fn focus(&mut self, direction: PaneDirection) -> bool {
+        let mut panes = Vec::with_capacity(4);
+        self.root.rectangles(
+            PaneRect {
+                left: 0,
+                top: 0,
+                right: 1_024,
+                bottom: 1_024,
+            },
+            &mut panes,
+        );
+        let Some((_, active)) = panes.iter().find(|(id, _)| *id == self.active) else {
+            return false;
+        };
+        let active = *active;
+        let (active_x, active_y) = active.center();
+        let target = panes
+            .into_iter()
+            .filter(|(id, _)| *id != self.active)
+            .filter_map(|(id, area)| {
+                let (x, y) = area.center();
+                match direction {
+                    PaneDirection::Left if x < active_x => Some((
+                        i32::from(!ranges_overlap(
+                            active.top,
+                            active.bottom,
+                            area.top,
+                            area.bottom,
+                        )),
+                        active_x - x,
+                        (active_y - y).abs(),
+                        id,
+                    )),
+                    PaneDirection::Down if y > active_y => Some((
+                        i32::from(!ranges_overlap(
+                            active.left,
+                            active.right,
+                            area.left,
+                            area.right,
+                        )),
+                        y - active_y,
+                        (active_x - x).abs(),
+                        id,
+                    )),
+                    PaneDirection::Up if y < active_y => Some((
+                        i32::from(!ranges_overlap(
+                            active.left,
+                            active.right,
+                            area.left,
+                            area.right,
+                        )),
+                        active_y - y,
+                        (active_x - x).abs(),
+                        id,
+                    )),
+                    PaneDirection::Right if x > active_x => Some((
+                        i32::from(!ranges_overlap(
+                            active.top,
+                            active.bottom,
+                            area.top,
+                            area.bottom,
+                        )),
+                        x - active_x,
+                        (active_y - y).abs(),
+                        id,
+                    )),
+                    _ => None,
+                }
+            })
+            .min()
+            .map(|(_, _, _, id)| id);
+        let Some(target) = target else {
+            return false;
+        };
+        self.active = target;
+        true
+    }
+
+    fn toggle(&mut self) -> bool {
+        let panes = self.pane_ids();
+        if panes.len() == 1 {
+            return false;
+        }
+        let current = panes.iter().position(|id| *id == self.active).unwrap_or(0);
+        self.active = panes[(current + 1) % panes.len()];
+        true
+    }
+}
+
+fn ranges_overlap(first_start: i32, first_end: i32, second_start: i32, second_end: i32) -> bool {
+    first_start < second_end && second_start < first_end
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum PrefixResult {
+    Inactive,
+    Command(PaneCommand),
+    Cancelled,
+    Unknown,
+}
+
+#[derive(Default)]
+pub(super) struct PanePrefix {
+    deadline: Option<Instant>,
+}
+
+impl PanePrefix {
+    pub(super) fn begin(&mut self, now: Instant) {
+        self.deadline = Some(now + PANE_PREFIX_TIMEOUT);
+    }
+
+    pub(super) fn cancel(&mut self) {
+        self.deadline = None;
+    }
+
+    pub(super) fn suffix(&mut self, now: Instant, key: gtk::gdk::Key) -> PrefixResult {
+        let Some(deadline) = self.deadline.take() else {
+            return PrefixResult::Inactive;
+        };
+        if now > deadline {
+            return PrefixResult::Inactive;
+        }
+        if key == gtk::gdk::Key::Escape {
+            return PrefixResult::Cancelled;
+        }
+        pane_command_for_key(key).map_or(PrefixResult::Unknown, PrefixResult::Command)
+    }
+}
+
+fn pane_command_for_key(key: gtk::gdk::Key) -> Option<PaneCommand> {
+    match key {
+        gtk::gdk::Key::v | gtk::gdk::Key::V => Some(PaneCommand::Layout(PaneLayout::SideBySide)),
+        gtk::gdk::Key::s | gtk::gdk::Key::S => Some(PaneCommand::Layout(PaneLayout::Stacked)),
+        gtk::gdk::Key::h | gtk::gdk::Key::H | gtk::gdk::Key::Left => {
+            Some(PaneCommand::Focus(PaneDirection::Left))
+        }
+        gtk::gdk::Key::j | gtk::gdk::Key::J | gtk::gdk::Key::Down => {
+            Some(PaneCommand::Focus(PaneDirection::Down))
+        }
+        gtk::gdk::Key::k | gtk::gdk::Key::K | gtk::gdk::Key::Up => {
+            Some(PaneCommand::Focus(PaneDirection::Up))
+        }
+        gtk::gdk::Key::l | gtk::gdk::Key::L | gtk::gdk::Key::Right => {
+            Some(PaneCommand::Focus(PaneDirection::Right))
+        }
+        gtk::gdk::Key::w | gtk::gdk::Key::W => Some(PaneCommand::Toggle),
+        gtk::gdk::Key::c | gtk::gdk::Key::C => Some(PaneCommand::Close),
+        _ => None,
+    }
+}
+
+struct Pane {
+    id: u64,
+    shell: gtk::Box,
+    view: BrowserView,
+}
+
+type ChangedHandler = Rc<dyn Fn(PaneLayout)>;
+type PinHandler = Rc<dyn Fn(Location, String)>;
+type PinStatusHandler = Rc<dyn Fn(&Location) -> PinStatus>;
+
+struct WorkspaceState {
+    widget: gtk::Box,
+    locations: gtk::Stack,
+    panes: RefCell<Vec<Pane>>,
+    pane_state: RefCell<PaneState>,
+    next_id: Cell<u64>,
+    source: Rc<dyn FileSource>,
+    operation_provider: Rc<dyn OperationProvider>,
+    preferences: Rc<ThemeManager>,
+    cut_state: Rc<SharedCutState>,
+    preview: PreviewDrawer,
+    peek_enabled: Cell<bool>,
+    single_click_previews: Cell<bool>,
+    pin_handler: RefCell<Option<PinHandler>>,
+    pin_status_handler: RefCell<Option<PinStatusHandler>>,
+    changed_handlers: RefCell<Vec<ChangedHandler>>,
+}
+
+#[derive(Clone)]
+pub(super) struct PaneWorkspace {
+    state: Rc<WorkspaceState>,
+}
+
+impl PaneWorkspace {
+    pub(super) fn new(
+        source: Rc<dyn FileSource>,
+        operation_provider: Rc<dyn OperationProvider>,
+        preferences: Rc<ThemeManager>,
+        preview: PreviewDrawer,
+        initial_location: Location,
+    ) -> Self {
+        let widget = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+        widget.add_css_class("pane-workspace");
+        widget.set_hexpand(true);
+        widget.set_vexpand(true);
+        let locations = gtk::Stack::builder()
+            .hhomogeneous(false)
+            .vhomogeneous(false)
+            .transition_type(gtk::StackTransitionType::Crossfade)
+            .transition_duration(100)
+            .hexpand(true)
+            .build();
+        let workspace = Self {
+            state: Rc::new(WorkspaceState {
+                widget,
+                locations,
+                panes: RefCell::new(Vec::with_capacity(2)),
+                pane_state: RefCell::new(PaneState::default()),
+                next_id: Cell::new(1),
+                source,
+                operation_provider,
+                preferences: preferences.clone(),
+                cut_state: Rc::new(SharedCutState::default()),
+                preview,
+                peek_enabled: Cell::new(true),
+                single_click_previews: Cell::new(preferences.single_click_previews()),
+                pin_handler: RefCell::new(None),
+                pin_status_handler: RefCell::new(None),
+                changed_handlers: RefCell::new(Vec::new()),
+            }),
+        };
+        workspace.create_pane(0);
+        workspace.rebuild();
+        workspace.active_browser().navigate(initial_location);
+        workspace
+    }
+
+    pub(super) fn widget(&self) -> gtk::Widget {
+        self.state.widget.clone().upcast()
+    }
+
+    pub(super) fn location_widget(&self) -> gtk::Widget {
+        self.state.locations.clone().upcast()
+    }
+
+    pub(super) fn layout(&self) -> PaneLayout {
+        self.state.pane_state.borrow().layout()
+    }
+
+    pub(super) fn pane_count(&self) -> usize {
+        self.state.pane_state.borrow().pane_count()
+    }
+
+    pub(super) fn active_view(&self) -> BrowserView {
+        let active = self.state.pane_state.borrow().active;
+        self.state
+            .panes
+            .borrow()
+            .iter()
+            .find(|pane| pane.id == active)
+            .expect("active pane exists")
+            .view
+            .clone()
+    }
+
+    pub(super) fn active_browser(&self) -> Rc<Browser> {
+        self.active_view().browser()
+    }
+
+    pub(super) fn preview_occupied_width(&self) -> i32 {
+        if self.pane_count() == 2 {
+            self.state.widget.width()
+        } else {
+            self.active_view().preview_occupied_width()
+        }
+    }
+
+    pub(super) fn observe_changed(&self, handler: ChangedHandler) {
+        self.state.changed_handlers.borrow_mut().push(handler);
+    }
+
+    pub(super) fn set_pin_handlers(&self, handler: PinHandler, status: PinStatusHandler) {
+        self.state.pin_handler.replace(Some(handler.clone()));
+        self.state.pin_status_handler.replace(Some(status.clone()));
+        for pane in self.state.panes.borrow().iter() {
+            pane.view.set_pin_handlers(handler.clone(), status.clone());
+        }
+    }
+
+    pub(super) fn set_view_mode(&self, mode: BrowserMode) {
+        for pane in self.state.panes.borrow().iter() {
+            pane.view.set_view_mode(mode);
+        }
+    }
+
+    pub(super) fn set_density(&self, density: BrowserDensity) {
+        for pane in self.state.panes.borrow().iter() {
+            pane.view.set_density(density);
+        }
+    }
+
+    pub(super) fn set_peek_enabled(&self, enabled: bool) {
+        self.state.peek_enabled.set(enabled);
+        for pane in self.state.panes.borrow().iter() {
+            pane.view.set_peek_enabled(enabled);
+        }
+    }
+
+    pub(super) fn set_single_click_previews(&self, enabled: bool) {
+        self.state.single_click_previews.set(enabled);
+        for pane in self.state.panes.borrow().iter() {
+            pane.view.set_single_click_previews(enabled);
+        }
+    }
+
+    pub(super) fn set_layout(&self, layout: PaneLayout) {
+        match layout {
+            PaneLayout::Single => self.keep_active(),
+            PaneLayout::SideBySide | PaneLayout::Stacked => self.split_active(layout),
+            PaneLayout::Grid => self.set_grid(),
+        }
+    }
+
+    fn keep_active(&self) {
+        if self.pane_count() == 1 {
+            return;
+        }
+        let removed = self.state.pane_state.borrow_mut().keep_active();
+        for id in removed {
+            self.remove_pane(id);
+        }
+        self.finish_layout_change();
+    }
+
+    fn split_active(&self, layout: PaneLayout) {
+        if self.pane_count() == 4 {
+            let removed = self.state.pane_state.borrow_mut().keep_pair(layout);
+            for id in removed {
+                self.remove_pane(id);
+            }
+            self.finish_layout_change();
+            return;
+        }
+        let location = self.active_browser().active_location();
+        let id = self.allocate_pane_id();
+        self.create_pane(id);
+        let split = self.state.pane_state.borrow_mut().split(layout, id);
+        debug_assert!(split);
+        if let Some(location) = location {
+            self.active_browser().navigate(location);
+        }
+        self.finish_layout_change();
+    }
+
+    fn set_grid(&self) {
+        let location = self.active_browser().active_location();
+        let mut ids = self.state.pane_state.borrow().pane_ids();
+        let mut created = Vec::new();
+        while ids.len() < 4 {
+            let id = self.allocate_pane_id();
+            self.create_pane(id);
+            ids.push(id);
+            created.push(id);
+        }
+        self.state
+            .pane_state
+            .borrow_mut()
+            .set_grid(ids.try_into().expect("grid has four panes"));
+        if let Some(location) = location {
+            for id in created {
+                let browser = self
+                    .state
+                    .panes
+                    .borrow()
+                    .iter()
+                    .find(|pane| pane.id == id)
+                    .expect("created pane exists")
+                    .view
+                    .browser();
+                browser.navigate(location.clone());
+            }
+        }
+        self.finish_layout_change();
+    }
+
+    fn finish_layout_change(&self) {
+        self.rebuild();
+        self.focus_active();
+        self.sync_preview();
+        self.notify_changed();
+    }
+
+    fn allocate_pane_id(&self) -> u64 {
+        let id = self.state.next_id.get();
+        self.state.next_id.set(id.saturating_add(1));
+        id
+    }
+
+    pub(super) fn apply_command(&self, command: PaneCommand) {
+        match command {
+            PaneCommand::Layout(layout) => self.set_layout(layout),
+            PaneCommand::Focus(direction) => {
+                let changed = self.state.pane_state.borrow_mut().focus(direction);
+                if changed {
+                    self.activate_current(true);
+                }
+            }
+            PaneCommand::Toggle => {
+                let changed = self.state.pane_state.borrow_mut().toggle();
+                if changed {
+                    self.activate_current(true);
+                }
+            }
+            PaneCommand::Close => self.close_active(),
+        }
+    }
+
+    pub(super) fn close_active(&self) {
+        let closed = self.state.pane_state.borrow_mut().close_active();
+        let Some(id) = closed else {
+            return;
+        };
+        self.remove_pane(id);
+        self.rebuild();
+        self.focus_active();
+        self.sync_preview();
+        self.notify_changed();
+    }
+
+    pub(super) fn clear(&self) {
+        for pane in self.state.panes.borrow().iter() {
+            pane.view.browser().clear_observer();
+        }
+        self.state.changed_handlers.borrow_mut().clear();
+    }
+
+    fn create_pane(&self, id: u64) {
+        let view = BrowserView::new(
+            self.state.source.clone(),
+            PeekBehavior::default(),
+            self.state.cut_state.clone(),
+        );
+        view.set_view_mode(self.state.preferences.browser_mode());
+        view.set_density(self.state.preferences.browser_density());
+        view.set_peek_enabled(self.state.peek_enabled.get());
+        view.set_single_click_previews(self.state.single_click_previews.get());
+        view.set_operation_provider(self.state.operation_provider.clone());
+        if let (Some(handler), Some(status)) = (
+            self.state.pin_handler.borrow().clone(),
+            self.state.pin_status_handler.borrow().clone(),
+        ) {
+            view.set_pin_handlers(handler, status);
+        }
+
+        let shell = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        shell.add_css_class("browser-pane");
+        shell.set_focusable(true);
+        shell.set_hexpand(true);
+        shell.set_vexpand(true);
+        shell.append(&view.widget());
+
+        let weak_workspace = Rc::downgrade(&self.state);
+        let activity_shell = shell.clone();
+        let focus = gtk::EventControllerFocus::new();
+        focus.connect_enter(move |_| {
+            if let Some(state) = weak_workspace.upgrade() {
+                PaneWorkspace { state }.activate_shell(&activity_shell);
+            }
+        });
+        shell.add_controller(focus);
+
+        let weak_workspace = Rc::downgrade(&self.state);
+        let activity_shell = shell.clone();
+        let pointer = gtk::GestureClick::new();
+        pointer.set_button(0);
+        pointer.set_propagation_phase(gtk::PropagationPhase::Capture);
+        pointer.connect_pressed(move |_, _, _, _| {
+            if let Some(state) = weak_workspace.upgrade() {
+                PaneWorkspace { state }.activate_shell(&activity_shell);
+            }
+        });
+        shell.add_controller(pointer);
+
+        let browser = view.browser();
+        let weak_browser = Rc::downgrade(&browser);
+        let weak_workspace = Rc::downgrade(&self.state);
+        browser.observe(move |event| {
+            if let (Some(state), Some(browser)) = (weak_workspace.upgrade(), weak_browser.upgrade())
+            {
+                PaneWorkspace { state }.handle_browser_event(&browser, event);
+            }
+        });
+
+        self.state
+            .locations
+            .add_named(&view.location_widget(), Some(&format!("pane-{id}")));
+        self.state.panes.borrow_mut().push(Pane { id, shell, view });
+        self.show_active_location();
+    }
+
+    fn remove_pane(&self, id: u64) {
+        let index = self
+            .state
+            .panes
+            .borrow()
+            .iter()
+            .position(|pane| pane.id == id)
+            .expect("removed pane exists");
+        let pane = self.state.panes.borrow_mut().remove(index);
+        self.state.locations.remove(&pane.view.location_widget());
+        pane.view.browser().clear_observer();
+    }
+
+    fn rebuild(&self) {
+        if let Some(child) = self.state.widget.first_child() {
+            self.state.widget.remove(&child);
+            Self::detach_tree(&child);
+        }
+        self.state.widget.remove_css_class("split");
+        if self.pane_count() > 1 {
+            self.state.widget.add_css_class("split");
+        }
+        let root = self.state.pane_state.borrow().root.clone();
+        self.state.widget.append(&self.build_tree(&root));
+        self.update_active_style();
+        self.show_active_location();
+    }
+
+    fn build_tree(&self, node: &PaneNode) -> gtk::Widget {
+        match node {
+            PaneNode::Leaf(id) => self
+                .state
+                .panes
+                .borrow()
+                .iter()
+                .find(|pane| pane.id == *id)
+                .expect("pane tree leaf exists")
+                .shell
+                .clone()
+                .upcast(),
+            PaneNode::Split {
+                axis,
+                first,
+                second,
+            } => {
+                let paned = gtk::Paned::new(match axis {
+                    SplitAxis::Horizontal => gtk::Orientation::Horizontal,
+                    SplitAxis::Vertical => gtk::Orientation::Vertical,
+                });
+                paned.set_wide_handle(false);
+                paned.set_resize_start_child(true);
+                paned.set_resize_end_child(true);
+                paned.set_shrink_start_child(false);
+                paned.set_shrink_end_child(false);
+                paned.set_hexpand(true);
+                paned.set_vexpand(true);
+                paned.set_start_child(Some(&self.build_tree(first)));
+                paned.set_end_child(Some(&self.build_tree(second)));
+                Self::center_divider(&paned);
+                paned.upcast()
+            }
+        }
+    }
+
+    fn detach_tree(widget: &gtk::Widget) {
+        let Ok(paned) = widget.clone().downcast::<gtk::Paned>() else {
+            return;
+        };
+        if let Some(child) = paned.start_child() {
+            paned.set_start_child(None::<&gtk::Widget>);
+            Self::detach_tree(&child);
+        }
+        if let Some(child) = paned.end_child() {
+            paned.set_end_child(None::<&gtk::Widget>);
+            Self::detach_tree(&child);
+        }
+    }
+
+    fn center_divider(paned: &gtk::Paned) {
+        let paned = paned.clone();
+        glib::idle_add_local_once(move || {
+            let size = match paned.orientation() {
+                gtk::Orientation::Horizontal => paned.width(),
+                gtk::Orientation::Vertical => paned.height(),
+                _ => 0,
+            };
+            if size > 0 {
+                paned.set_position(size / 2);
+            }
+        });
+    }
+
+    fn activate_shell(&self, shell: &gtk::Box) {
+        let id = self
+            .state
+            .panes
+            .borrow()
+            .iter()
+            .find(|pane| pane.shell == *shell)
+            .map(|pane| pane.id);
+        let Some(id) = id else {
+            return;
+        };
+        let changed = {
+            let mut state = self.state.pane_state.borrow_mut();
+            let changed = state.active != id;
+            state.active = id;
+            changed
+        };
+        if changed {
+            self.activate_current(false);
+        }
+    }
+
+    fn activate_current(&self, focus: bool) {
+        self.update_active_style();
+        self.show_active_location();
+        self.sync_preview();
+        self.notify_changed();
+        if focus {
+            self.focus_active();
+        }
+    }
+
+    fn update_active_style(&self) {
+        let state = self.state.pane_state.borrow();
+        for pane in self.state.panes.borrow().iter() {
+            if state.pane_count() > 1 && pane.id == state.active {
+                pane.shell.add_css_class("active-pane");
+            } else {
+                pane.shell.remove_css_class("active-pane");
+            }
+        }
+    }
+
+    fn show_active_location(&self) {
+        let active = self.state.pane_state.borrow().active;
+        if let Some(pane) = self
+            .state
+            .panes
+            .borrow()
+            .iter()
+            .find(|pane| pane.id == active)
+        {
+            self.state
+                .locations
+                .set_visible_child_name(&format!("pane-{}", pane.id));
+        }
+    }
+
+    fn focus_active(&self) {
+        let active = self.state.pane_state.borrow().active;
+        let (shell, browser) = {
+            let panes = self.state.panes.borrow();
+            let pane = panes
+                .iter()
+                .find(|pane| pane.id == active)
+                .expect("active pane exists");
+            (pane.shell.clone(), pane.view.browser())
+        };
+        shell.grab_focus();
+        browser.focus_active();
+    }
+
+    fn is_active_browser(&self, browser: &Rc<Browser>) -> bool {
+        Rc::ptr_eq(browser, &self.active_browser())
+    }
+
+    fn handle_browser_event(&self, source: &Rc<Browser>, event: BrowserEvent) {
+        if let BrowserEvent::LocationsInvalidated { locations } = &event {
+            let peers = self
+                .state
+                .panes
+                .borrow()
+                .iter()
+                .map(|pane| pane.view.browser())
+                .collect::<Vec<_>>();
+            for browser in peers {
+                if !Rc::ptr_eq(&browser, source) {
+                    browser.invalidate_locations(locations);
+                }
+            }
+        }
+        if !self.is_active_browser(source) {
+            return;
+        }
+        match event {
+            BrowserEvent::PreviewRequested { entry } => self.state.preview.show(entry),
+            BrowserEvent::FocusChanged { .. } if self.state.preview.is_open() => {
+                self.sync_preview();
+            }
+            _ => {}
+        }
+        self.notify_changed();
+    }
+
+    fn sync_preview(&self) {
+        if !self.state.preview.is_open() {
+            return;
+        }
+        match self.active_browser().focused_entry() {
+            Some(entry) if !entry.is_directory() => self.state.preview.show(entry),
+            _ => self.state.preview.close(),
+        }
+    }
+
+    fn notify_changed(&self) {
+        let handlers = self.state.changed_handlers.borrow().clone();
+        let layout = self.layout();
+        for handler in handlers {
+            handler(layout);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/ui/panes/tests.rs
+++ b/src/ui/panes/tests.rs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use super::*;
+
+#[test]
+fn suffixes_accept_case_and_arrow_aliases() {
+    for (key, command) in [
+        (
+            gtk::gdk::Key::v,
+            PaneCommand::Layout(PaneLayout::SideBySide),
+        ),
+        (
+            gtk::gdk::Key::V,
+            PaneCommand::Layout(PaneLayout::SideBySide),
+        ),
+        (gtk::gdk::Key::s, PaneCommand::Layout(PaneLayout::Stacked)),
+        (gtk::gdk::Key::S, PaneCommand::Layout(PaneLayout::Stacked)),
+        (gtk::gdk::Key::h, PaneCommand::Focus(PaneDirection::Left)),
+        (gtk::gdk::Key::Left, PaneCommand::Focus(PaneDirection::Left)),
+        (gtk::gdk::Key::j, PaneCommand::Focus(PaneDirection::Down)),
+        (gtk::gdk::Key::Down, PaneCommand::Focus(PaneDirection::Down)),
+        (gtk::gdk::Key::K, PaneCommand::Focus(PaneDirection::Up)),
+        (gtk::gdk::Key::Up, PaneCommand::Focus(PaneDirection::Up)),
+        (gtk::gdk::Key::L, PaneCommand::Focus(PaneDirection::Right)),
+        (
+            gtk::gdk::Key::Right,
+            PaneCommand::Focus(PaneDirection::Right),
+        ),
+        (gtk::gdk::Key::w, PaneCommand::Toggle),
+        (gtk::gdk::Key::C, PaneCommand::Close),
+    ] {
+        assert_eq!(pane_command_for_key(key), Some(command));
+    }
+    assert_eq!(pane_command_for_key(gtk::gdk::Key::q), None);
+}
+
+#[test]
+fn prefix_cancels_on_escape_unknown_keys_and_timeout() {
+    let now = Instant::now();
+    let mut prefix = PanePrefix::default();
+
+    prefix.begin(now);
+    assert_eq!(
+        prefix.suffix(now, gtk::gdk::Key::Escape),
+        PrefixResult::Cancelled
+    );
+    prefix.begin(now);
+    assert_eq!(prefix.suffix(now, gtk::gdk::Key::q), PrefixResult::Unknown);
+    prefix.begin(now);
+    assert_eq!(
+        prefix.suffix(
+            now + PANE_PREFIX_TIMEOUT + Duration::from_millis(1),
+            gtk::gdk::Key::v
+        ),
+        PrefixResult::Inactive
+    );
+}
+
+#[test]
+fn splits_target_the_active_pane_and_stop_at_four() {
+    let mut state = PaneState::default();
+
+    assert!(state.split(PaneLayout::SideBySide, 1));
+    assert_eq!(state.active, 1);
+    assert!(state.split(PaneLayout::Stacked, 2));
+    assert_eq!(state.pane_count(), 3);
+    assert!(state.focus(PaneDirection::Up));
+    assert_eq!(state.active, 1);
+    assert!(state.focus(PaneDirection::Down));
+    assert!(state.split(PaneLayout::SideBySide, 3));
+    assert_eq!(state.pane_count(), 4);
+    assert!(!state.split(PaneLayout::Stacked, 4));
+}
+
+#[test]
+fn directional_focus_never_wraps_and_toggle_cycles_panes() {
+    let mut state = PaneState::default();
+    state.set_grid([0, 1, 2, 3]);
+
+    assert!(state.focus(PaneDirection::Right));
+    assert_eq!(state.active, 2);
+    assert!(!state.focus(PaneDirection::Right));
+    assert!(state.focus(PaneDirection::Down));
+    assert_eq!(state.active, 3);
+    assert!(state.focus(PaneDirection::Left));
+    assert_eq!(state.active, 1);
+    assert!(state.toggle());
+    assert_eq!(state.active, 2);
+    assert!(state.toggle());
+    assert_eq!(state.active, 3);
+    assert!(state.toggle());
+    assert_eq!(state.active, 0);
+}
+
+#[test]
+fn closing_collapses_the_split_and_the_last_pane_is_refused() {
+    let mut state = PaneState::default();
+    assert_eq!(state.close_active(), None);
+    state.split(PaneLayout::SideBySide, 1);
+    state.split(PaneLayout::Stacked, 2);
+    assert_eq!(state.close_active(), Some(2));
+    assert_eq!(state.active, 1);
+    assert_eq!(state.pane_count(), 2);
+    assert_eq!(state.close_active(), Some(1));
+    assert_eq!(state, PaneState::default());
+}
+
+#[test]
+fn single_keeps_the_active_pane_and_grid_reuses_existing_panes() {
+    let mut state = PaneState::default();
+    state.split(PaneLayout::SideBySide, 1);
+    state.split(PaneLayout::Stacked, 2);
+    assert_eq!(state.keep_active(), vec![0, 1]);
+    assert_eq!(state.pane_ids(), vec![2]);
+
+    state.set_grid([2, 3, 4, 5]);
+    assert_eq!(state.layout(), PaneLayout::Grid);
+    assert_eq!(state.pane_ids(), vec![2, 3, 4, 5]);
+    assert_eq!(state.active, 2);
+}
+
+#[test]
+fn four_panes_collapse_directly_to_the_requested_pair_layout() {
+    let mut state = PaneState::default();
+    state.set_grid([0, 1, 2, 3]);
+    assert_eq!(state.keep_pair(PaneLayout::SideBySide), vec![1, 3]);
+    assert_eq!(state.pane_ids(), vec![0, 2]);
+    assert_eq!(state.layout(), PaneLayout::SideBySide);
+
+    state.set_grid([0, 1, 2, 3]);
+    state.active = 3;
+    assert_eq!(state.keep_pair(PaneLayout::Stacked), vec![0, 1]);
+    assert_eq!(state.pane_ids(), vec![2, 3]);
+    assert_eq!(state.layout(), PaneLayout::Stacked);
+    assert_eq!(state.active, 3);
+}

--- a/src/ui/preview.rs
+++ b/src/ui/preview.rs
@@ -811,7 +811,8 @@ fn preview_width_for_empty_space(available: i32, occupied: i32) -> i32 {
         .saturating_sub(occupied)
         .saturating_mul(9)
         .saturating_div(10)
-        .max(MIN_WIDTH)
+        .max(available.saturating_div(3))
+        .max(DEFAULT_WIDTH)
 }
 
 fn pdf_zoom_after_scroll(current: f64, dy: f64) -> f64 {

--- a/src/ui/preview/tests.rs
+++ b/src/ui/preview/tests.rs
@@ -13,9 +13,10 @@ fn formats_preview_file_sizes() {
 }
 
 #[test]
-fn initial_preview_uses_most_of_the_unoccupied_width() {
+fn initial_preview_uses_empty_space_or_a_responsive_floor() {
     assert_eq!(preview_width_for_empty_space(2_000, 500), 1_350);
-    assert_eq!(preview_width_for_empty_space(700, 650), 280);
+    assert_eq!(preview_width_for_empty_space(2_000, 2_000), 666);
+    assert_eq!(preview_width_for_empty_space(700, 650), 520);
 }
 
 #[test]

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -19,7 +19,7 @@ mod tests;
 
 use super::{
     blur::BlurBin,
-    browser::{BrowserView, dismiss_modal_layer, modal_layer},
+    browser::{dismiss_modal_layer, modal_layer},
     controls::{form_entry, modal_layout, segmented_control},
     motion::set_reduce_motion,
     theme::{Theme, ThemeManager, ThemeTokens},
@@ -150,11 +150,12 @@ fn uses_compact_navigation(dialog_width: i32) -> bool {
 }
 
 pub fn build_layer(
-    browser: &BrowserView,
     settings_button: &gtk::Button,
     root: &BlurBin,
     themes: Rc<ThemeManager>,
     update_notice: UpdateNoticeHandler,
+    set_peek_enabled: Rc<dyn Fn(bool)>,
+    set_single_click_previews: Rc<dyn Fn(bool)>,
 ) -> gtk::Box {
     let layer = gtk::Box::new(gtk::Orientation::Vertical, 0);
     layer.add_css_class("app-modal-layer");
@@ -201,7 +202,10 @@ pub fn build_layer(
         .hexpand(true)
         .vexpand(true)
         .build();
-    stack.add_named(&general_page(browser, themes.clone()), Some("general"));
+    stack.add_named(
+        &general_page(themes.clone(), set_peek_enabled, set_single_click_previews),
+        Some("general"),
+    );
     stack.add_named(
         &updates_page(themes.clone(), update_notice),
         Some("updates"),
@@ -294,37 +298,39 @@ fn hide(layer: &gtk::Box, button: &gtk::Button, root: &BlurBin) {
     button.remove_css_class("active");
 }
 
-fn general_page(browser: &BrowserView, manager: Rc<ThemeManager>) -> gtk::Widget {
+fn general_page(
+    manager: Rc<ThemeManager>,
+    set_peek_enabled: Rc<dyn Fn(bool)>,
+    set_single_click_previews: Rc<dyn Fn(bool)>,
+) -> gtk::Widget {
     let preferences = page_content();
     append_heading(&preferences, "BROWSING");
     let peeking_enabled = manager.folder_peeking();
-    browser.set_peek_enabled(peeking_enabled);
+    set_peek_enabled(peeking_enabled);
     let (peeking_row, peeking) = settings_option(
         "Folder peeking",
         "Preview folders automatically while moving through a pane.",
         peeking_enabled,
     );
-    let browser_for_peeking = browser.clone();
     let manager_for_peeking = manager.clone();
     peeking.connect_active_notify(move |toggle| {
         let enabled = toggle.is_active();
-        browser_for_peeking.set_peek_enabled(enabled);
+        set_peek_enabled(enabled);
         manager_for_peeking.set_folder_peeking(enabled);
     });
     preferences.append(&peeking_row);
 
     let single_click_enabled = manager.single_click_previews();
-    browser.set_single_click_previews(single_click_enabled);
+    set_single_click_previews(single_click_enabled);
     let (preview_row, single_click_previews) = settings_option(
         "Single-click file previews",
         "Show a quick preview when selecting a supported file.",
         single_click_enabled,
     );
-    let browser_for_previews = browser.clone();
     let manager_for_previews = manager.clone();
     single_click_previews.connect_active_notify(move |toggle| {
         let enabled = toggle.is_active();
-        browser_for_previews.set_single_click_previews(enabled);
+        set_single_click_previews(enabled);
         manager_for_previews.set_single_click_previews(enabled);
     });
     preferences.append(&preview_row);
@@ -1043,6 +1049,17 @@ fn keybindings_page() -> gtk::Widget {
         ("Cut", "Ctrl + X"),
         ("Copy", "Ctrl + C"),
         ("Paste", "Ctrl + V"),
+    ] {
+        append_keybinding(&content, label, keys);
+    }
+
+    append_heading(&content, "PANE MANAGEMENT");
+    for (label, keys) in [
+        ("Split active pane side by side", "Ctrl + S, V"),
+        ("Split active pane top and bottom", "Ctrl + S, S"),
+        ("Focus a pane", "Ctrl + S, H / J / K / L  or  arrows"),
+        ("Cycle through panes", "Ctrl + S, W"),
+        ("Close active pane", "Ctrl + S, C"),
     ] {
         append_keybinding(&content, label, keys);
     }

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -12,15 +12,16 @@ use gtk::{gio, glib, prelude::*};
 
 use crate::{
     adapters::{LocalFileSource, LocalOperationProvider, LocalPreviewProvider, location_for_file},
-    app::{Browser, BrowserEvent},
+    app::Browser,
     model::{EntryKind, FileEntry, Location, MetadataValue},
 };
 
 use super::{
     blur::BlurBin,
-    browser::{BrowserView, PeekBehavior, PinStatus, show_error_dialog},
+    browser::{PinStatus, show_error_dialog},
     browser_modes::{BrowserDensity, BrowserMode},
     motion::{animations_enabled, emphasized_deceleration},
+    panes::{PANE_PREFIX_TIMEOUT, PaneLayout, PanePrefix, PaneWorkspace, PrefixResult},
     preview::PreviewDrawer,
     search::SearchDialog,
 };
@@ -45,34 +46,14 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
         .default_height(760)
         .build();
 
-    let browser = BrowserView::new(Rc::new(LocalFileSource), PeekBehavior::default());
-    browser.set_view_mode(theme_manager.browser_mode());
-    browser.set_density(theme_manager.browser_density());
-    browser.set_operation_provider(Rc::new(LocalOperationProvider));
-    let controller = browser.browser();
-
     let preview = PreviewDrawer::new(Rc::new(LocalPreviewProvider));
-    let preview_for_selection = preview.clone();
-    let weak_controller = Rc::downgrade(&controller);
-    controller.observe(move |event| match event {
-        BrowserEvent::PreviewRequested { entry } => preview_for_selection.show(entry),
-        BrowserEvent::FocusChanged {
-            depth,
-            position: Some(position),
-        } if preview_for_selection.is_open() => {
-            if let Some(entry) = weak_controller
-                .upgrade()
-                .and_then(|browser| browser.entry_at(depth, position))
-            {
-                if entry.is_directory() {
-                    preview_for_selection.close();
-                } else {
-                    preview_for_selection.show(entry);
-                }
-            }
-        }
-        _ => {}
-    });
+    let workspace = PaneWorkspace::new(
+        Rc::new(LocalFileSource),
+        Rc::new(LocalOperationProvider),
+        theme_manager.clone(),
+        preview.clone(),
+        Location::local(location.unwrap_or_else(home_directory)),
+    );
 
     let header = gtk::HeaderBar::new();
     header.set_show_title_buttons(false);
@@ -87,7 +68,7 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
     )));
     sidebar_toggle.add_css_class("sidebar-toggle");
     header.pack_start(&sidebar_toggle);
-    header.pack_start(&browser.location_widget());
+    header.pack_start(&workspace.location_widget());
     let search_button = gtk::Button::builder()
         .tooltip_text("Search (Ctrl+K)")
         .build();
@@ -96,7 +77,8 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
         20,
     )));
     search_button.add_css_class("header-action");
-    let appearance = build_appearance_menu(&browser, &controller, theme_manager.clone());
+    let appearance = build_appearance_menu(&workspace, theme_manager.clone());
+    let pane_layout = build_pane_layout_menu(&workspace);
     let settings = gtk::Button::builder().tooltip_text("Settings").build();
     settings.set_child(Some(&crate::assets::text_icon(
         crate::assets::icons::SETTINGS,
@@ -112,6 +94,7 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
     header_actions.add_css_class("header-actions");
     header_actions.append(&search_button);
     header_actions.append(&appearance);
+    header_actions.append(&pane_layout);
     header_actions.append(&settings);
     header_actions.append(&close_window);
     header.pack_end(&header_actions);
@@ -125,10 +108,10 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
     content.set_resize_start_child(false);
     content.set_position(SIDEBAR_WIDTH);
     content.set_vexpand(true);
-    let sidebar = build_sidebar(browser.clone());
+    let sidebar = build_sidebar(workspace.clone());
     let weak_sidebar = Rc::downgrade(&sidebar.state);
     let pinned_places = sidebar.state.pinned_places.clone();
-    browser.set_pin_handlers(
+    workspace.set_pin_handlers(
         Rc::new(move |location, name| {
             if let Some(sidebar) = weak_sidebar.upgrade() {
                 sidebar.pin_location(location, name);
@@ -138,7 +121,7 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
     );
     sidebar.widget.set_size_request(MIN_SIDEBAR_WIDTH, -1);
     content.set_start_child(Some(&sidebar.widget));
-    content.set_end_child(Some(&browser.widget()));
+    content.set_end_child(Some(&workspace.widget()));
     let animation_generation = Rc::new(Cell::new(0));
     let sidebar_animating = Rc::new(Cell::new(false));
     let constrained_content = content.clone();
@@ -175,10 +158,10 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
     preview_split.set_position(i32::MAX);
     preview_split.set_vexpand(true);
     let measured_content = content.clone();
-    let measured_browser = browser.clone();
+    let measured_workspace = workspace.clone();
     preview.attach_split(
         &preview_split,
-        Rc::new(move || measured_content.position() + measured_browser.preview_occupied_width()),
+        Rc::new(move || measured_content.position() + measured_workspace.preview_occupied_width()),
     );
     root.append(&preview_split);
 
@@ -186,21 +169,23 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
     let blurred_root = BlurBin::new(&root);
     window_overlay.set_child(Some(&blurred_root));
 
-    let search_controller = controller.clone();
+    let search_workspace = workspace.clone();
     let search_preview = preview.clone();
     let search_preferences = theme_manager.clone();
     let activate_search_result = Rc::new(move |item: crate::services::SearchItem| {
         let location = Location::local(item.path.clone());
         if item.is_directory {
             search_preview.close();
-            search_controller.navigate(location);
+            search_workspace.active_browser().navigate(location);
             return;
         }
         if let Some(parent) = item.path.parent() {
-            search_controller.navigate(Location::local(parent));
+            search_workspace
+                .active_browser()
+                .navigate(Location::local(parent));
         }
         if search_preferences.search_open_files_directly() {
-            search_controller.open_location(location);
+            search_workspace.active_browser().open_location(location);
         } else {
             search_preview.show(FileEntry {
                 location,
@@ -221,14 +206,15 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
     let search_dialog = SearchDialog::new(activate_search_result, dismiss_search);
     window_overlay.add_overlay(&search_dialog.widget());
     let shown_search = search_dialog.clone();
-    let search_browser = controller.clone();
+    let search_workspace = workspace.clone();
     let search_blurred_root = blurred_root.clone();
     search_button.connect_clicked(move |button| {
         if shown_search.is_visible() {
             shown_search.hide();
             return;
         }
-        let root = search_browser
+        let root = search_workspace
+            .active_browser()
             .active_location()
             .and_then(|location| location.native_path().map(std::path::Path::to_path_buf))
             .unwrap_or_else(home_directory);
@@ -238,14 +224,15 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
     });
     let search_action = gio::SimpleAction::new("search", None);
     let shortcut_search = search_dialog.clone();
-    let shortcut_browser = controller.clone();
+    let shortcut_workspace = workspace.clone();
     let shortcut_search_button = search_button.clone();
     let shortcut_search_root = blurred_root.clone();
     search_action.connect_activate(move |_, _| {
         if shortcut_search.is_visible() {
             shortcut_search.hide();
         } else {
-            let root = shortcut_browser
+            let root = shortcut_workspace
+                .active_browser()
                 .active_location()
                 .and_then(|location| location.native_path().map(std::path::Path::to_path_buf))
                 .unwrap_or_else(home_directory);
@@ -283,12 +270,15 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
             update_area.set_visible(false);
         }
     });
+    let peek_workspace = workspace.clone();
+    let preview_workspace = workspace.clone();
     let settings_layer = super::settings::build_layer(
-        &browser,
         &settings,
         &blurred_root,
         theme_manager,
         update_notice,
+        Rc::new(move |enabled| peek_workspace.set_peek_enabled(enabled)),
+        Rc::new(move |enabled| preview_workspace.set_single_click_previews(enabled)),
     );
     window_overlay.add_overlay(&settings_layer);
     let shown_settings = settings_layer.clone();
@@ -312,12 +302,19 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
     window.add_controller(settings_shortcut);
     window.set_child(Some(&window_overlay));
     install_modal_focus_trap(&window);
-    install_keyboard_navigation(&window, &browser, &sidebar, &sidebar_toggle, &preview);
-    browser.navigate(location.unwrap_or_else(home_directory));
+    install_keyboard_navigation(
+        &window,
+        &workspace,
+        &sidebar,
+        &sidebar_toggle,
+        &preview,
+        &search_dialog,
+        &settings_layer,
+    );
 
-    let browser_controller = browser.browser();
+    let destroyed_workspace = workspace.clone();
     window.connect_destroy(move |_| {
-        browser_controller.clear_observer();
+        destroyed_workspace.clear();
         sidebar.disconnect();
     });
     window.present();
@@ -381,26 +378,34 @@ fn animate_sidebar(
 
 fn install_keyboard_navigation(
     window: &gtk::ApplicationWindow,
-    view: &BrowserView,
+    workspace: &PaneWorkspace,
     sidebar: &SidebarView,
     sidebar_toggle: &gtk::ToggleButton,
     preview: &PreviewDrawer,
+    search: &SearchDialog,
+    settings: &gtk::Box,
 ) {
     let keys = gtk::EventControllerKey::new();
     keys.set_propagation_phase(gtk::PropagationPhase::Capture);
-    let view = view.clone();
+    let workspace = workspace.clone();
     let sidebar_state = sidebar.state.clone();
     let sidebar_widget = sidebar.widget.clone();
     let sidebar_toggle = sidebar_toggle.clone();
     let preview = preview.clone();
+    let search = search.clone();
+    let settings = settings.clone();
     let dialog_parent = window.clone();
     let focus_before_sidebar = Rc::new(RefCell::new(None::<gtk::Widget>));
-    let weak_browser = Rc::downgrade(&view.browser());
+    let prefix = Rc::new(RefCell::new(PanePrefix::default()));
+    let prefix_timeout = Rc::new(RefCell::new(None::<glib::SourceId>));
+    let focus_prefix = prefix.clone();
+    let focus_timeout = prefix_timeout.clone();
+    window.connect_focus_widget_notify(move |_| {
+        cancel_pane_prefix(&focus_prefix, &focus_timeout);
+    });
     keys.connect_key_pressed(move |_, key, _, modifiers| {
-        let Some(browser) = weak_browser.upgrade() else {
-            return glib::Propagation::Proceed;
-        };
         if let Some(layer) = visible_modal_layer(&dialog_parent) {
+            cancel_pane_prefix(&prefix, &prefix_timeout);
             let focus_is_inside = gtk::prelude::RootExt::focus(&dialog_parent)
                 .is_some_and(|focus| focus == layer || focus.is_ancestor(&layer));
             if !focus_is_inside {
@@ -409,6 +414,8 @@ fn install_keyboard_navigation(
             }
             return glib::Propagation::Proceed;
         }
+        let view = workspace.active_view();
+        let browser = workspace.active_browser();
         let alt = modifiers.contains(gtk::gdk::ModifierType::ALT_MASK);
         let control = modifiers.contains(gtk::gdk::ModifierType::CONTROL_MASK);
         let shift = modifiers.contains(gtk::gdk::ModifierType::SHIFT_MASK);
@@ -416,6 +423,44 @@ fn install_keyboard_navigation(
         let sidebar_has_focus = focused.as_ref().is_some_and(|focused| {
             focused == &sidebar_widget || focused.is_ancestor(&sidebar_widget)
         });
+        let prefix_blocked = search.is_visible()
+            || settings.is_visible()
+            || view.location_has_focus()
+            || view.filter_has_focus()
+            || view.rename_is_active()
+            || view.new_entry_is_active();
+        if prefix_blocked {
+            cancel_pane_prefix(&prefix, &prefix_timeout);
+        } else {
+            let prefix_result = prefix.borrow_mut().suffix(Instant::now(), key);
+            match prefix_result {
+                PrefixResult::Command(command) => {
+                    cancel_pane_prefix(&prefix, &prefix_timeout);
+                    workspace.apply_command(command);
+                    return glib::Propagation::Stop;
+                }
+                PrefixResult::Cancelled => {
+                    cancel_pane_prefix(&prefix, &prefix_timeout);
+                    return glib::Propagation::Stop;
+                }
+                PrefixResult::Unknown => {
+                    cancel_pane_prefix(&prefix, &prefix_timeout);
+                }
+                PrefixResult::Inactive => {}
+            }
+            if control && !shift && !alt && key == gtk::gdk::Key::s {
+                cancel_pane_prefix(&prefix, &prefix_timeout);
+                prefix.borrow_mut().begin(Instant::now());
+                let expired_prefix = prefix.clone();
+                let expired_timeout = prefix_timeout.clone();
+                let timeout = glib::timeout_add_local_once(PANE_PREFIX_TIMEOUT, move || {
+                    expired_prefix.borrow_mut().cancel();
+                    expired_timeout.borrow_mut().take();
+                });
+                prefix_timeout.replace(Some(timeout));
+                return glib::Propagation::Stop;
+            }
+        }
         if control && matches!(key, gtk::gdk::Key::k | gtk::gdk::Key::K) {
             if let Err(error) =
                 gtk::prelude::WidgetExt::activate_action(&dialog_parent, "win.search", None)
@@ -662,6 +707,16 @@ fn vim_focus_direction(key: gtk::gdk::Key) -> Option<gtk::DirectionType> {
     }
 }
 
+fn cancel_pane_prefix(
+    prefix: &Rc<RefCell<PanePrefix>>,
+    timeout: &Rc<RefCell<Option<glib::SourceId>>>,
+) {
+    prefix.borrow_mut().cancel();
+    if let Some(timeout) = timeout.borrow_mut().take() {
+        timeout.remove();
+    }
+}
+
 fn visible_modal_layer(window: &gtk::ApplicationWindow) -> Option<gtk::Widget> {
     let overlay = window.child().and_downcast::<gtk::Overlay>()?;
     let mut child = overlay.first_child();
@@ -688,14 +743,13 @@ fn install_modal_focus_trap(window: &gtk::ApplicationWindow) {
 }
 
 fn build_appearance_menu(
-    view: &BrowserView,
-    controller: &Rc<Browser>,
+    workspace: &PaneWorkspace,
     preferences: Rc<super::theme::ThemeManager>,
 ) -> gtk::MenuButton {
     let content = gtk::Box::new(gtk::Orientation::Vertical, 0);
     content.add_css_class("appearance-menu");
     append_menu_heading(&content, "VIEW");
-    let current_mode = view.view_mode();
+    let current_mode = preferences.browser_mode();
     let (list, list_check, _) = appearance_option(
         crate::assets::icons::LIST,
         "List",
@@ -719,13 +773,13 @@ fn build_appearance_menu(
         (&grid, BrowserMode::Grid),
         (&explorer, BrowserMode::Explorer),
     ] {
-        let view = view.clone();
+        let workspace = workspace.clone();
         let list_check = list_check.clone();
         let grid_check = grid_check.clone();
         let explorer_check = explorer_check.clone();
         let preferences = preferences.clone();
         button.connect_clicked(move |_| {
-            view.set_view_mode(mode);
+            workspace.set_view_mode(mode);
             preferences.set_browser_mode(mode);
             list_check.set_visible(mode == BrowserMode::Columns);
             grid_check.set_visible(mode == BrowserMode::Grid);
@@ -752,21 +806,21 @@ fn build_appearance_menu(
         true,
     );
     {
-        let view = view.clone();
+        let workspace = workspace.clone();
         let compact_check = compact_check.clone();
         let airy_check = airy_check.clone();
         let preferences = preferences.clone();
         compact.connect_clicked(move |_| {
-            view.set_density(BrowserDensity::Compact);
+            workspace.set_density(BrowserDensity::Compact);
             preferences.set_browser_density(BrowserDensity::Compact);
             compact_check.set_visible(true);
             airy_check.set_visible(false);
         });
     }
     {
-        let view = view.clone();
+        let workspace = workspace.clone();
         airy.connect_clicked(move |_| {
-            view.set_density(BrowserDensity::Airy);
+            workspace.set_density(BrowserDensity::Airy);
             preferences.set_browser_density(BrowserDensity::Airy);
             compact_check.set_visible(false);
             airy_check.set_visible(true);
@@ -779,7 +833,7 @@ fn build_appearance_menu(
     let (hidden, hidden_check, hidden_icon) =
         appearance_option(crate::assets::icons::EYE_OFF, "Hidden files", false, true);
     let hidden_state = Rc::new(Cell::new(false));
-    let weak_controller = Rc::downgrade(controller);
+    let hidden_workspace = workspace.clone();
     hidden.connect_clicked(move |_| {
         let shown = !hidden_state.get();
         hidden_state.set(shown);
@@ -792,9 +846,7 @@ fn build_appearance_menu(
                 crate::assets::icons::EYE_OFF
             },
         );
-        if let Some(controller) = weak_controller.upgrade() {
-            controller.toggle_hidden();
-        }
+        hidden_workspace.active_browser().toggle_hidden();
     });
     content.append(&hidden);
 
@@ -823,6 +875,134 @@ fn build_appearance_menu(
         );
     });
     button
+}
+
+fn build_pane_layout_menu(workspace: &PaneWorkspace) -> gtk::MenuButton {
+    let content = gtk::Box::new(gtk::Orientation::Vertical, 6);
+    content.add_css_class("pane-layout-menu");
+    append_menu_heading(&content, "PANE LAYOUT");
+    let layouts = Rc::new([
+        (
+            PaneLayout::Single,
+            pane_layout_option(
+                crate::assets::icons::SQUARE,
+                "Single",
+                "Keep the active pane",
+                "Ctrl+S, C",
+            ),
+        ),
+        (
+            PaneLayout::SideBySide,
+            pane_layout_option(
+                crate::assets::icons::COLUMNS_2,
+                "Side by side",
+                "Split the active pane left and right",
+                "Ctrl+S, V",
+            ),
+        ),
+        (
+            PaneLayout::Stacked,
+            pane_layout_option(
+                crate::assets::icons::ROWS_2,
+                "Stacked",
+                "Split the active pane top and bottom",
+                "Ctrl+S, S",
+            ),
+        ),
+        (
+            PaneLayout::Grid,
+            pane_layout_option(
+                crate::assets::icons::GRID_2X2,
+                "2 × 2",
+                "Arrange four browser panes",
+                "Preset",
+            ),
+        ),
+    ]);
+    for (_, option) in layouts.iter() {
+        content.append(option);
+    }
+
+    let popover = gtk::Popover::builder()
+        .child(&content)
+        .has_arrow(false)
+        .halign(gtk::Align::End)
+        .position(gtk::PositionType::Bottom)
+        .build();
+    popover.add_css_class("pane-layout-popover");
+    for (layout, option) in layouts.iter() {
+        let selected_layout = *layout;
+        let selected_workspace = workspace.clone();
+        let selected_popover = popover.clone();
+        option.connect_clicked(move |_| {
+            selected_workspace.set_layout(selected_layout);
+            selected_popover.popdown();
+        });
+    }
+
+    let button = gtk::MenuButton::builder()
+        .tooltip_text("Pane layout (Ctrl+S prefix)")
+        .popover(&popover)
+        .build();
+    let icon = crate::assets::text_icon(crate::assets::icons::SQUARE, 20);
+    button.set_child(Some(&icon));
+    button.add_css_class("header-action");
+    sync_pane_layout_menu(workspace.layout(), &icon, &layouts);
+    let observed_icon = icon.clone();
+    let observed_layouts = layouts.clone();
+    workspace.observe_changed(Rc::new(move |layout| {
+        sync_pane_layout_menu(layout, &observed_icon, &observed_layouts);
+    }));
+    button
+}
+
+fn pane_layout_option(icon: &str, title: &str, description: &str, shortcut: &str) -> gtk::Button {
+    let row = gtk::Box::new(gtk::Orientation::Horizontal, 12);
+    let symbol = gtk::CenterBox::new();
+    symbol.add_css_class("pane-layout-symbol");
+    symbol.set_center_widget(Some(&crate::assets::primary_icon(icon, 22)));
+    let labels = gtk::Box::new(gtk::Orientation::Vertical, 1);
+    labels.set_hexpand(true);
+    let title = gtk::Label::new(Some(title));
+    title.add_css_class("pane-layout-title");
+    title.set_xalign(0.0);
+    let description = gtk::Label::new(Some(description));
+    description.add_css_class("pane-layout-description");
+    description.set_xalign(0.0);
+    labels.append(&title);
+    labels.append(&description);
+    let shortcut = gtk::Label::new(Some(shortcut));
+    shortcut.add_css_class("pane-layout-shortcut");
+    row.append(&symbol);
+    row.append(&labels);
+    row.append(&shortcut);
+    let option = gtk::Button::builder().child(&row).build();
+    option.add_css_class("pane-layout-option");
+    option.set_has_frame(false);
+    option
+}
+
+fn sync_pane_layout_menu(
+    layout: PaneLayout,
+    icon: &gtk::Image,
+    options: &[(PaneLayout, gtk::Button); 4],
+) {
+    crate::assets::set_text_icon(
+        icon,
+        match layout {
+            PaneLayout::Single => crate::assets::icons::SQUARE,
+            PaneLayout::SideBySide => crate::assets::icons::COLUMNS_2,
+            PaneLayout::Stacked => crate::assets::icons::ROWS_2,
+            PaneLayout::Grid => crate::assets::icons::GRID_2X2,
+        },
+    );
+    for (candidate, option) in options {
+        if *candidate == layout {
+            option.add_css_class("selected");
+        } else {
+            option.remove_css_class("selected");
+        }
+    }
 }
 
 fn appearance_option(
@@ -866,8 +1046,7 @@ fn append_menu_heading(container: &gtk::Box, text: &str) {
 
 struct SidebarState {
     widget: gtk::Box,
-    view: BrowserView,
-    browser: Rc<Browser>,
+    workspace: PaneWorkspace,
     volume_monitor: gio::VolumeMonitor,
     place_order: RefCell<Vec<&'static str>>,
     pinned_places: Rc<RefCell<Vec<(Location, String)>>>,
@@ -981,7 +1160,7 @@ impl SidebarState {
     }
 
     fn sync_active_place(&self) {
-        let active = self.browser.active_location();
+        let active = self.workspace.active_browser().active_location();
         let rows = self.place_rows.borrow();
         let selected = rows
             .iter()
@@ -1016,14 +1195,12 @@ impl SidebarState {
         self.place_rows
             .borrow_mut()
             .push((location.clone(), row.clone()));
-        let weak_browser = Rc::downgrade(&self.browser);
+        let workspace = self.workspace.clone();
         let sidebar = self.widget.clone();
         let selected_row = row.clone();
         row.connect_clicked(move |_| {
             select_sidebar_row(&sidebar, &selected_row);
-            if let Some(browser) = weak_browser.upgrade() {
-                browser.navigate(location.clone());
-            }
+            workspace.active_browser().navigate(location.clone());
         });
 
         let menu = gtk::Box::new(gtk::Orientation::Vertical, 0);
@@ -1042,20 +1219,22 @@ impl SidebarState {
         popover.add_css_class("folder-context-popover");
         popover.set_parent(&row);
         let properties_popover = popover.downgrade();
-        let properties_view = self.view.clone();
+        let properties_workspace = self.workspace.clone();
         properties.connect_clicked(move |_| {
             if let Some(popover) = properties_popover.upgrade() {
                 popover.popdown();
             }
-            properties_view.show_location_properties(&Location::uri("trash:///"));
+            properties_workspace
+                .active_view()
+                .show_location_properties(&Location::uri("trash:///"));
         });
         let empty_popover = popover.downgrade();
-        let empty_view = self.view.clone();
+        let empty_workspace = self.workspace.clone();
         empty.connect_clicked(move |_| {
             if let Some(popover) = empty_popover.upgrade() {
                 popover.popdown();
             }
-            empty_view.confirm_empty_trash();
+            empty_workspace.active_view().confirm_empty_trash();
         });
         let context = gtk::GestureClick::new();
         context.set_button(3);
@@ -1091,14 +1270,12 @@ impl SidebarState {
         self.place_rows
             .borrow_mut()
             .push((location.clone(), row.clone()));
-        let weak_browser = Rc::downgrade(&self.browser);
+        let workspace = self.workspace.clone();
         let sidebar = self.widget.clone();
         let selected_row = row.clone();
         row.connect_clicked(move |_| {
             select_sidebar_row(&sidebar, &selected_row);
-            if let Some(browser) = weak_browser.upgrade() {
-                browser.navigate(location.clone());
-            }
+            workspace.active_browser().navigate(location.clone());
         });
 
         let drag = gtk::DragSource::builder()
@@ -1167,14 +1344,12 @@ impl SidebarState {
             let location = location_for_file(&mount.root());
             self.place_rows.borrow_mut().push((location, row.clone()));
         }
-        let weak_browser = Rc::downgrade(&self.browser);
+        let workspace = self.workspace.clone();
         let sidebar = self.widget.clone();
         let selected_row = row.clone();
         row.connect_clicked(move |button| {
             select_sidebar_row(&sidebar, &selected_row);
-            let Some(browser) = weak_browser.upgrade() else {
-                return;
-            };
+            let browser = workspace.active_browser();
             if let Some(mount) = volume.get_mount() {
                 navigate_to_gio_file(&browser, &mount.root());
                 return;
@@ -1227,16 +1402,18 @@ impl SidebarState {
         popover.set_parent(&row);
 
         let properties_popover = popover.downgrade();
-        let properties_view = self.view.clone();
+        let properties_workspace = self.workspace.clone();
         properties.connect_clicked(move |_| {
             if let Some(popover) = properties_popover.upgrade() {
                 popover.popdown();
             }
-            properties_view.show_location_properties(&properties_location);
+            properties_workspace
+                .active_view()
+                .show_location_properties(&properties_location);
         });
 
         let disconnect_popover = popover.downgrade();
-        let parent = self.view.widget();
+        let parent = self.widget.clone();
         disconnect.connect_clicked(move |_| {
             if let Some(popover) = disconnect_popover.upgrade() {
                 popover.popdown();
@@ -1302,14 +1479,16 @@ impl SidebarState {
                 state.unpin_location(&unpinned_location);
             }
         });
-        let properties_view = self.view.clone();
+        let properties_workspace = self.workspace.clone();
         let properties_location = location;
         let properties_popover = popover.downgrade();
         properties.connect_clicked(move |_| {
             if let Some(popover) = properties_popover.upgrade() {
                 popover.popdown();
             }
-            properties_view.show_location_properties(&properties_location);
+            properties_workspace
+                .active_view()
+                .show_location_properties(&properties_location);
         });
         let context = gtk::GestureClick::new();
         context.set_button(3);
@@ -1336,14 +1515,14 @@ impl SidebarState {
         self.place_rows
             .borrow_mut()
             .push((location.clone(), row.clone()));
-        let weak_browser = Rc::downgrade(&self.browser);
+        let workspace = self.workspace.clone();
         let sidebar = self.widget.clone();
         let selected_row = row.clone();
         row.connect_clicked(move |_| {
             select_sidebar_row(&sidebar, &selected_row);
-            if let Some(browser) = weak_browser.upgrade() {
-                browser.navigate_location(location.clone());
-            }
+            workspace
+                .active_browser()
+                .navigate_location(location.clone());
         });
         self.widget.append(&row);
         row
@@ -1496,7 +1675,7 @@ fn navigate_to_gio_file(browser: &Rc<Browser>, file: &gio::File) {
     browser.navigate(location_for_file(file));
 }
 
-fn build_sidebar(view: BrowserView) -> SidebarView {
+fn build_sidebar(workspace: PaneWorkspace) -> SidebarView {
     let widget = gtk::Box::new(gtk::Orientation::Vertical, 2);
     widget.add_css_class("sidebar");
     let scroller = gtk::ScrolledWindow::builder()
@@ -1539,8 +1718,7 @@ fn build_sidebar(view: BrowserView) -> SidebarView {
     let volume_monitor = gio::VolumeMonitor::get();
     let state = Rc::new(SidebarState {
         widget,
-        browser: view.browser(),
-        view,
+        workspace: workspace.clone(),
         volume_monitor,
         place_order: RefCell::new(vec![
             "desktop",
@@ -1554,11 +1732,11 @@ fn build_sidebar(view: BrowserView) -> SidebarView {
     });
 
     let weak = Rc::downgrade(&state);
-    state.browser.observe(move |_| {
+    workspace.observe_changed(Rc::new(move |_| {
         if let Some(state) = weak.upgrade() {
             state.sync_active_place();
         }
-    });
+    }));
 
     let mut handlers = Vec::new();
     let weak = Rc::downgrade(&state);


### PR DESCRIPTION
## Summary

- Add one to four independently navigable browser panes with side-by-side, stacked, nested, and 2×2 layouts.
- Add `Ctrl+S` pane-management chords and a compact header layout menu.
- Route navigation, search, previews, appearance, settings, and file operations through the active pane.
- Support cross-pane drag-and-drop, shared cut state, and operation invalidation.
- Add active-pane highlighting, clearer dividers, drag-safe previews, and responsive preview sizing.

## Behavior

- Strata still starts with one pane; layouts are not persisted.
- New panes clone the active location while keeping independent history and selection.
- Side-by-side and stacked layouts can be subdivided up to four panes.
- Switching from 2×2 directly to Side by side or Stacked keeps the active row or column.
- Closing the last pane remains a no-op.
- The shared preview follows the active pane and opens at a responsive width.
- Dragging files between panes no longer triggers an accidental preview or launch.


https://github.com/user-attachments/assets/0f58dbfc-66b5-45b0-a1a2-0c637449eb7c


https://github.com/user-attachments/assets/88b669a0-7107-43e7-8e4d-229fbb6d9bc2


## Keyboard controls

- `Ctrl+S, V` — split side by side
- `Ctrl+S, S` — split top and bottom
- `Ctrl+S, H/J/K/L` or arrows — focus a pane
- `Ctrl+S, W` — cycle panes
- `Ctrl+S, C` — close the active pane

## Testing

- `cargo fmt --all --check`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features` — 234 passed
- Manual smoke testing of pane layouts, keyboard navigation, previews, and cross-pane drag-and-drop

Closes #47