### PR TITLE
feat(ui): double-click column resize handle to autofit width

### DIFF
--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -4168,10 +4168,24 @@ impl ViewState {
         resize.set_button(1);
         let resize_start = Rc::new(Cell::new(COLUMN_WIDTH));
         let pointer_start = Rc::new(Cell::new(None));
+        let last_press = Rc::new(Cell::new(0u64));
         let shell_for_resize_start = shell.clone();
+        let shell_for_autofit = shell.clone();
+        let column_for_autofit = column.clone();
         let resize_start_for_begin = resize_start.clone();
         let pointer_start_for_begin = pointer_start.clone();
+        let last_press_for_begin = last_press.clone();
         resize.connect_drag_begin(move |gesture, _, _| {
+            let now = glib::monotonic_time() as u64;
+            let prev = last_press_for_begin.get();
+            last_press_for_begin.set(now);
+            if now.wrapping_sub(prev) <= 400_000 {
+                let max_natural =
+                    max_child_natural_width(column_for_autofit.upcast_ref::<gtk::Widget>());
+                shell_for_autofit.set_size_request(max_natural.max(COLUMN_WIDTH), -1);
+                gesture.set_state(gtk::EventSequenceState::Denied);
+                return;
+            }
             resize_start_for_begin.set(shell_for_resize_start.width().max(COLUMN_WIDTH));
             if let Some((pointer_x, _)) = gesture.current_event().and_then(|event| event.position())
             {
@@ -6090,6 +6104,20 @@ fn resized_column_width(initial_width: i32, horizontal_offset: f64) -> i32 {
     (f64::from(initial_width) + horizontal_offset)
         .round()
         .max(f64::from(COLUMN_WIDTH)) as i32
+}
+
+pub(super) fn max_child_natural_width(widget: &gtk::Widget) -> i32 {
+    let (_, natural, _, _) = widget.measure(gtk::Orientation::Horizontal, -1);
+    let mut max_natural = natural;
+    let mut child = widget.first_child();
+    while let Some(c) = child {
+        let child_max = max_child_natural_width(&c);
+        if child_max > max_natural {
+            max_natural = child_max;
+        }
+        child = c.next_sibling();
+    }
+    max_natural
 }
 
 fn horizontal_reveal_target(

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -1445,10 +1445,28 @@ fn column_resize_handle(
     resize.set_button(1);
     let starting_width = Rc::new(Cell::new(initial_width));
     let pointer_start = Rc::new(Cell::new(None::<f64>));
+    let last_press = Rc::new(Cell::new(0u64));
     let starting_for_begin = starting_width.clone();
     let pointer_for_begin = pointer_start.clone();
+    let last_press_for_begin = last_press.clone();
     let columns_for_begin = columns.clone();
+    let columns_for_autofit = columns.clone();
     resize.connect_drag_begin(move |gesture, _, _| {
+        let now = glib::monotonic_time() as u64;
+        let prev = last_press_for_begin.get();
+        last_press_for_begin.set(now);
+        if now.wrapping_sub(prev) <= 400_000 {
+            let natural = columns_for_autofit.cells[index]
+                .borrow()
+                .iter()
+                .filter_map(glib::WeakRef::upgrade)
+                .map(|widget| super::browser::max_child_natural_width(&widget))
+                .max()
+                .unwrap_or(initial_width);
+            set_explorer_column_width(&columns_for_autofit, index, natural.max(64));
+            gesture.set_state(gtk::EventSequenceState::Denied);
+            return;
+        }
         let width = columns_for_begin.cells[index]
             .borrow()
             .iter()
@@ -1463,6 +1481,7 @@ fn column_resize_handle(
         );
         gesture.set_state(gtk::EventSequenceState::Claimed);
     });
+    let columns_for_update = columns.clone();
     resize.connect_drag_update(move |gesture, fallback_offset_x, _| {
         let pointer_x = gesture
             .current_event()
@@ -1473,7 +1492,7 @@ fn column_resize_handle(
             .zip(pointer_x)
             .map_or(fallback_offset_x, |(start, current)| current - start);
         let width = (f64::from(starting_width.get()) + offset_x).round() as i32;
-        set_explorer_column_width(&columns, index, width.max(64));
+        set_explorer_column_width(&columns_for_update, index, width.max(64));
     });
     handle.add_controller(resize);
     handle


### PR DESCRIPTION
## Summary

### What
- Double-click the column resize handle (the thin strip on the right edge of any column) to auto-fit the column width to its widest content
- Works in both columns mode and explorer mode

### Why
- Drag-to-resize requires guessing the right width; double-click auto-fits to the longest file name in one action
- Matches the behavior of Finder, Windows Explorer, and other file managers
- Reuses the existing `GestureDrag` instead of adding a separate `GestureClick` that would fight the drag for event ownership — double-click is detected by tracking the time between `drag_begin` calls (400ms window)

#### Manual verification
- [x] In columns mode, double-click the right edge of a column — it widens/narrows to fit the longest file name
- [x] In explorer mode, double-click the right edge of any column — same behavior
- [x] Single-click + drag still works to manually resize
- [x] Column does not shrink below the minimum width (300px columns, 64px explorer)
<img width="960" height="540" alt="screenrecording-2026-09-01_19-46-04" src="https://github.com/user-attachments/assets/d04fcaa1-1c9a-4ceb-aa1c-52c7a538fb26" />