### PR TITLE
refactor(ui): standardize dialogs and form controls

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,6 +47,15 @@ Dependencies point inward. A filesystem adapter must not manipulate widgets, and
 
 Models should distinguish “unknown/not loaded” from meaningful empty values.
 
+### Dialogs and form controls
+
+Action dialogs use the modal shell and themed form controls in `ui/controls.rs`. The shell owns
+header alignment, icon bezels, body and action spacing, focus treatment, and semantic accent or
+danger states; dialog-specific code supplies only content and behavior. The search palette remains a
+specialized command interface because its query field and results are one continuous keyboard
+surface. Settings remains a specialized navigable workspace rather than an action dialog. Native
+platform choosers, such as GTK's color dialog, are also kept native.
+
 ### Browser presentation modes
 
 Browser presentations consume the same `BrowserEvent` stream and send intents back to the same

--- a/src/style.css
+++ b/src/style.css
@@ -365,75 +365,11 @@ headerbar menubutton.header-action > button:focus-visible image {
   outline: none;
 }
 
-.delete-confirmation {
-  background: @theme_surface;
-  border: 1px solid alpha(@theme_accent, 0.22);
-  border-radius: 7px;
-  box-shadow: 0 18px 54px alpha(@theme_bg, 0.72);
-  color: @theme_text;
-}
 
-.delete-confirmation-content {
-  min-width: 480px;
-}
-
-.delete-confirmation-header {
-  border-bottom: 1px solid alpha(@theme_border, 0.22);
-  padding: 14px 20px;
-}
-
-.delete-confirmation-symbol {
-  background: alpha(@theme_danger, 0.14);
-  border-radius: 6px;
-  min-height: 40px;
-  min-width: 40px;
-}
-
-.delete-confirmation-title {
-  color: @theme_text;
-  font-size: 1.08em;
-  font-weight: 700;
-}
-
-.delete-confirmation-subtitle,
-.delete-confirmation-explanation,
 .delete-confirmation-file-metadata {
   color: @theme_dim_text;
 }
 
-.delete-confirmation-subtitle {
-  font-size: 0.82em;
-}
-
-.delete-confirmation-close {
-  background: transparent;
-  border: none;
-  border-radius: 5px;
-  box-shadow: none;
-  color: @theme_dim_text;
-  min-height: 28px;
-  min-width: 28px;
-  padding: 4px;
-}
-
-.delete-confirmation-close:hover {
-  background: alpha(@theme_muted, 0.56);
-  color: @theme_text;
-}
-
-.delete-confirmation-close:active {
-  background: alpha(@theme_muted, 0.78);
-  color: @theme_accent;
-}
-
-.delete-confirmation-close:focus-visible {
-  outline: 2px solid alpha(@theme_accent, 0.52);
-  outline-offset: 1px;
-}
-
-.delete-confirmation-body {
-  padding: 20px 20px 10px;
-}
 
 .delete-confirmation-list {
   background: alpha(@theme_highlight, 0.42);
@@ -460,91 +396,6 @@ headerbar menubutton.header-action > button:focus-visible image {
   font-size: 0.82em;
 }
 
-.collision-apply-all {
-  color: @theme_text;
-  padding-top: 2px;
-}
-
-.collision-apply-all check {
-  background: alpha(@theme_bg, 0.72);
-  border: 1px solid alpha(@theme_border, 0.72);
-  border-radius: 4px;
-  color: @theme_bg;
-}
-
-.collision-apply-all:hover check {
-  border-color: @theme_accent;
-}
-
-.collision-apply-all:checked check {
-  background: @theme_accent;
-  border-color: @theme_accent;
-  color: @theme_bg;
-}
-
-.collision-apply-all:focus-visible {
-  outline: 2px solid alpha(@theme_accent, 0.5);
-  outline-offset: 2px;
-}
-
-.delete-confirmation-actions {
-  border-top: 1px solid alpha(@theme_border, 0.22);
-  padding: 10px 20px 12px;
-}
-
-.delete-confirmation-actions button {
-  border-radius: 5px;
-  box-shadow: none;
-  min-height: 26px;
-  padding: 2px 11px;
-}
-
-.delete-confirmation-cancel {
-  background: transparent;
-  border: 1px solid alpha(@theme_border, 0.54);
-  color: @theme_text;
-}
-
-.delete-confirmation-cancel:hover {
-  background: alpha(@theme_muted, 0.62);
-  border-color: @theme_text;
-  color: @theme_text;
-}
-
-.delete-confirmation-cancel:active {
-  background: alpha(@theme_muted, 0.82);
-  border-color: @theme_accent;
-  color: @theme_accent;
-}
-
-.delete-confirmation-cancel:focus-visible {
-  border-color: @theme_accent;
-  outline: 2px solid alpha(@theme_accent, 0.5);
-  outline-offset: 1px;
-}
-
-.delete-confirmation-delete {
-  background: alpha(@theme_danger, 0.1);
-  border: 1px solid @theme_danger;
-  color: @theme_danger;
-}
-
-.delete-confirmation-delete:hover {
-  background: alpha(@theme_danger, 0.18);
-  border-color: @theme_danger;
-  color: @theme_danger;
-}
-
-.delete-confirmation-delete:active {
-  background: alpha(@theme_danger, 0.28);
-  border-color: @theme_danger;
-  color: @theme_danger;
-}
-
-.delete-confirmation-delete:focus-visible {
-  border-color: @theme_danger;
-  outline-color: @theme_accent;
-}
 
 .action-dialog {
   background: @theme_surface;
@@ -569,6 +420,19 @@ headerbar menubutton.header-action > button:focus-visible image {
   min-width: 40px;
 }
 
+.action-dialog-symbol.danger {
+  background: alpha(@theme_danger, 0.14);
+  border-color: alpha(@theme_danger, 0.32);
+}
+
+.action-dialog.wide {
+  min-width: 520px;
+}
+
+.action-dialog.compact {
+  min-width: 440px;
+}
+
 .action-dialog-title {
   color: @theme_text;
   font-size: 1.08em;
@@ -576,7 +440,9 @@ headerbar menubutton.header-action > button:focus-visible image {
 }
 
 .action-dialog-subtitle,
-.action-dialog-field-label {
+.action-dialog-field-label,
+.action-dialog-description,
+.modal-progress-status {
   color: @theme_dim_text;
 }
 
@@ -633,7 +499,11 @@ headerbar menubutton.header-action > button:focus-visible image {
 .action-dialog-cancel {
   background: transparent;
   border: 1px solid alpha(@theme_border, 0.54);
+  border-radius: 5px;
+  box-shadow: none;
   color: @theme_text;
+  min-height: 26px;
+  padding: 2px 11px;
 }
 
 .action-dialog-cancel:hover {
@@ -656,7 +526,11 @@ headerbar menubutton.header-action > button:focus-visible image {
 .action-dialog-confirm {
   background: alpha(@theme_accent, 0.1);
   border: 1px solid @theme_accent;
+  border-radius: 5px;
+  box-shadow: none;
   color: @theme_accent;
+  min-height: 26px;
+  padding: 2px 11px;
 }
 
 .action-dialog-confirm:hover {
@@ -670,6 +544,98 @@ headerbar menubutton.header-action > button:focus-visible image {
 .action-dialog-confirm:focus-visible {
   outline: 2px solid @theme_accent;
   outline-offset: 1px;
+}
+
+.action-dialog-confirm.danger {
+  background: alpha(@theme_danger, 0.1);
+  border-color: @theme_danger;
+  color: @theme_danger;
+}
+
+.action-dialog-confirm.danger:hover {
+  background: alpha(@theme_danger, 0.18);
+}
+
+.action-dialog-confirm.danger:active {
+  background: alpha(@theme_danger, 0.28);
+}
+
+.action-dialog-confirm.danger:focus-visible {
+  outline-color: @theme_accent;
+}
+
+.action-dialog-cancel:disabled,
+.action-dialog-confirm:disabled,
+.action-dialog-close:disabled {
+  background: alpha(@theme_muted, 0.3);
+  border-color: alpha(@theme_border, 0.38);
+  color: @theme_dim_text;
+  opacity: 0.7;
+}
+
+.form-check {
+  color: @theme_text;
+  padding-top: 2px;
+}
+
+.form-check check {
+  background: alpha(@theme_bg, 0.72);
+  border: 1px solid alpha(@theme_border, 0.72);
+  border-radius: 4px;
+  color: @theme_bg;
+}
+
+.form-check:hover check {
+  border-color: @theme_accent;
+}
+
+.form-check:checked check {
+  background: @theme_accent;
+  border-color: @theme_accent;
+  color: @theme_bg;
+}
+
+.form-check:focus-visible {
+  outline: 2px solid @theme_accent;
+  outline-offset: 2px;
+}
+
+.form-check:disabled {
+  color: @theme_dim_text;
+  opacity: 0.7;
+}
+
+.form-message {
+  border-radius: 5px;
+  font-size: 0.82em;
+  padding: 7px 9px;
+}
+
+.form-message.error,
+.authentication-error {
+  background: alpha(@theme_danger, 0.1);
+  border: 1px solid alpha(@theme_danger, 0.5);
+  color: @theme_danger;
+}
+
+.form-message.warning {
+  background: alpha(@theme_accent, 0.1);
+  border: 1px solid alpha(@theme_accent, 0.46);
+  color: @theme_accent;
+}
+
+.modal-progress trough {
+  background: alpha(@theme_bg, 0.72);
+  border: 1px solid alpha(@theme_border, 0.42);
+  border-radius: 5px;
+  min-height: 8px;
+}
+
+.modal-progress progress {
+  background: @theme_accent;
+  border: none;
+  border-radius: 4px;
+  min-height: 8px;
 }
 
 entry.form-control {
@@ -694,6 +660,11 @@ entry.form-control:focus-within {
   box-shadow: 0 0 0 1px alpha(@theme_accent, 0.42);
   outline: 2px solid @theme_accent;
   outline-offset: -2px;
+}
+
+entry.form-control placeholder {
+  color: @theme_dim_text;
+  opacity: 1;
 }
 
 entry.form-control selection {
@@ -751,35 +722,11 @@ dropdown.form-control:disabled > button {
   min-width: 500px;
 }
 
-.update-dialog-header {
-  border-bottom: 1px solid alpha(@theme_border, 0.28);
-  padding: 18px 20px;
-}
 
-.update-dialog-symbol {
-  background: alpha(@theme_accent, 0.12);
-  border: 1px solid alpha(@theme_accent, 0.32);
-  border-radius: 7px;
-  color: @theme_accent;
-  min-height: 40px;
-  min-width: 40px;
-}
-
-.update-dialog-title {
-  color: @theme_text;
-  font-size: 1.05em;
-  font-weight: 700;
-}
-
-.update-dialog-subtitle,
 .update-dialog-status {
   color: @theme_dim_text;
 }
 
-.update-dialog-body {
-  background: alpha(@theme_bg, 0.3);
-  padding: 16px 20px;
-}
 
 .update-dialog-notes {
   background: alpha(@theme_bg, 0.55);
@@ -808,36 +755,6 @@ dropdown.form-control:disabled > button {
   background: @theme_danger;
 }
 
-.update-dialog-actions {
-  border-top: 1px solid alpha(@theme_border, 0.28);
-  padding: 12px 20px;
-}
-
-.update-dialog-action {
-  background: alpha(@theme_accent, 0.12);
-  border: 1px solid alpha(@theme_accent, 0.6);
-  border-radius: 5px;
-  box-shadow: none;
-  color: @theme_accent;
-  min-height: 30px;
-  padding: 4px 14px;
-}
-
-.update-dialog-action:hover {
-  background: alpha(@theme_accent, 0.22);
-  border-color: @theme_accent;
-  color: @theme_accent;
-}
-
-.update-dialog-action:active {
-  background: alpha(@theme_accent, 0.32);
-  color: @theme_accent;
-}
-
-.update-dialog-action:focus-visible {
-  outline: 2px solid alpha(@theme_accent, 0.5);
-  outline-offset: 1px;
-}
 
 .settings-dialog {
   background: @theme_surface;
@@ -1580,28 +1497,11 @@ menubutton.column-header-action > button:focus-visible image {
   color: @theme_text;
 }
 
-.transfer-dialog {
-  background: @theme_surface;
-  border: 1px solid alpha(@theme_accent, 0.34);
-  border-radius: 7px;
-  box-shadow: 0 18px 54px alpha(@theme_bg, 0.76);
-  color: @theme_text;
-  min-width: 500px;
-}
-
-.transfer-header {
-  border-bottom: 1px solid alpha(@theme_border, 0.28);
-  padding: 14px 18px;
-}
 
 .authentication-dialog {
   min-width: 520px;
 }
 
-.authentication-symbol {
-  background: alpha(@theme_accent, 0.12);
-  border-color: alpha(@theme_accent, 0.34);
-}
 
 .authentication-body {
   background: alpha(@theme_bg, 0.18);
@@ -1672,92 +1572,12 @@ menubutton.column-header-action > button:focus-visible image {
 }
 
 .authentication-fields .form-control:disabled,
-.authentication-fields .transfer-field:disabled,
 .segmented-control-option:disabled {
   background: alpha(@theme_muted, 0.3);
   border-color: alpha(@theme_border, 0.38);
   color: @theme_dim_text;
 }
 
-.transfer-symbol {
-  background: alpha(@theme_highlight, 0.64);
-  border: 1px solid alpha(@theme_accent, 0.24);
-  border-radius: 6px;
-  min-height: 40px;
-  min-width: 40px;
-}
-
-.transfer-title {
-  color: @theme_text;
-  font-size: 1.08em;
-  font-weight: 700;
-}
-
-.transfer-subtitle,
-.transfer-field-label {
-  color: @theme_dim_text;
-}
-
-.transfer-subtitle {
-  font-size: 0.82em;
-}
-
-.transfer-close {
-  background: transparent;
-  border: none;
-  border-radius: 5px;
-  box-shadow: none;
-  color: @theme_dim_text;
-  min-height: 28px;
-  min-width: 28px;
-  padding: 4px;
-}
-
-.transfer-close:hover {
-  background: alpha(@theme_muted, 0.56);
-  color: @theme_text;
-}
-
-.transfer-close:active {
-  background: alpha(@theme_muted, 0.78);
-  color: @theme_accent;
-}
-
-.transfer-close:focus-visible {
-  outline: 2px solid alpha(@theme_accent, 0.52);
-  outline-offset: 1px;
-}
-
-.transfer-body {
-  padding: 18px 20px 16px;
-}
-
-.transfer-field-label {
-  font-size: 0.76em;
-  font-weight: 700;
-}
-
-.transfer-field {
-  background: alpha(@theme_bg, 0.72);
-  border: 1px solid alpha(@theme_border, 0.54);
-  border-radius: 5px;
-  color: @theme_text;
-  min-height: 34px;
-  padding: 3px 9px;
-}
-
-.transfer-field:focus,
-.transfer-field:focus-visible,
-.transfer-field:focus-within {
-  border-color: @theme_accent;
-  box-shadow: 0 0 0 1px alpha(@theme_accent, 0.42);
-  outline: none;
-}
-
-.transfer-field.error {
-  border-color: @theme_danger;
-  box-shadow: 0 0 0 1px alpha(@theme_danger, 0.4);
-}
 
 .transfer-suggestion-scroll,
 .transfer-suggestion-scroll viewport {
@@ -1799,124 +1619,11 @@ menubutton.column-header-action > button:focus-visible image {
   color: @theme_accent;
 }
 
-.transfer-error,
-.transfer-warning {
-  border-radius: 5px;
-  font-size: 0.82em;
-  padding: 7px 9px;
-}
-
-.transfer-error {
-  background: alpha(@theme_danger, 0.1);
-  border: 1px solid alpha(@theme_danger, 0.5);
-  color: @theme_danger;
-}
-
-.transfer-warning {
-  background: alpha(@theme_accent, 0.1);
-  border: 1px solid alpha(@theme_accent, 0.46);
-  color: @theme_accent;
-}
-
-.delete-progress-dialog {
-  min-width: 440px;
-}
-
-.delete-progress-status {
-  color: @theme_dim_text;
-}
-
-.delete-progress-bar trough {
-  background: alpha(@theme_bg, 0.72);
-  border: 1px solid alpha(@theme_border, 0.42);
-  border-radius: 5px;
-  min-height: 8px;
-}
-
-.delete-progress-bar progress {
-  background: @theme_accent;
-  border: none;
-  border-radius: 4px;
-  min-height: 8px;
-}
-
-.transfer-actions {
-  border-top: 1px solid alpha(@theme_border, 0.28);
-  padding: 11px 20px 13px;
-}
-
-.transfer-actions button {
-  border-radius: 5px;
-  box-shadow: none;
-  min-height: 28px;
-  padding: 3px 12px;
-}
-
-.transfer-cancel {
-  background: transparent;
-  border: 1px solid alpha(@theme_border, 0.54);
-  color: @theme_text;
-}
-
-.transfer-cancel:hover {
-  background: alpha(@theme_muted, 0.62);
-  border-color: @theme_text;
-}
-
-.transfer-cancel:active {
-  background: alpha(@theme_muted, 0.82);
-  border-color: @theme_accent;
-  color: @theme_accent;
-}
-
-.transfer-confirm {
-  background: alpha(@theme_accent, 0.14);
-  border: 1px solid @theme_accent;
-  color: @theme_accent;
-}
-
-.transfer-confirm:hover {
-  background: alpha(@theme_accent, 0.22);
-}
-
-.transfer-confirm:active {
-  background: alpha(@theme_accent, 0.32);
-}
-
-.transfer-cancel:focus-visible,
-.transfer-confirm:focus-visible {
-  outline: 2px solid alpha(@theme_accent, 0.5);
-  outline-offset: 1px;
-}
-
-.properties-dialog {
-  background: @theme_surface;
-  border: 1px solid alpha(@theme_accent, 0.36);
-  border-radius: 7px;
-  box-shadow: 0 18px 54px alpha(@theme_bg, 0.76);
-  color: @theme_text;
-}
-
 .properties-content {
   min-width: 382px;
 }
 
-.properties-header {
-  border-bottom: 1px solid alpha(@theme_border, 0.3);
-  padding: 14px 16px;
-}
 
-.properties-icon {
-  color: @theme_accent;
-}
-
-.properties-title {
-  color: @theme_text;
-  font-size: 1.05em;
-  font-weight: 700;
-}
-
-.properties-kind,
 .properties-row-label,
 .properties-section-title,
 .properties-permission-identity,
@@ -1924,35 +1631,6 @@ menubutton.column-header-action > button:focus-visible image {
   color: @theme_dim_text;
 }
 
-.properties-kind {
-  font-size: 0.82em;
-}
-
-.properties-close {
-  background: transparent;
-  border: none;
-  border-radius: 5px;
-  box-shadow: none;
-  color: @theme_dim_text;
-  min-height: 26px;
-  min-width: 26px;
-  padding: 3px;
-}
-
-.properties-close:hover {
-  background: alpha(@theme_muted, 0.56);
-  color: @theme_text;
-}
-
-.properties-close:active {
-  background: alpha(@theme_muted, 0.78);
-  color: @theme_accent;
-}
-
-.properties-close:focus-visible {
-  outline: 2px solid alpha(@theme_accent, 0.52);
-  outline-offset: 1px;
-}
 
 .properties-details {
   padding: 8px 16px 10px;
@@ -2480,25 +2158,6 @@ menubutton.column-header-action > button:focus-visible image {
   padding: 16px;
 }
 
-.theme-name,
-.theme-name:focus {
-  background: @theme_bg;
-  border: 1px solid alpha(@theme_border, 0.7);
-  box-shadow: none;
-  color: @theme_text;
-  min-height: 30px;
-}
-
-.theme-name:focus {
-  border-color: @theme_accent;
-  box-shadow: 0 0 0 1px alpha(@theme_accent, 0.38);
-}
-
-.theme-name placeholder {
-  color: @theme_dim_text;
-  opacity: 1;
-}
-
 .theme-color-picker,
 .theme-color-picker:hover,
 .theme-color-picker:focus {
@@ -2524,37 +2183,6 @@ menubutton.column-header-action > button:focus-visible image {
   border-color: @theme_accent;
   box-shadow: none;
   padding: 0;
-}
-
-.theme-editor-cancel,
-.theme-editor-save {
-  border-radius: 5px;
-  box-shadow: none;
-  min-height: 30px;
-  padding: 3px 14px;
-}
-
-.theme-editor-cancel {
-  background: @theme_muted;
-  border: 1px solid alpha(@theme_border, 0.7);
-  color: @theme_text;
-}
-
-.theme-editor-cancel:hover {
-  background: @theme_highlight;
-  border-color: @theme_border;
-}
-
-.theme-editor-save {
-  background: @theme_accent;
-  border: 1px solid @theme_accent;
-  color: @theme_bg;
-}
-
-.theme-editor-save:hover {
-  background: @theme_text;
-  border-color: @theme_text;
-  color: @theme_bg;
 }
 
 .theme-editor-error {

--- a/src/style.css
+++ b/src/style.css
@@ -630,10 +630,10 @@ headerbar menubutton.header-action > button:focus-visible image {
   color: @theme_accent;
 }
 
-.message-dialog-loading {
+.action-dialog-loading {
   color: @theme_accent;
-  min-height: 20px;
-  min-width: 20px;
+  min-height: 18px;
+  min-width: 18px;
 }
 
 .modal-progress trough {

--- a/src/style.css
+++ b/src/style.css
@@ -27,6 +27,12 @@ headerbar {
   min-width: 8em;
 }
 
+.global-activity-spinner {
+  color: @theme_accent;
+  min-height: 16px;
+  min-width: 16px;
+}
+
 headerbar .sidebar-toggle {
   color: @theme_accent;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -630,6 +630,12 @@ headerbar menubutton.header-action > button:focus-visible image {
   color: @theme_accent;
 }
 
+.message-dialog-loading {
+  color: @theme_accent;
+  min-height: 20px;
+  min-width: 20px;
+}
+
 .modal-progress trough {
   background: alpha(@theme_bg, 0.72);
   border: 1px solid alpha(@theme_border, 0.42);

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -1678,15 +1678,11 @@ impl ViewState {
         let explanation = message_dialog_description(
             "Everything in Trash will be permanently deleted. This action cannot be undone.",
         );
-        let loading = gtk::Spinner::new();
-        loading.add_css_class("message-dialog-loading");
-        loading.set_halign(gtk::Align::Start);
-        loading.set_tooltip_text(Some("Calculating Trash contents…"));
-        loading.start();
-        layout.body.append(&loading);
+        layout.set_loading(true, Some("Calculating Trash contents…"));
         layout.body.append(&explanation);
         layout.confirm.set_sensitive(false);
         let subtitle = layout.subtitle.clone();
+        let loading = layout.loading.clone();
         let content = layout.content;
         let close = layout.close;
         let cancel = layout.cancel;

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -25,7 +25,10 @@ use crate::{
 use super::{
     blur::BlurBin,
     browser_modes::{BrowserDensity, BrowserMode, ModeViews},
-    controls::{form_entry, form_password_entry, modal_layout, segmented_control},
+    controls::{
+        ModalTone, form_check_button, form_entry, form_label, form_password_entry, modal_layout,
+        modal_layout_with_tone, segmented_control,
+    },
     motion::{animations_enabled, emphasized_deceleration},
 };
 
@@ -999,69 +1002,33 @@ impl ViewState {
         }
 
         let name = source.display_name();
-        let content = gtk::Box::new(gtk::Orientation::Vertical, 0);
-        content.add_css_class("delete-confirmation");
-        content.add_css_class("delete-confirmation-content");
-        content.set_halign(gtk::Align::Center);
-        content.set_valign(gtk::Align::Center);
-        let header = gtk::Box::new(gtk::Orientation::Horizontal, 12);
-        header.add_css_class("delete-confirmation-header");
-        let symbol = gtk::CenterBox::new();
-        symbol.add_css_class("delete-confirmation-symbol");
-        symbol.set_size_request(40, 40);
-        symbol.set_center_widget(Some(&crate::assets::danger_icon(
+        let layout = modal_layout_with_tone(
             crate::assets::icons::COPY,
-            20,
-        )));
-        let heading = gtk::Box::new(gtk::Orientation::Vertical, 1);
-        heading.set_hexpand(true);
-        heading.set_valign(gtk::Align::Center);
-        let title = gtk::Label::new(Some("File already exists"));
-        title.add_css_class("delete-confirmation-title");
-        title.set_xalign(0.0);
-        let subtitle = gtk::Label::new(Some(&name));
-        subtitle.add_css_class("delete-confirmation-subtitle");
-        subtitle.set_ellipsize(gtk::pango::EllipsizeMode::Middle);
-        subtitle.set_xalign(0.0);
-        heading.append(&title);
-        heading.append(&subtitle);
-        header.append(&symbol);
-        header.append(&heading);
-        content.append(&header);
-
-        let body = gtk::Box::new(gtk::Orientation::Vertical, 12);
-        body.add_css_class("delete-confirmation-body");
+            "File already exists",
+            &name,
+            "Replace",
+            ModalTone::Danger,
+        );
         let explanation = gtk::Label::new(Some(&format!(
             "An item named “{name}” already exists in {}. Replacing it will overwrite its contents.",
             compact_display_path(&destination)
         )));
-        explanation.add_css_class("delete-confirmation-explanation");
+        explanation.add_css_class("action-dialog-description");
         explanation.set_max_width_chars(64);
         explanation.set_wrap(true);
         explanation.set_xalign(0.0);
-        body.append(&explanation);
-        let apply_all =
-            gtk::CheckButton::with_label("Apply this choice to all remaining conflicts");
-        apply_all.add_css_class("collision-apply-all");
+        layout.body.append(&explanation);
+        let apply_all = form_check_button("Apply this choice to all remaining conflicts");
         apply_all.set_visible(!collisions.is_empty());
-        body.append(&apply_all);
-        content.append(&body);
-
-        let actions = gtk::Box::new(gtk::Orientation::Horizontal, 8);
-        actions.add_css_class("delete-confirmation-actions");
-        let spacer = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-        spacer.set_hexpand(true);
-        let cancel = gtk::Button::with_label("Cancel");
-        cancel.add_css_class("delete-confirmation-cancel");
+        layout.body.append(&apply_all);
         let skip = gtk::Button::with_label("Skip");
-        skip.add_css_class("delete-confirmation-cancel");
-        let replace = gtk::Button::with_label("Replace");
-        replace.add_css_class("delete-confirmation-delete");
-        actions.append(&spacer);
-        actions.append(&cancel);
-        actions.append(&skip);
-        actions.append(&replace);
-        content.append(&actions);
+        skip.add_css_class("action-dialog-cancel");
+        layout
+            .actions
+            .insert_child_after(&skip, Some(&layout.cancel));
+        let content = layout.content;
+        let cancel = layout.cancel;
+        let replace = layout.confirm;
 
         let layer = modal_layer(&content);
         window_overlay.add_overlay(&layer);
@@ -1252,62 +1219,32 @@ impl ViewState {
             .active_location()
             .and_then(|location| location.native_path().map(Path::to_path_buf))
             .unwrap_or_else(glib::home_dir);
-        let content = gtk::Box::new(gtk::Orientation::Vertical, 0);
-        content.add_css_class("transfer-dialog");
-        content.set_halign(gtk::Align::Center);
-        content.set_valign(gtk::Align::Center);
-
-        let header = gtk::Box::new(gtk::Orientation::Horizontal, 12);
-        header.add_css_class("transfer-header");
-        let symbol = gtk::CenterBox::new();
-        symbol.add_css_class("transfer-symbol");
-        symbol.set_center_widget(Some(&crate::assets::primary_icon(
+        let layout = modal_layout(
             if move_sources {
                 crate::assets::icons::FOLDER
             } else {
                 crate::assets::icons::COPY
             },
-            20,
-        )));
-        let heading = gtk::Box::new(gtk::Orientation::Vertical, 1);
-        heading.set_hexpand(true);
-        heading.set_valign(gtk::Align::Center);
-        let title = gtk::Label::new(Some(if move_sources { "Move to" } else { "Copy to" }));
-        title.add_css_class("transfer-title");
-        title.set_xalign(0.0);
-        let subtitle = gtk::Label::new(Some(&format!(
-            "Choose a destination for {}",
-            item_count_label(entries.len())
-        )));
-        subtitle.add_css_class("transfer-subtitle");
-        subtitle.set_xalign(0.0);
-        heading.append(&title);
-        heading.append(&subtitle);
-        let close = gtk::Button::new();
-        close.add_css_class("transfer-close");
-        close.set_tooltip_text(Some("Cancel"));
-        close.set_child(Some(&crate::assets::primary_icon(
-            crate::assets::icons::X,
-            16,
-        )));
-        header.append(&symbol);
-        header.append(&heading);
-        header.append(&close);
-        content.append(&header);
-
-        let body = gtk::Box::new(gtk::Orientation::Vertical, 8);
-        body.add_css_class("transfer-body");
-        let field_label = gtk::Label::new(Some("DESTINATION FOLDER"));
-        field_label.add_css_class("transfer-field-label");
-        field_label.set_xalign(0.0);
-        let field = gtk::Entry::new();
-        field.add_css_class("transfer-field");
+            if move_sources { "Move to" } else { "Copy to" },
+            &format!(
+                "Choose a destination for {}",
+                item_count_label(entries.len())
+            ),
+            if move_sources {
+                "Move here"
+            } else {
+                "Copy here"
+            },
+        );
+        layout.content.add_css_class("wide");
+        let field_label = form_label("Destination folder");
+        let field = form_entry();
         field.set_hexpand(true);
         field.set_placeholder_text(Some("Type a folder path…"));
         field.set_text(&folder_input_path(&base));
         field.set_position(-1);
-        body.append(&field_label);
-        body.append(&field);
+        layout.body.append(&field_label);
+        layout.body.append(&field);
 
         let suggestions = gtk::Box::new(gtk::Orientation::Vertical, 2);
         suggestions.add_css_class("transfer-suggestions");
@@ -1320,31 +1257,18 @@ impl ViewState {
             .propagate_natural_height(true)
             .build();
         suggestion_scroll.add_css_class("transfer-suggestion-scroll");
-        body.append(&suggestion_scroll);
+        layout.body.append(&suggestion_scroll);
         let error = gtk::Label::new(None);
-        error.add_css_class("transfer-error");
+        error.add_css_class("form-message");
+        error.add_css_class("error");
         error.set_wrap(true);
         error.set_xalign(0.0);
         error.set_visible(false);
-        body.append(&error);
-        content.append(&body);
-
-        let actions = gtk::Box::new(gtk::Orientation::Horizontal, 8);
-        actions.add_css_class("transfer-actions");
-        let spacer = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-        spacer.set_hexpand(true);
-        let cancel = gtk::Button::with_label("Cancel");
-        cancel.add_css_class("transfer-cancel");
-        let confirm = gtk::Button::with_label(if move_sources {
-            "Move here"
-        } else {
-            "Copy here"
-        });
-        confirm.add_css_class("transfer-confirm");
-        actions.append(&spacer);
-        actions.append(&cancel);
-        actions.append(&confirm);
-        content.append(&actions);
+        layout.body.append(&error);
+        let content = layout.content;
+        let close = layout.close;
+        let cancel = layout.cancel;
+        let confirm = layout.confirm;
 
         let generation = Rc::new(Cell::new(0_u64));
         let pending_creation = Rc::new(RefCell::new(None::<std::path::PathBuf>));
@@ -1358,8 +1282,8 @@ impl ViewState {
         field.connect_changed(move |field| {
             field.remove_css_class("error");
             suggestions_error.set_visible(false);
-            suggestions_error.remove_css_class("transfer-warning");
-            suggestions_error.add_css_class("transfer-error");
+            suggestions_error.remove_css_class("warning");
+            suggestions_error.add_css_class("error");
             changed_creation.borrow_mut().take();
             changed_confirm.set_label(if move_sources {
                 "Move here"
@@ -1413,8 +1337,8 @@ impl ViewState {
             let path =
                 resolve_destination_path(&confirm_field.text(), &confirm_base, &glib::home_dir());
             if path.exists() && !path.is_dir() {
-                confirm_error.remove_css_class("transfer-warning");
-                confirm_error.add_css_class("transfer-error");
+                confirm_error.remove_css_class("warning");
+                confirm_error.add_css_class("error");
                 confirm_error.set_text("The destination exists, but it is not a folder.");
                 confirm_error.set_visible(true);
                 confirm_field.add_css_class("error");
@@ -1423,8 +1347,8 @@ impl ViewState {
             }
             if !path.exists() && confirm_creation.borrow().as_ref() != Some(&path) {
                 confirm_creation.replace(Some(path.clone()));
-                confirm_error.remove_css_class("transfer-error");
-                confirm_error.add_css_class("transfer-warning");
+                confirm_error.remove_css_class("error");
+                confirm_error.add_css_class("warning");
                 confirm_error.set_text(&format!(
                     "{} does not exist. It will be created before the items are transferred.",
                     compact_native_path(&path)
@@ -1488,8 +1412,8 @@ impl ViewState {
                         created_creating.set(false);
                         created_cancel.set_sensitive(true);
                         created_close.set_sensitive(true);
-                        created_error.remove_css_class("transfer-warning");
-                        created_error.add_css_class("transfer-error");
+                        created_error.remove_css_class("warning");
+                        created_error.add_css_class("error");
                         created_error.set_text(&format!("Unable to create that folder: {error}"));
                         created_error.set_visible(true);
                         created_field.add_css_class("error");
@@ -1506,8 +1430,8 @@ impl ViewState {
                         created_creating.set(false);
                         created_cancel.set_sensitive(true);
                         created_close.set_sensitive(true);
-                        created_error.remove_css_class("transfer-warning");
-                        created_error.add_css_class("transfer-error");
+                        created_error.remove_css_class("warning");
+                        created_error.add_css_class("error");
                         created_error.set_text("Unable to create that folder.");
                         created_error.set_visible(true);
                         created_field.add_css_class("error");
@@ -1569,51 +1493,20 @@ impl ViewState {
             root.set_blurred(true);
         }
 
-        let content = gtk::Box::new(gtk::Orientation::Vertical, 0);
-        content.add_css_class("transfer-dialog");
-        content.add_css_class("delete-progress-dialog");
-        content.set_halign(gtk::Align::Center);
-        content.set_valign(gtk::Align::Center);
-        let header = gtk::Box::new(gtk::Orientation::Horizontal, 12);
-        header.add_css_class("transfer-header");
-        let symbol = gtk::CenterBox::new();
-        symbol.add_css_class("transfer-symbol");
-        symbol.set_center_widget(Some(&crate::assets::primary_icon(icon, 20)));
-        let heading = gtk::Box::new(gtk::Orientation::Vertical, 1);
-        heading.set_valign(gtk::Align::Center);
-        let title = gtk::Label::new(Some(title_text));
-        title.add_css_class("transfer-title");
-        title.set_xalign(0.0);
-        let subtitle = gtk::Label::new(Some(subtitle_text));
-        subtitle.add_css_class("transfer-subtitle");
-        subtitle.set_xalign(0.0);
-        heading.append(&title);
-        heading.append(&subtitle);
-        header.append(&symbol);
-        header.append(&heading);
-        content.append(&header);
-
-        let body = gtk::Box::new(gtk::Orientation::Vertical, 10);
-        body.add_css_class("transfer-body");
+        let layout = modal_layout(icon, title_text, subtitle_text, "Cancel");
+        layout.content.add_css_class("compact");
+        layout.close.set_visible(false);
+        layout.cancel.set_visible(false);
         let status = gtk::Label::new(Some("0%"));
-        status.add_css_class("delete-progress-status");
+        status.add_css_class("modal-progress-status");
         status.set_xalign(0.0);
         let progress = gtk::ProgressBar::new();
-        progress.add_css_class("delete-progress-bar");
+        progress.add_css_class("modal-progress");
         progress.set_fraction(0.0);
-        body.append(&status);
-        body.append(&progress);
-        content.append(&body);
-
-        let actions = gtk::Box::new(gtk::Orientation::Horizontal, 8);
-        actions.add_css_class("transfer-actions");
-        let spacer = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-        spacer.set_hexpand(true);
-        let cancel = gtk::Button::with_label("Cancel");
-        cancel.add_css_class("transfer-cancel");
-        actions.append(&spacer);
-        actions.append(&cancel);
-        content.append(&actions);
+        layout.body.append(&status);
+        layout.body.append(&progress);
+        let content = layout.content;
+        let cancel = layout.confirm;
 
         let layer = modal_layer(&content);
         window_overlay.add_overlay(&layer);
@@ -1718,70 +1611,28 @@ impl ViewState {
             root.set_blurred(true);
         }
 
-        let content = gtk::Box::new(gtk::Orientation::Vertical, 0);
-        content.add_css_class("delete-confirmation");
-        content.add_css_class("delete-confirmation-content");
-        content.set_halign(gtk::Align::Center);
-        content.set_valign(gtk::Align::Center);
-        let header = gtk::Box::new(gtk::Orientation::Horizontal, 12);
-        header.add_css_class("delete-confirmation-header");
-        let symbol = gtk::CenterBox::new();
-        symbol.add_css_class("delete-confirmation-symbol");
-        symbol.set_size_request(40, 40);
-        symbol.set_center_widget(Some(&crate::assets::danger_icon(
+        let layout = modal_layout_with_tone(
             crate::assets::icons::TRASH,
-            21,
-        )));
-        let heading = gtk::Box::new(gtk::Orientation::Vertical, 1);
-        heading.set_hexpand(true);
-        heading.set_valign(gtk::Align::Center);
-        let title = gtk::Label::new(Some("Empty Trash?"));
-        title.add_css_class("delete-confirmation-title");
-        title.set_xalign(0.0);
-        let subtitle = gtk::Label::new(Some(&format!(
-            "{} · {} will be reclaimed",
-            item_count_label(summary.item_count),
-            format_file_size(summary.total_size)
-        )));
-        subtitle.add_css_class("delete-confirmation-subtitle");
-        subtitle.set_xalign(0.0);
-        heading.append(&title);
-        heading.append(&subtitle);
-        let close = gtk::Button::new();
-        close.add_css_class("delete-confirmation-close");
-        close.set_tooltip_text(Some("Cancel"));
-        close.set_child(Some(&crate::assets::primary_icon(
-            crate::assets::icons::X,
-            16,
-        )));
-        header.append(&symbol);
-        header.append(&heading);
-        header.append(&close);
-        content.append(&header);
-
-        let body = gtk::Box::new(gtk::Orientation::Vertical, 0);
-        body.add_css_class("delete-confirmation-body");
+            "Empty Trash?",
+            &format!(
+                "{} · {} will be reclaimed",
+                item_count_label(summary.item_count),
+                format_file_size(summary.total_size)
+            ),
+            "Empty Trash",
+            ModalTone::Danger,
+        );
         let explanation = gtk::Label::new(Some(
             "Everything in Trash will be permanently deleted. This action cannot be undone.",
         ));
-        explanation.add_css_class("delete-confirmation-explanation");
+        explanation.add_css_class("action-dialog-description");
         explanation.set_wrap(true);
         explanation.set_xalign(0.0);
-        body.append(&explanation);
-        content.append(&body);
-
-        let actions = gtk::Box::new(gtk::Orientation::Horizontal, 8);
-        actions.add_css_class("delete-confirmation-actions");
-        let spacer = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-        spacer.set_hexpand(true);
-        let cancel = gtk::Button::with_label("Cancel");
-        cancel.add_css_class("delete-confirmation-cancel");
-        let empty = gtk::Button::with_label("Empty Trash");
-        empty.add_css_class("delete-confirmation-delete");
-        actions.append(&spacer);
-        actions.append(&cancel);
-        actions.append(&empty);
-        content.append(&actions);
+        layout.body.append(&explanation);
+        let content = layout.content;
+        let close = layout.close;
+        let cancel = layout.cancel;
+        let empty = layout.confirm;
 
         let layer = modal_layer(&content);
         window_overlay.add_overlay(&layer);
@@ -1856,46 +1707,23 @@ impl ViewState {
         }
 
         let count = entries.len();
-        let content = gtk::Box::new(gtk::Orientation::Vertical, 0);
-        content.add_css_class("delete-confirmation");
-        content.add_css_class("delete-confirmation-content");
-        content.set_halign(gtk::Align::Center);
-        content.set_valign(gtk::Align::Center);
-
-        let header = gtk::Box::new(gtk::Orientation::Horizontal, 12);
-        header.add_css_class("delete-confirmation-header");
-        let symbol = gtk::CenterBox::new();
-        symbol.add_css_class("delete-confirmation-symbol");
-        symbol.set_size_request(40, 40);
-        symbol.set_hexpand(false);
-        let symbol_icon = crate::assets::danger_icon(crate::assets::icons::TRASH, 21);
-        symbol.set_center_widget(Some(&symbol_icon));
-        let heading = gtk::Box::new(gtk::Orientation::Vertical, 1);
-        heading.set_hexpand(true);
-        heading.set_valign(gtk::Align::Center);
-        let question = gtk::Label::new(Some(&if permanent {
+        let title = if permanent {
             format!("Permanently delete {}?", item_count_label(count))
         } else {
             format!("Move {} to trash?", item_count_label(count))
-        }));
-        question.add_css_class("delete-confirmation-title");
-        question.set_xalign(0.0);
-        let subtitle = gtk::Label::new(Some(&entry_kind_summary(&entries)));
-        subtitle.add_css_class("delete-confirmation-subtitle");
-        subtitle.set_xalign(0.0);
-        heading.append(&question);
-        heading.append(&subtitle);
-        let close = gtk::Button::new();
-        close.add_css_class("delete-confirmation-close");
-        close.set_tooltip_text(Some("Cancel"));
-        close.set_child(Some(&crate::assets::text_icon(crate::assets::icons::X, 16)));
-        header.append(&symbol);
-        header.append(&heading);
-        header.append(&close);
-        content.append(&header);
-
-        let body = gtk::Box::new(gtk::Orientation::Vertical, 12);
-        body.add_css_class("delete-confirmation-body");
+        };
+        let confirm_label = if permanent {
+            format!("Permanently delete {}", item_count_label(count))
+        } else {
+            format!("Move {}", item_count_label(count))
+        };
+        let layout = modal_layout_with_tone(
+            crate::assets::icons::TRASH,
+            &title,
+            &entry_kind_summary(&entries),
+            &confirm_label,
+            ModalTone::Danger,
+        );
         let files = gtk::Box::new(gtk::Orientation::Vertical, 3);
         files.add_css_class("delete-confirmation-files");
         for entry in &entries {
@@ -1934,38 +1762,20 @@ impl ViewState {
             .propagate_natural_height(true)
             .build();
         file_scroller.add_css_class("delete-confirmation-list");
-        body.append(&file_scroller);
+        layout.body.append(&file_scroller);
         let explanation = gtk::Label::new(Some(if permanent {
             "These items will be permanently deleted. This action cannot be undone."
         } else {
             "The items will be moved to trash. You can restore them later."
         }));
-        explanation.add_css_class("delete-confirmation-explanation");
+        explanation.add_css_class("action-dialog-description");
         explanation.set_wrap(true);
         explanation.set_xalign(0.0);
-        body.append(&explanation);
-        content.append(&body);
-
-        let actions = gtk::Box::new(gtk::Orientation::Horizontal, 8);
-        actions.add_css_class("delete-confirmation-actions");
-        let action_spacer = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-        action_spacer.set_hexpand(true);
-        let cancel = gtk::Button::with_label("Cancel");
-        cancel.add_css_class("delete-confirmation-cancel");
-        let confirm_label = if permanent {
-            format!("Permanently delete {}", item_count_label(count))
-        } else {
-            format!("Move {}", item_count_label(count))
-        };
-        let confirm_content = gtk::Box::new(gtk::Orientation::Horizontal, 6);
-        confirm_content.append(&crate::assets::danger_icon(crate::assets::icons::TRASH, 15));
-        confirm_content.append(&gtk::Label::new(Some(&confirm_label)));
-        let confirm = gtk::Button::builder().child(&confirm_content).build();
-        confirm.add_css_class("delete-confirmation-delete");
-        actions.append(&action_spacer);
-        actions.append(&cancel);
-        actions.append(&confirm);
-        content.append(&actions);
+        layout.body.append(&explanation);
+        let content = layout.content;
+        let close = layout.close;
+        let cancel = layout.cancel;
+        let confirm = layout.confirm;
 
         let layer = modal_layer(&content);
         window_overlay.add_overlay(&layer);
@@ -2121,39 +1931,29 @@ impl ViewState {
         let subtitle = entry_kind_summary(&entries);
         let (body, confirm, dismiss) = self.build_archive_modal(&title, &subtitle, "Compress");
 
-        let name_label = gtk::Label::new(Some("Archive name"));
-        name_label.add_css_class("action-dialog-field-label");
-        name_label.set_xalign(0.0);
+        let name_label = form_label("Archive name");
         let name_entry = form_entry();
         name_entry.set_text(&default_name);
         body.append(&name_label);
         body.append(&name_entry);
 
-        let format_label = gtk::Label::new(Some("Format"));
-        format_label.add_css_class("action-dialog-field-label");
-        format_label.set_xalign(0.0);
+        let format_label = form_label("Format");
         let (format_control, format_options) =
             segmented_control(&["ZIP", "7Z", "TAR.GZ", "TAR"], 0);
         let selected_format = Rc::new(Cell::new(ArchiveFormat::Zip));
         body.append(&format_label);
         body.append(&format_control);
 
-        let protection_label = gtk::Label::new(Some("Protection"));
-        protection_label.add_css_class("action-dialog-field-label");
-        protection_label.set_xalign(0.0);
+        let protection_label = form_label("Protection");
         let (protection_control, protection_options) =
             segmented_control(&["No password", "Password protected"], 0);
         let no_password = protection_options[0].clone();
         let password_protected = protection_options[1].clone();
 
-        let password_label = gtk::Label::new(Some("Password"));
-        password_label.add_css_class("action-dialog-field-label");
-        password_label.set_xalign(0.0);
+        let password_label = form_label("Password");
         let password_entry = form_password_entry();
         password_entry.set_show_peek_icon(true);
-        let confirm_label = gtk::Label::new(Some("Confirm password"));
-        confirm_label.add_css_class("action-dialog-field-label");
-        confirm_label.set_xalign(0.0);
+        let confirm_label = form_label("Confirm password");
         let confirm_entry = form_password_entry();
         confirm_entry.set_show_peek_icon(true);
         let password_fields = gtk::Box::new(gtk::Orientation::Vertical, 6);
@@ -2278,9 +2078,7 @@ impl ViewState {
             .unwrap_or_else(glib::home_dir);
         let (body, confirm, dismiss) =
             self.build_archive_modal("Extract to", &entry.display_name, "Extract here");
-        let field_label = gtk::Label::new(Some("Destination folder"));
-        field_label.add_css_class("action-dialog-field-label");
-        field_label.set_xalign(0.0);
+        let field_label = form_label("Destination folder");
         let field = form_entry();
         field.set_hexpand(true);
         field.set_placeholder_text(Some("Type a folder path…"));
@@ -2302,7 +2100,8 @@ impl ViewState {
         suggestion_scroll.add_css_class("transfer-suggestion-scroll");
         body.append(&suggestion_scroll);
         let error = gtk::Label::new(None);
-        error.add_css_class("transfer-error");
+        error.add_css_class("form-message");
+        error.add_css_class("error");
         error.set_wrap(true);
         error.set_xalign(0.0);
         error.set_visible(false);
@@ -2367,9 +2166,7 @@ impl ViewState {
         let (body, confirm, dismiss) =
             self.build_archive_modal("Extract", &entry.display_name, "Extract");
 
-        let password_label = gtk::Label::new(Some("Password"));
-        password_label.add_css_class("action-dialog-field-label");
-        password_label.set_xalign(0.0);
+        let password_label = form_label("Password");
         let password_entry = form_password_entry();
         password_entry.set_show_peek_icon(true);
         body.append(&password_label);
@@ -2411,38 +2208,20 @@ impl ViewState {
             .map(entry_icon)
             .unwrap_or(crate::assets::icons::FOLDER);
 
-        let content = gtk::Box::new(gtk::Orientation::Vertical, 0);
-        content.add_css_class("properties-dialog");
-        content.add_css_class("properties-content");
-        content.set_halign(gtk::Align::Center);
-        content.set_valign(gtk::Align::Center);
-        let header = gtk::Box::new(gtk::Orientation::Horizontal, 12);
-        header.add_css_class("properties-header");
-        let icon = crate::assets::primary_icon(icon_name, 30);
-        icon.add_css_class("properties-icon");
-        let heading = gtk::Box::new(gtk::Orientation::Vertical, 1);
-        heading.set_hexpand(true);
-        heading.set_valign(gtk::Align::Center);
-        let title = gtk::Label::new(Some(&name));
-        title.add_css_class("properties-title");
-        title.set_ellipsize(gtk::pango::EllipsizeMode::Middle);
-        title.set_xalign(0.0);
-        let kind = gtk::Label::new(Some(if is_directory { "Folder" } else { "File" }));
-        kind.add_css_class("properties-kind");
-        kind.set_xalign(0.0);
-        heading.append(&title);
-        heading.append(&kind);
-        let close = gtk::Button::new();
-        close.add_css_class("properties-close");
-        close.set_tooltip_text(Some("Close properties"));
-        close.set_child(Some(&crate::assets::primary_icon(
-            crate::assets::icons::X,
-            15,
-        )));
-        header.append(&icon);
-        header.append(&heading);
-        header.append(&close);
-        content.append(&header);
+        let layout = modal_layout(
+            icon_name,
+            &name,
+            if is_directory { "Folder" } else { "File" },
+            "Close",
+        );
+        layout.content.add_css_class("properties-content");
+        layout
+            .title
+            .set_ellipsize(gtk::pango::EllipsizeMode::Middle);
+        layout.cancel.set_visible(false);
+        layout.confirm.set_visible(false);
+        let kind = layout.subtitle.clone();
+        let close = layout.close.clone();
 
         let details = gtk::Box::new(gtk::Orientation::Vertical, 0);
         details.add_css_class("properties-details");
@@ -2490,7 +2269,7 @@ impl ViewState {
                 "No"
             },
         );
-        content.append(&details);
+        layout.body.append(&details);
 
         let permissions = gtk::Box::new(gtk::Orientation::Vertical, 8);
         permissions.add_css_class("properties-permissions");
@@ -2507,7 +2286,7 @@ impl ViewState {
         let owner = permission_row(&permissions, "Owner");
         let group = permission_row(&permissions, "Group");
         let others = permission_row(&permissions, "Others");
-        content.append(&permissions);
+        layout.body.append(&permissions);
 
         let actions = gtk::Box::new(gtk::Orientation::Horizontal, 6);
         actions.add_css_class("properties-actions");
@@ -2527,7 +2306,8 @@ impl ViewState {
         actions.append(&rename);
         actions.append(&pin);
         actions.append(&copy_path);
-        content.append(&actions);
+        layout.actions.prepend(&actions);
+        let content = layout.content;
 
         let layer = modal_layer(&content);
         window_overlay.add_overlay(&layer);
@@ -6397,48 +6177,14 @@ fn show_authentication_dialog(
         root.set_blurred(true);
     }
 
-    let content = gtk::Box::new(gtk::Orientation::Vertical, 0);
-    content.add_css_class("transfer-dialog");
-    content.add_css_class("authentication-dialog");
-    content.set_halign(gtk::Align::Center);
-    content.set_valign(gtk::Align::Center);
-
-    let header = gtk::Box::new(gtk::Orientation::Horizontal, 12);
-    header.add_css_class("transfer-header");
-    let symbol = gtk::CenterBox::new();
-    symbol.add_css_class("transfer-symbol");
-    symbol.add_css_class("authentication-symbol");
-    symbol.set_center_widget(Some(&crate::assets::primary_icon(
+    let layout = modal_layout(
         crate::assets::icons::KEY,
-        20,
-    )));
-    let heading = gtk::Box::new(gtk::Orientation::Vertical, 1);
-    heading.set_hexpand(true);
-    heading.set_valign(gtk::Align::Center);
-    let title = gtk::Label::new(Some("Authentication required"));
-    title.add_css_class("transfer-title");
-    title.set_xalign(0.0);
-    let subtitle = gtk::Label::new(Some("Sign in to access this network location"));
-    subtitle.add_css_class("transfer-subtitle");
-    subtitle.set_xalign(0.0);
-    heading.append(&title);
-    heading.append(&subtitle);
-    let close = gtk::Button::new();
-    close.add_css_class("transfer-close");
-    close.set_tooltip_text(Some("Cancel authentication"));
-    close.set_valign(gtk::Align::Center);
-    close.set_child(Some(&crate::assets::primary_icon(
-        crate::assets::icons::X,
-        16,
-    )));
-    header.append(&symbol);
-    header.append(&heading);
-    header.append(&close);
-    content.append(&header);
-
-    let body = gtk::Box::new(gtk::Orientation::Vertical, 14);
-    body.add_css_class("transfer-body");
-    body.add_css_class("authentication-body");
+        "Authentication required",
+        "Sign in to access this network location",
+        "Connect",
+    );
+    layout.content.add_css_class("wide");
+    layout.body.add_css_class("authentication-body");
     let explanation_text =
         wrap_dialog_text(message.trim(), AUTHENTICATION_TEXT_WIDTH_CHARS as usize);
     let explanation = gtk::Label::new(Some(&explanation_text));
@@ -6446,7 +6192,7 @@ fn show_authentication_dialog(
     explanation.set_max_width_chars(AUTHENTICATION_TEXT_WIDTH_CHARS);
     explanation.set_wrap(true);
     explanation.set_xalign(0.0);
-    body.append(&explanation);
+    layout.body.append(&explanation);
     if authentication_failed {
         let error_text = wrap_dialog_text(
             "Those credentials weren’t accepted. Check the username, domain, and password, then try again.",
@@ -6457,7 +6203,7 @@ fn show_authentication_dialog(
         error.set_max_width_chars(AUTHENTICATION_TEXT_WIDTH_CHARS);
         error.set_wrap(true);
         error.set_xalign(0.0);
-        body.append(&error);
+        layout.body.append(&error);
     }
 
     let credentials = gtk::Box::new(gtk::Orientation::Vertical, 10);
@@ -6486,40 +6232,24 @@ fn show_authentication_dialog(
     let anonymous = connect_as_buttons[1].clone();
     if flags.contains(gio::AskPasswordFlags::ANONYMOUS_SUPPORTED) {
         let connect_as = gtk::Box::new(gtk::Orientation::Vertical, 7);
-        let label = gtk::Label::new(Some("Connect as"));
-        label.add_css_class("transfer-field-label");
-        label.set_xalign(0.0);
-        connect_as.append(&label);
+        connect_as.append(&form_label("Connect as"));
         connect_as.append(&connect_as_control);
-        body.append(&connect_as);
+        layout.body.append(&connect_as);
     }
-    body.append(&credentials);
+    layout.body.append(&credentials);
 
     let (remember, remember_buttons) =
         segmented_control(&["Don't remember", "Until logout", "Forever"], 0);
     if flags.contains(gio::AskPasswordFlags::SAVING_SUPPORTED) {
         let remember_field = gtk::Box::new(gtk::Orientation::Vertical, 5);
-        let label = gtk::Label::new(Some("Password storage"));
-        label.add_css_class("transfer-field-label");
-        label.set_xalign(0.0);
-        remember_field.append(&label);
+        remember_field.append(&form_label("Password storage"));
         remember_field.append(&remember);
-        body.append(&remember_field);
+        layout.body.append(&remember_field);
     }
-    content.append(&body);
-
-    let actions = gtk::Box::new(gtk::Orientation::Horizontal, 8);
-    actions.add_css_class("transfer-actions");
-    let spacer = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-    spacer.set_hexpand(true);
-    let cancel = gtk::Button::with_label("Cancel");
-    cancel.add_css_class("transfer-cancel");
-    let connect = gtk::Button::with_label("Connect");
-    connect.add_css_class("transfer-confirm");
-    actions.append(&spacer);
-    actions.append(&cancel);
-    actions.append(&connect);
-    content.append(&actions);
+    let content = layout.content;
+    let close = layout.close;
+    let cancel = layout.cancel;
+    let connect = layout.confirm;
 
     let credential_widgets = [
         username.clone().upcast::<gtk::Widget>(),
@@ -6670,10 +6400,7 @@ fn wrap_dialog_text(text: &str, max_chars: usize) -> String {
 
 fn append_authentication_field(fields: &gtk::Box, label_text: &str, field: &impl IsA<gtk::Widget>) {
     let group = gtk::Box::new(gtk::Orientation::Vertical, 5);
-    let label = gtk::Label::new(Some(label_text));
-    label.add_css_class("transfer-field-label");
-    label.set_xalign(0.0);
-    group.append(&label);
+    group.append(&form_label(label_text));
     group.append(field);
     fields.append(&group);
 }
@@ -6939,68 +6666,28 @@ pub(super) fn show_error_dialog(parent: &impl IsA<gtk::Widget>, message: &str, d
         root.set_blurred(true);
     }
 
-    let content = gtk::Box::new(gtk::Orientation::Vertical, 0);
-    content.add_css_class("delete-confirmation");
-    content.add_css_class("delete-confirmation-content");
-    content.set_halign(gtk::Align::Center);
-    content.set_valign(gtk::Align::Center);
-
-    let header = gtk::Box::new(gtk::Orientation::Horizontal, 12);
-    header.add_css_class("delete-confirmation-header");
-    let symbol = gtk::CenterBox::new();
-    symbol.add_css_class("delete-confirmation-symbol");
-    symbol.set_size_request(40, 40);
-    symbol.set_center_widget(Some(&crate::assets::danger_icon(
+    let layout = modal_layout_with_tone(
         crate::assets::icons::X,
-        20,
-    )));
-    let heading = gtk::Box::new(gtk::Orientation::Vertical, 1);
-    heading.set_hexpand(true);
-    heading.set_valign(gtk::Align::Center);
-    let title = gtk::Label::new(Some(message));
-    title.add_css_class("delete-confirmation-title");
-    title.set_xalign(0.0);
-    let subtitle = gtk::Label::new(Some(if message == "Completed with errors" {
-        "Some items could not be processed"
-    } else {
-        "The operation could not be completed"
-    }));
-    subtitle.add_css_class("delete-confirmation-subtitle");
-    subtitle.set_xalign(0.0);
-    heading.append(&title);
-    heading.append(&subtitle);
-    let close_icon = gtk::Button::new();
-    close_icon.add_css_class("delete-confirmation-close");
-    close_icon.set_tooltip_text(Some("Close"));
-    close_icon.set_child(Some(&crate::assets::primary_icon(
-        crate::assets::icons::X,
-        16,
-    )));
-    header.append(&symbol);
-    header.append(&heading);
-    header.append(&close_icon);
-    content.append(&header);
-
-    let body = gtk::Box::new(gtk::Orientation::Vertical, 0);
-    body.add_css_class("delete-confirmation-body");
+        message,
+        if message == "Completed with errors" {
+            "Some items could not be processed"
+        } else {
+            "The operation could not be completed"
+        },
+        "Close",
+        ModalTone::Danger,
+    );
+    layout.cancel.set_visible(false);
     let explanation = gtk::Label::new(Some(detail));
-    explanation.add_css_class("delete-confirmation-explanation");
+    explanation.add_css_class("action-dialog-description");
     explanation.set_max_width_chars(64);
     explanation.set_wrap(true);
     explanation.set_xalign(0.0);
     explanation.set_selectable(true);
-    body.append(&explanation);
-    content.append(&body);
-
-    let actions = gtk::Box::new(gtk::Orientation::Horizontal, 8);
-    actions.add_css_class("delete-confirmation-actions");
-    let spacer = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-    spacer.set_hexpand(true);
-    let close = gtk::Button::with_label("Close");
-    close.add_css_class("delete-confirmation-cancel");
-    actions.append(&spacer);
-    actions.append(&close);
-    content.append(&actions);
+    layout.body.append(&explanation);
+    let content = layout.content;
+    let close_icon = layout.close;
+    let close = layout.confirm;
 
     let layer = modal_layer(&content);
     window_overlay.add_overlay(&layer);

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -1654,30 +1654,6 @@ impl ViewState {
     }
 
     fn load_trash_summary(self: &Rc<Self>) {
-        let weak = Rc::downgrade(self);
-        glib::MainContext::default().spawn_local(async move {
-            let trash = gio::File::for_uri("trash:///");
-            match summarize_trash(&trash).await {
-                Ok(summary) if !summary.entries.is_empty() => {
-                    if let Some(state) = weak.upgrade() {
-                        state.show_empty_trash_confirmation(summary);
-                    }
-                }
-                Ok(_) => {}
-                Err(error) => {
-                    if let Some(state) = weak.upgrade() {
-                        show_error_dialog(
-                            &state.overlay,
-                            "Unable to read Trash",
-                            &error.to_string(),
-                        );
-                    }
-                }
-            }
-        });
-    }
-
-    fn show_empty_trash_confirmation(self: &Rc<Self>, summary: TrashSummary) {
         let Some(window_overlay) = self
             .overlay
             .root()
@@ -1695,22 +1671,27 @@ impl ViewState {
         let layout = message_dialog_layout(
             crate::assets::icons::TRASH,
             "Empty Trash?",
-            &format!(
-                "{} · {} will be reclaimed",
-                item_count_label(summary.item_count),
-                format_file_size(summary.total_size)
-            ),
+            "Calculating items and size…",
             "Empty Trash",
             ModalTone::Danger,
         );
         let explanation = message_dialog_description(
             "Everything in Trash will be permanently deleted. This action cannot be undone.",
         );
+        let loading = gtk::Spinner::new();
+        loading.add_css_class("message-dialog-loading");
+        loading.set_halign(gtk::Align::Start);
+        loading.set_tooltip_text(Some("Calculating Trash contents…"));
+        loading.start();
+        layout.body.append(&loading);
         layout.body.append(&explanation);
+        layout.confirm.set_sensitive(false);
+        let subtitle = layout.subtitle.clone();
         let content = layout.content;
         let close = layout.close;
         let cancel = layout.cancel;
         let empty = layout.confirm;
+        let entries = Rc::new(RefCell::new(None::<Vec<FileEntry>>));
 
         let layer = modal_layer(&content);
         window_overlay.add_overlay(&layer);
@@ -1733,17 +1714,23 @@ impl ViewState {
         let empty_layer = layer.clone();
         let empty_overlay = window_overlay.clone();
         let empty_root = blurred_root.clone();
+        let empty_entries = entries.clone();
         let browser = self.browser.clone();
         empty.connect_clicked(move |_| {
+            let Some(entries) = empty_entries.borrow().clone() else {
+                return;
+            };
             dismiss_modal_layer(&empty_layer, &empty_overlay, empty_root.as_ref());
-            browser.delete(summary.entries.clone(), true);
+            if !entries.is_empty() {
+                browser.delete(entries, true);
+            }
             browser.focus_active();
         });
         let keys = gtk::EventControllerKey::new();
         let escape_layer = layer.clone();
         let focused_layer = layer.clone();
-        let escape_overlay = window_overlay;
-        let escape_root = blurred_root;
+        let escape_overlay = window_overlay.clone();
+        let escape_root = blurred_root.clone();
         let escape_browser = self.browser.clone();
         keys.connect_key_pressed(move |_, key, _, modifiers| {
             if key == gtk::gdk::Key::Escape {
@@ -1761,10 +1748,47 @@ impl ViewState {
             }
         });
         layer.add_controller(keys);
+        let initial_focus = cancel.clone();
         glib::idle_add_local_once(move || {
-            cancel.grab_focus();
-            if let Some(window) = cancel.root().and_downcast::<gtk::Window>() {
+            initial_focus.grab_focus();
+            if let Some(window) = initial_focus.root().and_downcast::<gtk::Window>() {
                 window.set_focus_visible(true);
+            }
+        });
+
+        let result_layer = layer.clone();
+        let result_overlay = window_overlay;
+        let result_root = blurred_root;
+        let result_parent = self.overlay.clone();
+        glib::MainContext::default().spawn_local(async move {
+            let result = summarize_trash(&gio::File::for_uri("trash:///")).await;
+            if result_layer.parent().is_none() {
+                return;
+            }
+            loading.stop();
+            loading.set_visible(false);
+            match result {
+                Ok(summary) if summary.entries.is_empty() => {
+                    subtitle.set_text("Trash is empty");
+                    explanation.set_text("There is nothing to delete.");
+                    empty.set_label("Close");
+                    empty.remove_css_class("danger");
+                    entries.replace(Some(Vec::new()));
+                    empty.set_sensitive(true);
+                }
+                Ok(summary) => {
+                    subtitle.set_text(&format!(
+                        "{} · {} will be reclaimed",
+                        item_count_label(summary.item_count),
+                        format_file_size(summary.total_size)
+                    ));
+                    entries.replace(Some(summary.entries));
+                    empty.set_sensitive(true);
+                }
+                Err(error) => {
+                    dismiss_modal_layer(&result_layer, &result_overlay, result_root.as_ref());
+                    show_error_dialog(&result_parent, "Unable to read Trash", &error.to_string());
+                }
             }
         });
     }

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -212,9 +212,47 @@ pub(super) enum PinStatus {
     Unavailable,
 }
 
+#[derive(Default)]
+struct GlobalActivityState {
+    next_id: u64,
+    active: Vec<(u64, String)>,
+}
+
+impl GlobalActivityState {
+    fn begin(&mut self, label: impl Into<String>) -> u64 {
+        self.next_id = self.next_id.saturating_add(1);
+        self.active.push((self.next_id, label.into()));
+        self.next_id
+    }
+
+    fn finish(&mut self, id: u64) {
+        self.active.retain(|(active_id, _)| *active_id != id);
+    }
+
+    fn current_label(&self) -> Option<&str> {
+        self.active.last().map(|(_, label)| label.as_str())
+    }
+}
+
+pub struct GlobalActivity {
+    state: std::rc::Weak<ViewState>,
+    id: u64,
+}
+
+impl Drop for GlobalActivity {
+    fn drop(&mut self) {
+        if let Some(state) = self.state.upgrade() {
+            state.finish_global_activity(self.id);
+        }
+    }
+}
+
 pub(super) struct ViewState {
     overlay: gtk::Overlay,
+    location_control: gtk::Box,
     location_stack: gtk::Stack,
+    global_activity_spinner: gtk::Spinner,
+    global_activity: RefCell<GlobalActivityState>,
     breadcrumbs: gtk::Box,
     location_entry: gtk::Entry,
     columns_widget: gtk::Box,
@@ -329,9 +367,19 @@ impl BrowserView {
         location_stack.add_named(&breadcrumb_scroller, Some("breadcrumbs"));
         location_stack.add_named(&entry_control, Some("entry"));
         location_stack.set_visible_child_name("breadcrumbs");
-        location_stack.add_css_class("location-control");
         location_stack.set_hexpand(true);
         location_stack.set_valign(gtk::Align::Center);
+
+        let global_activity_spinner = gtk::Spinner::new();
+        global_activity_spinner.add_css_class("global-activity-spinner");
+        global_activity_spinner.set_tooltip_text(Some("Working…"));
+        global_activity_spinner.set_visible(false);
+        let location_control = gtk::Box::new(gtk::Orientation::Horizontal, 6);
+        location_control.add_css_class("location-control");
+        location_control.set_hexpand(true);
+        location_control.set_valign(gtk::Align::Center);
+        location_control.append(&location_stack);
+        location_control.append(&global_activity_spinner);
 
         let preferences = super::theme::ThemeManager::shared();
         let browser = Browser::with_preferences(source, preferences.sort_preferences());
@@ -343,7 +391,10 @@ impl BrowserView {
         overlay.set_child(Some(&mode_views.widget()));
         let state = Rc::new(ViewState {
             overlay,
+            location_control,
             location_stack,
+            global_activity_spinner,
+            global_activity: RefCell::new(GlobalActivityState::default()),
             breadcrumbs,
             location_entry,
             columns_widget,
@@ -636,7 +687,12 @@ impl BrowserView {
     }
 
     pub fn location_widget(&self) -> gtk::Widget {
-        self.state.location_stack.clone().upcast()
+        self.state.location_control.clone().upcast()
+    }
+
+    /// Shows the shared header spinner until the returned activity guard is dropped.
+    pub fn begin_global_activity(&self, label: impl Into<String>) -> GlobalActivity {
+        self.state.begin_global_activity(label)
     }
 
     pub fn begin_location_edit(&self) {
@@ -846,6 +902,34 @@ impl BrowserView {
 }
 
 impl ViewState {
+    fn begin_global_activity(self: &Rc<Self>, label: impl Into<String>) -> GlobalActivity {
+        let label = label.into();
+        let id = self.global_activity.borrow_mut().begin(label.clone());
+        self.global_activity_spinner.set_tooltip_text(Some(&label));
+        self.global_activity_spinner.set_visible(true);
+        self.global_activity_spinner.start();
+        GlobalActivity {
+            state: Rc::downgrade(self),
+            id,
+        }
+    }
+
+    fn finish_global_activity(&self, id: u64) {
+        let current = {
+            let mut activity = self.global_activity.borrow_mut();
+            activity.finish(id);
+            activity.current_label().map(str::to_owned)
+        };
+        if let Some(label) = current {
+            self.global_activity_spinner.set_tooltip_text(Some(&label));
+        } else {
+            self.global_activity_spinner.stop();
+            self.global_activity_spinner.set_visible(false);
+            self.global_activity_spinner
+                .set_tooltip_text(Some("Working…"));
+        }
+    }
+
     fn sync_mode_selection(&self) {
         let Some((depth, positions)) = self.mode_views.borrow().selected_positions() else {
             return;
@@ -2764,6 +2848,10 @@ impl ViewState {
         if self.overlay.root().and_downcast::<gtk::Window>().is_none() {
             return;
         }
+        let activity = BrowserView {
+            state: self.clone(),
+        }
+        .begin_global_activity("Connecting…");
         let file = gio_file_for_location(&location);
         let operation = gio::MountOperation::new();
         let prompt_overlay = self.overlay.clone();
@@ -2816,6 +2904,7 @@ impl ViewState {
         let weak = Rc::downgrade(self);
         let result_overlay = self.overlay.clone();
         glib::MainContext::default().spawn_local(async move {
+            let _activity = activity;
             let result = match strategy {
                 MountStrategy::EnclosingVolume => {
                     file.mount_enclosing_volume_future(gio::MountMountFlags::NONE, Some(&operation))

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -26,8 +26,9 @@ use super::{
     blur::BlurBin,
     browser_modes::{BrowserDensity, BrowserMode, ModeViews},
     controls::{
-        ModalTone, form_check_button, form_entry, form_label, form_password_entry, modal_layout,
-        modal_layout_with_tone, segmented_control,
+        ModalTone, form_check_button, form_entry, form_label, form_password_entry,
+        message_dialog_description, message_dialog_layout, modal_layout, segmented_control,
+        wrap_dialog_text,
     },
     motion::{animations_enabled, emphasized_deceleration},
 };
@@ -1002,21 +1003,17 @@ impl ViewState {
         }
 
         let name = source.display_name();
-        let layout = modal_layout_with_tone(
+        let layout = message_dialog_layout(
             crate::assets::icons::COPY,
             "File already exists",
             &name,
             "Replace",
             ModalTone::Danger,
         );
-        let explanation = gtk::Label::new(Some(&format!(
+        let explanation = message_dialog_description(&format!(
             "An item named “{name}” already exists in {}. Replacing it will overwrite its contents.",
             compact_display_path(&destination)
-        )));
-        explanation.add_css_class("action-dialog-description");
-        explanation.set_max_width_chars(64);
-        explanation.set_wrap(true);
-        explanation.set_xalign(0.0);
+        ));
         layout.body.append(&explanation);
         let apply_all = form_check_button("Apply this choice to all remaining conflicts");
         apply_all.set_visible(!collisions.is_empty());
@@ -1611,7 +1608,7 @@ impl ViewState {
             root.set_blurred(true);
         }
 
-        let layout = modal_layout_with_tone(
+        let layout = message_dialog_layout(
             crate::assets::icons::TRASH,
             "Empty Trash?",
             &format!(
@@ -1622,12 +1619,9 @@ impl ViewState {
             "Empty Trash",
             ModalTone::Danger,
         );
-        let explanation = gtk::Label::new(Some(
+        let explanation = message_dialog_description(
             "Everything in Trash will be permanently deleted. This action cannot be undone.",
-        ));
-        explanation.add_css_class("action-dialog-description");
-        explanation.set_wrap(true);
-        explanation.set_xalign(0.0);
+        );
         layout.body.append(&explanation);
         let content = layout.content;
         let close = layout.close;
@@ -1717,7 +1711,7 @@ impl ViewState {
         } else {
             format!("Move {}", item_count_label(count))
         };
-        let layout = modal_layout_with_tone(
+        let layout = message_dialog_layout(
             crate::assets::icons::TRASH,
             &title,
             &entry_kind_summary(&entries),
@@ -1763,14 +1757,11 @@ impl ViewState {
             .build();
         file_scroller.add_css_class("delete-confirmation-list");
         layout.body.append(&file_scroller);
-        let explanation = gtk::Label::new(Some(if permanent {
+        let explanation = message_dialog_description(if permanent {
             "These items will be permanently deleted. This action cannot be undone."
         } else {
             "The items will be moved to trash. You can restore them later."
-        }));
-        explanation.add_css_class("action-dialog-description");
-        explanation.set_wrap(true);
-        explanation.set_xalign(0.0);
+        });
         layout.body.append(&explanation);
         let content = layout.content;
         let close = layout.close;
@@ -6380,24 +6371,6 @@ fn dismiss_authentication_prompt(browser_overlay: &gtk::Overlay, layer: &gtk::Bo
     dismiss_modal_layer(layer, &window_overlay, blurred_root.as_ref());
 }
 
-fn wrap_dialog_text(text: &str, max_chars: usize) -> String {
-    let mut wrapped = String::new();
-    let mut line_chars = 0;
-    for word in text.split_whitespace() {
-        let word_chars = word.chars().count();
-        if line_chars > 0 && line_chars + 1 + word_chars > max_chars {
-            wrapped.push('\n');
-            line_chars = 0;
-        } else if line_chars > 0 {
-            wrapped.push(' ');
-            line_chars += 1;
-        }
-        wrapped.push_str(word);
-        line_chars += word_chars;
-    }
-    wrapped
-}
-
 fn append_authentication_field(fields: &gtk::Box, label_text: &str, field: &impl IsA<gtk::Widget>) {
     let group = gtk::Box::new(gtk::Orientation::Vertical, 5);
     group.append(&form_label(label_text));
@@ -6666,7 +6639,7 @@ pub(super) fn show_error_dialog(parent: &impl IsA<gtk::Widget>, message: &str, d
         root.set_blurred(true);
     }
 
-    let layout = modal_layout_with_tone(
+    let layout = message_dialog_layout(
         crate::assets::icons::X,
         message,
         if message == "Completed with errors" {
@@ -6678,11 +6651,7 @@ pub(super) fn show_error_dialog(parent: &impl IsA<gtk::Widget>, message: &str, d
         ModalTone::Danger,
     );
     layout.cancel.set_visible(false);
-    let explanation = gtk::Label::new(Some(detail));
-    explanation.add_css_class("action-dialog-description");
-    explanation.set_max_width_chars(64);
-    explanation.set_wrap(true);
-    explanation.set_xalign(0.0);
+    let explanation = message_dialog_description(detail);
     explanation.set_selectable(true);
     layout.body.append(&explanation);
     let content = layout.content;

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -3,6 +3,19 @@
 use super::*;
 
 #[test]
+fn global_activity_uses_the_latest_active_label() {
+    let mut activity = GlobalActivityState::default();
+    let connecting = activity.begin("Connecting…");
+    let copying = activity.begin("Copying…");
+    assert_eq!(activity.current_label(), Some("Copying…"));
+
+    activity.finish(copying);
+    assert_eq!(activity.current_label(), Some("Connecting…"));
+    activity.finish(connecting);
+    assert_eq!(activity.current_label(), None);
+}
+
+#[test]
 fn file_sizes_use_compact_decimal_units() {
     assert_eq!(format_file_size(999), "999 B");
     assert_eq!(format_file_size(1_200), "1.2 kB");

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -33,6 +33,15 @@ fn dialog_copy_wraps_at_word_boundaries() {
 }
 
 #[test]
+fn dialog_copy_wraps_long_paths_without_spaces() {
+    let wrapped = wrap_dialog_text(&"a".repeat(80), 32);
+    assert_eq!(
+        wrapped.lines().map(str::len).collect::<Vec<_>>(),
+        [32, 32, 16]
+    );
+}
+
+#[test]
 fn password_storage_selection_maps_to_gio_values() {
     assert_eq!(password_save_for_selection(0), gio::PasswordSave::Never);
     assert_eq!(

--- a/src/ui/controls.rs
+++ b/src/ui/controls.rs
@@ -82,9 +82,24 @@ pub(super) struct ModalLayout {
     pub actions: gtk::Box,
     pub title: gtk::Label,
     pub subtitle: gtk::Label,
+    pub loading: gtk::Spinner,
     pub close: gtk::Button,
     pub cancel: gtk::Button,
     pub confirm: gtk::Button,
+}
+
+impl ModalLayout {
+    pub fn set_loading(&self, loading: bool, tooltip: Option<&str>) {
+        if loading {
+            self.loading.set_tooltip_text(tooltip.or(Some("Working…")));
+            self.loading.set_visible(true);
+            self.loading.start();
+        } else {
+            self.loading.stop();
+            self.loading.set_visible(false);
+            self.loading.set_tooltip_text(None);
+        }
+    }
 }
 
 /// Builds the shared structure and styling for an action modal.
@@ -163,6 +178,10 @@ pub(super) fn modal_layout_with_tone(
     heading.append(&title);
     heading.append(&subtitle);
 
+    let loading = gtk::Spinner::new();
+    loading.add_css_class("action-dialog-loading");
+    loading.set_visible(false);
+
     let close = gtk::Button::new();
     close.add_css_class("action-dialog-close");
     close.set_valign(gtk::Align::Center);
@@ -174,6 +193,7 @@ pub(super) fn modal_layout_with_tone(
 
     header.append(&symbol);
     header.append(&heading);
+    header.append(&loading);
     header.append(&close);
     content.append(&header);
 
@@ -203,6 +223,7 @@ pub(super) fn modal_layout_with_tone(
         actions,
         title,
         subtitle,
+        loading,
         close,
         cancel,
         confirm,

--- a/src/ui/controls.rs
+++ b/src/ui/controls.rs
@@ -14,9 +14,32 @@ pub(super) fn form_password_entry() -> gtk::PasswordEntry {
     entry
 }
 
+pub(super) fn form_label(text: &str) -> gtk::Label {
+    let label = gtk::Label::new(Some(text));
+    label.add_css_class("action-dialog-field-label");
+    label.set_xalign(0.0);
+    label
+}
+
+pub(super) fn form_check_button(label: &str) -> gtk::CheckButton {
+    let button = gtk::CheckButton::with_label(label);
+    button.add_css_class("form-check");
+    button
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(super) enum ModalTone {
+    #[default]
+    Accent,
+    Danger,
+}
+
 pub(super) struct ModalLayout {
     pub content: gtk::Box,
     pub body: gtk::Box,
+    pub actions: gtk::Box,
+    pub title: gtk::Label,
+    pub subtitle: gtk::Label,
     pub close: gtk::Button,
     pub cancel: gtk::Button,
     pub confirm: gtk::Button,
@@ -29,6 +52,16 @@ pub(super) fn modal_layout(
     subtitle: &str,
     confirm_label: &str,
 ) -> ModalLayout {
+    modal_layout_with_tone(icon, title, subtitle, confirm_label, ModalTone::Accent)
+}
+
+pub(super) fn modal_layout_with_tone(
+    icon: &str,
+    title: &str,
+    subtitle: &str,
+    confirm_label: &str,
+    tone: ModalTone,
+) -> ModalLayout {
     let content = gtk::Box::new(gtk::Orientation::Vertical, 0);
     content.add_css_class("action-dialog");
     content.set_halign(gtk::Align::Center);
@@ -40,9 +73,16 @@ pub(super) fn modal_layout(
 
     let symbol = gtk::CenterBox::new();
     symbol.add_css_class("action-dialog-symbol");
+    if tone == ModalTone::Danger {
+        symbol.add_css_class("danger");
+    }
     symbol.set_size_request(40, 40);
     symbol.set_hexpand(false);
-    symbol.set_center_widget(Some(&crate::assets::primary_icon(icon, 21)));
+    let icon = match tone {
+        ModalTone::Accent => crate::assets::primary_icon(icon, 21),
+        ModalTone::Danger => crate::assets::danger_icon(icon, 21),
+    };
+    symbol.set_center_widget(Some(&icon));
 
     let heading = gtk::Box::new(gtk::Orientation::Vertical, 1);
     heading.add_css_class("action-dialog-heading");
@@ -60,7 +100,7 @@ pub(super) fn modal_layout(
     let close = gtk::Button::new();
     close.add_css_class("action-dialog-close");
     close.set_valign(gtk::Align::Center);
-    close.set_tooltip_text(Some("Cancel"));
+    close.set_tooltip_text(Some("Close dialog"));
     close.set_child(Some(&crate::assets::primary_icon(
         crate::assets::icons::X,
         16,
@@ -83,6 +123,9 @@ pub(super) fn modal_layout(
     cancel.add_css_class("action-dialog-cancel");
     let confirm = gtk::Button::with_label(confirm_label);
     confirm.add_css_class("action-dialog-confirm");
+    if tone == ModalTone::Danger {
+        confirm.add_css_class("danger");
+    }
     actions.append(&spacer);
     actions.append(&cancel);
     actions.append(&confirm);
@@ -91,6 +134,9 @@ pub(super) fn modal_layout(
     ModalLayout {
         content,
         body,
+        actions,
+        title,
+        subtitle,
         close,
         cancel,
         confirm,

--- a/src/ui/controls.rs
+++ b/src/ui/controls.rs
@@ -34,6 +34,48 @@ pub(super) enum ModalTone {
     Danger,
 }
 
+pub(super) const MESSAGE_DIALOG_WIDTH_CHARS: usize = 64;
+
+pub(super) fn wrap_dialog_text(text: &str, max_chars: usize) -> String {
+    let mut wrapped = String::new();
+    let mut line_chars = 0;
+    for word in text.split_whitespace() {
+        let chunks = word
+            .chars()
+            .collect::<Vec<_>>()
+            .chunks(max_chars.max(1))
+            .map(|chunk| chunk.iter().collect::<String>())
+            .collect::<Vec<_>>();
+        for (index, chunk) in chunks.iter().enumerate() {
+            let chunk_chars = chunk.chars().count();
+            if line_chars > 0 && line_chars + 1 + chunk_chars > max_chars {
+                wrapped.push('\n');
+                line_chars = 0;
+            } else if line_chars > 0 {
+                wrapped.push(' ');
+                line_chars += 1;
+            }
+            wrapped.push_str(chunk);
+            line_chars += chunk_chars;
+            if index + 1 < chunks.len() {
+                wrapped.push('\n');
+                line_chars = 0;
+            }
+        }
+    }
+    wrapped
+}
+
+pub(super) fn message_dialog_description(text: &str) -> gtk::Label {
+    let label = gtk::Label::new(Some(&wrap_dialog_text(text, MESSAGE_DIALOG_WIDTH_CHARS)));
+    label.add_css_class("action-dialog-description");
+    label.set_max_width_chars(MESSAGE_DIALOG_WIDTH_CHARS as i32);
+    label.set_wrap(true);
+    label.set_wrap_mode(gtk::pango::WrapMode::WordChar);
+    label.set_xalign(0.0);
+    label
+}
+
 pub(super) struct ModalLayout {
     pub content: gtk::Box,
     pub body: gtk::Box,
@@ -53,6 +95,30 @@ pub(super) fn modal_layout(
     confirm_label: &str,
 ) -> ModalLayout {
     modal_layout_with_tone(icon, title, subtitle, confirm_label, ModalTone::Accent)
+}
+
+pub(super) fn message_dialog_layout(
+    icon: &str,
+    title: &str,
+    subtitle: &str,
+    confirm_label: &str,
+    tone: ModalTone,
+) -> ModalLayout {
+    let layout = modal_layout_with_tone(
+        icon,
+        &wrap_dialog_text(title, MESSAGE_DIALOG_WIDTH_CHARS),
+        &wrap_dialog_text(subtitle, MESSAGE_DIALOG_WIDTH_CHARS),
+        confirm_label,
+        tone,
+    );
+    layout.content.add_css_class("message-dialog");
+    layout.content.set_size_request(560, -1);
+    for label in [&layout.title, &layout.subtitle] {
+        label.set_max_width_chars(MESSAGE_DIALOG_WIDTH_CHARS as i32);
+        label.set_wrap(true);
+        label.set_wrap_mode(gtk::pango::WrapMode::WordChar);
+    }
+    layout
 }
 
 pub(super) fn modal_layout_with_tone(

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -20,6 +20,7 @@ mod tests;
 use super::{
     blur::BlurBin,
     browser::{BrowserView, dismiss_modal_layer, modal_layer},
+    controls::{form_entry, modal_layout},
     motion::set_reduce_motion,
     theme::{Theme, ThemeManager, ThemeTokens},
 };
@@ -817,40 +818,18 @@ pub(super) fn show_update_dialog(
         root.set_blurred(true);
     }
 
-    let content = gtk::Box::new(gtk::Orientation::Vertical, 0);
-    content.add_css_class("transfer-dialog");
-    content.add_css_class("update-dialog");
-    content.set_halign(gtk::Align::Center);
-    content.set_valign(gtk::Align::Center);
-    content.set_size_request(560, -1);
-    let header = gtk::Box::new(gtk::Orientation::Horizontal, 12);
-    header.add_css_class("update-dialog-header");
-    let symbol = gtk::CenterBox::new();
-    symbol.add_css_class("update-dialog-symbol");
-    symbol.set_size_request(40, 40);
-    symbol.set_valign(gtk::Align::Center);
-    symbol.set_center_widget(Some(&crate::assets::primary_icon(icons::DOWNLOADS, 20)));
-    let heading = gtk::Box::new(gtk::Orientation::Vertical, 2);
-    heading.set_valign(gtk::Align::Center);
-    let title = gtk::Label::new(Some(&format!("Strata v{} is available", release.version)));
-    title.add_css_class("update-dialog-title");
-    title.set_xalign(0.0);
-    let subtitle = gtk::Label::new(Some(&format!(
-        "Installed v{}  →  Available v{}",
-        env!("CARGO_PKG_VERSION"),
-        release.version
-    )));
-    subtitle.add_css_class("update-dialog-subtitle");
-    subtitle.set_xalign(0.0);
-    subtitle.set_wrap(true);
-    heading.append(&title);
-    heading.append(&subtitle);
-    header.append(&symbol);
-    header.append(&heading);
-    content.append(&header);
-
-    let body = gtk::Box::new(gtk::Orientation::Vertical, 10);
-    body.add_css_class("update-dialog-body");
+    let layout = modal_layout(
+        icons::DOWNLOADS,
+        &format!("Strata v{} is available", release.version),
+        &format!(
+            "Installed v{}  →  Available v{}",
+            env!("CARGO_PKG_VERSION"),
+            release.version
+        ),
+        "Download update",
+    );
+    layout.content.add_css_class("update-dialog");
+    layout.content.set_size_request(560, -1);
     let notes_heading = gtk::Label::new(Some("What’s new"));
     notes_heading.add_css_class("release-notes-title");
     notes_heading.set_xalign(0.0);
@@ -885,43 +864,62 @@ pub(super) fn show_update_dialog(
     progress.add_css_class("update-dialog-progress");
     progress.set_fraction(0.0);
     progress.set_visible(false);
-    body.append(&notes_heading);
-    body.append(&notes_scroll);
-    body.append(&fallback);
-    body.append(&status);
-    body.append(&progress);
-    content.append(&body);
-
-    let actions = gtk::Box::new(gtk::Orientation::Horizontal, 8);
-    actions.add_css_class("update-dialog-actions");
-    let spacer = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-    spacer.set_hexpand(true);
-    let cancel = gtk::Button::with_label("Cancel");
-    cancel.add_css_class("transfer-cancel");
-    let action = gtk::Button::with_label("Download update");
-    action.add_css_class("update-dialog-action");
-    actions.append(&spacer);
-    actions.append(&cancel);
-    actions.append(&action);
-    content.append(&actions);
+    layout.body.append(&notes_heading);
+    layout.body.append(&notes_scroll);
+    layout.body.append(&fallback);
+    layout.body.append(&status);
+    layout.body.append(&progress);
+    let content = layout.content;
+    let close = layout.close;
+    let cancel = layout.cancel;
+    let action = layout.confirm;
 
     let layer = modal_layer(&content);
     window_overlay.add_overlay(&layer);
     action.grab_focus();
 
+    let started = Rc::new(Cell::new(false));
     let cancel_layer = layer.clone();
     let cancel_overlay = window_overlay.clone();
     let cancel_root = blurred_root.clone();
+    let cancel_started = started.clone();
     cancel.connect_clicked(move |_| {
-        dismiss_modal_layer(&cancel_layer, &cancel_overlay, cancel_root.as_ref());
+        if !cancel_started.get() {
+            dismiss_modal_layer(&cancel_layer, &cancel_overlay, cancel_root.as_ref());
+        }
     });
+    let close_layer = layer.clone();
+    let close_overlay = window_overlay.clone();
+    let close_root = blurred_root.clone();
+    let close_started = started.clone();
+    close.connect_clicked(move |_| {
+        if !close_started.get() {
+            dismiss_modal_layer(&close_layer, &close_overlay, close_root.as_ref());
+        }
+    });
+    let escape = gtk::EventControllerKey::new();
+    let escape_layer = layer.clone();
+    let escape_overlay = window_overlay.clone();
+    let escape_root = blurred_root.clone();
+    let escape_started = started.clone();
+    escape.connect_key_pressed(move |_, key, _, _| {
+        if key == gtk::gdk::Key::Escape {
+            if !escape_started.get() {
+                dismiss_modal_layer(&escape_layer, &escape_overlay, escape_root.as_ref());
+            }
+            glib::Propagation::Stop
+        } else {
+            glib::Propagation::Proceed
+        }
+    });
+    layer.add_controller(escape);
 
-    let started = Rc::new(Cell::new(false));
     let installed = Rc::new(Cell::new(false));
     let action_layer = layer.clone();
     let action_overlay = window_overlay.clone();
     let action_root = blurred_root.clone();
     let application = parent.application();
+    let action_close = close.clone();
     action.connect_clicked(move |button| {
         if installed.get() {
             restart(application.as_ref());
@@ -936,6 +934,7 @@ pub(super) fn show_update_dialog(
 
         button.set_sensitive(false);
         cancel.set_sensitive(false);
+        action_close.set_sensitive(false);
         progress.set_visible(true);
         status.set_text("Starting download…");
         let receiver = services::install_update(download_url.clone());
@@ -1354,8 +1353,8 @@ fn theme_editor(
     title.set_hexpand(true);
     header.append(&title);
     panel.append(&header);
-    let name = gtk::Entry::builder().placeholder_text("Theme name").build();
-    name.add_css_class("theme-name");
+    let name = form_entry();
+    name.set_placeholder_text(Some("Theme name"));
     panel.append(&name);
 
     let values = Rc::new(RefCell::new(manager.starter_tokens()));
@@ -1413,9 +1412,9 @@ fn theme_editor(
     let actions = gtk::Box::new(gtk::Orientation::Horizontal, 8);
     actions.set_halign(gtk::Align::End);
     let cancel = gtk::Button::with_label("Cancel");
-    cancel.add_css_class("theme-editor-cancel");
+    cancel.add_css_class("action-dialog-cancel");
     let save = gtk::Button::with_label("Add theme");
-    save.add_css_class("theme-editor-save");
+    save.add_css_class("action-dialog-confirm");
     actions.append(&cancel);
     actions.append(&save);
     panel.append(&actions);


### PR DESCRIPTION
## Description

Standardizes Strata's action dialogs on the shared modal shell and shared themed form controls. This removes duplicated widget construction and one-off CSS while adding consistent accent/danger states, icon bezels, spacing, focus outlines, disabled controls, validation messages, and progress styling.

The architecture documentation records why the search palette, settings workspace, and native GTK choosers remain specialized. A reusable, reference-counted activity spinner now sits beside the address bar and reports SMB connection attempts without being cleared by overlapping operations.

## Visual evidence

Before/after screenshots will be added before merge.

## How to test

1. Open the copy/move destination, conflict, delete, empty Trash, properties, archive, authentication, update, progress, and error dialogs.
2. Empty a populated Trash and confirm the dialog opens immediately in a calculating state, then enables its destructive action after the item count and size load.
3. Connect to an authenticated SMB location and confirm the header spinner remains visible while connecting and waiting for credentials, then stops after success, cancellation, or failure.
4. Exercise keyboard focus and normal, hover, active, disabled, error, selected, and destructive states; switch between built-in, custom, and Omarchy themes while dialogs are open.

**Expected result:**

Dialogs share aligned headers, themed icon bezels, consistent spacing and actions, and accent-colored focus-visible outlines. Form controls and semantic danger/error states update immediately with the active theme. The accent-colored global spinner accurately reflects active SMB connection work.

## Related issue

Closes #88


