### PR TITLE
fix(browser): delete the entered folder when unselected

### DIFF
--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -687,6 +687,22 @@ impl Browser {
         self.state.borrow().selected_entries()
     }
 
+    pub fn deletion_entries(&self) -> Vec<FileEntry> {
+        let state = self.state.borrow();
+        let selected = state.selected_entries();
+        if !selected.is_empty() {
+            return selected;
+        }
+
+        let Some(parent_depth) = state.active_depth().and_then(|depth| depth.checked_sub(1)) else {
+            return Vec::new();
+        };
+        let Some(position) = state.active_child_position(parent_depth) else {
+            return Vec::new();
+        };
+        state.entry_at(parent_depth, position).into_iter().collect()
+    }
+
     pub fn set_selection(&self, depth: usize, positions: &[usize], focused: Option<usize>) {
         let mut state = self.state.borrow_mut();
         if state.set_selection(depth, positions, focused) {

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -649,6 +649,19 @@ fn navigating_to_the_active_location_is_a_noop() {
 }
 
 #[test]
+fn deletion_targets_the_entered_folder_when_the_child_has_no_selection() {
+    let browser = Browser::new(Rc::new(FakeFileSource));
+    browser.navigate(Location::local("/fixture"));
+    browser.select(0, 0);
+    browser.descend(0, Location::local("/fixture/child"));
+
+    let entries = browser.deletion_entries();
+
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].location, Location::local("/fixture/child"));
+}
+
+#[test]
 fn completed_deletions_remove_entries_without_reloading_the_column() {
     let browser = Browser::new(Rc::new(FakeFileSource));
     browser.navigate(Location::local("/fixture"));

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -750,7 +750,8 @@ impl BrowserView {
     }
 
     pub fn confirm_delete(&self, permanent: bool) -> bool {
-        let entries = self.state.browser.selected_entries();
+        self.state.sync_mode_selection();
+        let entries = self.state.browser.deletion_entries();
         if entries.is_empty() {
             return false;
         }


### PR DESCRIPTION
## Description

Use the folder that opened the active column as the deletion target when that column has no selection. Also synchronize grid/explorer selection before resolving the delete target.

## Visual evidence

<img width="1282" height="706" alt="image" src="https://github.com/user-attachments/assets/a1eaba52-f454-4388-8e30-8c51426c9606" />

## How to test

1. Open a directory containing a subfolder, then enter that subfolder without selecting one of its children.
2. Press `Delete` and confirm the operation.

**Expected result:** The confirmation names the entered subfolder, and confirming moves it to Trash instead of silently doing nothing.

## Related issue

Closes #85
