### PR TITLE
fix(ui): close stale preview after deleting the previewed file

### DIFF
--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -1474,6 +1474,10 @@ impl Browser {
                     take_focus: false,
                 });
             }
+            self.emit(BrowserEvent::FocusChanged {
+                depth,
+                position: selected,
+            });
         }
     }
 

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -71,6 +71,9 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
                 }
             }
         }
+        BrowserEvent::FocusChanged { position: None, .. } if preview_for_selection.is_open() => {
+            preview_for_selection.close();
+        }
         _ => {}
     });
 


### PR DESCRIPTION
## Why this happens

The preview pane is driven by a window-level observer (`window.rs`) that listens for two events:
- `PreviewRequested` — user presses Space to open preview
- `FocusChanged` — focus moves to a new entry, so preview should follow

When a file is deleted, `handle_directory_change` (`app/browser.rs`) updates the column and emits `SelectionSetChanged` — but **not** `FocusChanged`. The observer doesn't listen for `SelectionSetChanged`, so it never finds out the previewed entry was removed. The preview keeps rendering the deleted file's content.

When the deleted file was the only entry in the column, `selected` becomes `None` and neither `SelectionSetChanged` nor `FocusChanged` fires — so the preview has no signal at all.

## Why this fix

`FocusChanged` is already the established channel for "the focused entry changed, update dependents." The observer already handles it for navigation, keyboard movement, and column changes. Deletion changing the selection is the same semantic event — it just wasn't wired up.

Emitting `FocusChanged` from `handle_directory_change` with the new `selected` position closes the gap:
- **Selection moved to another file** → `FocusChanged { position: Some(n) }` → observer calls `show(new_entry)`
- **Column is now empty** → `FocusChanged { position: None }` → observer closes the preview (new `None` arm)

This reuses the existing observer logic instead of adding a parallel deletion-specific channel, so the diff is two lines across two files.

#### Test plan
- [x] Select a file, press Space to preview, then Delete — preview closes or switches to the newly focused file
- [x] Delete the only file in a directory while previewing it — preview closes (column is empty)
- [x] Delete a file that is not the one being previewed — preview stays on the current file

<img width="960" height="540" alt="screenrecording-2026-09-02_01-48-34" src="https://github.com/user-attachments/assets/d5dc52e4-a726-43ff-8ca1-398c21c4a758" />