### PR TITLE
fix(ui): modal animation and design polish

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -48,6 +48,7 @@ headerbar menubutton.header-action > button {
   min-height: 30px;
   min-width: 30px;
   padding: 5px;
+  transition: transform 160ms ease-out, background 160ms ease-out;
 }
 
 headerbar .sidebar-toggle:hover,
@@ -62,6 +63,7 @@ headerbar button.header-action:active,
 headerbar menubutton.header-action > button:active,
 headerbar menubutton.header-action > button:checked {
   background: alpha(@theme_muted, 0.8);
+  transform: scale(0.97);
 }
 
 .header-actions {
@@ -107,9 +109,9 @@ headerbar menubutton.header-action > button:focus-visible image {
 
 .appearance-popover contents {
   background: @theme_surface;
-  border: 1px solid alpha(@theme_accent, 0.22);
-  border-radius: 7px;
-  box-shadow: 0 8px 28px alpha(#000000, 0.45);
+  border: 1px solid alpha(@theme_border, 0.6);
+  border-radius: 9px;
+  box-shadow: 0 0 14px alpha(@theme_accent, 0.24);
   padding: 0;
 }
 
@@ -140,11 +142,16 @@ headerbar menubutton.header-action > button:focus-visible image {
   margin: 0;
   min-height: 26px;
   padding: 0 8px;
+  transition: background 160ms ease-out, transform 160ms ease-out;
 }
 
 .appearance-option:hover {
   background: alpha(@theme_muted, 0.5);
   color: @theme_text;
+}
+
+.appearance-option:active {
+  transform: scale(0.97);
 }
 
 .appearance-option:disabled {
@@ -190,6 +197,12 @@ headerbar menubutton.header-action > button:focus-visible image {
   min-height: 22px;
   min-width: 22px;
   padding: 2px;
+  transition: transform 160ms ease-out, background 160ms ease-out;
+}
+
+.location-action:active {
+  background: alpha(@theme_muted, 0.78);
+  transform: scale(0.97);
 }
 
 .breadcrumbs {
@@ -201,11 +214,16 @@ headerbar menubutton.header-action > button:focus-visible image {
   color: @theme_dim_text;
   min-height: 22px;
   padding: 0 5px;
+  transition: transform 160ms ease-out, background 160ms ease-out, color 160ms ease-out;
 }
 
 .breadcrumb:hover {
   background: alpha(@theme_muted, 0.62);
   color: @theme_text;
+}
+
+.breadcrumb:not(.current):active {
+  transform: scale(0.97);
 }
 
 .breadcrumb.current:hover {
@@ -233,6 +251,7 @@ headerbar menubutton.header-action > button:focus-visible image {
   min-width: 22px;
   opacity: 0;
   padding: 2px 4px;
+  transition: opacity 160ms ease-out, background 160ms ease-out;
 }
 
 .current-breadcrumb:hover .copy-path,
@@ -257,13 +276,18 @@ headerbar menubutton.header-action > button:focus-visible image {
 
 .search-backdrop {
   background: alpha(@theme_bg, 0.58);
+  transition: opacity 200ms ease-out;
+}
+
+.search-backdrop.modal-hidden {
+  opacity: 0;
 }
 
 .search-dialog {
   background: @theme_surface;
-  border: 1px solid @theme_accent;
+  border: 1px solid alpha(@theme_border, 0.6);
   border-radius: 9px;
-  box-shadow: 0 12px 38px alpha(@theme_bg, 0.82), 0 0 14px alpha(@theme_accent, 0.24);
+  box-shadow: 0 0 14px alpha(@theme_accent, 0.24);
   min-height: 452px;
   min-width: 760px;
 }
@@ -309,6 +333,7 @@ headerbar menubutton.header-action > button:focus-visible image {
   border-bottom: 1px solid alpha(@theme_border, 0.28);
   color: @theme_text;
   padding: 0;
+  transition: background 160ms ease-out;
 }
 
 .search-result > box {
@@ -361,14 +386,37 @@ headerbar menubutton.header-action > button:focus-visible image {
 
 .settings-backdrop {
   background: alpha(@theme_bg, 0.82);
+  transition: opacity 200ms ease-out;
+}
+
+.settings-backdrop.modal-hidden {
+  opacity: 0;
 }
 
 .modal-backdrop,
 .modal-backdrop:focus,
 .modal-backdrop:focus-visible,
 .modal-backdrop:focus-within {
-  background: alpha(@theme_bg, 0.08);
+  background: alpha(@theme_bg, 0.55);
   outline: none;
+  transition: opacity 200ms ease-out;
+}
+
+.modal-backdrop.modal-hidden {
+  opacity: 0;
+}
+
+.action-dialog,
+.search-dialog,
+.settings-dialog {
+  transition: opacity 200ms ease-out, transform 200ms ease-out;
+}
+
+.modal-hidden .action-dialog,
+.modal-hidden .search-dialog,
+.modal-hidden .settings-dialog {
+  opacity: 0;
+  transform: scale(0.96);
 }
 
 
@@ -405,9 +453,9 @@ headerbar menubutton.header-action > button:focus-visible image {
 
 .action-dialog {
   background: @theme_surface;
-  border: 1px solid alpha(@theme_accent, 0.22);
-  border-radius: 7px;
-  box-shadow: 0 18px 54px alpha(@theme_bg, 0.72);
+  border: 1px solid alpha(@theme_border, 0.6);
+  border-radius: 9px;
+  box-shadow: 0 0 14px alpha(@theme_accent, 0.24);
   color: @theme_text;
   min-width: 480px;
 }
@@ -469,6 +517,7 @@ headerbar menubutton.header-action > button:focus-visible image {
   min-height: 28px;
   min-width: 28px;
   padding: 4px;
+  transition: transform 160ms ease-out, background 160ms ease-out, color 160ms ease-out;
 }
 
 .action-dialog-close:hover {
@@ -479,6 +528,7 @@ headerbar menubutton.header-action > button:focus-visible image {
 .action-dialog-close:active {
   background: alpha(@theme_muted, 0.78);
   color: @theme_accent;
+  transform: scale(0.97);
 }
 
 .action-dialog-close:focus-visible {
@@ -510,6 +560,7 @@ headerbar menubutton.header-action > button:focus-visible image {
   color: @theme_text;
   min-height: 26px;
   padding: 2px 11px;
+  transition: transform 160ms ease-out, background 160ms ease-out, border-color 160ms ease-out, color 160ms ease-out;
 }
 
 .action-dialog-cancel:hover {
@@ -521,6 +572,7 @@ headerbar menubutton.header-action > button:focus-visible image {
   background: alpha(@theme_muted, 0.82);
   border-color: @theme_accent;
   color: @theme_accent;
+  transform: scale(0.97);
 }
 
 .action-dialog-cancel:focus-visible {
@@ -537,6 +589,7 @@ headerbar menubutton.header-action > button:focus-visible image {
   color: @theme_accent;
   min-height: 26px;
   padding: 2px 11px;
+  transition: transform 160ms ease-out, background 160ms ease-out;
 }
 
 .action-dialog-confirm:hover {
@@ -545,6 +598,7 @@ headerbar menubutton.header-action > button:focus-visible image {
 
 .action-dialog-confirm:active {
   background: alpha(@theme_accent, 0.28);
+  transform: scale(0.97);
 }
 
 .action-dialog-confirm:focus-visible {
@@ -564,6 +618,7 @@ headerbar menubutton.header-action > button:focus-visible image {
 
 .action-dialog-confirm.danger:active {
   background: alpha(@theme_danger, 0.28);
+  transform: scale(0.97);
 }
 
 .action-dialog-confirm.danger:focus-visible {
@@ -589,6 +644,7 @@ headerbar menubutton.header-action > button:focus-visible image {
   border: 1px solid alpha(@theme_border, 0.72);
   border-radius: 4px;
   color: @theme_bg;
+  transition: background 160ms ease-out, border-color 160ms ease-out, color 160ms ease-out;
 }
 
 .form-check:hover check {
@@ -707,11 +763,17 @@ dropdown.form-control > button {
   color: @theme_text;
   min-height: 34px;
   padding: 3px 9px;
+  transition: transform 160ms ease-out, background 160ms ease-out, border-color 160ms ease-out;
 }
 
 dropdown.form-control > button:hover {
   background: alpha(@theme_muted, 0.62);
   border-color: alpha(@theme_accent, 0.68);
+}
+
+dropdown.form-control > button:active {
+  background: alpha(@theme_muted, 0.78);
+  transform: scale(0.97);
 }
 
 dropdown.form-control:focus > button,
@@ -770,9 +832,9 @@ dropdown.form-control:disabled > button {
 
 .settings-dialog {
   background: @theme_surface;
-  border: 1px solid alpha(@theme_accent, 0.22);
-  border-radius: 7px;
-  box-shadow: 0 18px 54px alpha(#000000, 0.6);
+  border: 1px solid alpha(@theme_border, 0.6);
+  border-radius: 9px;
+  box-shadow: 0 0 14px alpha(@theme_accent, 0.24);
 }
 
 .settings-navigation {
@@ -796,6 +858,7 @@ dropdown.form-control:disabled > button {
   color: @theme_dim_text;
   min-height: 38px;
   padding: 5px 10px;
+  transition: background 160ms ease-out, color 160ms ease-out, transform 160ms ease-out;
 }
 
 .settings-navigation.compact button {
@@ -805,6 +868,10 @@ dropdown.form-control:disabled > button {
 .settings-navigation button:hover {
   background: alpha(@theme_muted, 0.62);
   color: @theme_text;
+}
+
+.settings-navigation button:active {
+  transform: scale(0.97);
 }
 
 .settings-navigation button.settings-nav-active {
@@ -837,10 +904,16 @@ dropdown.form-control:disabled > button {
   min-height: 28px;
   min-width: 28px;
   padding: 4px;
+  transition: transform 160ms ease-out, background 160ms ease-out;
 }
 
 .settings-close:hover {
   background: alpha(@theme_muted, 0.62);
+}
+
+.settings-close:active {
+  background: alpha(@theme_muted, 0.82);
+  transform: scale(0.97);
 }
 
 .settings-preferences {
@@ -943,12 +1016,17 @@ dropdown.form-control:disabled > button {
   box-shadow: none;
   color: @theme_accent;
   padding: 2px 0;
+  transition: transform 160ms ease-out, color 160ms ease-out;
 }
 
 .release-notes-fallback:hover,
-.release-notes-fallback:active,
 .release-notes-fallback:visited {
   color: @theme_accent;
+}
+
+.release-notes-fallback:active {
+  color: @theme_accent;
+  transform: scale(0.97);
 }
 
 .release-notes-fallback:focus-visible {
@@ -987,6 +1065,7 @@ dropdown.form-control:disabled > button {
   color: @theme_accent;
   min-height: 28px;
   padding: 3px 12px;
+  transition: transform 160ms ease-out, background 160ms ease-out;
 }
 
 .settings-update-check:hover {
@@ -999,6 +1078,7 @@ dropdown.form-control:disabled > button {
   background: alpha(@theme_accent, 0.32);
   border-color: @theme_accent;
   color: @theme_accent;
+  transform: scale(0.97);
 }
 
 .settings-update-check:focus-visible {
@@ -1069,6 +1149,7 @@ dropdown.form-control:disabled > button {
   min-height: 42px;
   padding: 4px 14px;
   text-decoration: none;
+  transition: transform 160ms ease-out, background 160ms ease-out, color 160ms ease-out;
 }
 
 .about-repository:hover {
@@ -1079,6 +1160,7 @@ dropdown.form-control:disabled > button {
 .about-repository:active {
   background: alpha(@theme_highlight, 0.72);
   color: @theme_accent;
+  transform: scale(0.97);
 }
 
 .about-repository:focus-visible {
@@ -1092,6 +1174,7 @@ switch {
   box-shadow: none;
   min-height: 22px;
   min-width: 40px;
+  transition: background 160ms ease-out, border-color 160ms ease-out;
 }
 
 switch:checked {
@@ -1106,6 +1189,7 @@ switch:checked slider {
   box-shadow: 0 1px 3px alpha(#000000, 0.4);
   min-height: 18px;
   min-width: 18px;
+  transition: background 160ms ease-out;
 }
 
 .sidebar-shell,
@@ -1131,6 +1215,7 @@ switch:checked slider {
   color: @theme_accent;
   min-height: 38px;
   padding: 4px 13px;
+  transition: transform 160ms ease-out, background 160ms ease-out;
 }
 
 .sidebar-update:hover {
@@ -1141,6 +1226,7 @@ switch:checked slider {
 .sidebar-update:active {
   background: alpha(@theme_muted, 0.56);
   color: @theme_accent;
+  transform: scale(0.97);
 }
 
 .sidebar-update:focus-visible {
@@ -1167,10 +1253,15 @@ switch:checked slider {
   color: @theme_text;
   min-height: 30px;
   padding: 3px 8px;
+  transition: background 160ms ease-out, transform 160ms ease-out;
 }
 
 .sidebar-row:hover {
   background: alpha(@theme_muted, 0.38);
+}
+
+.sidebar-row:active {
+  transform: scale(0.97);
 }
 
 .sidebar-row.active,
@@ -1250,6 +1341,7 @@ paned > separator {
   min-height: 24px;
   min-width: 24px;
   padding: 2px;
+  transition: transform 160ms ease-out, background 160ms ease-out, border-color 160ms ease-out, color 160ms ease-out;
 }
 
 .preview-header-action:hover {
@@ -1262,6 +1354,7 @@ paned > separator {
   background: alpha(@theme_muted, 0.82);
   border-color: @theme_accent;
   color: @theme_accent;
+  transform: scale(0.97);
 }
 
 .preview-header-action:focus-visible {
@@ -1382,9 +1475,9 @@ paned > separator {
 
 .peek-popover {
   background: @theme_surface;
-  border: 1px solid alpha(@theme_accent, 0.34);
-  border-radius: 6px;
-  box-shadow: 0 12px 32px alpha(#000000, 0.42);
+  border: 1px solid alpha(@theme_border, 0.6);
+  border-radius: 9px;
+  box-shadow: 0 0 14px alpha(@theme_accent, 0.24);
   color: @theme_text;
   padding: 0;
 }
@@ -1419,15 +1512,20 @@ menubutton.column-header-action > button {
   min-height: 24px;
   min-width: 24px;
   padding: 3px;
+  transition: transform 160ms ease-out, background 160ms ease-out;
 }
 
 button.column-header-action:hover,
-button.column-header-action:active,
 button.column-header-action:checked,
 menubutton.column-header-action > button:hover,
-menubutton.column-header-action > button:active,
 menubutton.column-header-action > button:checked {
   background: alpha(@theme_muted, 0.62);
+}
+
+button.column-header-action:active,
+menubutton.column-header-action > button:active {
+  background: alpha(@theme_muted, 0.78);
+  transform: scale(0.97);
 }
 
 .column-header-action image {
@@ -1477,9 +1575,9 @@ menubutton.column-header-action > button:focus-visible image {
 
 .column-popover contents {
   background: @theme_surface;
-  border: 1px solid alpha(@theme_accent, 0.22);
-  border-radius: 7px;
-  box-shadow: 0 8px 28px alpha(#000000, 0.45);
+  border: 1px solid alpha(@theme_border, 0.6);
+  border-radius: 9px;
+  box-shadow: 0 0 14px alpha(@theme_accent, 0.24);
   padding: 0;
 }
 
@@ -1502,11 +1600,17 @@ menubutton.column-header-action > button:focus-visible image {
   color: @theme_text;
   min-height: 30px;
   padding: 3px 7px;
+  transition: transform 160ms ease-out, background 160ms ease-out, color 160ms ease-out;
 }
 
 .column-menu-option:hover {
   background: alpha(@theme_muted, 0.5);
   color: @theme_text;
+}
+
+.column-menu-option:active {
+  background: alpha(@theme_muted, 0.78);
+  transform: scale(0.97);
 }
 
 
@@ -1544,6 +1648,7 @@ menubutton.column-header-action > button:focus-visible image {
   color: @theme_dim_text;
   min-height: 32px;
   padding: 3px 12px;
+  transition: transform 160ms ease-out, background 160ms ease-out, border-color 160ms ease-out, color 160ms ease-out;
 }
 
 .segmented-control-option.first {
@@ -1576,6 +1681,7 @@ menubutton.column-header-action > button:focus-visible image {
 .segmented-control-option:active {
   background: alpha(@theme_muted, 0.82);
   color: @theme_accent;
+  transform: scale(0.97);
 }
 
 .segmented-control-option:focus-visible {
@@ -1617,6 +1723,7 @@ menubutton.column-header-action > button:focus-visible image {
   color: @theme_text;
   min-height: 30px;
   padding: 3px 7px;
+  transition: transform 160ms ease-out, background 160ms ease-out, color 160ms ease-out;
 }
 
 .transfer-suggestion:hover,
@@ -1629,6 +1736,7 @@ menubutton.column-header-action > button:focus-visible image {
 .transfer-suggestion:active {
   background: alpha(@theme_muted, 0.8);
   color: @theme_accent;
+  transform: scale(0.97);
 }
 
 .properties-content {
@@ -1720,6 +1828,7 @@ menubutton.column-header-action > button:focus-visible image {
   color: @theme_text;
   min-height: 28px;
   padding: 3px 9px;
+  transition: transform 160ms ease-out, background 160ms ease-out, border-color 160ms ease-out, color 160ms ease-out;
 }
 
 .properties-action:hover {
@@ -1732,6 +1841,7 @@ menubutton.column-header-action > button:focus-visible image {
   background: alpha(@theme_muted, 0.78);
   border-color: @theme_accent;
   color: @theme_accent;
+  transform: scale(0.97);
 }
 
 .properties-action:focus-visible {
@@ -1749,9 +1859,9 @@ menubutton.column-header-action > button:focus-visible image {
 
 .folder-context-popover contents {
   background: @theme_surface;
-  border: 1px solid alpha(@theme_accent, 0.24);
-  border-radius: 7px;
-  box-shadow: 0 8px 28px alpha(@theme_bg, 0.72);
+  border: 1px solid alpha(@theme_border, 0.6);
+  border-radius: 9px;
+  box-shadow: 0 0 14px alpha(@theme_accent, 0.24);
   color: @theme_text;
   padding: 0;
 }
@@ -1795,6 +1905,7 @@ menubutton.column-header-action > button:focus-visible image {
   color: @theme_text;
   min-height: 26px;
   padding: 1px 6px;
+  transition: transform 160ms ease-out, background 160ms ease-out, color 160ms ease-out;
 }
 
 .item-context-option:hover {
@@ -1804,6 +1915,7 @@ menubutton.column-header-action > button:focus-visible image {
 
 .item-context-option:active {
   background: alpha(@theme_muted, 0.78);
+  transform: scale(0.97);
 }
 
 .item-context-option:disabled {
@@ -1834,6 +1946,7 @@ menubutton.column-header-action > button:focus-visible image {
 .item-context-option.danger:active {
   background: alpha(@theme_danger, 0.24);
   color: @theme_danger;
+  transform: scale(0.97);
 }
 
 .item-context-option.danger:focus-visible {
@@ -1854,6 +1967,7 @@ menubutton.column-header-action > button:focus-visible image {
   color: @theme_text;
   min-height: 30px;
   padding: 3px 8px;
+  transition: transform 160ms ease-out, background 160ms ease-out, color 160ms ease-out;
 }
 
 .folder-context-option:hover {
@@ -1863,6 +1977,7 @@ menubutton.column-header-action > button:focus-visible image {
 
 .folder-context-option:active {
   background: alpha(@theme_muted, 0.78);
+  transform: scale(0.97);
 }
 
 .folder-context-option.danger {
@@ -1877,6 +1992,7 @@ menubutton.column-header-action > button:focus-visible image {
 .folder-context-option.danger:active {
   background: alpha(@theme_danger, 0.24);
   color: @theme_danger;
+  transform: scale(0.97);
 }
 
 .folder-context-option.danger:focus-visible {
@@ -1917,6 +2033,7 @@ menubutton.column-header-action > button:focus-visible image {
   border-radius: 6px;
   margin: 1px 8px;
   padding: 0;
+  transition: background 160ms ease-out, color 160ms ease-out;
 }
 
 .file-row {
@@ -2110,11 +2227,16 @@ entry.theme-search {
   min-height: 26px;
   min-width: 26px;
   padding: 4px;
+  transition: transform 160ms ease-out, background 160ms ease-out;
 }
 
 .theme-search-clear:hover,
 .theme-search-clear:active {
   background: alpha(@theme_muted, 0.62);
+}
+
+.theme-search-clear:active {
+  transform: scale(0.97);
 }
 
 .theme-search-clear:focus-visible {
@@ -2229,12 +2351,17 @@ entry.theme-search {
 .add-theme-card {
   border: 1px dashed alpha(@theme_border, 0.75);
   color: @theme_dim_text;
+  transition: transform 160ms ease-out, background 160ms ease-out, border-color 160ms ease-out, color 160ms ease-out;
 }
 
 .add-theme-card:hover {
   background: alpha(@theme_muted, 0.45);
   border-color: @theme_accent;
   color: @theme_text;
+}
+
+.add-theme-card:active {
+  transform: scale(0.97);
 }
 
 .add-theme-card:focus-visible {
@@ -2271,15 +2398,23 @@ entry.theme-search {
   border: 1px solid alpha(@theme_border, 0.7);
   box-shadow: none;
   padding: 0;
+  transition: transform 160ms ease-out, border-color 160ms ease-out;
 }
 
 .theme-color-picker button:hover,
-.theme-color-picker button:focus,
+.theme-color-picker button:focus {
+  background: transparent;
+  border-color: @theme_accent;
+  box-shadow: none;
+  padding: 0;
+}
+
 .theme-color-picker button:active {
   background: transparent;
   border-color: @theme_accent;
   box-shadow: none;
   padding: 0;
+  transform: scale(0.97);
 }
 
 .theme-editor-error {
@@ -2340,9 +2475,9 @@ entry.theme-search {
 
 .grid-thumbnail-popover contents {
   background: @theme_surface;
-  border: 1px solid alpha(@theme_accent, 0.28);
-  border-radius: 7px;
-  box-shadow: 0 8px 28px alpha(@theme_bg, 0.72);
+  border: 1px solid alpha(@theme_border, 0.6);
+  border-radius: 9px;
+  box-shadow: 0 0 14px alpha(@theme_accent, 0.24);
   color: @theme_text;
   padding: 14px;
 }
@@ -2391,6 +2526,26 @@ entry.theme-search {
 .grid-thumbnail-scale:active slider {
   background: @theme_highlight;
   border-color: @theme_accent;
+}
+
+menubutton.grid-thumbnail-menu > button {
+  background: transparent;
+  border: none;
+  border-radius: 5px;
+  box-shadow: none;
+  min-height: 24px;
+  min-width: 24px;
+  padding: 3px;
+  transition: transform 160ms ease-out, background 160ms ease-out;
+}
+
+menubutton.grid-thumbnail-menu > button:hover {
+  background: alpha(@theme_muted, 0.62);
+}
+
+menubutton.grid-thumbnail-menu > button:active {
+  background: alpha(@theme_muted, 0.82);
+  transform: scale(0.97);
 }
 
 .grid-thumbnail-scale:focus-visible slider,
@@ -2529,6 +2684,7 @@ menubutton.grid-thumbnail-menu > button:focus-visible {
   color: @theme_dim_text;
   min-height: 28px;
   padding: 0 12px;
+  transition: background 160ms ease-out, color 160ms ease-out;
 }
 
 .explorer-heading-button:hover {
@@ -2539,6 +2695,7 @@ menubutton.grid-thumbnail-menu > button:focus-visible {
 .explorer-heading-button:active {
   background: alpha(@theme_muted, 0.72);
   color: @theme_accent;
+  transform: scale(0.97);
 }
 
 .explorer-heading-button:focus-visible {
@@ -2569,6 +2726,7 @@ menubutton.grid-thumbnail-menu > button:focus-visible {
   min-height: 26px;
   min-width: 26px;
   padding: 3px;
+  transition: transform 160ms ease-out, background 160ms ease-out, color 160ms ease-out;
 }
 
 .explorer-navigation-button image {
@@ -2597,6 +2755,7 @@ menubutton.grid-thumbnail-menu > button:focus-visible {
 .explorer-navigation-button:active {
   background: alpha(@theme_muted, 0.78);
   color: @theme_accent;
+  transform: scale(0.97);
 }
 
 .explorer-navigation-button:focus-visible {
@@ -2608,6 +2767,7 @@ menubutton.grid-thumbnail-menu > button:focus-visible {
   background: transparent;
   color: @theme_text;
   outline: none;
+  transition: background 160ms ease-out, color 160ms ease-out;
 }
 
 .explorer-list row:hover {
@@ -2654,4 +2814,10 @@ menubutton.grid-thumbnail-menu > button:focus-visible {
   min-height: 38px;
   padding-bottom: 5px;
   padding-top: 5px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    transition-duration: 1ms !important;
+  }
 }

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -6259,7 +6259,25 @@ pub(super) fn modal_layer(
         }
     });
     layer.add_controller(click);
+    animate_in(&layer);
     layer
+}
+
+pub(super) fn animate_in(layer: &gtk::Box) {
+    layer.remove_css_class("dismissing");
+    layer.set_sensitive(true);
+    layer.add_css_class("modal-hidden");
+    let weak = layer.downgrade();
+    glib::timeout_add_local_once(Duration::from_millis(16), move || {
+        if let Some(layer) = weak.upgrade() {
+            layer.remove_css_class("modal-hidden");
+        }
+    });
+}
+
+pub(super) fn animate_out(layer: &gtk::Box, on_done: impl FnOnce() + 'static) {
+    layer.add_css_class("modal-hidden");
+    glib::timeout_add_local_once(Duration::from_millis(200), on_done);
 }
 
 pub(super) fn dismiss_modal_layer(
@@ -6267,10 +6285,21 @@ pub(super) fn dismiss_modal_layer(
     overlay: &gtk::Overlay,
     root: Option<&BlurBin>,
 ) {
-    overlay.remove_overlay(layer);
-    if let Some(root) = root {
-        root.set_blurred(false);
+    if layer.has_css_class("dismissing") {
+        return;
     }
+    layer.add_css_class("dismissing");
+    layer.set_sensitive(false);
+    let overlay = overlay.clone();
+    let layer_for_anim = layer.clone();
+    let layer = layer.clone();
+    let root = root.cloned();
+    animate_out(&layer_for_anim, move || {
+        overlay.remove_overlay(&layer);
+        if let Some(root) = root {
+            root.set_blurred(false);
+        }
+    });
 }
 
 fn gio_file_for_location(location: &Location) -> gio::File {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -1111,7 +1111,7 @@ impl ViewState {
         let cancel = layout.cancel;
         let replace = layout.confirm;
 
-        let layer = modal_layer(&content);
+        let layer = modal_layer(&content, &window_overlay, blurred_root.clone(), None);
         window_overlay.add_overlay(&layer);
         let cancel_layer = layer.clone();
         let cancel_overlay = window_overlay.clone();
@@ -1379,7 +1379,12 @@ impl ViewState {
             );
         });
 
-        let layer = modal_layer(&content);
+        let layer = modal_layer(
+            &content,
+            &window_overlay,
+            blurred_root.clone(),
+            Some(creating_destination.clone()),
+        );
         window_overlay.add_overlay(&layer);
         let cancel_layer = layer.clone();
         let cancel_overlay = window_overlay.clone();
@@ -1589,7 +1594,7 @@ impl ViewState {
         let content = layout.content;
         let cancel = layout.confirm;
 
-        let layer = modal_layer(&content);
+        let layer = modal_layer(&content, &window_overlay, blurred_root.clone(), None);
         window_overlay.add_overlay(&layer);
         self.delete_progress.replace(Some(DeleteProgressView {
             layer,
@@ -1689,7 +1694,7 @@ impl ViewState {
         let empty = layout.confirm;
         let entries = Rc::new(RefCell::new(None::<Vec<FileEntry>>));
 
-        let layer = modal_layer(&content);
+        let layer = modal_layer(&content, &window_overlay, blurred_root.clone(), None);
         window_overlay.add_overlay(&layer);
         let cancel_layer = layer.clone();
         let cancel_overlay = window_overlay.clone();
@@ -1872,7 +1877,7 @@ impl ViewState {
         let cancel = layout.cancel;
         let confirm = layout.confirm;
 
-        let layer = modal_layer(&content);
+        let layer = modal_layer(&content, &window_overlay, blurred_root.clone(), None);
         window_overlay.add_overlay(&layer);
         let cancelled_layer = layer.clone();
         let cancelled_overlay = window_overlay.clone();
@@ -1980,7 +1985,7 @@ impl ViewState {
             subtitle,
             confirm_label,
         );
-        let layer = modal_layer(&layout.content);
+        let layer = modal_layer(&layout.content, &window_overlay, blurred_root.clone(), None);
         window_overlay.add_overlay(&layer);
 
         let dismiss: Rc<dyn Fn()> = Rc::new({
@@ -2404,7 +2409,7 @@ impl ViewState {
         layout.actions.prepend(&actions);
         let content = layout.content;
 
-        let layer = modal_layer(&content);
+        let layer = modal_layer(&content, &window_overlay, blurred_root.clone(), None);
         window_overlay.add_overlay(&layer);
         let closing_layer = layer.clone();
         let closing_overlay = window_overlay.clone();
@@ -6188,7 +6193,16 @@ fn vim_focus_direction(key: gtk::gdk::Key) -> Option<gtk::DirectionType> {
     }
 }
 
-pub(super) fn modal_layer(content: &impl IsA<gtk::Widget>) -> gtk::Box {
+#[expect(
+    deprecated,
+    reason = "GTK 4.12 deprecated translate_coordinates and allocation without a replacement for click-in-bounds checks"
+)]
+pub(super) fn modal_layer(
+    content: &impl IsA<gtk::Widget>,
+    overlay: &gtk::Overlay,
+    root: Option<BlurBin>,
+    block_dismiss: Option<Rc<Cell<bool>>>,
+) -> gtk::Box {
     let layer = gtk::Box::new(gtk::Orientation::Vertical, 0);
     layer.add_css_class("app-modal-layer");
     layer.add_css_class("modal-backdrop");
@@ -6201,9 +6215,50 @@ pub(super) fn modal_layer(content: &impl IsA<gtk::Widget>) -> gtk::Box {
     top.set_vexpand(true);
     let bottom = gtk::Box::new(gtk::Orientation::Vertical, 0);
     bottom.set_vexpand(true);
+    let left = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    left.set_hexpand(true);
+    let right = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    right.set_hexpand(true);
+    let row = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    row.append(&left);
+    row.append(content);
+    row.append(&right);
     layer.append(&top);
-    layer.append(content);
+    layer.append(&row);
     layer.append(&bottom);
+
+    let click = gtk::GestureClick::new();
+    let weak_layer = layer.downgrade();
+    let weak_content = content.downgrade();
+    let overlay = overlay.clone();
+    let root = root.clone();
+    let block = block_dismiss.clone();
+    click.connect_pressed(move |_, _, x, y| {
+        if let Some(block) = block.as_ref()
+            && block.get()
+        {
+            return;
+        }
+        let Some(layer) = weak_layer.upgrade() else {
+            return;
+        };
+        let Some(content) = weak_content.upgrade() else {
+            return;
+        };
+        let on_dialog = content
+            .translate_coordinates(&layer, 0.0, 0.0)
+            .is_some_and(|(cx, cy)| {
+                let alloc = content.allocation();
+                x >= cx
+                    && x < cx + alloc.width() as f64
+                    && y >= cy
+                    && y < cy + alloc.height() as f64
+            });
+        if !on_dialog {
+            dismiss_modal_layer(&layer, &overlay, root.as_ref());
+        }
+    });
+    layer.add_controller(click);
     layer
 }
 
@@ -6373,7 +6428,7 @@ fn show_authentication_dialog(
         }
     });
 
-    let layer = modal_layer(&content);
+    let layer = modal_layer(&content, &window_overlay, blurred_root.clone(), None);
     window_overlay.add_overlay(&layer);
 
     let cancel_operation = operation.cloned();
@@ -6777,7 +6832,7 @@ pub(super) fn show_error_dialog(parent: &impl IsA<gtk::Widget>, message: &str, d
     let close_icon = layout.close;
     let close = layout.confirm;
 
-    let layer = modal_layer(&content);
+    let layer = modal_layer(&content, &window_overlay, blurred_root.clone(), None);
     window_overlay.add_overlay(&layer);
     let close_layer = layer.clone();
     let close_overlay = window_overlay.clone();

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -234,6 +234,7 @@ impl SearchDialog {
         self.state.status.set_visible(true);
         self.state.status.set_text("Type to search the whole tree");
         self.state.layer.set_visible(true);
+        super::browser::animate_in(&self.state.layer);
         self.state.field.grab_focus();
 
         let (handle, receiver) = index_tree(root);
@@ -445,8 +446,19 @@ fn hide(state: &SearchState) {
     state.generation.set(state.generation.get() + 1);
     state.search.borrow_mut().take();
     clear_results(state);
-    state.layer.set_visible(false);
-    (state.dismiss)();
+    if state.layer.has_css_class("dismissing") {
+        return;
+    }
+    state.layer.add_css_class("dismissing");
+    state.layer.set_sensitive(false);
+    let layer = state.layer.clone();
+    let dismiss = state.dismiss.clone();
+    super::browser::animate_out(&state.layer, move || {
+        layer.set_visible(false);
+        layer.remove_css_class("dismissing");
+        layer.set_sensitive(true);
+        dismiss();
+    });
 }
 
 fn clear_results(state: &SearchState) {

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -37,6 +37,10 @@ struct SearchState {
 }
 
 impl SearchDialog {
+    #[expect(
+        deprecated,
+        reason = "GTK 4.12 deprecated translate_coordinates and allocation without a replacement for click-in-bounds checks"
+    )]
     pub fn new(activate: Rc<dyn Fn(SearchItem)>, dismiss: Rc<dyn Fn()>) -> Self {
         let layer = gtk::Box::new(gtk::Orientation::Vertical, 0);
         layer.add_css_class("search-backdrop");
@@ -106,8 +110,16 @@ impl SearchDialog {
         top_spacer.set_vexpand(true);
         let bottom_spacer = gtk::Box::new(gtk::Orientation::Vertical, 0);
         bottom_spacer.set_vexpand(true);
+        let left_spacer = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+        left_spacer.set_hexpand(true);
+        let right_spacer = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+        right_spacer.set_hexpand(true);
+        let row = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+        row.append(&left_spacer);
+        row.append(&panel);
+        row.append(&right_spacer);
         layer.append(&top_spacer);
-        layer.append(&panel);
+        layer.append(&row);
         layer.append(&bottom_spacer);
 
         let state = Rc::new(SearchState {
@@ -169,6 +181,28 @@ impl SearchDialog {
             glib::Propagation::Proceed
         });
         state.layer.add_controller(keys);
+
+        let click_state = Rc::downgrade(&state);
+        let click_panel = panel.clone();
+        let click = gtk::GestureClick::new();
+        click.connect_pressed(move |_, _, x, y| {
+            let Some(state) = click_state.upgrade() else {
+                return;
+            };
+            let on_panel = click_panel
+                .translate_coordinates(&state.layer, 0.0, 0.0)
+                .is_some_and(|(px, py)| {
+                    let alloc = click_panel.allocation();
+                    x >= px
+                        && x < px + alloc.width() as f64
+                        && y >= py
+                        && y < py + alloc.height() as f64
+                });
+            if !on_panel {
+                hide(&state);
+            }
+        });
+        state.layer.add_controller(click);
         let adjustment = state.scroller.vadjustment();
         let changed = Rc::downgrade(&state);
         adjustment.connect_changed(move |_| {

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -149,6 +149,10 @@ fn uses_compact_navigation(dialog_width: i32) -> bool {
     dialog_width < COMPACT_NAVIGATION_BREAKPOINT
 }
 
+#[expect(
+    deprecated,
+    reason = "GTK 4.12 deprecated translate_coordinates and allocation without a replacement for click-in-bounds checks"
+)]
 pub fn build_layer(
     browser: &BrowserView,
     settings_button: &gtk::Button,
@@ -265,9 +269,23 @@ pub fn build_layer(
         navigation_contents,
         responsive_flows,
     );
-    responsive_panel.set_hexpand(true);
-    responsive_panel.set_vexpand(true);
-    layer.append(&responsive_panel);
+    responsive_panel.set_hexpand(false);
+    responsive_panel.set_vexpand(false);
+    let top = gtk::Box::new(gtk::Orientation::Vertical, 0);
+    top.set_vexpand(true);
+    let bottom = gtk::Box::new(gtk::Orientation::Vertical, 0);
+    bottom.set_vexpand(true);
+    let left = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    left.set_hexpand(true);
+    let right = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    right.set_hexpand(true);
+    let row = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    row.append(&left);
+    row.append(&responsive_panel);
+    row.append(&right);
+    layer.append(&top);
+    layer.append(&row);
+    layer.append(&bottom);
 
     let hidden_layer = layer.clone();
     let inactive_settings = settings_button.clone();
@@ -285,6 +303,27 @@ pub fn build_layer(
         gtk::glib::Propagation::Stop
     });
     layer.add_controller(keys);
+
+    let click_layer = layer.clone();
+    let click_dialog = responsive_panel.clone();
+    let click_settings = settings_button.clone();
+    let click_root = root.clone();
+    let click = gtk::GestureClick::new();
+    click.connect_pressed(move |_, _, x, y| {
+        let on_dialog = click_dialog
+            .translate_coordinates(&click_layer, 0.0, 0.0)
+            .is_some_and(|(dx, dy)| {
+                let alloc = click_dialog.allocation();
+                x >= dx
+                    && x < dx + alloc.width() as f64
+                    && y >= dy
+                    && y < dy + alloc.height() as f64
+            });
+        if !on_dialog {
+            hide(&click_layer, &click_settings, &click_root);
+        }
+    });
+    layer.add_controller(click);
     layer
 }
 
@@ -880,7 +919,7 @@ pub(super) fn show_update_dialog(
     let cancel = layout.cancel;
     let action = layout.confirm;
 
-    let layer = modal_layer(&content);
+    let layer = modal_layer(&content, &window_overlay, blurred_root.clone(), None);
     window_overlay.add_overlay(&layer);
     action.grab_focus();
 

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -328,9 +328,22 @@ pub fn build_layer(
 }
 
 fn hide(layer: &gtk::Box, button: &gtk::Button, root: &BlurBin) {
-    layer.set_visible(false);
-    root.set_blurred(false);
-    button.remove_css_class("active");
+    if layer.has_css_class("dismissing") {
+        return;
+    }
+    layer.add_css_class("dismissing");
+    layer.set_sensitive(false);
+    let layer_for_anim = layer.clone();
+    let layer = layer.clone();
+    let root = root.clone();
+    let button = button.clone();
+    super::browser::animate_out(&layer_for_anim, move || {
+        layer.set_visible(false);
+        layer.remove_css_class("dismissing");
+        layer.set_sensitive(true);
+        root.set_blurred(false);
+        button.remove_css_class("active");
+    });
 }
 
 fn general_page(browser: &BrowserView, manager: Rc<ThemeManager>) -> gtk::Widget {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -855,6 +855,7 @@ fn show_settings(layer: &gtk::Box, button: &gtk::Button, root: &BlurBin) {
     layer.set_visible(true);
     layer.grab_focus();
     button.add_css_class("active");
+    super::browser::animate_in(layer);
 }
 
 fn append_menu_heading(container: &gtk::Box, text: &str) {


### PR DESCRIPTION
## Summary

### Modal animation rewrite (commit 1)

**What:** Removed the manual `allocate()`/`gsk::Transform` timer-based animation and replaced it with CSS class toggles (`animate_in`/`animate_out` add/remove a `modal-hidden` class that CSS transitions on opacity and transform). Added a `dismissing` guard to `dismiss_modal_layer`, search `hide`, and settings `hide`.

**Why:** The timer approach had three root causes of bugs:
1. `allocate()` from a 16ms timer overrides GTK's own layout allocation — the dialog jumped/startled and broke centering because GTK re-layouts and our timer re-allocates in conflict
2. `connect_map` handlers stacked up on persistent search/settings layers each time they were reopened, producing duplicate competing animations
3. No re-entry guard meant rapid outside clicks scheduled multiple fade-out callbacks before the first finished, leaving stale overlays stuck (the "double modal" bug)

CSS transitions run in GTK's render thread, don't conflict with layout, and handle timing internally. The `dismissing` class + `set_sensitive(false)` prevents any second dismissal from scheduling.

### Design polish (commit 2)

**What:** Added `transform: scale(0.97)` on `:active` and CSS transitions to 12 interactive elements (breadcrumb, location-action, dropdown, column-header-action, column-menu-option, preview-header-action, segmented-control-option, transfer-suggestion, properties-action, release-notes-fallback, theme-color-picker button, grid-thumbnail-menu button). Added transitions to switch, switch slider, and form-check. Replaced all dark `#000000` shadows on modals and popovers with one reused accent glow (`0 0 14px alpha(@theme_accent, 0.24)`). Unified border-radius to 9px and border to `alpha(@theme_border, 0.6)`. Added `@media (prefers-reduced-motion: reduce)`.

**Why:**
- Pressable elements without `:active` scale feel dead — no feedback that the UI heard the press (Apple: respond on pointer-down; Emil: buttons must feel responsive)
- State changes without transitions snap instantly instead of animating — feels broken (Emil: every state change needs a transition)
- Dark shadows on floating surfaces were inconsistent (some `#000000`, some `@theme_bg` which is invisible in light themes) and didn't match the accent-tinted design language; one reused accent glow provides identity and consistency with a single value
- Mixed border-radius (7px/9px) and border colors across surfaces looked unpolished
- Reduced-motion users get motion sickness from transforms; the media query keeps opacity cross-fades but removes movement (Apple: reduced motion means gentler, not zero)

Stacked on top of #107 — merge #107 first, then this one.

#### Manual verification

- [ ] Open/close confirmation dialogs repeatedly — no startle, no double modal
- [ ] Click outside dialog rapidly — dismisses once, no stuck overlay
- [ ] Open/close search repeatedly — smooth fade, no duplicate animation
- [ ] Open/close settings repeatedly — smooth fade, no duplicate animation
- [ ] Press any button — visible scale-down feedback on press
- [ ] Toggle switch — smooth background transition
- [ ] Open popovers (peek, column, appearance, context menu) — accent glow, no dark shadow
- [ ] Enable reduced motion in OS settings — modals cross-fade without scaling