### PR TITLE
fix(sidebar): increase selected item contrast

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1175,8 +1175,12 @@ switch:checked slider {
 
 .sidebar-row.active,
 .sidebar-row.active:hover {
-  background: alpha(@theme_highlight, 0.82);
+  background: alpha(@theme_accent, 0.18);
   color: @theme_text;
+}
+
+.sidebar-row.active image {
+  color: @theme_accent;
 }
 
 .sidebar-row.reorderable.dragging {


### PR DESCRIPTION
## Description

Use a direct 18% accent tint for the selected sidebar row instead of tinting the already-subtle highlight token. The selected row icon also uses the accent color, making the active location clearer while preserving theme-aware styling.

## Visual evidence

**Before:**
<img width="278" height="1403" alt="image" src="https://github.com/user-attachments/assets/30f1a642-5b77-4e56-9dbd-df2a9d9649e5" />

**After:**
<img width="280" height="1407" alt="image" src="https://github.com/user-attachments/assets/99109094-4e74-43de-b8e3-06cf18fffc3a" />

## How to test

1. Open Strata with a dark built-in or Omarchy theme.
2. Select several locations in the sidebar and compare the active row with its neighbors and hover states.

**Expected result:** The selected location has a visible accent-tinted background and accent icon without overpowering the sidebar.

## Related issue

Closes #104
