### PR TITLE
fix(ui): polish peek popover depth, alignment, and slide animation

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1479,9 +1479,9 @@ paned > separator {
 
 .peek-popover {
   background: @theme_surface;
-  border: 1px solid alpha(@theme_border, 0.6);
+  border: 1px solid alpha(@theme_border, 0.8);
   border-radius: 9px;
-  box-shadow: 0 0 14px alpha(@theme_accent, 0.24);
+  box-shadow: 0 0 14px alpha(@theme_accent, 0.24), 0 6px 20px alpha(@theme_bg, 0.45);
   color: @theme_text;
   padding: 0;
 }
@@ -1489,13 +1489,15 @@ paned > separator {
 .peek-popover .column-header {
   background: @theme_surface;
   border-bottom: 1px solid alpha(@theme_border, 0.24);
-  border-radius: 6px 6px 0 0;
+  border-radius: 9px 9px 0 0;
+  color: @theme_dim_text;
 }
 
 .peek-popover scrolledwindow,
 .peek-popover viewport,
 .peek-popover listview {
   background: @theme_surface;
+  padding: 6px 0;
 }
 
 .column-header {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -196,7 +196,7 @@ impl Default for PeekBehavior {
         Self {
             open_delay: Duration::from_millis(180),
             close_delay: Duration::from_millis(80),
-            fade_duration: Duration::from_millis(100),
+            fade_duration: Duration::from_millis(150),
             item_limit: 8,
         }
     }
@@ -4450,21 +4450,24 @@ impl ViewState {
             return;
         };
         content.add_css_class("peek-popover");
-        let right = bounds.x() + bounds.width() + 4.0;
+        let gap = 8.0;
+        let right = bounds.x() + bounds.width() + gap;
         let left = (bounds.x() - 260.0).max(0.0);
-        let x = if right + 256.0 <= self.overlay.width() as f32 {
-            right
-        } else {
-            left
-        };
+        let positioned_right = right + 256.0 <= self.overlay.width() as f32;
+        let x = if positioned_right { right } else { left };
         let transition_duration = self
             .peek_behavior
             .fade_duration
             .as_millis()
             .min(u128::from(u32::MAX)) as u32;
+        let transition_type = if positioned_right {
+            gtk::RevealerTransitionType::SlideRight
+        } else {
+            gtk::RevealerTransitionType::SlideLeft
+        };
         let revealer = gtk::Revealer::builder()
             .child(&content)
-            .transition_type(gtk::RevealerTransitionType::Crossfade)
+            .transition_type(transition_type)
             .transition_duration(transition_duration)
             .reveal_child(false)
             .halign(gtk::Align::Start)


### PR DESCRIPTION
## Summary
- Header border-radius was `6px 6px 0 0` while the container was `9px` — visible gap between header background and container border. Now matches at `9px 9px 0 0`.
- The popover had only an accent glow with no depth shadow, so it didn't read as a floating surface. Layered `0 6px 20px alpha(@theme_bg, 0.45)` under the existing accent glow.
- Header label used `alpha(@theme_accent, 0.58)` which read as a broken/placeholder color. Switched to `@theme_dim_text` — the established pattern for secondary labels in this app.
- List items touched the top/bottom edges with no breathing room. Added `padding: 6px 0` to the scroll/list area.
- The popover used a `Crossfade` transition, ignoring its spatial origin. Now slides directionally (`SlideRight` when positioned right of the anchor, `SlideLeft` when on the left) so enter and exit follow the same path.
- Fade duration was 100ms — below the 125–200ms range for small popovers. Bumped to 150ms for a more deliberate feel.
- The 4px gap between anchor and popover was too tight, making them visually merge. Widened to 8px.

#### Test plan
- [x] Hover a folder — popover slides in from the anchor direction with the accent glow + depth shadow
- [x] Check header top corners match the container's rounded corners
- [x] Check header label reads as a proper dim label, not a faded accent
- [x] Check list items have vertical breathing room at top and bottom
- [x] Hover a folder near the right edge — popover falls back to the left and slides in from the left
- [x] Move away — popover slides out along the same path
<img width="358" height="326" alt="image" src="https://github.com/user-attachments/assets/80130971-905b-4cd8-9931-4165fac9ad36" />
<img width="960" height="540" alt="screenrecording-2026-09-02_01-21-09" src="https://github.com/user-attachments/assets/f35c1d1b-4384-42ae-8773-6ea13e7f0dac" />