### PR TITLE
fix(uri): sanitize embedded remote credentials

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,11 @@
 - Write commits and pull request titles in Conventional Commits format: `<type>(optional-scope): <imperative description>`.
 - Keep commits focused. Use `!` and a `BREAKING CHANGE:` footer for breaking changes, and reference the issue in the pull request body.
 
+## Pre-push checks
+
+- Do not push until the full local CI suite passes: `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all-targets --all-features`.
+- Fix failures before pushing rather than relying on CI for feedback. Keep tests portable across supported environments and avoid assertions that depend on platform-specific URI normalization or other incidental system behavior.
+
 ## Issues and pull requests
 
 - Automated agents must follow the same issue-first workflow and pull request template as human contributors; do not remove or bypass template sections.

--- a/src/adapters/local_files.rs
+++ b/src/adapters/local_files.rs
@@ -15,7 +15,7 @@ use crate::{
     model::{EntryKind, FileEntry, Location, MetadataValue},
     services::{
         DirectoryChange, DirectoryEvent, DirectoryRequest, FileSource, LoadHandle,
-        LocationValidationError, RequestId, backend_unavailable_message,
+        LocationValidationError, RequestId, backend_unavailable_message, validate_uri_credentials,
     },
 };
 
@@ -45,13 +45,16 @@ fn map_validation_error(error: std::io::Error) -> LocationValidationError {
 /// SFTP, ...) can still return a `.path()` via its FUSE mirror even though the
 /// file isn't native; using that path would leak the mirror's opaque
 /// `/run/user/$UID/gvfs/...` location instead of the clean URI (lgse/strata#5).
-pub(crate) fn location_for_file(file: &gio::File) -> Location {
+/// Returns `None` when GIO preserves embedded credentials in that URI.
+pub(crate) fn location_for_file(file: &gio::File) -> Option<Location> {
     if file.is_native()
         && let Some(path) = file.path()
     {
-        return Location::local(path);
+        return Some(Location::local(path));
     }
-    Location::uri(file.uri())
+    let uri = file.uri();
+    validate_uri_credentials(&uri).ok()?;
+    Some(Location::uri(uri))
 }
 
 fn uri_validation_result(
@@ -227,9 +230,9 @@ impl FileSource for LocalFileSource {
                         let entries: Vec<_> = files
                             .into_iter()
                             .filter(|info| request.include_hidden || !info_is_hidden(info))
-                            .map(|info| {
+                            .filter_map(|info| {
                                 let child = directory.child(info.name());
-                                entry_from_info(location_for_file(&child), info)
+                                Some(entry_from_info(location_for_file(&child)?, info))
                             })
                             .collect();
                         total_entries += entries.len();

--- a/src/adapters/local_files.rs
+++ b/src/adapters/local_files.rs
@@ -15,7 +15,7 @@ use crate::{
     model::{EntryKind, FileEntry, Location, MetadataValue},
     services::{
         DirectoryChange, DirectoryEvent, DirectoryRequest, FileSource, LoadHandle,
-        LocationValidationError, RequestId, backend_unavailable_message, validate_uri_credentials,
+        LocationValidationError, RequestId, backend_unavailable_message, sanitize_uri_credentials,
     },
 };
 
@@ -45,7 +45,7 @@ fn map_validation_error(error: std::io::Error) -> LocationValidationError {
 /// SFTP, ...) can still return a `.path()` via its FUSE mirror even though the
 /// file isn't native; using that path would leak the mirror's opaque
 /// `/run/user/$UID/gvfs/...` location instead of the clean URI (lgse/strata#5).
-/// Returns `None` when GIO preserves embedded credentials in that URI.
+/// Returns `None` when GIO provides a malformed URI.
 pub(crate) fn location_for_file(file: &gio::File) -> Option<Location> {
     if file.is_native()
         && let Some(path) = file.path()
@@ -53,8 +53,8 @@ pub(crate) fn location_for_file(file: &gio::File) -> Option<Location> {
         return Some(Location::local(path));
     }
     let uri = file.uri();
-    validate_uri_credentials(&uri).ok()?;
-    Some(Location::uri(uri))
+    let (sanitized, _) = sanitize_uri_credentials(&uri).ok()?;
+    Some(Location::uri(sanitized))
 }
 
 fn uri_validation_result(

--- a/src/adapters/local_files/tests.rs
+++ b/src/adapters/local_files/tests.rs
@@ -197,9 +197,14 @@ fn gio_files_with_embedded_credentials_are_sanitized() {
         "smb://user%3Bpassword=secret@host/share",
         "smb://user:secret@host/share",
     ] {
+        let location = location_for_file(&gio::File::for_uri(uri))
+            .expect("credential URI should produce a sanitized location");
         assert_eq!(
-            location_for_file(&gio::File::for_uri(uri)),
-            Some(Location::uri("smb://user@host/share/")),
+            location
+                .uri_value()
+                .expect("remote location should have a URI")
+                .trim_end_matches('/'),
+            "smb://user@host/share",
             "did not sanitize {uri}"
         );
     }

--- a/src/adapters/local_files/tests.rs
+++ b/src/adapters/local_files/tests.rs
@@ -179,14 +179,35 @@ fn unmounted_network_shares_are_treated_as_directories() {
 #[test]
 fn native_files_are_located_by_their_real_path() {
     let file = gio::File::for_path("/tmp");
-    assert_eq!(location_for_file(&file), Location::local("/tmp"));
+    assert_eq!(location_for_file(&file), Some(Location::local("/tmp")));
 }
 
 #[test]
 fn gvfs_backed_files_use_their_uri_even_when_a_fuse_path_exists() {
     let file = gio::File::for_uri("smb://host/share");
     assert!(!file.is_native(), "smb:// should never be reported native");
-    assert_eq!(location_for_file(&file), Location::uri(file.uri()));
+    assert_eq!(location_for_file(&file), Some(Location::uri(file.uri())));
+}
+
+#[test]
+fn gio_files_with_embedded_credentials_are_rejected() {
+    for uri in [
+        "smb://user%3Asecret@host/share",
+        "smb://user;password=secret@host/share",
+        "smb://user%3Bpassword=secret@host/share",
+    ] {
+        assert_eq!(
+            location_for_file(&gio::File::for_uri(uri)),
+            None,
+            "accepted {uri}"
+        );
+    }
+
+    let file = gio::File::for_uri("smb://user:secret@host/share");
+    assert_eq!(
+        location_for_file(&file),
+        Some(Location::uri("smb://user@host/share/"))
+    );
 }
 
 #[test]

--- a/src/adapters/local_files/tests.rs
+++ b/src/adapters/local_files/tests.rs
@@ -190,24 +190,19 @@ fn gvfs_backed_files_use_their_uri_even_when_a_fuse_path_exists() {
 }
 
 #[test]
-fn gio_files_with_embedded_credentials_are_rejected() {
+fn gio_files_with_embedded_credentials_are_sanitized() {
     for uri in [
         "smb://user%3Asecret@host/share",
         "smb://user;password=secret@host/share",
         "smb://user%3Bpassword=secret@host/share",
+        "smb://user:secret@host/share",
     ] {
         assert_eq!(
             location_for_file(&gio::File::for_uri(uri)),
-            None,
-            "accepted {uri}"
+            Some(Location::uri("smb://user@host/share/")),
+            "did not sanitize {uri}"
         );
     }
-
-    let file = gio::File::for_uri("smb://user:secret@host/share");
-    assert_eq!(
-        location_for_file(&file),
-        Some(Location::uri("smb://user@host/share/"))
-    );
 }
 
 #[test]

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -15,8 +15,8 @@ use crate::{
         ArchiveFormat, CompressRequest, CreateDirectoryRequest, CreateFileRequest, DeleteRequest,
         DirectoryChange, DirectoryEvent, DirectoryRequest, ExtractRequest, FileSource, LoadHandle,
         LocationValidationError, OperationEvent, OperationProvider, OperationRequestId, PasteItem,
-        PasteRequest, RenameRequest, RequestId, RestoreRequest, uri_has_embedded_password,
-        validate_basename,
+        PasteRequest, RenameRequest, RequestId, RestoreRequest, validate_basename,
+        validate_uri_credentials,
     },
 };
 
@@ -219,9 +219,6 @@ impl Browser {
             return Err(LocationValidationError::UnsupportedShorthand(
                 message.to_owned(),
             ));
-        }
-        if uri_has_embedded_password(input) {
-            return Err(LocationValidationError::EmbeddedCredential);
         }
         if let Some(current) = self
             .active_location()
@@ -1588,6 +1585,7 @@ fn location_from_input(input: &str) -> Result<Location, LocationValidationError>
              smb://, sftp://, ftp://, ftps://, dav://, or davs://."
         )));
     }
+    validate_uri_credentials(input)?;
     let uri = format!("{normalized}{}", &input[scheme_end..]);
     Ok(Location::uri(uri))
 }

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -851,6 +851,12 @@ fn location_input_rejects_uris_with_an_embedded_password() {
 
     for uri in [
         "smb://user:secret@host/share",
+        "smb://user%3Asecret@host/share",
+        "smb://user:sec%72et@host/share",
+        "smb://user;password=secret@host/share",
+        "smb://user%3Bpassword=secret@host/share",
+        "smb://user%3Bpassword%3Dsecret@host/share",
+        "smb://user;password=sec%72et@host/share",
         "sftp://user:secret@host:2222/path",
     ] {
         assert_eq!(
@@ -859,6 +865,12 @@ fn location_input_rejects_uris_with_an_embedded_password() {
         );
         assert_eq!(browser.active_location(), Some(Location::local("/fixture")));
     }
+
+    assert_eq!(
+        browser.navigate_input("smb://user%ZZ@host/share"),
+        Err(LocationValidationError::InvalidUri)
+    );
+    assert_eq!(browser.active_location(), Some(Location::local("/fixture")));
 
     assert_eq!(
         browser.navigate_input("smb://user@host/share"),

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -16,6 +16,12 @@ pub struct Location {
     kind: LocationKind,
 }
 
+pub(crate) fn uri_contains_credentials(uri: &gio::glib::Uri) -> bool {
+    uri.password().is_some()
+        || uri.auth_params().is_some()
+        || uri.user().is_some_and(|user| user.contains([':', ';']))
+}
+
 impl Location {
     pub fn local(path: impl Into<PathBuf>) -> Self {
         Self {
@@ -122,7 +128,19 @@ impl Location {
     pub fn display_path(&self) -> String {
         match &self.kind {
             LocationKind::Native(path) => path.to_string_lossy().into_owned(),
-            LocationKind::Uri(uri) => uri.clone(),
+            LocationKind::Uri(uri) => gio::glib::Uri::parse(
+                uri,
+                gio::glib::UriFlags::HAS_PASSWORD | gio::glib::UriFlags::HAS_AUTH_PARAMS,
+            )
+            .map(|uri| {
+                let hidden = if uri_contains_credentials(&uri) {
+                    gio::glib::UriHideFlags::USERINFO
+                } else {
+                    gio::glib::UriHideFlags::empty()
+                };
+                uri.to_string_partial(hidden).to_string()
+            })
+            .unwrap_or_else(|_| "<invalid-uri>".into()),
         }
     }
 

--- a/src/model/tests.rs
+++ b/src/model/tests.rs
@@ -77,6 +77,28 @@ fn diagnostic_paths_preserve_native_paths_and_redact_remote_secrets() {
 }
 
 #[test]
+fn display_paths_hide_remote_credentials_but_preserve_usernames() {
+    for uri in [
+        "smb://alice:secret@host/share",
+        "smb://alice%3Asecret@host/share",
+        "smb://alice:sec%72et@host/share",
+        "smb://alice;password=secret@host/share",
+        "smb://alice%3Bpassword=secret@host/share",
+        "smb://alice;password=sec%72et@host/share",
+    ] {
+        assert_eq!(Location::uri(uri).display_path(), "smb://host/share");
+    }
+    assert_eq!(
+        Location::uri("smb://alice@host/share").display_path(),
+        "smb://alice@host/share"
+    );
+    assert_eq!(
+        Location::uri("smb://alice%ZZ@host/share").display_path(),
+        "<invalid-uri>"
+    );
+}
+
+#[test]
 fn root_has_one_breadcrumb() {
     assert_eq!(
         Location::local("/").breadcrumbs(),

--- a/src/services/file_source.rs
+++ b/src/services/file_source.rs
@@ -88,17 +88,74 @@ pub fn backend_unavailable_message(uri: &str) -> String {
     }
 }
 
-/// Rejects URI password and authentication-parameter fields, including encoded delimiters.
-pub fn validate_uri_credentials(uri: &str) -> Result<(), LocationValidationError> {
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UriCredentials {
+    pub username: String,
+    pub password: String,
+}
+
+/// Removes URI user-info secrets while preserving the username separately.
+pub fn sanitize_uri_credentials(
+    input: &str,
+) -> Result<(String, Option<UriCredentials>), LocationValidationError> {
     let uri = glib::Uri::parse(
-        uri,
+        input,
         glib::UriFlags::HAS_PASSWORD | glib::UriFlags::HAS_AUTH_PARAMS,
     )
     .map_err(|_| LocationValidationError::InvalidUri)?;
-    if uri_contains_credentials(&uri) {
-        Err(LocationValidationError::EmbeddedCredential)
-    } else {
-        Ok(())
+    if !uri_contains_credentials(&uri) {
+        return Ok((uri.to_str().to_string(), None));
+    }
+
+    let mut username = uri.user().map(|user| user.to_string()).unwrap_or_default();
+    let mut password = uri.password().map(|password| password.to_string());
+    let mut auth_params = uri.auth_params().map(|params| params.to_string());
+
+    if password.is_none()
+        && let Some((user, embedded_password)) = username.split_once(':')
+    {
+        password = Some(embedded_password.to_owned());
+        username = user.to_owned();
+    }
+    if auth_params.is_none()
+        && let Some((user, embedded_params)) = username.split_once(';')
+    {
+        auth_params = Some(embedded_params.to_owned());
+        username = user.to_owned();
+    }
+    if password.is_none() {
+        password = auth_params
+            .as_deref()
+            .and_then(|params| params.strip_prefix("password="))
+            .map(str::to_owned);
+    }
+
+    let sanitized = glib::Uri::build_with_user(
+        glib::UriFlags::empty(),
+        &uri.scheme(),
+        (!username.is_empty()).then_some(username.as_str()),
+        None,
+        None,
+        uri.host().as_deref(),
+        uri.port(),
+        &uri.path(),
+        uri.query().as_deref(),
+        uri.fragment().as_deref(),
+    )
+    .to_str()
+    .to_string();
+    let credentials = UriCredentials {
+        username,
+        password: password.unwrap_or_default(),
+    };
+    Ok((sanitized, Some(credentials)))
+}
+
+/// Rejects URI password and authentication-parameter fields, including encoded delimiters.
+pub fn validate_uri_credentials(uri: &str) -> Result<(), LocationValidationError> {
+    match sanitize_uri_credentials(uri)? {
+        (_, Some(_)) => Err(LocationValidationError::EmbeddedCredential),
+        (_, None) => Ok(()),
     }
 }
 

--- a/src/services/file_source.rs
+++ b/src/services/file_source.rs
@@ -5,7 +5,7 @@ mod tests;
 
 use std::{fmt, rc::Rc};
 
-use crate::model::{FileEntry, Location};
+use crate::model::{FileEntry, Location, uri_contains_credentials};
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct RequestId(pub u64);
@@ -21,6 +21,7 @@ pub struct DirectoryRequest {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum LocationValidationError {
     Empty,
+    InvalidUri,
     NotAbsolute,
     Missing,
     NotDirectory,
@@ -38,6 +39,7 @@ impl fmt::Display for LocationValidationError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Empty => formatter.write_str("Enter a location."),
+            Self::InvalidUri => formatter.write_str("Enter a valid URI."),
             Self::NotAbsolute => formatter.write_str("Enter an absolute path."),
             Self::Missing => formatter.write_str("That location does not exist."),
             Self::NotDirectory => formatter.write_str("That location is not a directory."),
@@ -86,21 +88,18 @@ pub fn backend_unavailable_message(uri: &str) -> String {
     }
 }
 
-/// Detects a `user:password@host` (or `user:password@host:port`) userinfo
-/// segment in a URI's authority. Per lgse/strata#20, a URI typed with an
-/// embedded password must never be accepted, stored, or echoed back.
-pub fn uri_has_embedded_password(uri: &str) -> bool {
-    let Some(after_scheme) = uri.split_once("://").map(|(_, rest)| rest) else {
-        return false;
-    };
-    let authority = after_scheme
-        .split(['/', '?', '#'])
-        .next()
-        .unwrap_or(after_scheme);
-    let Some((userinfo, _host)) = authority.rsplit_once('@') else {
-        return false;
-    };
-    userinfo.contains(':')
+/// Rejects URI password and authentication-parameter fields, including encoded delimiters.
+pub fn validate_uri_credentials(uri: &str) -> Result<(), LocationValidationError> {
+    let uri = glib::Uri::parse(
+        uri,
+        glib::UriFlags::HAS_PASSWORD | glib::UriFlags::HAS_AUTH_PARAMS,
+    )
+    .map_err(|_| LocationValidationError::InvalidUri)?;
+    if uri_contains_credentials(&uri) {
+        Err(LocationValidationError::EmbeddedCredential)
+    } else {
+        Ok(())
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/services/file_source/tests.rs
+++ b/src/services/file_source/tests.rs
@@ -1,35 +1,56 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use super::{backend_unavailable_message, uri_has_embedded_password};
+use super::{LocationValidationError, backend_unavailable_message, validate_uri_credentials};
 
 #[test]
-fn embedded_passwords_are_detected_in_the_uri_authority() {
+fn embedded_uri_credentials_are_rejected() {
     for uri in [
         "smb://user:secret@host/share",
+        "smb://user%3Asecret@host/share",
+        "smb://user:sec%72et@host/share",
+        "smb://user:@host/share",
+        "smb://user;password=secret@host/share",
+        "smb://user%3Bpassword=secret@host/share",
+        "smb://user%3Bpassword%3Dsecret@host/share",
+        "smb://user;password=sec%72et@host/share",
+        "smb://user;@host/share",
         "sftp://user:secret@host:2222/path",
         "ftp://user:secret@host/public",
     ] {
-        assert!(
-            uri_has_embedded_password(uri),
-            "{uri:?} should be flagged as carrying a password"
+        assert_eq!(
+            validate_uri_credentials(uri),
+            Err(LocationValidationError::EmbeddedCredential),
+            "{uri:?} should be rejected"
         );
     }
 }
 
 #[test]
-fn uris_without_an_embedded_password_are_not_flagged() {
+fn credential_free_uris_are_accepted() {
     for uri in [
         "smb://host/share",
         "smb://user@host/share",
         "sftp://user@host:2222/path",
         "network:///",
-        "/regular/absolute/path",
     ] {
-        assert!(
-            !uri_has_embedded_password(uri),
-            "{uri:?} should not be flagged"
+        assert_eq!(
+            validate_uri_credentials(uri),
+            Ok(()),
+            "{uri:?} should be safe"
         );
     }
+}
+
+#[test]
+fn malformed_uris_fail_without_echoing_input() {
+    assert_eq!(
+        validate_uri_credentials("smb://user%ZZ@host/share"),
+        Err(LocationValidationError::InvalidUri)
+    );
+    assert_eq!(
+        LocationValidationError::InvalidUri.to_string(),
+        "Enter a valid URI."
+    );
 }
 
 #[test]

--- a/src/services/file_source/tests.rs
+++ b/src/services/file_source/tests.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use super::{LocationValidationError, backend_unavailable_message, validate_uri_credentials};
+use super::{
+    LocationValidationError, UriCredentials, backend_unavailable_message, sanitize_uri_credentials,
+    validate_uri_credentials,
+};
 
 #[test]
 fn embedded_uri_credentials_are_rejected() {
@@ -21,6 +24,28 @@ fn embedded_uri_credentials_are_rejected() {
             validate_uri_credentials(uri),
             Err(LocationValidationError::EmbeddedCredential),
             "{uri:?} should be rejected"
+        );
+    }
+}
+
+#[test]
+fn embedded_uri_credentials_are_separated_from_the_sanitized_uri() {
+    for uri in [
+        "smb://user:secret@host/share",
+        "smb://user%3Asecret@host/share",
+        "smb://user;password=secret@host/share",
+        "smb://user%3Bpassword=secret@host/share",
+    ] {
+        assert_eq!(
+            sanitize_uri_credentials(uri),
+            Ok((
+                "smb://user@host/share".to_owned(),
+                Some(UriCredentials {
+                    username: "user".to_owned(),
+                    password: "secret".to_owned(),
+                }),
+            )),
+            "did not separate {uri:?}"
         );
     }
 }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -9,7 +9,7 @@ mod update_install;
 
 pub use file_source::{
     DirectoryChange, DirectoryEvent, DirectoryRequest, FileSource, LoadHandle,
-    LocationValidationError, RequestId, backend_unavailable_message, uri_has_embedded_password,
+    LocationValidationError, RequestId, backend_unavailable_message, validate_uri_credentials,
 };
 pub use operations::{
     ArchiveFormat, CompressRequest, CreateDirectoryRequest, CreateFileRequest, DeleteRequest,

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -9,7 +9,8 @@ mod update_install;
 
 pub use file_source::{
     DirectoryChange, DirectoryEvent, DirectoryRequest, FileSource, LoadHandle,
-    LocationValidationError, RequestId, backend_unavailable_message, validate_uri_credentials,
+    LocationValidationError, RequestId, UriCredentials, backend_unavailable_message,
+    sanitize_uri_credentials, validate_uri_credentials,
 };
 pub use operations::{
     ArchiveFormat, CompressRequest, CreateDirectoryRequest, CreateFileRequest, DeleteRequest,

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -1285,7 +1285,7 @@ impl ViewState {
             };
             let sources = files
                 .into_iter()
-                .map(|file| location_for_file(&file))
+                .filter_map(|file| location_for_file(&file))
                 .collect::<Vec<_>>();
             if let Some(state) = weak.upgrade() {
                 let move_sources = same_locations(&sources, &state.cut_locations.borrow());
@@ -6058,13 +6058,9 @@ pub(super) fn locations_from_file_list_value(value: &glib::Value) -> Option<Vec<
     let locations = files
         .files()
         .iter()
-        .map(location_for_gio_file)
+        .filter_map(location_for_file)
         .collect::<Vec<_>>();
     (!locations.is_empty()).then_some(locations)
-}
-
-pub(super) fn location_for_gio_file(file: &gio::File) -> Location {
-    location_for_file(file)
 }
 
 pub(super) fn file_drag_content(entries: &[FileEntry]) -> Option<gtk::gdk::ContentProvider> {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -17,8 +17,9 @@ use crate::{
     model::{EntryKind, FileEntry, Location, SortDirection, SortKey},
     services::{
         ArchiveFormat, FileSource, LoadHandle, LocationValidationError, OperationProvider,
-        PasteItem, PreviewContent, SearchEvent, TransferConflict, backend_unavailable_message,
-        content_family, has_plain_text_extension, index_tree, validate_basename,
+        PasteItem, PreviewContent, SearchEvent, TransferConflict, UriCredentials,
+        backend_unavailable_message, content_family, has_plain_text_extension, index_tree,
+        sanitize_uri_credentials, validate_basename,
     },
 };
 
@@ -283,6 +284,7 @@ pub(super) struct ViewState {
     pending_select: RefCell<Vec<String>>,
     pending_extract_retry: RefCell<Option<(FileEntry, Location)>>,
     pending_navigate: RefCell<Option<Location>>,
+    pending_location_credentials: RefCell<Option<MountCredentials>>,
     pending_trash_summary: RefCell<Option<LoadHandle>>,
     pending_empty_trash: RefCell<Option<LoadHandle>>,
     trash_loading: RefCell<Option<TrashLoadingView>>,
@@ -428,6 +430,7 @@ impl BrowserView {
             pending_select: RefCell::new(Vec::new()),
             pending_extract_retry: RefCell::new(None),
             pending_navigate: RefCell::new(None),
+            pending_location_credentials: RefCell::new(None),
             pending_trash_summary: RefCell::new(None),
             pending_empty_trash: RefCell::new(None),
             trash_loading: RefCell::new(None),
@@ -2898,18 +2901,42 @@ impl ViewState {
 
     fn submit_location(self: &Rc<Self>) {
         let input = self.location_entry.text();
-        match self.browser.navigate_input(input.as_str()) {
+        let (input, credentials) = match credentials_from_location_input(input.as_str()) {
+            Ok(parsed) => parsed,
+            Err(error) => {
+                self.restore_location_text();
+                self.location_stack.set_visible_child_name("breadcrumbs");
+                show_error_dialog(&self.overlay, "Unable to open location", &error.to_string());
+                return;
+            }
+        };
+        if credentials.is_some() {
+            self.location_entry.set_text(&input);
+        }
+        self.pending_location_credentials.replace(credentials);
+        match self.browser.navigate_input(&input) {
             Ok(()) => {
                 self.location_stack.set_visible_child_name("breadcrumbs");
                 self.browser.focus_active();
             }
             Err(LocationValidationError::NotMounted(location)) => {
-                self.mount_then_navigate(location, MountStrategy::EnclosingVolume);
+                let credentials = self.pending_location_credentials.take();
+                self.mount_then_navigate_with_credentials(
+                    location,
+                    MountStrategy::EnclosingVolume,
+                    credentials,
+                );
             }
             Err(LocationValidationError::Mountable(location)) => {
-                self.mount_then_navigate(location, MountStrategy::Mountable);
+                let credentials = self.pending_location_credentials.take();
+                self.mount_then_navigate_with_credentials(
+                    location,
+                    MountStrategy::Mountable,
+                    credentials,
+                );
             }
             Err(error) => {
+                self.pending_location_credentials.take();
                 self.restore_location_text();
                 self.location_stack.set_visible_child_name("breadcrumbs");
                 show_error_dialog(&self.overlay, "Unable to open location", &error.to_string());
@@ -2937,10 +2964,6 @@ impl ViewState {
                 );
             }
         }
-    }
-
-    fn mount_then_navigate(self: &Rc<Self>, location: Location, strategy: MountStrategy) {
-        self.mount_then_navigate_with_credentials(location, strategy, None);
     }
 
     fn mount_then_navigate_with_credentials(
@@ -3313,6 +3336,7 @@ impl ViewState {
         self.mode_views.borrow_mut().handle(&event);
         match event {
             BrowserEvent::Reset => {
+                self.pending_location_credentials.take();
                 self.truncate(0);
             }
             BrowserEvent::ColumnsTruncated { len } => {
@@ -3596,17 +3620,30 @@ impl ViewState {
             BrowserEvent::EmptyTrashRequested => {
                 self.load_trash_summary();
             }
-            BrowserEvent::LocationNavigationRejected { error } => match error {
-                LocationValidationError::NotMounted(location) => {
-                    self.mount_then_navigate(location, MountStrategy::EnclosingVolume);
+            BrowserEvent::LocationNavigationRejected { error } => {
+                let credentials = self.pending_location_credentials.take();
+                match error {
+                    LocationValidationError::NotMounted(location) => {
+                        self.mount_then_navigate_with_credentials(
+                            location,
+                            MountStrategy::EnclosingVolume,
+                            credentials,
+                        );
+                    }
+                    LocationValidationError::Mountable(location) => {
+                        self.mount_then_navigate_with_credentials(
+                            location,
+                            MountStrategy::Mountable,
+                            credentials,
+                        );
+                    }
+                    error => show_error_dialog(
+                        &self.overlay,
+                        "Unable to open location",
+                        &error.to_string(),
+                    ),
                 }
-                LocationValidationError::Mountable(location) => {
-                    self.mount_then_navigate(location, MountStrategy::Mountable);
-                }
-                error => {
-                    show_error_dialog(&self.overlay, "Unable to open location", &error.to_string())
-                }
-            },
+            }
             BrowserEvent::ArchiveStarted { total } => {
                 let browser = self.browser.clone();
                 self.show_file_operation_progress(
@@ -7134,6 +7171,23 @@ fn password_save_for_selection(selected: u32) -> gio::PasswordSave {
     }
 }
 
+fn credentials_from_location_input(
+    input: &str,
+) -> Result<(String, Option<MountCredentials>), LocationValidationError> {
+    if !input.contains("://") {
+        return Ok((input.to_owned(), None));
+    }
+    let (sanitized, credentials) = sanitize_uri_credentials(input)?;
+    let credentials = credentials.map(|credentials: UriCredentials| MountCredentials {
+        anonymous: false,
+        username: credentials.username,
+        domain: String::new(),
+        password: credentials.password,
+        save: gio::PasswordSave::Never,
+    });
+    Ok((sanitized, credentials))
+}
+
 #[derive(Clone)]
 struct MountCredentials {
     anonymous: bool,
@@ -7161,7 +7215,9 @@ fn apply_mount_credentials(operation: &gio::MountOperation, credentials: &MountC
         return;
     }
     operation.set_username(Some(&credentials.username));
-    operation.set_domain(Some(&credentials.domain));
+    if !credentials.domain.is_empty() {
+        operation.set_domain(Some(&credentials.domain));
+    }
     operation.set_password(Some(&credentials.password));
     operation.set_password_save(credentials.save);
 }

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -69,6 +69,18 @@ fn password_storage_selection_maps_to_gio_values() {
 }
 
 #[test]
+fn location_input_credentials_are_one_shot_and_never_saved() {
+    let (location, credentials) = credentials_from_location_input("smb://alice:secret@host/share")
+        .expect("credential URI should parse");
+    let credentials = credentials.expect("credentials should be separated");
+
+    assert_eq!(location, "smb://alice@host/share");
+    assert_eq!(credentials.username, "alice");
+    assert_eq!(credentials.password, "secret");
+    assert_eq!(credentials.save, gio::PasswordSave::Never);
+}
+
+#[test]
 fn remote_permission_denials_are_treated_as_authentication_failures() {
     let denied = glib::Error::new(gio::IOErrorEnum::PermissionDenied, "Permission denied");
     let smb_denied = glib::Error::new(
@@ -254,7 +266,7 @@ fn incoming_file_lists_preserve_local_and_remote_locations() {
 }
 
 #[test]
-fn incoming_file_lists_omit_remote_credentials() {
+fn incoming_file_lists_sanitize_remote_credentials() {
     let files = gtk::gdk::FileList::from_array(&[
         gio::File::for_uri("smb://user%3Asecret@host/share"),
         gio::File::for_uri("smb://user%3Bpassword=secret@host/share"),
@@ -263,7 +275,11 @@ fn incoming_file_lists_omit_remote_credentials() {
 
     assert_eq!(
         locations_from_file_list_value(&files.to_value()),
-        Some(vec![Location::uri("sftp://user@host/home/user/video.mp4")])
+        Some(vec![
+            Location::uri("smb://user@host/share/"),
+            Location::uri("smb://user@host/share/"),
+            Location::uri("sftp://user@host/home/user/video.mp4"),
+        ])
     );
 }
 

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -254,6 +254,20 @@ fn incoming_file_lists_preserve_local_and_remote_locations() {
 }
 
 #[test]
+fn incoming_file_lists_omit_remote_credentials() {
+    let files = gtk::gdk::FileList::from_array(&[
+        gio::File::for_uri("smb://user%3Asecret@host/share"),
+        gio::File::for_uri("smb://user%3Bpassword=secret@host/share"),
+        gio::File::for_uri("sftp://user@host/home/user/video.mp4"),
+    ]);
+
+    assert_eq!(
+        locations_from_file_list_value(&files.to_value()),
+        Some(vec![Location::uri("sftp://user@host/home/user/video.mp4")])
+    );
+}
+
+#[test]
 fn local_file_drops_prefer_move_while_external_drops_prefer_copy() {
     let both = gtk::gdk::DragAction::COPY | gtk::gdk::DragAction::MOVE;
 

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -273,13 +273,24 @@ fn incoming_file_lists_sanitize_remote_credentials() {
         gio::File::for_uri("sftp://user@host/home/user/video.mp4"),
     ]);
 
+    let locations = locations_from_file_list_value(&files.to_value())
+        .expect("file list should contain sanitized locations");
+    let uris = locations
+        .iter()
+        .map(|location| {
+            location
+                .uri_value()
+                .expect("remote location should have a URI")
+                .trim_end_matches('/')
+        })
+        .collect::<Vec<_>>();
     assert_eq!(
-        locations_from_file_list_value(&files.to_value()),
-        Some(vec![
-            Location::uri("smb://user@host/share/"),
-            Location::uri("smb://user@host/share/"),
-            Location::uri("sftp://user@host/home/user/video.mp4"),
-        ])
+        uris,
+        [
+            "smb://user@host/share",
+            "smb://user@host/share",
+            "sftp://user@host/home/user/video.mp4",
+        ]
     );
 }
 

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -14,7 +14,7 @@ use crate::{
     adapters::{LocalFileSource, LocalOperationProvider, LocalPreviewProvider, location_for_file},
     app::{Browser, BrowserEvent},
     model::{EntryKind, FileEntry, Location, MetadataValue},
-    services::validate_uri_credentials,
+    services::sanitize_uri_credentials,
 };
 
 use super::{
@@ -1653,7 +1653,7 @@ fn parse_pinned_places(contents: &str) -> Vec<(Location, String)> {
         let (uri, label) = line
             .split_once(' ')
             .map_or((line, None), |(uri, label)| (uri, Some(label)));
-        if uri.is_empty() || validate_uri_credentials(uri).is_err() {
+        if uri.is_empty() {
             continue;
         }
         let file = gio::File::for_uri(uri);
@@ -1695,7 +1695,8 @@ fn serialize_pinned_places(places: &[(Location, String)]) -> String {
             .map(gio::File::for_path)
             .map(|file| file.uri().to_string())
             .or_else(|| location.uri_value().map(str::to_owned));
-        let Some(uri) = uri.filter(|uri| validate_uri_credentials(uri).is_ok()) else {
+        let Some(uri) = uri.and_then(|uri| sanitize_uri_credentials(&uri).ok().map(|(uri, _)| uri))
+        else {
             continue;
         };
         let label = name.replace(['\n', '\r'], " ");

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -14,6 +14,7 @@ use crate::{
     adapters::{LocalFileSource, LocalOperationProvider, LocalPreviewProvider, location_for_file},
     app::{Browser, BrowserEvent},
     model::{EntryKind, FileEntry, Location, MetadataValue},
+    services::validate_uri_credentials,
 };
 
 use super::{
@@ -965,10 +966,10 @@ impl SidebarState {
             .mounts()
             .into_iter()
             .filter(|mount| !mount.is_shadowed() && mount.volume().is_none())
-            .map(|mount| {
+            .filter_map(|mount| {
                 let name = mount.name().to_string();
-                let location = location_for_file(&mount.root());
-                (name, location, mount)
+                let location = location_for_file(&mount.root())?;
+                Some((name, location, mount))
             })
             .collect();
         if !volumes.is_empty() || !mounts.is_empty() {
@@ -1187,8 +1188,9 @@ impl SidebarState {
         let name = volume.name().to_string();
         let row = sidebar_button(crate::assets::icons::HARD_DRIVE, &name);
         row.set_tooltip_text(Some(&name));
-        if let Some(mount) = volume.get_mount() {
-            let location = location_for_file(&mount.root());
+        if let Some(mount) = volume.get_mount()
+            && let Some(location) = location_for_file(&mount.root())
+        {
             self.place_rows.borrow_mut().push((location, row.clone()));
         }
         let weak_browser = Rc::downgrade(&self.browser);
@@ -1517,7 +1519,9 @@ fn sidebar_button(icon: &str, name: &str) -> gtk::Button {
 }
 
 fn navigate_to_gio_file(browser: &Rc<Browser>, file: &gio::File) {
-    browser.navigate(location_for_file(file));
+    if let Some(location) = location_for_file(file) {
+        browser.navigate(location);
+    }
 }
 
 fn build_sidebar(view: BrowserView) -> SidebarView {
@@ -1649,11 +1653,13 @@ fn parse_pinned_places(contents: &str) -> Vec<(Location, String)> {
         let (uri, label) = line
             .split_once(' ')
             .map_or((line, None), |(uri, label)| (uri, Some(label)));
-        if uri.is_empty() {
+        if uri.is_empty() || validate_uri_credentials(uri).is_err() {
             continue;
         }
         let file = gio::File::for_uri(uri);
-        let location = location_for_file(&file);
+        let Some(location) = location_for_file(&file) else {
+            continue;
+        };
         if places
             .iter()
             .any(|(existing, _): &(Location, String)| existing == &location)
@@ -1677,6 +1683,11 @@ fn save_pinned_places(places: &[(Location, String)]) {
     if std::fs::create_dir_all(parent).is_err() {
         return;
     }
+    let contents = serialize_pinned_places(places);
+    let _result = crate::storage::atomic_write(&path, contents.as_bytes());
+}
+
+fn serialize_pinned_places(places: &[(Location, String)]) -> String {
     let mut contents = String::new();
     for (location, name) in places {
         let uri = location
@@ -1684,12 +1695,13 @@ fn save_pinned_places(places: &[(Location, String)]) {
             .map(gio::File::for_path)
             .map(|file| file.uri().to_string())
             .or_else(|| location.uri_value().map(str::to_owned));
-        if let Some(uri) = uri {
-            let label = name.replace(['\n', '\r'], " ");
-            contents.push_str(&format!("{uri} {label}\n"));
-        }
+        let Some(uri) = uri.filter(|uri| validate_uri_credentials(uri).is_ok()) else {
+            continue;
+        };
+        let label = name.replace(['\n', '\r'], " ");
+        contents.push_str(&format!("{uri} {label}\n"));
     }
-    let _result = crate::storage::atomic_write(&path, contents.as_bytes());
+    contents
 }
 
 fn home_directory() -> PathBuf {

--- a/src/ui/window/tests.rs
+++ b/src/ui/window/tests.rs
@@ -92,17 +92,18 @@ fn gtk_bookmarks_become_native_and_remote_pinned_places() {
 }
 
 #[test]
-fn gtk_bookmarks_omit_uris_with_credentials() {
+fn gtk_bookmarks_sanitize_uris_with_credentials() {
     let places = parse_pinned_places(
         "smb://alice@host/safe Safe\nsmb://alice:secret@host/private Password\nsmb://alice%3Asecret@host/private Encoded password delimiter\nsmb://alice;password=secret@host/private Auth\nsmb://alice%3Bpassword=secret@host/private Encoded auth delimiter\nsmb://alice;password=sec%72et@host/private Encoded value\nsmb://alice%ZZ@host/private Invalid\n",
     );
 
-    assert_eq!(places.len(), 1);
+    assert_eq!(places.len(), 2);
     assert_eq!(places[0].0.uri_value(), Some("smb://alice@host/safe/"));
+    assert_eq!(places[1].0.uri_value(), Some("smb://alice@host/private/"));
 }
 
 #[test]
-fn gtk_bookmark_serialization_omits_uris_with_credentials() {
+fn gtk_bookmark_serialization_sanitizes_uris_with_credentials() {
     let places = vec![
         (
             crate::model::Location::uri("smb://alice@host/safe"),
@@ -124,7 +125,10 @@ fn gtk_bookmark_serialization_omits_uris_with_credentials() {
 
     assert_eq!(
         serialize_pinned_places(&places),
-        "smb://alice@host/safe Safe\n"
+        "smb://alice@host/safe Safe\n\
+         smb://alice@host/private Password\n\
+         smb://alice@host/private Auth\n\
+         smb://alice@host/private Encoded\n"
     );
 }
 

--- a/src/ui/window/tests.rs
+++ b/src/ui/window/tests.rs
@@ -98,8 +98,22 @@ fn gtk_bookmarks_sanitize_uris_with_credentials() {
     );
 
     assert_eq!(places.len(), 2);
-    assert_eq!(places[0].0.uri_value(), Some("smb://alice@host/safe/"));
-    assert_eq!(places[1].0.uri_value(), Some("smb://alice@host/private/"));
+    assert_eq!(
+        places[0]
+            .0
+            .uri_value()
+            .expect("remote place should have a URI")
+            .trim_end_matches('/'),
+        "smb://alice@host/safe"
+    );
+    assert_eq!(
+        places[1]
+            .0
+            .uri_value()
+            .expect("remote place should have a URI")
+            .trim_end_matches('/'),
+        "smb://alice@host/private"
+    );
 }
 
 #[test]

--- a/src/ui/window/tests.rs
+++ b/src/ui/window/tests.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use super::{
     PinStatus, is_sidebar_focus_shortcut, is_smb_location, is_standard_place_location,
-    parse_pinned_places, pin_status, remove_pinned_place, reorder_places,
+    parse_pinned_places, pin_status, remove_pinned_place, reorder_places, serialize_pinned_places,
     should_show_standard_place, vim_focus_direction,
 };
 
@@ -89,6 +89,43 @@ fn gtk_bookmarks_become_native_and_remote_pinned_places() {
     );
     assert_eq!(places[1].1, "Remote");
     assert_eq!(places.len(), 2);
+}
+
+#[test]
+fn gtk_bookmarks_omit_uris_with_credentials() {
+    let places = parse_pinned_places(
+        "smb://alice@host/safe Safe\nsmb://alice:secret@host/private Password\nsmb://alice%3Asecret@host/private Encoded password delimiter\nsmb://alice;password=secret@host/private Auth\nsmb://alice%3Bpassword=secret@host/private Encoded auth delimiter\nsmb://alice;password=sec%72et@host/private Encoded value\nsmb://alice%ZZ@host/private Invalid\n",
+    );
+
+    assert_eq!(places.len(), 1);
+    assert_eq!(places[0].0.uri_value(), Some("smb://alice@host/safe/"));
+}
+
+#[test]
+fn gtk_bookmark_serialization_omits_uris_with_credentials() {
+    let places = vec![
+        (
+            crate::model::Location::uri("smb://alice@host/safe"),
+            "Safe".to_owned(),
+        ),
+        (
+            crate::model::Location::uri("smb://alice:secret@host/private"),
+            "Password".to_owned(),
+        ),
+        (
+            crate::model::Location::uri("smb://alice;password=secret@host/private"),
+            "Auth".to_owned(),
+        ),
+        (
+            crate::model::Location::uri("smb://alice%3Asecret@host/private"),
+            "Encoded".to_owned(),
+        ),
+    ];
+
+    assert_eq!(
+        serialize_pinned_places(&places),
+        "smb://alice@host/safe Safe\n"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Description

Parse remote URIs with GLib's password and authentication-parameter flags, including percent-encoded delimiters. Address-bar credentials are removed from the URI immediately, supplied only to the pending mount attempt with password saving disabled, and discarded after that attempt. Failed authentication falls back to the normal sign-in flow.

Route other URI ingress through the same sanitization boundary so clipboard items, dropped files, directory entries, mount roots, and GTK bookmarks cannot introduce credential-bearing locations. Unsafe bookmarks retain their username and location while their secrets are removed on load and save; display sanitization remains a defense for legacy values.

## Visual evidence

N/A: the only visible change is that the address returns to its sanitized form instead of showing a credential-rejection error.

## How to test

1. Enter `smb://alice:secret@host/share`, `smb://alice;password=secret@host/share`, and their percent-encoded delimiter variants in the location bar.
2. Confirm the address becomes `smb://alice@host/share` and the supplied credentials are used for the connection attempt without an initial duplicate prompt.
3. Confirm failed credentials open the normal sign-in dialog and are not remembered unless a storage option is explicitly selected there.
4. Add safe and credential-bearing remote URIs to the GTK bookmarks file, then reopen Strata and save the bookmarks.
5. Confirm the bookmarks remain available with their username but no password or authentication parameters.

**Expected result:** Embedded credentials are consumed only for one connection attempt, are never shown or persisted, and sanitized remote locations remain usable.

## Related issue

Closes #111
