### PR TITLE
build: add local development targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
-.PHONY: start-dev build
+.PHONY: start-dev run-dev build install-local
 
 start-dev:
 	./scripts/dev.sh
 
+run-dev:
+	cargo run
+
 build:
 	cargo build --release
+
+install-local: build
+	install -Dm755 target/release/strata "$(HOME)/.local/bin/strata"


### PR DESCRIPTION
## Description

Add Makefile targets for running a one-shot development build and installing a release build to the standard per-user binary location. This keeps `start-dev` dedicated to hot reload while making both local workflows explicit.

## Visual evidence

N/A — developer tooling only.

## How to test

1. Run `make run-dev` and confirm Cargo builds and launches Strata once without the watcher.
2. Run `make install-local` and confirm the release binary replaces `~/.local/bin/strata`.

**Expected result:** Both commands complete their respective one-shot development and local installation workflows.

## Related issue

Closes #94