### PR TITLE
fix(archive): make compression output failure-safe

### DIFF
--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -9,14 +9,17 @@ use std::{
     io,
     os::{
         fd::{AsFd, OwnedFd},
-        unix::ffi::{OsStrExt, OsStringExt},
+        unix::{
+            ffi::{OsStrExt, OsStringExt},
+            fs::PermissionsExt,
+        },
     },
     path::{Component, Path, PathBuf},
     pin::Pin,
     rc::Rc,
     sync::{
         Arc,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
 };
 
@@ -287,6 +290,50 @@ fn operation_error_summary(errors: &[String], action: &str) -> String {
         summary.push_str(&format!("\n\n…and {} more", errors.len() - 8));
     }
     summary
+}
+
+async fn write_staged_archive<F>(
+    destination: &Path,
+    archive_path: &Path,
+    conflict: TransferConflict,
+    write_archive: F,
+) -> Result<(), String>
+where
+    F: FnOnce(std::fs::File) -> Result<(), String> + Send + 'static,
+{
+    let existing_permissions = if conflict == TransferConflict::ReplaceExisting {
+        match std::fs::symlink_metadata(archive_path) {
+            Ok(metadata) if metadata.file_type().is_file() => Some(metadata.permissions()),
+            Ok(_) => None,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+            Err(error) => return Err(error.to_string()),
+        }
+    } else {
+        None
+    };
+    let mut builder = tempfile::Builder::new();
+    builder
+        .prefix(".strata-compression-")
+        .permissions(std::fs::Permissions::from_mode(0o666));
+    let staged = builder
+        .tempfile_in(destination)
+        .map_err(|error| error.to_string())?;
+    let file = staged.reopen().map_err(|error| error.to_string())?;
+    gio::spawn_blocking(move || write_archive(file))
+        .await
+        .map_err(|_| "Compression task panicked".to_owned())??;
+    if let Some(permissions) = existing_permissions {
+        staged
+            .as_file()
+            .set_permissions(permissions)
+            .map_err(|error| error.to_string())?;
+    }
+    match conflict {
+        TransferConflict::FailIfExists => staged.persist_noclobber(archive_path),
+        TransferConflict::ReplaceExisting => staged.persist(archive_path),
+    }
+    .map(|_| ())
+    .map_err(|error| error.to_string())
 }
 
 fn deletion_error_summary(errors: &[String]) -> String {
@@ -565,14 +612,23 @@ impl OperationProvider for LocalOperationProvider {
     }
 
     fn compress(&self, request: CompressRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle {
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let task_cancelled = cancelled.clone();
         let task = glib::MainContext::default().spawn_local(async move {
-            let Some(dest_dir) = request.destination.native_path() else {
+            let Some(dest_dir) = request.destination.native_path().map(Path::to_path_buf) else {
                 emit(OperationEvent::Failed {
                     request_id: request.id,
                     message: "Archive destination must be a local path".to_owned(),
                 });
                 return;
             };
+            if let Err(message) = validate_basename(&request.archive_name) {
+                emit(OperationEvent::Failed {
+                    request_id: request.id,
+                    message: message.to_owned(),
+                });
+                return;
+            }
             let archive_name = format!("{}.{}", request.archive_name, request.format.extension());
             let archive_path = dest_dir.join(&archive_name);
             let entries: Vec<std::path::PathBuf> = request
@@ -593,50 +649,49 @@ impl OperationProvider for LocalOperationProvider {
                 request_id: request.id,
                 total: 0,
             });
-            let timer_id = archive_progress_timer(request.id, &progress, &total, &emit);
+            let timer_id =
+                archive_progress_timer(request.id, &progress, &total, &task_cancelled, &emit);
             let format = request.format;
             let password = request.password.clone();
             let work_progress = progress.clone();
             let work_total = total.clone();
-            let result = gio::spawn_blocking(move || {
-                let count = count_files(&entries);
-                work_total.store(count, Ordering::Relaxed);
-                match format {
-                    ArchiveFormat::Zip => {
-                        compress_zip(&archive_path, &entries, password.as_deref(), &work_progress)
+            let result =
+                write_staged_archive(&dest_dir, &archive_path, request.conflict, move |file| {
+                    let count = count_files(&entries);
+                    work_total.store(count, Ordering::Relaxed);
+                    match format {
+                        ArchiveFormat::Zip => {
+                            compress_zip(file, &entries, password.as_deref(), &work_progress)
+                        }
+                        ArchiveFormat::SevenZ => {
+                            compress_7z(file, &entries, password.as_deref(), &work_progress)
+                        }
+                        ArchiveFormat::TarGz => compress_tar(file, &entries, true, &work_progress),
+                        ArchiveFormat::Tar => compress_tar(file, &entries, false, &work_progress),
                     }
-                    ArchiveFormat::SevenZ => {
-                        compress_7z(&archive_path, &entries, password.as_deref(), &work_progress)
-                    }
-                    ArchiveFormat::TarGz => {
-                        compress_tar(&archive_path, &entries, true, &work_progress)
-                    }
-                    ArchiveFormat::Tar => {
-                        compress_tar(&archive_path, &entries, false, &work_progress)
-                    }
-                }
-            })
-            .await;
+                })
+                .await;
             timer_id.remove();
             match result {
-                Ok(Ok(())) => emit(OperationEvent::Compressed {
+                Ok(()) => emit(OperationEvent::Compressed {
                     request_id: request.id,
                     archive_name: archive_name.clone(),
                 }),
-                Ok(Err(error)) => emit(OperationEvent::Failed {
+                Err(error) => emit(OperationEvent::Failed {
                     request_id: request.id,
                     message: error,
                 }),
-                Err(_) => emit(OperationEvent::Failed {
-                    request_id: request.id,
-                    message: "Compression task panicked".to_owned(),
-                }),
             }
         });
-        LoadHandle::new(move || task.abort())
+        LoadHandle::new(move || {
+            cancelled.store(true, Ordering::Relaxed);
+            task.abort();
+        })
     }
 
     fn extract(&self, request: ExtractRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle {
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let task_cancelled = cancelled.clone();
         let task = glib::MainContext::default().spawn_local(async move {
             let Some(archive_path) = request.entry.location.native_path().map(Path::to_path_buf)
             else {
@@ -662,7 +717,8 @@ impl OperationProvider for LocalOperationProvider {
                 request_id: request.id,
                 total: 0,
             });
-            let timer_id = archive_progress_timer(request.id, &progress, &total, &emit);
+            let timer_id =
+                archive_progress_timer(request.id, &progress, &total, &task_cancelled, &emit);
             let work_progress = progress.clone();
             let work_total = total.clone();
             let result = gio::spawn_blocking(move || match format {
@@ -710,17 +766,19 @@ impl OperationProvider for LocalOperationProvider {
                 }),
             }
         });
-        LoadHandle::new(move || task.abort())
+        LoadHandle::new(move || {
+            cancelled.store(true, Ordering::Relaxed);
+            task.abort();
+        })
     }
 }
 
 fn compress_zip(
-    archive_path: &Path,
+    file: std::fs::File,
     entries: &[std::path::PathBuf],
     password: Option<&str>,
     progress: &Arc<AtomicUsize>,
 ) -> Result<(), String> {
-    let file = std::fs::File::create(archive_path).map_err(|e| e.to_string())?;
     let writer = std::io::BufWriter::with_capacity(COPY_BUF, file);
     let mut writer = zip::ZipWriter::new(writer);
     let deflated = zip::write::SimpleFileOptions::default()
@@ -759,7 +817,11 @@ fn compress_zip(
             progress.fetch_add(1, Ordering::Relaxed);
         }
     }
-    writer.finish().map_err(|e| e.to_string())?;
+    writer
+        .finish()
+        .map_err(|error| error.to_string())?
+        .into_inner()
+        .map_err(|error| error.to_string())?;
     Ok(())
 }
 
@@ -796,20 +858,33 @@ fn add_dir_to_zip<W: std::io::Write + std::io::Seek>(
 }
 
 fn compress_tar(
-    archive_path: &Path,
+    file: std::fs::File,
     entries: &[std::path::PathBuf],
     gzip: bool,
     progress: &Arc<AtomicUsize>,
 ) -> Result<(), String> {
-    let file = std::fs::File::create(archive_path).map_err(|e| e.to_string())?;
-    let writer: Box<dyn std::io::Write> = if gzip {
-        Box::new(std::io::BufWriter::with_capacity(
-            COPY_BUF,
-            flate2::write::GzEncoder::new(file, flate2::Compression::default()),
-        ))
+    let writer = std::io::BufWriter::with_capacity(COPY_BUF, file);
+    if gzip {
+        let mut encoder = flate2::write::GzEncoder::new(writer, flate2::Compression::default());
+        append_tar_entries(&mut encoder, entries, progress)?;
+        encoder
+            .finish()
+            .map_err(|error| error.to_string())?
+            .into_inner()
+            .map_err(|error| error.to_string())?;
     } else {
-        Box::new(std::io::BufWriter::with_capacity(COPY_BUF, file))
-    };
+        let mut writer = writer;
+        append_tar_entries(&mut writer, entries, progress)?;
+        writer.into_inner().map_err(|error| error.to_string())?;
+    }
+    Ok(())
+}
+
+fn append_tar_entries(
+    writer: &mut dyn std::io::Write,
+    entries: &[std::path::PathBuf],
+    progress: &Arc<AtomicUsize>,
+) -> Result<(), String> {
     let mut builder = tar::Builder::new(writer);
     for entry in entries {
         let name = entry
@@ -1002,12 +1077,17 @@ fn archive_progress_timer(
     request_id: OperationRequestId,
     progress: &Arc<AtomicUsize>,
     total: &Arc<AtomicUsize>,
+    cancelled: &Arc<AtomicBool>,
     emit: &Rc<dyn Fn(OperationEvent)>,
 ) -> glib::SourceId {
     let timer_progress = progress.clone();
     let timer_total = total.clone();
+    let timer_cancelled = cancelled.clone();
     let timer_emit = emit.clone();
     glib::timeout_add_local(std::time::Duration::from_millis(100), move || {
+        if timer_cancelled.load(Ordering::Relaxed) {
+            return glib::ControlFlow::Break;
+        }
         timer_emit(OperationEvent::ArchiveProgress {
             request_id,
             completed: timer_progress.load(Ordering::Relaxed),
@@ -1153,14 +1233,13 @@ fn extract_tar(
 }
 
 fn compress_7z(
-    archive_path: &Path,
+    file: std::fs::File,
     entries: &[std::path::PathBuf],
     password: Option<&str>,
     progress: &Arc<AtomicUsize>,
 ) -> Result<(), String> {
     use sevenz_rust2::encoder_options::{AesEncoderOptions, EncoderOptions, Lzma2Options};
-    let mut writer =
-        sevenz_rust2::ArchiveWriter::create(archive_path).map_err(|e| e.to_string())?;
+    let mut writer = sevenz_rust2::ArchiveWriter::new(file).map_err(|e| e.to_string())?;
     let threads = std::thread::available_parallelism()
         .map(|n| n.get() as u32)
         .unwrap_or(1);

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -3,11 +3,16 @@
 use std::{
     cell::{Cell, RefCell},
     error::Error,
+    ffi::OsString,
     fs,
     io::{Cursor, Write},
+    os::unix::fs::PermissionsExt,
     path::Path,
     rc::Rc,
-    sync::{Arc, Mutex, atomic::AtomicUsize},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
     time::SystemTime,
 };
 
@@ -19,12 +24,13 @@ use super::{
     LocalOperationProvider, copy_recursively, deletion_error_message, deletion_error_summary,
     extract_7z_from_reader, extract_tar, extract_zip_from_archive, operation_error_summary,
     replace_local, replace_local_with, transfer_is_noop, validated_archive_path, validated_child,
+    write_staged_archive,
 };
 use crate::{
-    model::Location,
+    model::{EntryKind, FileEntry, Location, MetadataValue},
     services::{
-        OperationEvent, OperationProvider, OperationRequestId, PasteItem, PasteRequest,
-        TransferConflict,
+        ArchiveFormat, CompressRequest, OperationEvent, OperationProvider, OperationRequestId,
+        PasteItem, PasteRequest, TransferConflict,
     },
 };
 
@@ -338,6 +344,270 @@ fn staged_directory_replacement_does_not_merge_old_contents() -> Result<(), Box<
     assert!(!target.join("old").exists());
     assert!(source.exists());
     fs::remove_dir_all(root)?;
+    Ok(())
+}
+
+fn test_file_entry(path: &Path) -> FileEntry {
+    let name = path.file_name().unwrap_or_default().to_os_string();
+    FileEntry {
+        location: Location::local(path),
+        native_name: name.clone(),
+        display_name: name.to_string_lossy().into_owned(),
+        kind: EntryKind::File,
+        size: MetadataValue::Unknown,
+        modified_unix_seconds: MetadataValue::Unknown,
+    }
+}
+
+fn run_compression(request: CompressRequest) -> Vec<OperationEvent> {
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let emitted = events.clone();
+    let operation = LocalOperationProvider.compress(
+        request,
+        Rc::new(move |event| emitted.borrow_mut().push(event)),
+    );
+    while !events.borrow().iter().any(|event| {
+        matches!(
+            event,
+            OperationEvent::Compressed { .. } | OperationEvent::Failed { .. }
+        )
+    }) {
+        glib::MainContext::default().iteration(true);
+    }
+    drop(operation);
+    events.borrow().clone()
+}
+
+fn compression_stages(destination: &Path) -> Result<Vec<OsString>, Box<dyn Error>> {
+    Ok(fs::read_dir(destination)?
+        .filter_map(Result::ok)
+        .map(|entry| entry.file_name())
+        .filter(|name| name.to_string_lossy().starts_with(".strata-compression-"))
+        .collect())
+}
+
+#[test]
+fn compression_provider_rejects_escaping_archive_names() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let root = tempfile::tempdir()?;
+    let destination = root.path().join("destination");
+    let source = root.path().join("source.txt");
+    fs::create_dir(&destination)?;
+    fs::write(&source, b"source")?;
+
+    let events = run_compression(CompressRequest {
+        id: OperationRequestId(1),
+        entries: vec![test_file_entry(&source)],
+        destination: Location::local(&destination),
+        archive_name: "../outside".to_owned(),
+        conflict: TransferConflict::ReplaceExisting,
+        format: ArchiveFormat::Zip,
+        password: None,
+    });
+
+    assert!(matches!(events.as_slice(), [OperationEvent::Failed { .. }]));
+    assert!(!root.path().join("outside.zip").exists());
+    assert!(compression_stages(&destination)?.is_empty());
+    Ok(())
+}
+
+#[test]
+fn compression_conflict_choices_preserve_or_replace_the_destination() -> Result<(), Box<dyn Error>>
+{
+    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let root = tempfile::tempdir()?;
+    let destination = root.path().join("destination");
+    let source = root.path().join("source.txt");
+    let archive = destination.join("existing.zip");
+    fs::create_dir(&destination)?;
+    fs::write(&source, b"replacement")?;
+    fs::write(&archive, b"original")?;
+    fs::set_permissions(&archive, fs::Permissions::from_mode(0o640))?;
+    let request = |conflict| CompressRequest {
+        id: OperationRequestId(1),
+        entries: vec![test_file_entry(&source)],
+        destination: Location::local(&destination),
+        archive_name: "existing".to_owned(),
+        conflict,
+        format: ArchiveFormat::Zip,
+        password: None,
+    };
+
+    let refused = run_compression(request(TransferConflict::FailIfExists));
+    assert!(
+        refused
+            .iter()
+            .any(|event| matches!(event, OperationEvent::Failed { .. }))
+    );
+    assert_eq!(fs::read(&archive)?, b"original");
+    assert_eq!(fs::metadata(&archive)?.permissions().mode() & 0o777, 0o640);
+
+    let replaced = run_compression(request(TransferConflict::ReplaceExisting));
+    assert!(
+        replaced
+            .iter()
+            .any(|event| matches!(event, OperationEvent::Compressed { .. }))
+    );
+    let extracted = destination.join("extracted");
+    fs::create_dir(&extracted)?;
+    assert_eq!(
+        extract_zip(&archive, &extracted)?,
+        Some("source.txt".to_owned())
+    );
+    assert_eq!(fs::metadata(&archive)?.permissions().mode() & 0o777, 0o640);
+    assert!(compression_stages(&destination)?.is_empty());
+    Ok(())
+}
+
+#[test]
+fn compression_failure_preserves_an_existing_archive() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let root = tempfile::tempdir()?;
+    let destination = root.path().join("destination");
+    let missing = root.path().join("missing.txt");
+    let archive = destination.join("existing.zip");
+    fs::create_dir(&destination)?;
+    fs::write(&archive, b"original")?;
+
+    let events = run_compression(CompressRequest {
+        id: OperationRequestId(1),
+        entries: vec![test_file_entry(&missing)],
+        destination: Location::local(&destination),
+        archive_name: "existing".to_owned(),
+        conflict: TransferConflict::ReplaceExisting,
+        format: ArchiveFormat::Zip,
+        password: None,
+    });
+
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, OperationEvent::Failed { .. }))
+    );
+    assert_eq!(fs::read(&archive)?, b"original");
+    assert!(compression_stages(&destination)?.is_empty());
+    Ok(())
+}
+
+#[test]
+fn every_compression_format_commits_a_readable_archive() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let root = tempfile::tempdir()?;
+    let destination = root.path().join("destination");
+    let source = root.path().join("source.txt");
+    let mode_reference = root.path().join("mode-reference");
+    fs::create_dir(&destination)?;
+    fs::write(&source, b"contents")?;
+    fs::File::create(&mode_reference)?;
+    let expected_mode = fs::metadata(&mode_reference)?.permissions().mode() & 0o777;
+
+    for format in [
+        ArchiveFormat::Zip,
+        ArchiveFormat::SevenZ,
+        ArchiveFormat::TarGz,
+        ArchiveFormat::Tar,
+    ] {
+        let base = format!("archive-{}", format.extension().replace('.', "-"));
+        let events = run_compression(CompressRequest {
+            id: OperationRequestId(1),
+            entries: vec![test_file_entry(&source)],
+            destination: Location::local(&destination),
+            archive_name: base.clone(),
+            conflict: TransferConflict::FailIfExists,
+            format,
+            password: None,
+        });
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, OperationEvent::Compressed { .. }))
+        );
+        let archive = destination.join(format!("{base}.{}", format.extension()));
+        let extracted = destination.join(format!("extracted-{base}"));
+        fs::create_dir(&extracted)?;
+        match format {
+            ArchiveFormat::Zip => {
+                extract_zip(&archive, &extracted)?;
+            }
+            ArchiveFormat::SevenZ => {
+                extract_7z_from_reader(
+                    fs::File::open(&archive)?,
+                    &extracted,
+                    sevenz_rust2::Password::empty(),
+                    &Arc::new(AtomicUsize::new(0)),
+                )?;
+            }
+            ArchiveFormat::TarGz => {
+                extract_tar(&archive, &extracted, true, &Arc::new(AtomicUsize::new(0)))?;
+            }
+            ArchiveFormat::Tar => {
+                extract_tar(&archive, &extracted, false, &Arc::new(AtomicUsize::new(0)))?;
+            }
+        }
+        assert_eq!(fs::read(extracted.join("source.txt"))?, b"contents");
+        assert_eq!(
+            fs::metadata(&archive)?.permissions().mode() & 0o777,
+            expected_mode
+        );
+    }
+    assert!(compression_stages(&destination)?.is_empty());
+    Ok(())
+}
+
+#[test]
+fn cancelling_staged_compression_unlinks_the_partial_output() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let root = tempfile::tempdir()?;
+    let destination = root.path().to_path_buf();
+    let archive = destination.join("existing.zip");
+    fs::write(&archive, b"original")?;
+    let started = Arc::new(AtomicBool::new(false));
+    let release = Arc::new(AtomicBool::new(false));
+    let finished = Arc::new(AtomicBool::new(false));
+    let worker_started = started.clone();
+    let worker_release = release.clone();
+    let worker_finished = finished.clone();
+    let worker_destination = destination.clone();
+    let worker_archive = archive.clone();
+    let task = glib::MainContext::default().spawn_local(async move {
+        write_staged_archive(
+            &worker_destination,
+            &worker_archive,
+            TransferConflict::ReplaceExisting,
+            move |mut file| {
+                file.write_all(b"partial")
+                    .map_err(|error| error.to_string())?;
+                worker_started.store(true, Ordering::Release);
+                while !worker_release.load(Ordering::Acquire) {
+                    std::thread::yield_now();
+                }
+                worker_finished.store(true, Ordering::Release);
+                Ok(())
+            },
+        )
+        .await
+    });
+    let context = glib::MainContext::default();
+    while !started.load(Ordering::Acquire) {
+        context.iteration(false);
+        std::thread::yield_now();
+    }
+    assert_eq!(compression_stages(&destination)?.len(), 1);
+
+    task.abort();
+    drop(task);
+    while context.pending() {
+        context.iteration(false);
+    }
+    let stage_was_removed = compression_stages(&destination)?.is_empty();
+    let destination_was_preserved = fs::read(&archive)? == b"original";
+    release.store(true, Ordering::Release);
+    while !finished.load(Ordering::Acquire) {
+        std::thread::yield_now();
+    }
+
+    assert!(stage_was_removed);
+    assert!(destination_was_preserved);
     Ok(())
 }
 

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -15,8 +15,8 @@ use crate::{
         ArchiveFormat, CompressRequest, CreateDirectoryRequest, CreateFileRequest, DeleteRequest,
         DirectoryChange, DirectoryEvent, DirectoryRequest, ExtractRequest, FileSource, LoadHandle,
         LocationValidationError, OperationEvent, OperationProvider, OperationRequestId, PasteItem,
-        PasteRequest, RenameRequest, RequestId, RestoreRequest, uri_has_embedded_password,
-        validate_basename,
+        PasteRequest, RenameRequest, RequestId, RestoreRequest, TransferConflict,
+        uri_has_embedded_password, validate_basename,
     },
 };
 
@@ -923,6 +923,7 @@ impl Browser {
         entries: Vec<FileEntry>,
         destination: Location,
         archive_name: String,
+        conflict: TransferConflict,
         format: ArchiveFormat,
         password: Option<String>,
     ) {
@@ -942,6 +943,7 @@ impl Browser {
                 entries,
                 destination,
                 archive_name,
+                conflict,
                 format,
                 password,
             },

--- a/src/services/operations.rs
+++ b/src/services/operations.rs
@@ -124,6 +124,7 @@ pub struct CompressRequest {
     pub entries: Vec<FileEntry>,
     pub destination: Location,
     pub archive_name: String,
+    pub conflict: TransferConflict,
     pub format: ArchiveFormat,
     pub password: Option<String>,
 }

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -2248,6 +2248,109 @@ impl ViewState {
         (layout.body, layout.confirm, dismiss)
     }
 
+    fn start_compression(
+        self: &Rc<Self>,
+        entries: Vec<FileEntry>,
+        destination: Location,
+        archive_name: String,
+        format: ArchiveFormat,
+        password: Option<String>,
+    ) {
+        let final_name = format!("{archive_name}.{}", format.extension());
+        if !archive_has_collision(&destination, &final_name) {
+            self.browser.compress(
+                entries,
+                destination,
+                archive_name,
+                TransferConflict::FailIfExists,
+                format,
+                password,
+            );
+            return;
+        }
+        let Some(window_overlay) = self
+            .overlay
+            .root()
+            .and_downcast::<gtk::Window>()
+            .and_then(|window| window.child())
+            .and_downcast::<gtk::Overlay>()
+        else {
+            return;
+        };
+        let blurred_root = window_overlay.child().and_downcast::<BlurBin>();
+        if let Some(root) = blurred_root.as_ref() {
+            root.set_blurred(true);
+        }
+        let layout = message_dialog_layout(
+            crate::assets::icons::FILE_ARCHIVE,
+            "File already exists",
+            &final_name,
+            "Replace",
+            ModalTone::Danger,
+        );
+        layout.body.append(&message_dialog_description(&format!(
+            "An archive named “{final_name}” already exists in {}. Replacing it will overwrite its contents.",
+            compact_display_path(&destination)
+        )));
+        let content = layout.content;
+        let close = layout.close;
+        let cancel = layout.cancel;
+        let replace = layout.confirm;
+        let layer = modal_layer(&content, &window_overlay, blurred_root.clone(), None);
+        window_overlay.add_overlay(&layer);
+
+        for button in [&close, &cancel] {
+            let dismissed_layer = layer.clone();
+            let dismissed_overlay = window_overlay.clone();
+            let dismissed_root = blurred_root.clone();
+            let browser = self.browser.clone();
+            button.connect_clicked(move |_| {
+                dismiss_modal_layer(
+                    &dismissed_layer,
+                    &dismissed_overlay,
+                    dismissed_root.as_ref(),
+                );
+                browser.focus_active();
+            });
+        }
+
+        let replaced_layer = layer.clone();
+        let replaced_overlay = window_overlay.clone();
+        let replaced_root = blurred_root.clone();
+        let browser = self.browser.clone();
+        replace.connect_clicked(move |_| {
+            dismiss_modal_layer(&replaced_layer, &replaced_overlay, replaced_root.as_ref());
+            browser.compress(
+                entries.clone(),
+                destination.clone(),
+                archive_name.clone(),
+                TransferConflict::ReplaceExisting,
+                format,
+                password.clone(),
+            );
+        });
+
+        let keys = gtk::EventControllerKey::new();
+        keys.set_propagation_phase(gtk::PropagationPhase::Capture);
+        let escaped_layer = layer.clone();
+        let escaped_overlay = window_overlay;
+        let escaped_root = blurred_root;
+        let enter_replace = replace.clone();
+        keys.connect_key_pressed(move |_, key, _, _| {
+            if key == gtk::gdk::Key::Escape {
+                dismiss_modal_layer(&escaped_layer, &escaped_overlay, escaped_root.as_ref());
+                glib::Propagation::Stop
+            } else if key == gtk::gdk::Key::Return || key == gtk::gdk::Key::KP_Enter {
+                enter_replace.emit_clicked();
+                glib::Propagation::Stop
+            } else {
+                glib::Propagation::Proceed
+            }
+        });
+        layer.add_controller(keys);
+        replace.grab_focus();
+    }
+
     fn show_compress_dialog(self: &Rc<Self>, entries: Vec<FileEntry>) {
         if entries.is_empty() {
             return;
@@ -2268,6 +2371,9 @@ impl ViewState {
 
         let name_entry = form_entry();
         name_entry.set_text(&default_name);
+        name_entry.connect_changed(|field| {
+            update_basename_validation(field);
+        });
         let password_entry = form_password_entry();
         password_entry.set_show_peek_icon(true);
         let confirm_entry = form_password_entry();
@@ -2350,7 +2456,7 @@ impl ViewState {
             });
         }
 
-        let browser = self.browser.clone();
+        let state = Rc::downgrade(self);
         let confirm_entries = entries.clone();
         let confirm_destination = destination.clone();
         let name_for_confirm = name_entry.clone();
@@ -2363,6 +2469,13 @@ impl ViewState {
         confirm.connect_clicked(move |_| {
             let name = name_for_confirm.text().to_string();
             let format = format_for_confirm.get();
+            let archive_name = normalized_archive_name(&name, format);
+            if let Err(message) = validate_basename(&archive_name) {
+                name_for_confirm.add_css_class("error");
+                name_for_confirm.set_tooltip_text(Some(message));
+                name_for_confirm.grab_focus();
+                return;
+            }
             let password = if format.supports_password() && protected_for_confirm.is_active() {
                 let pw = password_for_confirm.text().to_string();
                 if pw.is_empty() {
@@ -2386,19 +2499,16 @@ impl ViewState {
             } else {
                 None
             };
-            let archive_name = if name.ends_with(format.extension()) {
-                name.trim_end_matches(format.extension()).to_owned()
-            } else {
-                name
-            };
             dismiss_for_confirm();
-            browser.compress(
-                confirm_entries.clone(),
-                confirm_destination.clone(),
-                archive_name,
-                format,
-                password,
-            );
+            if let Some(state) = state.upgrade() {
+                state.start_compression(
+                    confirm_entries.clone(),
+                    confirm_destination.clone(),
+                    archive_name,
+                    format,
+                    password,
+                );
+            }
         });
         name_entry.grab_focus();
     }
@@ -6039,6 +6149,18 @@ fn transfer_has_collision(source: &Location, destination: &Location) -> bool {
     target.query_exists(None::<&gio::Cancellable>)
 }
 
+fn normalized_archive_name(name: &str, format: ArchiveFormat) -> String {
+    name.strip_suffix(&format!(".{}", format.extension()))
+        .unwrap_or(name)
+        .to_owned()
+}
+
+fn archive_has_collision(destination: &Location, archive_name: &str) -> bool {
+    gio_file_for_location(destination)
+        .child(archive_name)
+        .query_exists(None::<&gio::Cancellable>)
+}
+
 fn transfer_dropped_files(
     state: &Rc<ViewState>,
     target: &gtk::DropTarget,
@@ -6861,10 +6983,23 @@ pub(super) fn dismiss_modal_layer(
     let root = root.cloned();
     animate_out(&layer_for_anim, move || {
         overlay.remove_overlay(&layer);
-        if let Some(root) = root {
+        if let Some(root) = root
+            && !overlay_has_modal_layer(&overlay)
+        {
             root.set_blurred(false);
         }
     });
+}
+
+fn overlay_has_modal_layer(overlay: &gtk::Overlay) -> bool {
+    let mut child = overlay.first_child();
+    while let Some(widget) = child {
+        if widget.is_visible() && widget.has_css_class("app-modal-layer") {
+            return true;
+        }
+        child = widget.next_sibling();
+    }
+    false
 }
 
 fn gio_file_for_location(location: &Location) -> gio::File {

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -328,6 +328,39 @@ fn transfer_collisions_detect_existing_destination_items() -> Result<(), Box<dyn
 }
 
 #[test]
+fn archive_names_strip_only_the_selected_dotted_extension() {
+    assert_eq!(
+        normalized_archive_name("backup.zip", ArchiveFormat::Zip),
+        "backup"
+    );
+    assert_eq!(
+        normalized_archive_name("backupzip", ArchiveFormat::Zip),
+        "backupzip"
+    );
+    assert_eq!(
+        normalized_archive_name("backup.tar.gz", ArchiveFormat::TarGz),
+        "backup"
+    );
+    assert!(
+        validate_basename(&normalized_archive_name(
+            "../outside.zip",
+            ArchiveFormat::Zip
+        ))
+        .is_err()
+    );
+}
+
+#[test]
+fn archive_collisions_use_the_final_name() -> Result<(), Box<dyn std::error::Error>> {
+    let root = tempfile::tempdir()?;
+    let destination = Location::local(root.path());
+    assert!(!archive_has_collision(&destination, "archive.zip"));
+    std::fs::write(root.path().join("archive.zip"), b"existing")?;
+    assert!(archive_has_collision(&destination, "archive.zip"));
+    Ok(())
+}
+
+#[test]
 fn destination_paths_expand_home_and_relative_input() {
     let base = std::path::Path::new("/work/current");
     let home = std::path::Path::new("/home/example");


### PR DESCRIPTION
## Description

- Reject unsafe compression output names in both the UI and provider.
- Prompt users to explicitly replace or cancel when an archive already exists.
- Build archives in same-directory temporary files and publish them atomically.
- Preserve existing archives and permissions when compression fails or is cancelled.
- Keep background blur correct while transitioning between compression dialogs.

## Visual evidence


https://github.com/user-attachments/assets/c6ca86ec-7b9e-4558-bca2-ae30bb95750c


## How to test

1. Select a file and open **Compress...** from its context menu.
2. Enter `../outside` and confirm that the name is rejected.
3. Create an archive, then attempt to create another archive with the same name.
4. Confirm that the **Replace/Cancel** dialog appears with the background blurred.
5. Choose **Cancel** and verify that the existing archive is unchanged.
6. Repeat and choose **Replace**, then verify that the resulting archive opens correctly.

**Expected result:**

Unsafe names are rejected, archive collisions require an explicit choice, and existing archives remain intact after cancellation or failure.

## Related issue

Closes #110
