### PR TITLE
build: publish split debug symbols for release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,6 +225,8 @@ jobs:
           key: release-${{ matrix.target }}
 
       - name: Build release binary
+        env:
+          CARGO_PROFILE_RELEASE_DEBUG: line-tables-only
         run: cargo build --release --locked --target "${{ matrix.target }}"
 
       - name: Package binary
@@ -236,12 +238,16 @@ jobs:
           package="strata-${VERSION}-${TARGET}"
           mkdir -p "dist/$package"
           install -m 755 "target/$TARGET/release/strata" "dist/$package/strata"
+          objcopy --only-keep-debug --compress-debug-sections=zlib "dist/$package/strata" "dist/$package.debug"
+          strip --strip-unneeded "dist/$package/strata"
+          objcopy --add-gnu-debuglink="dist/$package.debug" "dist/$package/strata"
           printf '%s\n' "$SOURCE_SHA" > "dist/$package/SOURCE_COMMIT"
           cp README.md LICENSE THIRD_PARTY_LICENSES.md "dist/$package/"
           install -m 644 data/io.github.lgse.Strata.desktop "dist/$package/"
           install -m 644 data/icons/scalable/apps/io.github.lgse.Strata.svg "dist/$package/"
           tar -C dist -czf "dist/$package.tar.gz" "$package"
           (cd dist && sha256sum "$package.tar.gz" > "$package.tar.gz.sha256")
+          (cd dist && sha256sum "$package.debug" > "$package.debug.sha256")
 
       - name: Upload release artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -249,6 +255,7 @@ jobs:
           name: strata-${{ matrix.target }}
           path: |
             dist/*.tar.gz
+            dist/*.debug
             dist/*.sha256
           if-no-files-found: error
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ strata
 
 If `command -v` fails, add `$HOME/.local/bin` to your shell's `PATH`. Every archive contains `SOURCE_COMMIT`, identifying the exact source revision used by GitHub Actions.
 
+#### Debug a release crash
+
+Download the matching `strata-<version>-<target>.debug` asset from the same release and place it beside the installed `strata` binary, keeping its filename unchanged. Then run `coredumpctl debug strata`; GDB will load its Rust function names and source lines.
+
 #### 3. Update or uninstall
 
 For a manual release installation, use **Settings → Updates** for verified in-app updates, or repeat the download, verification, and `install` steps for a newer release. An in-app update also refreshes an already installed desktop entry and application icon from the new archive; it never creates desktop metadata that was not installed before. Package-managed installations are updated only by their system package manager. To remove a per-user installation:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -24,7 +24,7 @@ Run the **Release** workflow from GitHub's Actions tab on the default branch, ch
 
 - the `prepare` job refuses to proceed if a release candidate tag exists for the target core version whose commit is not yet reachable from the release source -- promote or discard that RC first, so a stable release can never silently supersede an untested one;
 - the `release` job commits the new version into `Cargo.toml` and `Cargo.lock`, tags the commit `vX.Y.Z`, and pushes both to the default branch; and
-- it publishes x86-64 and ARM64 archives, checksums, and build-provenance attestations as an ordinary (non-prerelease) GitHub release -- the endpoint a Stable install polls.
+- it publishes x86-64 and ARM64 archives, matching debug-symbol files, checksums, and build-provenance attestations as an ordinary (non-prerelease) GitHub release -- the endpoint a Stable install polls.
 
 ## Cutting and promoting prereleases
 
@@ -39,6 +39,10 @@ Run the same workflow manually with `mode` set to `alpha`, `beta`, `rc`, or `nig
 - publishes a GitHub prerelease, keeping `/releases/latest` pointed at the last stable release.
 
 RC and nightly publication are intentionally manual. To promote a validated RC line to stable, run the workflow again with `mode: stable` and the same `bump` level. The resulting stable tag supersedes the prerelease line; the guard blocks promotion when an RC commit is not reachable from the stable source.
+
+## Debugging a release build
+
+Each release includes a `strata-VERSION-TARGET.debug` file matching its stripped binary. Download the debug file for the installed version and architecture, place it beside the `strata` binary, then run `coredumpctl debug strata`; GDB follows the binary's embedded debug link to load Rust function names and source lines.
 
 ## Version calculation
 


### PR DESCRIPTION
## Description

Build each Linux release with line-table debug information, extract it into a zlib-compressed `.debug` release asset, strip the binary included in the release archive, and embed a GNU debug link.

Each architecture publishes a matching debug file and checksum. Placing that file beside the installed binary lets GDB resolve Rust function names and source lines without increasing the shipped binary size.

The README and release runbook document how to use the debug artifact with `coredumpctl debug strata`.

## Visual evidence

N/A. Release packaging only.

## How to test

1. Build with `CARGO_PROFILE_RELEASE_DEBUG=line-tables-only`.
2. Extract symbols using `objcopy --only-keep-debug`.
3. Strip the packaged binary and add its GNU debug link.
4. Confirm the matching `.debug` file lets GDB resolve `strata::main` to `src/main.rs`.

Local x86_64 results:

- Current v0.9.0 release binary: 13,601,952 bytes
- Proposed shipped binary: 10,540,944 bytes
- Compressed debug artifact: 17,607,936 bytes
- GDB resolved `strata::main` to `src/main.rs:26`
- Formatting, compilation, and Clippy passed
- Full tests: 441 passed; one unrelated logging test flaked under the full suite and passed in isolation

## Related issue

Closes #100