### PR TITLE
fix(ui): disable Empty Trash button when trash is empty

### DIFF
--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -68,6 +68,7 @@ struct ColumnView {
     bound_rows: Rc<RefCell<Vec<BoundRow>>>,
     entry_count: Rc<Cell<usize>>,
     spinner: gtk::Spinner,
+    empty_trash_button: Option<gtk::Button>,
     new_entry_row: gtk::Box,
     new_entry_icon: gtk::Image,
     new_entry_entry: gtk::Entry,
@@ -1669,6 +1670,15 @@ impl ViewState {
     }
 
     fn load_trash_summary(self: &Rc<Self>) {
+        let trash_empty = self
+            .columns
+            .borrow()
+            .iter()
+            .find(|column| column.empty_trash_button.is_some())
+            .is_some_and(|column| column.entry_count.get() == 0);
+        if trash_empty {
+            return;
+        }
         let Some(window_overlay) = self
             .overlay
             .root()
@@ -3128,6 +3138,7 @@ impl ViewState {
                     let count = column.entry_count.get() + entry_count;
                     column.entry_count.set(count);
                     set_filter_placeholder(&column, count);
+                    update_empty_trash_sensitivity(&column, count);
                     crate::metrics::mark_batch_rendered(entry_count, render_started);
                 }
             }
@@ -3143,6 +3154,7 @@ impl ViewState {
                     column.model.splice(0, column.model.n_items(), &labels);
                     column.entry_count.set(entries.len());
                     set_filter_placeholder(&column, entries.len());
+                    update_empty_trash_sensitivity(&column, entries.len());
                 }
             }
             BrowserEvent::SortingStarted { depth } => {
@@ -3191,6 +3203,7 @@ impl ViewState {
                     } else {
                         column.presentation.show_content();
                     }
+                    update_empty_trash_sensitivity(column, count);
                 }
             }
             BrowserEvent::ColumnReloaded { depth } => {
@@ -3207,11 +3220,13 @@ impl ViewState {
                 if let Some(column) = self.columns.borrow().get(depth) {
                     column.spinner.stop();
                     column.spinner.set_visible(false);
-                    if column.entry_count.get() == 0 {
+                    let count = column.entry_count.get();
+                    if count == 0 {
                         column.presentation.show_empty();
                     } else {
                         column.presentation.show_content();
                     }
+                    update_empty_trash_sensitivity(column, count);
                 }
                 if self.browser.active_depth() == Some(depth)
                     && let Some(name) = self.pending_select.take()
@@ -3491,7 +3506,9 @@ impl ViewState {
         let header_actions = gtk::Box::new(gtk::Orientation::Horizontal, 0);
         header_actions.add_css_class("column-header-actions");
         let empty_trash = empty_trash_button(&self.browser);
-        empty_trash.set_visible(is_trash_root(location));
+        let is_trash = is_trash_root(location);
+        empty_trash.set_visible(is_trash);
+        empty_trash.set_sensitive(false);
         header_actions.append(&empty_trash);
         header_actions.append(&column_sort_direction_toggle(&self.browser, depth));
         header_actions.append(&column_sort_menu(&self.browser, depth));
@@ -4279,6 +4296,7 @@ impl ViewState {
             bound_rows,
             entry_count,
             spinner,
+            empty_trash_button: is_trash.then_some(empty_trash),
             new_entry_row,
             new_entry_icon,
             new_entry_entry,
@@ -5909,6 +5927,12 @@ fn sync_sort_direction_toggle(button: &gtk::Button, icon: &gtk::Image, direction
     } else {
         "Ascending — click to reverse"
     }));
+}
+
+fn update_empty_trash_sensitivity(column: &ColumnView, count: usize) {
+    if let Some(button) = &column.empty_trash_button {
+        button.set_sensitive(count > 0);
+    }
 }
 
 pub(super) fn empty_trash_button(browser: &Rc<Browser>) -> gtk::Button {

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -90,6 +90,7 @@ struct Pane {
     bound_items: Rc<RefCell<Vec<BoundModeItem>>>,
     filter_entry: Option<gtk::Entry>,
     filter_button: Option<gtk::ToggleButton>,
+    empty_trash_button: Option<gtk::Button>,
     new_entry_placeholder: Option<gtk::StringList>,
     new_entry_is_directory: Option<Rc<Cell<bool>>>,
 }
@@ -837,6 +838,7 @@ struct GridControls {
     filter_button: gtk::ToggleButton,
     thumbnail_scale: gtk::Scale,
     thumbnail_value: gtk::Label,
+    empty_trash_button: Option<gtk::Button>,
 }
 
 fn filter_controls(tooltip: &str) -> (gtk::Entry, gtk::Revealer, gtk::ToggleButton) {
@@ -928,9 +930,11 @@ fn grid_controls(browser: &Rc<Browser>, depth: usize, thumbnail_size: i32) -> Gr
         16,
     )));
     let empty_trash = super::browser::empty_trash_button(browser);
-    if let Some(location) = browser.location_at(depth) {
-        empty_trash.set_visible(super::browser::is_trash_root(&location));
-    }
+    let is_trash = browser
+        .location_at(depth)
+        .is_some_and(|location| super::browser::is_trash_root(&location));
+    empty_trash.set_visible(is_trash);
+    empty_trash.set_sensitive(false);
     actions.append(&empty_trash);
     actions.append(&thumbnail_menu);
     actions.append(&super::browser::column_sort_direction_toggle(
@@ -948,6 +952,7 @@ fn grid_controls(browser: &Rc<Browser>, depth: usize, thumbnail_size: i32) -> Gr
         filter_button,
         thumbnail_scale,
         thumbnail_value,
+        empty_trash_button: is_trash.then_some(empty_trash),
     }
 }
 
@@ -1250,6 +1255,7 @@ fn build_grid_pane(
         bound_items,
         filter_entry: Some(controls.filter_entry),
         filter_button: Some(controls.filter_button),
+        empty_trash_button: controls.empty_trash_button,
         new_entry_placeholder: Some(new_entry_placeholder),
         new_entry_is_directory: Some(new_entry_is_directory),
     }
@@ -1548,9 +1554,11 @@ fn build_explorer_pane(
     let actions = gtk::Box::new(gtk::Orientation::Horizontal, 0);
     actions.add_css_class("grid-header-actions");
     let empty_trash = super::browser::empty_trash_button(&browser);
-    if let Some(location) = browser.location_at(depth) {
-        empty_trash.set_visible(super::browser::is_trash_root(&location));
-    }
+    let is_trash = browser
+        .location_at(depth)
+        .is_some_and(|location| super::browser::is_trash_root(&location));
+    empty_trash.set_visible(is_trash);
+    empty_trash.set_sensitive(false);
     actions.append(&empty_trash);
     let (filter_entry, filter_revealer, filter_button) =
         filter_controls("Filter explorer (Ctrl+F)");
@@ -1834,6 +1842,7 @@ fn build_explorer_pane(
         bound_items,
         filter_entry: Some(filter_entry),
         filter_button: Some(filter_button),
+        empty_trash_button: is_trash.then_some(empty_trash),
         new_entry_placeholder: Some(new_entry_placeholder),
         new_entry_is_directory: Some(new_entry_is_directory),
     }
@@ -2446,12 +2455,16 @@ fn replace_entries(pane: &Pane, entries: &[FileEntry]) {
 }
 
 fn show_count(pane: &Pane) {
-    if pane.model.n_items() == 0 {
+    let count = pane.model.n_items();
+    if count == 0 {
         pane.status.remove_css_class("error");
         pane.status.set_label("This directory is empty");
         pane.stack.set_visible_child_name("status");
     } else {
         pane.stack.set_visible_child_name("content");
+    }
+    if let Some(button) = &pane.empty_trash_button {
+        button.set_sensitive(count > 0);
     }
 }
 


### PR DESCRIPTION
## Why

The Empty Trash button was always sensitive when visible. Clicking it on an empty `trash:///` opened a "Measuring Trash…" modal that flashed briefly and disappeared with no action — confusing and distracting for an operation that can't do anything.

## What changed

- **Button sensitivity**: The Empty Trash button is now stored per column (columns view) and per pane (grid and explorer views). Its sensitivity is updated whenever entry counts change (`EntriesInserted`, `EntriesReplaced`, `EntriesSpliced`, `LoadFinished`) — disabled when 0 entries, enabled when items exist.
- **Modal guard**: `load_trash_summary` returns early if the trash column has 0 entries, so the measurement modal never opens even if the button is somehow triggered.

This covers all three view modes (columns, grid, explorer) and keeps the button synchronized as trash contents load, change, or are emptied.

#### Manual steps
1. Navigate to `trash:///` when trash is empty — Empty Trash button should be greyed out
2. Move a file to trash — button should become active
3. Click the active button — confirmation modal should appear as before
4. Empty the trash — button should grey out again
5. Switch to grid and explorer modes and repeat

Closes #130
<img width="960" height="540" alt="screenrecording-2026-09-02_02-16-30" src="https://github.com/user-attachments/assets/98309d3b-bdb0-4a63-a5cb-04102c57a289" />