### PR TITLE
fix(browser): avoid duplicate double-click activation

### DIFF
--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -3797,9 +3797,10 @@ impl ViewState {
                 if let (Some(state), Some(source_position)) =
                     (weak_state_for_click.upgrade(), source_position)
                 {
-                    if press_count == 2 {
-                        state.browser.activate(depth, source_position);
-                    } else if !control && !shift && !preserve_group {
+                    // GtkListView owns double-click activation through its `activate`
+                    // signal. This gesture only handles selection and single-click previews;
+                    // activating here as well would open files twice.
+                    if should_preview_pointer_press(press_count, control, shift, preserve_group) {
                         let entry = state.browser.entry_at(depth, source_position);
                         if entry.as_ref().is_some_and(|entry| {
                             entry_responds_to_single_click(entry, state.single_click_previews.get())
@@ -5597,6 +5598,15 @@ fn set_location_files_clipboard(locations: &[Location]) -> bool {
             )))
             .is_ok()
     })
+}
+
+fn should_preview_pointer_press(
+    press_count: i32,
+    control: bool,
+    shift: bool,
+    preserve_group: bool,
+) -> bool {
+    press_count == 1 && !control && !shift && !preserve_group
 }
 
 fn should_preserve_drag_selection(clicked_selected: bool, selected_count: u64) -> bool {

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -398,6 +398,15 @@ fn file_names_map_to_specific_lucide_icons() {
 }
 
 #[test]
+fn pointer_preview_handler_ignores_double_click_activation() {
+    assert!(should_preview_pointer_press(1, false, false, false));
+    assert!(!should_preview_pointer_press(2, false, false, false));
+    assert!(!should_preview_pointer_press(1, true, false, false));
+    assert!(!should_preview_pointer_press(1, false, true, false));
+    assert!(!should_preview_pointer_press(1, false, false, true));
+}
+
+#[test]
 fn pressing_an_item_in_a_multi_selection_preserves_the_drag_group() {
     assert!(should_preserve_drag_selection(true, 2));
     assert!(should_preserve_drag_selection(true, 8));


### PR DESCRIPTION
## Description

Let `GtkListView` exclusively handle double-click activation in Miller columns. The row gesture now handles only selection and single-click previews, preventing the gesture and the list's `activate` signal from both opening the same file.

Adds regression coverage ensuring the preview gesture ignores double-clicks and modified/group-preserving clicks.

## Visual evidence

N/A — this changes launch behavior without changing the interface.

## How to test

1. Set a non-single-instance application such as Gwenview as the default image handler.
2. Double-click an image in Strata's Miller columns, then select it and press Enter.

**Expected result:** Each action opens exactly one application window.

## Related issue

Closes #84
