### PR TITLE
fix(ui): improve file size badge readability and hide on folders

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -2120,26 +2120,28 @@ menubutton.column-header-action > button:focus-visible image {
 }
 
 .file-size {
-  background: @theme_bg;
+  background: @theme_surface;
   color: @theme_dim_text;
   font-size: 0.9em;
   opacity: 0;
-  padding-left: 10px;
+  padding: 2px 7px;
+  border-radius: 5px;
+  transition: opacity 120ms ease-out;
 }
 
 .file-list row:hover .file-size {
-  background: alpha(@theme_muted, 0.65);
   opacity: 1;
 }
 
 .file-list row:selected .file-size {
-  background: alpha(@theme_muted, 0.65);
   color: @theme_dim_text;
+  opacity: 1;
 }
 
 .file-list .file-row.active-path .file-size {
   background: @theme_highlight;
   color: @theme_dim_text;
+  opacity: 1;
 }
 
 .file-list row:selected {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -3946,6 +3946,7 @@ impl ViewState {
                 })
                 .unwrap_or_default();
             size.set_label(&size_text);
+            size.set_visible(!size_text.is_empty());
         });
         factory.connect_unbind(|_, item| super::thumbnail::cancel_list_item_thumbnails(item));
 


### PR DESCRIPTION
## Summary
- The size badge overlay used a semi-transparent background (`alpha(@theme_muted, 0.65)`) that let the file name text bleed through, making it hard to read. Switched to an opaque `@theme_surface` chip with balanced `2px 7px` padding, `border-radius: 5px`, and a 120ms opacity fade so it reads as a distinct pill instead of a strip.
- The badge appeared as an empty pill on folders (size text was emptied but the widget stayed visible) and was invisible on selected rows (inherited `opacity: 0` from the base with no override). Now `set_visible(!size_text.is_empty())` hides it for folders/unknown sizes, and `:selected`/`.active-path` states explicitly set `opacity: 1`.

#### Test plan
- [x] Hover a file row — size badge fades in as a readable chip, no text bleeding through
- [x] Hover a folder row — no badge appears
- [x] Select a file row — badge stays visible
- [x] Navigate into a folder (active-path state) — badge shows with highlight background
<img width="410" height="135" alt="image" src="https://github.com/user-attachments/assets/c1b402cb-e440-4b7c-ba74-977c00a17e22" />