### PR TITLE
fix(preview): bound sandbox allocator arenas

### DIFF
--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -374,6 +374,10 @@ fn sandbox_command(
         }
         command.args(["--ro-bind", "/sys", "/sys"]);
     }
+    if operation != ParseOperation::PreviewMedia {
+        // Keep CPU-scaled glibc arenas within the helper's address-space limit.
+        command.args(["--setenv", "MALLOC_ARENA_MAX", "1"]);
+    }
     command.arg("--");
     if operation != ParseOperation::PreviewMedia {
         command

--- a/src/sandbox/tests.rs
+++ b/src/sandbox/tests.rs
@@ -84,6 +84,7 @@ fn sandbox_exposes_only_runtime_input_and_private_output() {
     assert!(joined.contains("--as=2147483648"));
     assert!(joined.contains("--cpu=10"));
     assert!(joined.contains("--fsize=536870912"));
+    assert!(joined.contains("--setenv MALLOC_ARENA_MAX 1"));
     assert!(joined.contains("--size 536870912 --tmpfs /tmp"));
     // RLIMIT_NPROC counts every process owned by the host user, not just the
     // sandbox, and can prevent legitimate media decoders from starting.
@@ -115,6 +116,7 @@ fn media_previews_use_bounded_streaming_instead_of_driver_wide_resource_limits()
     assert!(!joined.contains("--as="));
     assert!(!joined.contains("--cpu="));
     assert!(!joined.contains("--fsize="));
+    assert!(!joined.contains("MALLOC_ARENA_MAX"));
     assert!(joined.contains("--size 536870912 --tmpfs /tmp"));
     assert!(!joined.contains("--bind /tmp/private-output /output"));
     assert!(joined.contains("preview-media /input /dev/stdout"));


### PR DESCRIPTION
## Description

Limit glibc to one malloc arena in resource-limited preview helpers. glycin's ICC conversion scales its thread count with available CPUs, allowing allocator arenas and thread stacks to exhaust the helper's 2 GiB address-space limit on high-core systems.

This preserves the existing address-space limit and nested sandbox while preventing glycin thread creation from failing with `EAGAIN` and aborting the helper. Media previews are excluded because they do not use the address-space limit.

## Visual evidence

N/A — this changes sandbox process configuration without changing the interface.

## How to test

1. Build and run Strata on a high-core system using gdk-pixbuf with glycin.
2. Open a folder containing the affected JPEG or another ICC-profiled image and allow its thumbnail to render.
3. Open the same image in the preview drawer.

**Expected result:** The thumbnail and preview render without the helper aborting or producing a core dump, while media previews continue to work normally.

## Related issue

Closes #141
