### PR TITLE
fix(settings): persist folder peeking preference

### DIFF
--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -296,14 +296,19 @@ fn hide(layer: &gtk::Box, button: &gtk::Button, root: &BlurBin) {
 fn general_page(browser: &BrowserView, manager: Rc<ThemeManager>) -> gtk::Widget {
     let preferences = page_content();
     append_heading(&preferences, "BROWSING");
+    let peeking_enabled = manager.folder_peeking();
+    browser.set_peek_enabled(peeking_enabled);
     let (peeking_row, peeking) = settings_option(
         "Folder peeking",
         "Preview folders automatically while moving through a pane.",
-        true,
+        peeking_enabled,
     );
     let browser_for_peeking = browser.clone();
+    let manager_for_peeking = manager.clone();
     peeking.connect_active_notify(move |toggle| {
-        browser_for_peeking.set_peek_enabled(toggle.is_active())
+        let enabled = toggle.is_active();
+        browser_for_peeking.set_peek_enabled(enabled);
+        manager_for_peeking.set_folder_peeking(enabled);
     });
     preferences.append(&peeking_row);
 

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -74,6 +74,8 @@ struct Preferences {
     mode: String,
     theme: String,
     #[serde(default = "default_enabled")]
+    folder_peeking: bool,
+    #[serde(default = "default_enabled")]
     single_click_previews: bool,
     #[serde(default)]
     search_open_files_directly: bool,
@@ -94,6 +96,7 @@ impl Default for Preferences {
         Self {
             mode: "theme".to_owned(),
             theme: "azure-glow".to_owned(),
+            folder_peeking: true,
             single_click_previews: true,
             search_open_files_directly: false,
             browser_mode: default_browser_mode(),
@@ -190,6 +193,15 @@ impl ThemeManager {
 
     pub fn selected_id(&self) -> String {
         self.preferences.borrow().theme.clone()
+    }
+
+    pub fn folder_peeking(&self) -> bool {
+        self.preferences.borrow().folder_peeking
+    }
+
+    pub fn set_folder_peeking(&self, enabled: bool) {
+        self.preferences.borrow_mut().folder_peeking = enabled;
+        self.save_preferences();
     }
 
     pub fn single_click_previews(&self) -> bool {

--- a/src/ui/theme/tests.rs
+++ b/src/ui/theme/tests.rs
@@ -73,6 +73,7 @@ theme = "azure-glow"
     )
     .expect("legacy preferences should remain valid");
 
+    assert!(preferences.folder_peeking);
     assert!(preferences.single_click_previews);
     assert!(!preferences.search_open_files_directly);
     assert_eq!(preferences.browser_mode, "columns");
@@ -116,6 +117,20 @@ fn invalid_sorting_preferences_fall_back_as_a_pair() {
         };
         assert_eq!(sort_preferences(&preferences), ViewPreferences::default());
     }
+}
+
+#[test]
+fn folder_peeking_can_be_disabled_in_preferences() {
+    let preferences: Preferences = toml::from_str(
+        r#"
+mode = "theme"
+theme = "azure-glow"
+folder_peeking = false
+"#,
+    )
+    .expect("preferences should be valid");
+
+    assert!(!preferences.folder_peeking);
 }
 
 #[test]


### PR DESCRIPTION
## Description

Persist the Folder peeking preference in `settings.toml`, restore it when the UI is built, and keep existing installations enabled by default. This lets users keep folder peeking disabled after restarting Strata.

## Visual evidence

N/A — this changes preference persistence without changing the interface's appearance.

## How to test

1. Open **Settings → General** and disable **Folder peeking**.
2. Restart Strata and return to **Settings → General**.

**Expected result:** Folder peeking remains disabled after the restart and automatic folder previews do not occur.

## Related issue

Closes #98
