### PR TITLE
ci: authorize protected release pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ env:
 jobs:
   prepare:
     name: Determine release version
+    if: github.actor == github.repository_owner
     runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -196,6 +197,7 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.source_sha }}
           fetch-depth: 0
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
       - name: Download binaries
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0


### PR DESCRIPTION
## What changed

- Reject release dispatches unless the actor owns the repository.
- Authenticate the publishing checkout with the deploy key stored in the protected `release` environment.
- Pair the workflow with the active `main` ruleset, whose only bypass is a repository deploy key.

This lets an owner-approved release push its generated version commit and tag without granting bypass access to write collaborators.

## Manual verification

1. Open the Release workflow while signed in as a write collaborator and dispatch it.
2. Confirm the prepare job is skipped and no release is produced.
3. Dispatch as the repository owner and approve the `release` environment deployment.
4. Confirm the version commit and tag can be pushed to protected `main`.

Expected result: write collaborators cannot publish releases or bypass required PR approval; approved owner releases can push through the dedicated deploy key.

## Screenshots/video

N/A — workflow and repository-policy change only.

Closes #152