### PR TITLE
fix(ui): cancel rename on click outside

### DIFF
--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -283,7 +283,8 @@ impl ModeViews {
             return false;
         };
         rename.label.set_visible(true);
-        rename.field.unparent();
+        rename.field.set_visible(false);
+        rename.field.set_sensitive(true);
         true
     }
 
@@ -317,18 +318,14 @@ impl ModeViews {
         else {
             return false;
         };
-        let Some(parent) = label.parent().and_downcast::<gtk::Box>() else {
+        let Some(field) =
+            descendant_with_class(&widget, "inline-rename").and_downcast::<gtk::Entry>()
+        else {
             return false;
         };
-        let field = gtk::Entry::new();
-        field.add_css_class("inline-rename");
-        field.set_width_chars(12);
         field.set_text(&entry.display_name);
-        field.connect_changed(|field| {
-            super::browser::update_basename_validation(field);
-        });
+        field.set_visible(true);
         label.set_visible(false);
-        parent.append(&field);
         let browser = Rc::downgrade(&self.browser);
         let renamed_entry = entry.clone();
         let active = self.active_rename.clone();
@@ -337,7 +334,7 @@ impl ModeViews {
             if name == renamed_entry.display_name {
                 if let Some(rename) = active.take() {
                     rename.label.set_visible(true);
-                    rename.field.unparent();
+                    rename.field.set_visible(false);
                 }
             } else if let Some(browser) = browser.upgrade() {
                 field.set_sensitive(false);

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -311,6 +311,25 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
     });
     window.add_controller(settings_shortcut);
     window.set_child(Some(&window_overlay));
+    let rename_cancel_view = browser.clone();
+    let rename_cancel = gtk::GestureClick::new();
+    rename_cancel.set_propagation_phase(gtk::PropagationPhase::Capture);
+    rename_cancel.connect_pressed(move |gesture, _, x, y| {
+        if !rename_cancel_view.rename_is_active() {
+            return;
+        }
+        let on_entry = gesture
+            .widget()
+            .and_then(|widget| widget.pick(x, y, gtk::PickFlags::DEFAULT))
+            .is_some_and(|target| {
+                target.has_css_class("inline-rename")
+                    || target.ancestor(gtk::Entry::static_type()).is_some()
+            });
+        if !on_entry {
+            rename_cancel_view.cancel_rename();
+        }
+    });
+    window.add_controller(rename_cancel);
     install_modal_focus_trap(&window);
     install_keyboard_navigation(&window, &browser, &sidebar, &sidebar_toggle, &preview);
     browser.navigate(location.unwrap_or_else(home_directory));


### PR DESCRIPTION
## Summary

### What
- Clicking outside the rename entry cancels the rename and restores the original name
- Works in all three modes: columns, grid, explorer

### Why
- Previously clicking outside during rename left the field open indefinitely — only Escape or Enter could end it
- The fix reuses the existing hidden inline-rename field in grid/explorer mode instead of creating a new Entry each time, which also fixes a grid card resize/reflow bug (7 items jumping to 6)

#### Manual verification
- [x] In columns mode, start rename (F2), click another row — rename cancels
- [x] In columns mode, start rename, click the sidebar — rename cancels
- [x] In grid mode, start rename, click another card — rename cancels, no reflow
- [x] In explorer mode, start rename, click another row — rename cancels
- [x] Start rename, press Enter — rename submits
- [x] Start rename, press Escape — rename cancels
- [x] Start rename, click inside the entry — rename continues
<img width="960" height="540" alt="screenrecording-2026-09-01_20-26-26" src="https://github.com/user-attachments/assets/c09a2757-9730-4f7b-b898-be89dd0be61d" />