### PR TITLE
fix(settings): persist missing preferences across restarts

### DIFF
--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -206,6 +206,13 @@ impl Browser {
             .push(Rc::new(observer));
     }
 
+    fn notify_preferences_observers(&self) {
+        let preferences = self.preferences.get();
+        for observer in self.preferences_observers.borrow().iter() {
+            observer(preferences);
+        }
+    }
+
     pub fn set_operation_provider(&self, provider: Rc<dyn OperationProvider>) {
         self.operation_provider.replace(Some(provider));
     }
@@ -525,6 +532,7 @@ impl Browser {
         let mut preferences = self.preferences.get();
         preferences.show_hidden = !preferences.show_hidden;
         self.preferences.set(preferences);
+        self.notify_preferences_observers();
 
         let locations = {
             let mut state = self.state.borrow_mut();
@@ -583,10 +591,7 @@ impl Browser {
                 browser.preferences.set(preferences);
                 result
             };
-            let preferences = browser.preferences.get();
-            for observer in browser.preferences_observers.borrow().iter() {
-                observer(preferences);
-            }
+            browser.notify_preferences_observers();
             if let Some((entries, focused, positions)) = result {
                 browser.emit(BrowserEvent::EntriesReplaced { depth, entries });
                 if let Some(focused) = focused {

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -623,11 +623,21 @@ fn hidden_file_preference_is_applied_to_reloaded_requests() {
     let browser = Browser::new(Rc::new(RecordingFileSource {
         include_hidden: include_hidden.clone(),
     }));
+    let observed_preferences = Rc::new(Cell::new(None));
+    let observed = observed_preferences.clone();
+    browser.observe_preferences(move |preferences| observed.set(Some(preferences)));
 
     browser.navigate(Location::local("/fixture"));
     browser.toggle_hidden();
 
     assert_eq!(*include_hidden.borrow(), vec![false, true]);
+    assert_eq!(
+        observed_preferences.get(),
+        Some(ViewPreferences {
+            show_hidden: true,
+            ..ViewPreferences::default()
+        })
+    );
 }
 
 #[test]

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -21,7 +21,6 @@ use super::{
     blur::BlurBin,
     browser::{BrowserView, dismiss_modal_layer, modal_layer},
     controls::{form_entry, modal_layout, segmented_control},
-    motion::set_reduce_motion,
     theme::{Theme, ThemeManager, ThemeTokens},
 };
 
@@ -397,9 +396,11 @@ fn general_page(browser: &BrowserView, manager: Rc<ThemeManager>) -> gtk::Widget
     let (motion_row, reduce_motion) = settings_option(
         "Reduce motion",
         "Disable nonessential interface animations.",
-        false,
+        manager.reduce_motion(),
     );
-    reduce_motion.connect_active_notify(|toggle| set_reduce_motion(toggle.is_active()));
+    reduce_motion.connect_active_notify(move |toggle| {
+        manager.set_reduce_motion(toggle.is_active());
+    });
     preferences.append(&motion_row);
 
     scrollable_page(&preferences, None)

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -66,6 +66,8 @@ struct Preferences {
     single_click_previews: bool,
     #[serde(default)]
     search_open_files_directly: bool,
+    #[serde(default)]
+    reduce_motion: bool,
     #[serde(default = "default_browser_mode")]
     browser_mode: String,
     #[serde(default = "default_browser_density")]
@@ -86,6 +88,7 @@ impl Default for Preferences {
             folder_peeking: true,
             single_click_previews: true,
             search_open_files_directly: false,
+            reduce_motion: false,
             browser_mode: default_browser_mode(),
             browser_density: default_browser_density(),
             sort_key: default_sort_key(),
@@ -149,6 +152,7 @@ impl ThemeManager {
         } else if !settings_path().is_file() && omarchy_available {
             preferences.mode = "omarchy".to_owned();
         }
+        super::motion::set_reduce_motion(preferences.reduce_motion);
 
         let manager = Rc::new(Self {
             provider: gtk::CssProvider::new(),
@@ -205,6 +209,16 @@ impl ThemeManager {
 
     pub fn set_search_open_files_directly(&self, enabled: bool) {
         self.preferences.borrow_mut().search_open_files_directly = enabled;
+        self.save_preferences();
+    }
+
+    pub fn reduce_motion(&self) -> bool {
+        self.preferences.borrow().reduce_motion
+    }
+
+    pub fn set_reduce_motion(&self, reduced: bool) {
+        self.preferences.borrow_mut().reduce_motion = reduced;
+        super::motion::set_reduce_motion(reduced);
         self.save_preferences();
     }
 

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -72,6 +72,10 @@ struct Preferences {
     browser_mode: String,
     #[serde(default = "default_browser_density")]
     browser_density: String,
+    #[serde(default)]
+    show_hidden: bool,
+    #[serde(default = "default_enabled")]
+    folders_first: bool,
     #[serde(default = "default_sort_key")]
     sort_key: String,
     #[serde(default = "default_sort_direction")]
@@ -91,6 +95,8 @@ impl Default for Preferences {
             reduce_motion: false,
             browser_mode: default_browser_mode(),
             browser_density: default_browser_density(),
+            show_hidden: false,
+            folders_first: true,
             sort_key: default_sort_key(),
             sort_direction: default_sort_direction(),
             check_for_updates: true,
@@ -271,6 +277,8 @@ impl ThemeManager {
 
     pub fn set_sort_preferences(&self, preferences: ViewPreferences) {
         let mut stored = self.preferences.borrow_mut();
+        stored.show_hidden = preferences.show_hidden;
+        stored.folders_first = preferences.folders_first;
         stored.sort_key = match preferences.sort_key {
             SortKey::Name => "name",
             SortKey::Size => "size",
@@ -550,22 +558,26 @@ fn read_preferences() -> Option<Preferences> {
 }
 
 fn sort_preferences(preferences: &Preferences) -> ViewPreferences {
-    let sort_key = match preferences.sort_key.as_str() {
-        "name" => SortKey::Name,
-        "size" => SortKey::Size,
-        "modified" => SortKey::Modified,
-        "type" => SortKey::Type,
-        _ => return ViewPreferences::default(),
-    };
-    let sort_direction = match preferences.sort_direction.as_str() {
-        "ascending" => SortDirection::Ascending,
-        "descending" => SortDirection::Descending,
-        _ => return ViewPreferences::default(),
-    };
+    let sorting = match (
+        preferences.sort_key.as_str(),
+        preferences.sort_direction.as_str(),
+    ) {
+        ("name", "ascending") => Some((SortKey::Name, SortDirection::Ascending)),
+        ("name", "descending") => Some((SortKey::Name, SortDirection::Descending)),
+        ("size", "ascending") => Some((SortKey::Size, SortDirection::Ascending)),
+        ("size", "descending") => Some((SortKey::Size, SortDirection::Descending)),
+        ("modified", "ascending") => Some((SortKey::Modified, SortDirection::Ascending)),
+        ("modified", "descending") => Some((SortKey::Modified, SortDirection::Descending)),
+        ("type", "ascending") => Some((SortKey::Type, SortDirection::Ascending)),
+        ("type", "descending") => Some((SortKey::Type, SortDirection::Descending)),
+        _ => None,
+    }
+    .unwrap_or((SortKey::Name, SortDirection::Ascending));
     ViewPreferences {
-        sort_key,
-        sort_direction,
-        ..ViewPreferences::default()
+        show_hidden: preferences.show_hidden,
+        folders_first: preferences.folders_first,
+        sort_key: sorting.0,
+        sort_direction: sorting.1,
     }
 }
 

--- a/src/ui/theme/tests.rs
+++ b/src/ui/theme/tests.rs
@@ -164,6 +164,7 @@ theme = "azure-glow"
     assert!(preferences.folder_peeking);
     assert!(preferences.single_click_previews);
     assert!(!preferences.search_open_files_directly);
+    assert!(!preferences.reduce_motion);
     assert_eq!(preferences.browser_mode, "columns");
     assert_eq!(preferences.browser_density, "compact");
     assert_eq!(sort_preferences(&preferences), ViewPreferences::default());
@@ -208,29 +209,21 @@ fn invalid_sorting_preferences_fall_back_as_a_pair() {
 }
 
 #[test]
-fn folder_peeking_can_be_disabled_in_preferences() {
-    let preferences: Preferences = toml::from_str(
-        r#"
-mode = "theme"
-theme = "azure-glow"
-folder_peeking = false
-"#,
-    )
-    .expect("preferences should be valid");
+fn general_preferences_round_trip() {
+    let preferences = Preferences {
+        folder_peeking: false,
+        single_click_previews: false,
+        search_open_files_directly: true,
+        reduce_motion: true,
+        ..Preferences::default()
+    };
 
-    assert!(!preferences.folder_peeking);
-}
+    let serialized = toml::to_string(&preferences).expect("preferences should serialize");
+    let restored: Preferences =
+        toml::from_str(&serialized).expect("preferences should deserialize");
 
-#[test]
-fn single_click_previews_can_be_disabled_in_preferences() {
-    let preferences: Preferences = toml::from_str(
-        r#"
-mode = "theme"
-theme = "azure-glow"
-single_click_previews = false
-"#,
-    )
-    .expect("preferences should be valid");
-
-    assert!(!preferences.single_click_previews);
+    assert!(!restored.folder_peeking);
+    assert!(!restored.single_click_previews);
+    assert!(restored.search_open_files_directly);
+    assert!(restored.reduce_motion);
 }

--- a/src/ui/theme/tests.rs
+++ b/src/ui/theme/tests.rs
@@ -171,7 +171,7 @@ theme = "azure-glow"
 }
 
 #[test]
-fn sorting_preferences_round_trip_all_supported_values() {
+fn view_preferences_round_trip_all_supported_sorting_values() {
     for (key, stored_key) in [
         (SortKey::Name, "name"),
         (SortKey::Size, "size"),
@@ -183,6 +183,8 @@ fn sorting_preferences_round_trip_all_supported_values() {
             (SortDirection::Descending, "descending"),
         ] {
             let preferences = Preferences {
+                show_hidden: true,
+                folders_first: false,
                 sort_key: stored_key.to_owned(),
                 sort_direction: stored_direction.to_owned(),
                 ..Preferences::default()
@@ -190,8 +192,15 @@ fn sorting_preferences_round_trip_all_supported_values() {
             let serialized = toml::to_string(&preferences).expect("preferences should serialize");
             let restored: Preferences =
                 toml::from_str(&serialized).expect("preferences should deserialize");
-            assert_eq!(sort_preferences(&restored).sort_key, key);
-            assert_eq!(sort_preferences(&restored).sort_direction, direction);
+            assert_eq!(
+                sort_preferences(&restored),
+                ViewPreferences {
+                    show_hidden: true,
+                    folders_first: false,
+                    sort_key: key,
+                    sort_direction: direction,
+                }
+            );
         }
     }
 }
@@ -200,11 +209,20 @@ fn sorting_preferences_round_trip_all_supported_values() {
 fn invalid_sorting_preferences_fall_back_as_a_pair() {
     for (key, direction) in [("unknown", "descending"), ("size", "sideways")] {
         let preferences = Preferences {
+            show_hidden: true,
+            folders_first: false,
             sort_key: key.to_owned(),
             sort_direction: direction.to_owned(),
             ..Preferences::default()
         };
-        assert_eq!(sort_preferences(&preferences), ViewPreferences::default());
+        assert_eq!(
+            sort_preferences(&preferences),
+            ViewPreferences {
+                show_hidden: true,
+                folders_first: false,
+                ..ViewPreferences::default()
+            }
+        );
     }
 }
 

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -762,6 +762,7 @@ fn build_appearance_menu(
     content.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
     append_menu_heading(&content, "DENSITY");
     let current_density = preferences.browser_density();
+    let hidden_files_shown = preferences.sort_preferences().show_hidden;
     let (compact, compact_check, _) = appearance_option(
         crate::assets::icons::ROWS,
         "Compact",
@@ -799,22 +800,31 @@ fn build_appearance_menu(
     content.append(&airy);
 
     content.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
-    let (hidden, hidden_check, hidden_icon) =
-        appearance_option(crate::assets::icons::EYE_OFF, "Hidden files", false, true);
-    let hidden_state = Rc::new(Cell::new(false));
-    let weak_controller = Rc::downgrade(controller);
-    hidden.connect_clicked(move |_| {
-        let shown = !hidden_state.get();
-        hidden_state.set(shown);
-        hidden_check.set_visible(shown);
+    let (hidden, hidden_check, hidden_icon) = appearance_option(
+        if hidden_files_shown {
+            crate::assets::icons::EYE
+        } else {
+            crate::assets::icons::EYE_OFF
+        },
+        "Hidden files",
+        hidden_files_shown,
+        true,
+    );
+    let observed_hidden_check = hidden_check.clone();
+    let observed_hidden_icon = hidden_icon.clone();
+    controller.observe_preferences(move |preferences| {
+        observed_hidden_check.set_visible(preferences.show_hidden);
         crate::assets::set_primary_icon(
-            &hidden_icon,
-            if shown {
+            &observed_hidden_icon,
+            if preferences.show_hidden {
                 crate::assets::icons::EYE
             } else {
                 crate::assets::icons::EYE_OFF
             },
         );
+    });
+    let weak_controller = Rc::downgrade(controller);
+    hidden.connect_clicked(move |_| {
         if let Some(controller) = weak_controller.upgrade() {
             controller.toggle_hidden();
         }


### PR DESCRIPTION
## Description

Persist Reduce motion alongside the other General preferences and restore it before the interface is constructed. Also persist the Hidden files and Folders first view preferences discovered during review, and keep the Hidden files menu state synchronized with keyboard changes.

Add backward-compatible defaults and round-trip coverage for the persisted preferences.

## Visual evidence

https://github.com/user-attachments/assets/accb54ab-20d0-4796-b84c-fd40e1230344

## How to test

1. Open Settings → General and enable Reduce motion.
2. Open the Appearance menu and enable Hidden files.
3. Open a column sort menu and disable Folders first.
4. Quit Strata completely and restart it.
5. Reopen Settings, the Appearance menu, and a column sort menu.

**Expected result:**

All three preferences remain selected and effective after restart. Sidebar animations remain disabled, hidden files remain visible, and files retain the selected folder ordering.

## Related issue

Closes #129
Closes #146
