### PR TITLE
fix(ui): allow Delete key when focus is outside the file list

### DIFF
--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -601,11 +601,11 @@ fn install_keyboard_navigation(
         {
             return glib::Propagation::Stop;
         }
-        if !control && !alt && !view.item_view_has_focus() && !header_left_boundary {
-            return glib::Propagation::Proceed;
-        }
         if key == gtk::gdk::Key::Delete && !view.filter_has_focus() && view.confirm_delete(shift) {
             return glib::Propagation::Stop;
+        }
+        if !control && !alt && !view.item_view_has_focus() && !header_left_boundary {
+            return glib::Propagation::Proceed;
         }
         if key == gtk::gdk::Key::space && !alt && !control {
             preview.toggle(browser.focused_entry());


### PR DESCRIPTION
## Why this happens

The keyboard handler in `window.rs` gates all file-list shortcuts behind `item_view_has_focus()`. When you click something outside the list — like the close preview button, a header button, or the sidebar — focus moves to that widget, `item_view_has_focus()` returns false, and the handler returns `Proceed` before the Delete key is ever checked.

The file still looks selected because GTK's `ListView` selection visual persists regardless of where keyboard focus is. So you see a highlighted file, press Delete, and nothing happens — the shortcut is silently dead.

## Why this fix

Move the Delete check **before** the `item_view_has_focus()` gate. This is safe because:

- `filter_has_focus()` still blocks Delete while typing in a filter field
- `confirm_delete()` returns `false` when `deletion_entries()` is empty (nothing selected), so it won't fire spuriously
- Rename, dialogs, and other text inputs have their own key handlers that run earlier in the chain

No other shortcuts are moved — Space, Escape, navigation keys, etc. still require the file list to have focus, which is correct since they operate on the focused list item.

#### Test plan
- [x] Select a file, click the close preview button, press Delete — delete confirmation appears
- [x] Select a file, click a header button, press Delete — delete confirmation appears
- [x] With no file selected, press Delete — nothing happens (confirm_delete returns false)
- [x] While typing in a filter field, press Delete — filter text deletes, no confirmation appears
<img width="960" height="540" alt="screenrecording-2026-09-02_02-02-21" src="https://github.com/user-attachments/assets/6c4f5efc-3cc2-4959-a57d-9b8ffac699bc" />