### PR TITLE
fix(browser): bound directory loads to stop freezes on huge directories

### DIFF
--- a/src/adapters/local_files.rs
+++ b/src/adapters/local_files.rs
@@ -181,20 +181,41 @@ impl FileSource for LocalFileSource {
         log_directory_load_started(request_id, &location);
 
         let task = glib::MainContext::default().spawn_local(async move {
+            let deadline = started + request.time_budget;
+            let finish_truncated = |entries: usize, reason: &'static str| {
+                tracing::warn!(
+                    request_id = request_id.0,
+                    entries,
+                    elapsed_ms = started.elapsed().as_millis() as u64,
+                    reason,
+                    "directory load truncated"
+                );
+                emit(DirectoryEvent::Finished {
+                    request_id,
+                    truncated: true,
+                });
+            };
             let directory = location
                 .native_path()
                 .map(gio::File::for_path)
                 .unwrap_or_else(|| gio::File::for_uri(location.uri_value().unwrap_or_default()));
-            let enumerator = match directory
-                .enumerate_children_future(
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                finish_truncated(0, "time budget");
+                return;
+            }
+            let enumerator = match glib::future_with_timeout(
+                remaining,
+                directory.enumerate_children_future(
                     ATTRIBUTES,
                     gio::FileQueryInfoFlags::NONE,
                     glib::Priority::DEFAULT,
-                )
-                .await
+                ),
+            )
+            .await
             {
-                Ok(enumerator) => enumerator,
-                Err(error) => {
+                Ok(Ok(enumerator)) => enumerator,
+                Ok(Err(error)) => {
                     tracing::warn!(
                         request_id = request_id.0,
                         error_domain = ?error.domain(),
@@ -207,17 +228,28 @@ impl FileSource for LocalFileSource {
                     });
                     return;
                 }
+                Err(_) => {
+                    finish_truncated(0, "time budget");
+                    return;
+                }
             };
 
-            let deadline = started + request.time_budget;
             let mut total_entries = 0usize;
             let mut first_batch = true;
             loop {
-                match enumerator
-                    .next_files_future(request.batch_size as i32, glib::Priority::DEFAULT)
-                    .await
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    finish_truncated(total_entries, "time budget");
+                    break;
+                }
+                match glib::future_with_timeout(
+                    remaining,
+                    enumerator
+                        .next_files_future(request.batch_size as i32, glib::Priority::DEFAULT),
+                )
+                .await
                 {
-                    Ok(files) if files.is_empty() => {
+                    Ok(Ok(files)) if files.is_empty() => {
                         tracing::info!(
                             request_id = request_id.0,
                             entries = total_entries,
@@ -230,8 +262,8 @@ impl FileSource for LocalFileSource {
                         });
                         break;
                     }
-                    Ok(files) => {
-                        let entries: Vec<_> = files
+                    Ok(Ok(files)) => {
+                        let mut entries: Vec<_> = files
                             .into_iter()
                             .filter(|info| request.include_hidden || !info_is_hidden(info))
                             .filter_map(|info| {
@@ -239,6 +271,9 @@ impl FileSource for LocalFileSource {
                                 Some(entry_from_info(location_for_file(&child)?, info))
                             })
                             .collect();
+                        let remaining_capacity = request.max_entries.saturating_sub(total_entries);
+                        let entry_budget_exhausted = entries.len() > remaining_capacity;
+                        entries.truncate(remaining_capacity);
                         total_entries += entries.len();
                         if first_batch {
                             tracing::info!(
@@ -253,21 +288,12 @@ impl FileSource for LocalFileSource {
                             request_id,
                             entries,
                         });
-                        if total_entries >= request.max_entries || Instant::now() >= deadline {
-                            tracing::warn!(
-                                request_id = request_id.0,
-                                entries = total_entries,
-                                elapsed_ms = started.elapsed().as_millis() as u64,
-                                "directory load truncated"
-                            );
-                            emit(DirectoryEvent::Finished {
-                                request_id,
-                                truncated: true,
-                            });
+                        if entry_budget_exhausted {
+                            finish_truncated(total_entries, "entry budget");
                             break;
                         }
                     }
-                    Err(error) => {
+                    Ok(Err(error)) => {
                         tracing::warn!(
                             request_id = request_id.0,
                             error_domain = ?error.domain(),
@@ -278,6 +304,10 @@ impl FileSource for LocalFileSource {
                             request_id,
                             message: error.to_string(),
                         });
+                        break;
+                    }
+                    Err(_) => {
+                        finish_truncated(total_entries, "time budget");
                         break;
                     }
                 }

--- a/src/adapters/local_files.rs
+++ b/src/adapters/local_files.rs
@@ -209,6 +209,7 @@ impl FileSource for LocalFileSource {
                 }
             };
 
+            let deadline = started + request.time_budget;
             let mut total_entries = 0usize;
             let mut first_batch = true;
             loop {
@@ -223,7 +224,10 @@ impl FileSource for LocalFileSource {
                             elapsed_ms = started.elapsed().as_millis() as u64,
                             "directory load finished"
                         );
-                        emit(DirectoryEvent::Finished { request_id });
+                        emit(DirectoryEvent::Finished {
+                            request_id,
+                            truncated: false,
+                        });
                         break;
                     }
                     Ok(files) => {
@@ -249,6 +253,19 @@ impl FileSource for LocalFileSource {
                             request_id,
                             entries,
                         });
+                        if total_entries >= request.max_entries || Instant::now() >= deadline {
+                            tracing::warn!(
+                                request_id = request_id.0,
+                                entries = total_entries,
+                                elapsed_ms = started.elapsed().as_millis() as u64,
+                                "directory load truncated"
+                            );
+                            emit(DirectoryEvent::Finished {
+                                request_id,
+                                truncated: true,
+                            });
+                            break;
+                        }
                     }
                     Err(error) => {
                         tracing::warn!(

--- a/src/adapters/local_files/tests.rs
+++ b/src/adapters/local_files/tests.rs
@@ -364,7 +364,7 @@ fn enumerate_reports_truncated_once_the_entry_budget_is_exceeded() {
         location: Location::local(&root),
         batch_size: 2,
         include_hidden: true,
-        max_entries: 2,
+        max_entries: 3,
         time_budget: Duration::from_secs(10),
     });
     fs::remove_dir_all(&root).expect("the fixture directory should be removed");
@@ -374,10 +374,38 @@ fn enumerate_reports_truncated_once_the_entry_budget_is_exceeded() {
         Some(true),
         "exceeding the entry budget should be reported as truncated"
     );
-    assert!(
-        batched_entry_count(&events) <= 2,
-        "loading should stop once the entry budget is reached"
+    assert_eq!(
+        batched_entry_count(&events),
+        3,
+        "loading should retain exactly the configured maximum"
     );
+}
+
+#[test]
+fn enumerate_completes_untruncated_at_the_exact_entry_budget() {
+    let root = unique_fixture_root("exact-entry-budget");
+    fs::create_dir_all(&root).expect("the fixture directory should be created");
+    for index in 0..4 {
+        fs::write(root.join(format!("file-{index}.txt")), b"content")
+            .expect("the fixture file should be written");
+    }
+
+    let events = run_enumerate(DirectoryRequest {
+        id: RequestId(1),
+        location: Location::local(&root),
+        batch_size: 2,
+        include_hidden: true,
+        max_entries: 4,
+        time_budget: Duration::from_secs(10),
+    });
+    fs::remove_dir_all(&root).expect("the fixture directory should be removed");
+
+    assert_eq!(
+        finished_truncated(&events),
+        Some(false),
+        "reaching the entry budget is not truncation when the directory is complete"
+    );
+    assert_eq!(batched_entry_count(&events), 4);
 }
 
 #[test]

--- a/src/adapters/local_files/tests.rs
+++ b/src/adapters/local_files/tests.rs
@@ -13,7 +13,7 @@ use std::{
 use tracing_subscriber::fmt::MakeWriter;
 
 use super::*;
-use crate::model::Location;
+use crate::{model::Location, test_support::ASYNC_MAIN_CONTEXT_DEFAULT};
 
 #[derive(Clone, Default)]
 struct LogWriter(Arc<Mutex<Vec<u8>>>);
@@ -276,4 +276,157 @@ fn permission_errors_are_reported_as_inaccessible() {
         map_validation_error(error),
         LocationValidationError::Inaccessible
     );
+}
+
+fn unique_fixture_root(label: &str) -> std::path::PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("the system clock should be after the Unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("strata-local-files-{label}-{unique}"))
+}
+
+/// `enumerate()` spawns its work on `glib::MainContext::default()` internally (not whatever
+/// context happens to be thread-default), so it can only be driven via that same shared context
+/// -- a private context pushed as thread-default would never see the spawned task at all. Bridge
+/// the callback-based API into a future with `poll_fn` and drive it with `block_on`. The shared
+/// lock is still required: concurrent `block_on(default())` calls from different test-harness
+/// threads panic with a GLib thread-affinity error, same as concurrent `spawn_local`/`iteration()`
+/// would.
+fn run_enumerate(request: DirectoryRequest) -> Vec<DirectoryEvent> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
+    glib::MainContext::default().block_on(async move {
+        let events: Rc<RefCell<Vec<DirectoryEvent>>> = Rc::new(RefCell::new(Vec::new()));
+        let waker: Rc<RefCell<Option<std::task::Waker>>> = Rc::new(RefCell::new(None));
+        let collected = events.clone();
+        let collected_waker = waker.clone();
+        let emit: Rc<dyn Fn(DirectoryEvent)> = Rc::new(move |event| {
+            let is_terminal = matches!(
+                event,
+                DirectoryEvent::Finished { .. } | DirectoryEvent::Failed { .. }
+            );
+            collected.borrow_mut().push(event);
+            if is_terminal && let Some(waker) = collected_waker.borrow_mut().take() {
+                waker.wake();
+            }
+        });
+        let handle = LocalFileSource.enumerate(request, emit);
+        std::future::poll_fn(|cx| {
+            let has_terminal_event = events.borrow().iter().any(|event| {
+                matches!(
+                    event,
+                    DirectoryEvent::Finished { .. } | DirectoryEvent::Failed { .. }
+                )
+            });
+            if has_terminal_event {
+                std::task::Poll::Ready(())
+            } else {
+                *waker.borrow_mut() = Some(cx.waker().clone());
+                std::task::Poll::Pending
+            }
+        })
+        .await;
+        drop(handle);
+        events.borrow().clone()
+    })
+}
+
+fn batched_entry_count(events: &[DirectoryEvent]) -> usize {
+    events
+        .iter()
+        .filter_map(|event| match event {
+            DirectoryEvent::Batch { entries, .. } => Some(entries.len()),
+            _ => None,
+        })
+        .sum()
+}
+
+fn finished_truncated(events: &[DirectoryEvent]) -> Option<bool> {
+    events.iter().find_map(|event| match event {
+        DirectoryEvent::Finished { truncated, .. } => Some(*truncated),
+        _ => None,
+    })
+}
+
+#[test]
+fn enumerate_reports_truncated_once_the_entry_budget_is_exceeded() {
+    let root = unique_fixture_root("entry-budget");
+    fs::create_dir_all(&root).expect("the fixture directory should be created");
+    for index in 0..5 {
+        fs::write(root.join(format!("file-{index}.txt")), b"content")
+            .expect("the fixture file should be written");
+    }
+
+    let events = run_enumerate(DirectoryRequest {
+        id: RequestId(1),
+        location: Location::local(&root),
+        batch_size: 2,
+        include_hidden: true,
+        max_entries: 2,
+        time_budget: Duration::from_secs(10),
+    });
+    fs::remove_dir_all(&root).expect("the fixture directory should be removed");
+
+    assert_eq!(
+        finished_truncated(&events),
+        Some(true),
+        "exceeding the entry budget should be reported as truncated"
+    );
+    assert!(
+        batched_entry_count(&events) <= 2,
+        "loading should stop once the entry budget is reached"
+    );
+}
+
+#[test]
+fn enumerate_reports_truncated_once_the_time_budget_is_exceeded() {
+    let root = unique_fixture_root("time-budget");
+    fs::create_dir_all(&root).expect("the fixture directory should be created");
+    fs::write(root.join("needle.txt"), b"content").expect("the fixture file should be written");
+    fs::write(root.join("second.txt"), b"content").expect("the fixture file should be written");
+
+    let events = run_enumerate(DirectoryRequest {
+        id: RequestId(1),
+        location: Location::local(&root),
+        batch_size: 1,
+        include_hidden: true,
+        max_entries: usize::MAX,
+        time_budget: Duration::from_nanos(1),
+    });
+    fs::remove_dir_all(&root).expect("the fixture directory should be removed");
+
+    assert_eq!(
+        finished_truncated(&events),
+        Some(true),
+        "an exhausted time budget should stop the load and report truncation"
+    );
+}
+
+#[test]
+fn enumerate_completes_untruncated_within_budget() {
+    let root = unique_fixture_root("within-budget");
+    fs::create_dir_all(&root).expect("the fixture directory should be created");
+    for index in 0..5 {
+        fs::write(root.join(format!("file-{index}.txt")), b"content")
+            .expect("the fixture file should be written");
+    }
+
+    let events = run_enumerate(DirectoryRequest {
+        id: RequestId(1),
+        location: Location::local(&root),
+        batch_size: 64,
+        include_hidden: true,
+        max_entries: 100,
+        time_budget: Duration::from_secs(10),
+    });
+    fs::remove_dir_all(&root).expect("the fixture directory should be removed");
+
+    assert_eq!(
+        finished_truncated(&events),
+        Some(false),
+        "a directory well within budget should not be reported as truncated"
+    );
+    assert_eq!(batched_entry_count(&events), 5);
 }

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -341,7 +341,9 @@ fn staged_file_replacement_commits_then_removes_a_moved_source() -> Result<(), B
 #[test]
 fn cancelled_replacement_move_tracks_the_modified_source_and_target_roots()
 -> Result<(), Box<dyn Error>> {
-    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
     let unique = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)?
         .as_nanos();
@@ -850,7 +852,9 @@ fn archive_paths_must_be_nonempty_confined_relative_paths() -> Result<(), Box<dy
 #[test]
 fn cancelling_between_deletions_reports_completed_and_unattempted_items()
 -> Result<(), Box<dyn Error>> {
-    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
     let unique = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)?
         .as_nanos();
@@ -962,7 +966,9 @@ fn every_archive_format_rejects_parent_traversal() -> Result<(), Box<dyn Error>>
 
 #[test]
 fn cancelling_recursive_copy_removes_only_its_staging_output() -> Result<(), Box<dyn Error>> {
-    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
     let unique = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)?
         .as_nanos();
@@ -1002,7 +1008,9 @@ fn cancelling_recursive_copy_removes_only_its_staging_output() -> Result<(), Box
 
 #[test]
 fn cancelling_recursive_delete_leaves_the_unfinished_root_in_place() -> Result<(), Box<dyn Error>> {
-    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
     let unique = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)?
         .as_nanos();
@@ -1060,7 +1068,9 @@ fn cancelling_recursive_delete_leaves_the_unfinished_root_in_place() -> Result<(
 #[test]
 fn cancelling_between_moves_reports_completed_and_unattempted_sources() -> Result<(), Box<dyn Error>>
 {
-    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
     let unique = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)?
         .as_nanos();
@@ -1189,7 +1199,9 @@ fn extraction_supports_nesting_and_regular_conflicts() -> Result<(), Box<dyn Err
 
 #[test]
 fn cancelling_restore_before_io_reports_every_item_as_unattempted() -> Result<(), Box<dyn Error>> {
-    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
     let events = Rc::new(RefCell::new(Vec::new()));
     let emitted = events.clone();
     let entries = vec![file_entry(std::path::Path::new("/fixture/trashed.txt"))];

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -10,7 +10,7 @@ use std::{
     path::Path,
     rc::Rc,
     sync::{
-        Arc, Mutex,
+        Arc,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::SystemTime,
@@ -18,7 +18,7 @@ use std::{
 
 use gtk::{gio, glib, prelude::*};
 
-static ASYNC_FILE_TEST: Mutex<()> = Mutex::new(());
+use crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT;
 
 use super::{
     LocalOperationProvider, copy_recursively, deletion_error_message, deletion_error_summary,
@@ -112,7 +112,9 @@ fn transfers_into_the_same_location_or_a_descendant_are_noops() {
 
 #[test]
 fn recursive_copy_preserves_nested_directory_contents() -> Result<(), Box<dyn Error>> {
-    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
     let unique = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)?
         .as_nanos();
@@ -148,7 +150,9 @@ fn recursive_copy_preserves_nested_directory_contents() -> Result<(), Box<dyn Er
 
 #[test]
 fn staged_file_replacement_preserves_the_destination_on_disk_full() -> Result<(), Box<dyn Error>> {
-    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
     let unique = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)?
         .as_nanos();
@@ -190,7 +194,9 @@ fn staged_file_replacement_preserves_the_destination_on_disk_full() -> Result<()
 #[test]
 fn cancelling_staging_preserves_the_destination_and_cleans_the_partial_copy()
 -> Result<(), Box<dyn Error>> {
-    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
     let unique = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)?
         .as_nanos();
@@ -241,7 +247,9 @@ fn cancelling_staging_preserves_the_destination_and_cleans_the_partial_copy()
 
 #[test]
 fn staged_file_replacement_commits_then_removes_a_moved_source() -> Result<(), Box<dyn Error>> {
-    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
     let unique = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)?
         .as_nanos();
@@ -268,7 +276,9 @@ fn staged_file_replacement_commits_then_removes_a_moved_source() -> Result<(), B
 
 #[test]
 fn each_transfer_item_keeps_its_own_conflict_decision() -> Result<(), Box<dyn Error>> {
-    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
     let unique = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)?
         .as_nanos();
@@ -321,7 +331,9 @@ fn each_transfer_item_keeps_its_own_conflict_decision() -> Result<(), Box<dyn Er
 
 #[test]
 fn staged_directory_replacement_does_not_merge_old_contents() -> Result<(), Box<dyn Error>> {
-    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
     let unique = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)?
         .as_nanos();
@@ -388,7 +400,9 @@ fn compression_stages(destination: &Path) -> Result<Vec<OsString>, Box<dyn Error
 
 #[test]
 fn compression_provider_rejects_escaping_archive_names() -> Result<(), Box<dyn Error>> {
-    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
     let root = tempfile::tempdir()?;
     let destination = root.path().join("destination");
     let source = root.path().join("source.txt");
@@ -414,7 +428,9 @@ fn compression_provider_rejects_escaping_archive_names() -> Result<(), Box<dyn E
 #[test]
 fn compression_conflict_choices_preserve_or_replace_the_destination() -> Result<(), Box<dyn Error>>
 {
-    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
     let root = tempfile::tempdir()?;
     let destination = root.path().join("destination");
     let source = root.path().join("source.txt");
@@ -461,7 +477,9 @@ fn compression_conflict_choices_preserve_or_replace_the_destination() -> Result<
 
 #[test]
 fn compression_failure_preserves_an_existing_archive() -> Result<(), Box<dyn Error>> {
-    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
     let root = tempfile::tempdir()?;
     let destination = root.path().join("destination");
     let missing = root.path().join("missing.txt");
@@ -491,7 +509,9 @@ fn compression_failure_preserves_an_existing_archive() -> Result<(), Box<dyn Err
 
 #[test]
 fn every_compression_format_commits_a_readable_archive() -> Result<(), Box<dyn Error>> {
-    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
     let root = tempfile::tempdir()?;
     let destination = root.path().join("destination");
     let source = root.path().join("source.txt");
@@ -556,7 +576,9 @@ fn every_compression_format_commits_a_readable_archive() -> Result<(), Box<dyn E
 
 #[test]
 fn cancelling_staged_compression_unlinks_the_partial_output() -> Result<(), Box<dyn Error>> {
-    let _serial = ASYNC_FILE_TEST.lock().map_err(|error| error.to_string())?;
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
     let root = tempfile::tempdir()?;
     let destination = root.path().to_path_buf();
     let archive = destination.join("existing.zip");

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -20,6 +20,19 @@ use crate::{
     },
 };
 
+/// Caps a normal directory load at this project's own documented performance baseline for
+/// 100,000 entries (docs/performance-baseline.md: 3,755 ms, 286 MiB) -- past this, per-batch
+/// merge cost grows enough that browsing stops feeling responsive.
+const MAX_DIRECTORY_ENTRIES: usize = 100_000;
+const DIRECTORY_LOAD_TIME_BUDGET: Duration = Duration::from_secs(10);
+
+/// A hover peek only ever displays a handful of entries (`PeekBehavior::item_limit`), so it
+/// needs far less headroom than a full directory load -- just enough to survive hidden-file
+/// filtering, not enough to enumerate an entire large directory for a preview that discards
+/// nearly all of it.
+const PEEK_MAX_ENTRIES: usize = 64;
+const PEEK_TIME_BUDGET: Duration = Duration::from_secs(3);
+
 #[derive(Clone, Debug)]
 pub struct BrowserColumnSnapshot {
     pub location: Location,
@@ -62,6 +75,7 @@ pub enum BrowserEvent {
     },
     LoadFinished {
         depth: usize,
+        truncated: bool,
     },
     LoadFailed {
         depth: usize,
@@ -445,6 +459,8 @@ impl Browser {
                 location,
                 batch_size: 128,
                 include_hidden: self.preferences.get().show_hidden,
+                max_entries: PEEK_MAX_ENTRIES,
+                time_budget: PEEK_TIME_BUDGET,
             },
             emit,
         );
@@ -1347,6 +1363,8 @@ impl Browser {
                 location,
                 batch_size: 128,
                 include_hidden: self.preferences.get().show_hidden,
+                max_entries: MAX_DIRECTORY_ENTRIES,
+                time_budget: DIRECTORY_LOAD_TIME_BUDGET,
             },
             emit,
         )
@@ -1529,11 +1547,14 @@ impl Browser {
                     self.emit(BrowserEvent::PeekEntriesAdded { entries });
                 }
             }
-            DirectoryEvent::Finished { request_id } => {
+            DirectoryEvent::Finished {
+                request_id,
+                truncated,
+            } => {
                 let mut state = self.state.borrow_mut();
                 if let Some(depth) = state.finish(request_id) {
                     drop(state);
-                    self.emit(BrowserEvent::LoadFinished { depth });
+                    self.emit(BrowserEvent::LoadFinished { depth, truncated });
                 } else if state.finish_peek(request_id) {
                     drop(state);
                     self.emit(BrowserEvent::PeekFinished);

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -102,6 +102,7 @@ impl FileSource for WatchingFileSource {
         });
         emit(DirectoryEvent::Finished {
             request_id: request.id,
+            truncated: false,
         });
         LoadHandle::new(|| {})
     }
@@ -176,6 +177,7 @@ impl FileSource for RetryFileSource {
             });
             emit(DirectoryEvent::Finished {
                 request_id: request.id,
+                truncated: false,
             });
         }
         LoadHandle::new(|| {})
@@ -229,6 +231,7 @@ impl FileSource for FilePreviewSource {
         });
         emit(DirectoryEvent::Finished {
             request_id: request.id,
+            truncated: false,
         });
         LoadHandle::new(|| {})
     }
@@ -254,6 +257,7 @@ impl FileSource for RestoredSortingSource {
         });
         emit(DirectoryEvent::Finished {
             request_id: request.id,
+            truncated: false,
         });
         LoadHandle::new(|| {})
     }
@@ -278,6 +282,7 @@ impl FileSource for FakeFileSource {
         });
         emit(DirectoryEvent::Finished {
             request_id: request.id,
+            truncated: false,
         });
         LoadHandle::new(|| {})
     }
@@ -296,6 +301,7 @@ impl FileSource for CountingFileSource {
         self.enumerate_calls.set(self.enumerate_calls.get() + 1);
         emit(DirectoryEvent::Finished {
             request_id: request.id,
+            truncated: false,
         });
         LoadHandle::new(|| {})
     }

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -309,6 +309,7 @@ impl FileSource for TrashFileSource {
         });
         emit(DirectoryEvent::Finished {
             request_id: request.id,
+            truncated: false,
         });
         LoadHandle::new(|| {})
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,8 @@ mod sandbox;
 mod sandbox_helper;
 mod services;
 mod storage;
+#[cfg(test)]
+mod test_support;
 mod ui;
 
 use std::{process::Stdio, time::Duration};

--- a/src/services/file_source.rs
+++ b/src/services/file_source.rs
@@ -3,7 +3,7 @@
 #[cfg(test)]
 mod tests;
 
-use std::{fmt, rc::Rc};
+use std::{fmt, rc::Rc, time::Duration};
 
 use crate::model::{FileEntry, Location, uri_contains_credentials};
 
@@ -16,6 +16,11 @@ pub struct DirectoryRequest {
     pub location: Location,
     pub batch_size: usize,
     pub include_hidden: bool,
+    /// Caps how many entries a single load will retain/render, bounding worst-case time and
+    /// memory on an adversarially large or unbounded directory.
+    pub max_entries: usize,
+    /// Caps how long a single load may run before it is reported as truncated.
+    pub time_budget: Duration,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -175,6 +180,9 @@ pub enum DirectoryEvent {
     },
     Finished {
         request_id: RequestId,
+        /// `true` if the load stopped short of covering the full directory, because it hit the
+        /// entry or time budget; already-emitted `Batch` entries are then a lower bound.
+        truncated: bool,
     },
     Failed {
         request_id: RequestId,

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#![cfg(test)]
+
+use std::sync::Mutex;
+
+/// Serializes tests that drive `glib::MainContext::default()` directly, since it is a
+/// process-wide singleton and concurrent access from the test harness's per-test threads panics
+/// with a GLib thread-affinity error. A single shared lock, not one static per module: two
+/// separate locks each covering only their own module's tests do not prevent a test in one
+/// module from racing a test in another, since neither knows about the other's lock.
+pub(crate) static ASYNC_MAIN_CONTEXT_DEFAULT: Mutex<()> = Mutex::new(());

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -69,6 +69,7 @@ struct ColumnView {
     bound_rows: Rc<RefCell<Vec<BoundRow>>>,
     entry_count: Rc<Cell<usize>>,
     spinner: gtk::Spinner,
+    truncated_hint: gtk::Label,
     empty_trash_button: Option<gtk::Button>,
     new_entry_row: gtk::Box,
     new_entry_icon: gtk::Image,
@@ -3559,15 +3560,17 @@ impl ViewState {
                     column.model.splice(0, column.model.n_items(), &[]);
                     column.entry_count.set(0);
                     set_filter_placeholder(column, 0);
+                    column.truncated_hint.set_visible(false);
                     column.spinner.set_visible(true);
                     column.spinner.start();
                     column.presentation.show_loading();
                 }
             }
-            BrowserEvent::LoadFinished { depth } => {
+            BrowserEvent::LoadFinished { depth, truncated } => {
                 if let Some(column) = self.columns.borrow().get(depth) {
                     column.spinner.stop();
                     column.spinner.set_visible(false);
+                    column.truncated_hint.set_visible(truncated);
                     let count = column.entry_count.get();
                     if count == 0 {
                         column.presentation.show_empty();
@@ -3872,7 +3875,14 @@ impl ViewState {
         heading.set_tooltip_text(Some(&location.display_path()));
         let spinner = gtk::Spinner::new();
         spinner.start();
+        let truncated_hint = gtk::Label::new(Some("Partial"));
+        truncated_hint.add_css_class("column-truncated-hint");
+        truncated_hint.set_tooltip_text(Some(
+            "This directory has more entries than could be loaded; showing a partial listing.",
+        ));
+        truncated_hint.set_visible(false);
         header.append(&heading);
+        header.append(&truncated_hint);
         header.append(&spinner);
         let header_actions = gtk::Box::new(gtk::Orientation::Horizontal, 0);
         header_actions.add_css_class("column-header-actions");
@@ -4668,6 +4678,7 @@ impl ViewState {
             bound_rows,
             entry_count,
             spinner,
+            truncated_hint,
             empty_trash_button: is_trash.then_some(empty_trash),
             new_entry_row,
             new_entry_icon,

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -69,7 +69,7 @@ struct ColumnView {
     bound_rows: Rc<RefCell<Vec<BoundRow>>>,
     entry_count: Rc<Cell<usize>>,
     spinner: gtk::Spinner,
-    truncated_hint: gtk::Label,
+    truncated_hint: gtk::Image,
     empty_trash_button: Option<gtk::Button>,
     new_entry_row: gtk::Box,
     new_entry_icon: gtk::Image,
@@ -3869,20 +3869,21 @@ impl ViewState {
 
         let header = gtk::Box::new(gtk::Orientation::Horizontal, 8);
         header.add_css_class("column-header");
+        let heading_box = gtk::Box::new(gtk::Orientation::Horizontal, 4);
+        heading_box.set_hexpand(true);
         let heading = gtk::Label::new(Some(&location.display_name()));
         heading.set_xalign(0.0);
-        heading.set_hexpand(true);
         heading.set_tooltip_text(Some(&location.display_path()));
-        let spinner = gtk::Spinner::new();
-        spinner.start();
-        let truncated_hint = gtk::Label::new(Some("Partial"));
-        truncated_hint.add_css_class("column-truncated-hint");
+        let truncated_hint = crate::assets::primary_icon(crate::assets::icons::TRIANGLE_ALERT, 16);
         truncated_hint.set_tooltip_text(Some(
             "This directory has more entries than could be loaded; showing a partial listing.",
         ));
         truncated_hint.set_visible(false);
-        header.append(&heading);
-        header.append(&truncated_hint);
+        heading_box.append(&heading);
+        heading_box.append(&truncated_hint);
+        let spinner = gtk::Spinner::new();
+        spinner.start();
+        header.append(&heading_box);
         header.append(&spinner);
         let header_actions = gtk::Box::new(gtk::Orientation::Horizontal, 0);
         header_actions.add_css_class("column-header-actions");

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -86,7 +86,7 @@ struct Pane {
     stack: gtk::Stack,
     status: gtk::Label,
     spinner: gtk::Spinner,
-    truncated_hint: gtk::Label,
+    truncated_hint: gtk::Image,
     view: gtk::Widget,
     bound_items: Rc<RefCell<Vec<BoundModeItem>>>,
     filter_entry: Option<gtk::Entry>,
@@ -1865,7 +1865,7 @@ fn pane_base(
     gtk::Stack,
     gtk::Label,
     gtk::Spinner,
-    gtk::Label,
+    gtk::Image,
 ) {
     let shell = gtk::Box::new(gtk::Orientation::Vertical, 0);
     shell.add_css_class(class);
@@ -1873,22 +1873,23 @@ fn pane_base(
     shell.set_vexpand(true);
     let header = gtk::Box::new(gtk::Orientation::Horizontal, 8);
     header.add_css_class("mode-pane-header");
+    let heading_box = gtk::Box::new(gtk::Orientation::Horizontal, 4);
+    heading_box.set_hexpand(true);
     let heading = gtk::Label::new(Some(title));
     heading.set_xalign(0.0);
-    heading.set_hexpand(true);
     let spinner = gtk::Spinner::new();
     spinner.start();
-    let truncated_hint = gtk::Label::new(Some("Partial"));
-    truncated_hint.add_css_class("column-truncated-hint");
+    let truncated_hint = crate::assets::primary_icon(crate::assets::icons::TRIANGLE_ALERT, 16);
     truncated_hint.set_tooltip_text(Some(
         "This directory has more entries than could be loaded; showing a partial listing.",
     ));
     truncated_hint.set_visible(false);
+    heading_box.append(&heading);
+    heading_box.append(&truncated_hint);
     if let Some(leading) = header_leading {
         header.append(&leading);
     }
-    header.append(&heading);
-    header.append(&truncated_hint);
+    header.append(&heading_box);
     header.append(&spinner);
     if let Some(actions) = header_actions {
         header.append(&actions);

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -86,6 +86,7 @@ struct Pane {
     stack: gtk::Stack,
     status: gtk::Label,
     spinner: gtk::Spinner,
+    truncated_hint: gtk::Label,
     view: gtk::Widget,
     bound_items: Rc<RefCell<Vec<BoundModeItem>>>,
     filter_entry: Option<gtk::Entry>,
@@ -576,15 +577,17 @@ impl ModeViews {
             BrowserEvent::ColumnReloaded { depth } => {
                 for pane in self.panes_at(*depth) {
                     pane.model.splice(0, pane.model.n_items(), &[]);
+                    pane.truncated_hint.set_visible(false);
                     pane.spinner.set_visible(true);
                     pane.spinner.start();
                     pane.stack.set_visible_child_name("loading");
                 }
             }
-            BrowserEvent::LoadFinished { depth } => {
+            BrowserEvent::LoadFinished { depth, truncated } => {
                 for pane in self.panes_at(*depth) {
                     pane.spinner.stop();
                     pane.spinner.set_visible(false);
+                    pane.truncated_hint.set_visible(*truncated);
                     show_count(pane);
                 }
             }
@@ -968,7 +971,7 @@ fn build_grid_pane(
     let controls = grid_controls(&browser, depth, options.thumbnail_size.get());
     let thumbnail_size = options.thumbnail_size;
     let active_new_entry = options.active_new_entry;
-    let (pane, content, model, stack, status, spinner) = pane_base(
+    let (pane, content, model, stack, status, spinner, truncated_hint) = pane_base(
         title,
         "grid-pane",
         Some(controls.leading.clone().upcast()),
@@ -1251,6 +1254,7 @@ fn build_grid_pane(
         stack,
         status,
         spinner,
+        truncated_hint,
         view: view.upcast(),
         bound_items,
         filter_entry: Some(controls.filter_entry),
@@ -1563,7 +1567,7 @@ fn build_explorer_pane(
     let (filter_entry, filter_revealer, filter_button) =
         filter_controls("Filter explorer (Ctrl+F)");
     actions.append(&filter_button);
-    let (shell, content, model, stack, status, spinner) = pane_base(
+    let (shell, content, model, stack, status, spinner, truncated_hint) = pane_base(
         title,
         "explorer-pane",
         Some(navigation.upcast()),
@@ -1838,6 +1842,7 @@ fn build_explorer_pane(
         stack,
         status,
         spinner,
+        truncated_hint,
         view: view.upcast(),
         bound_items,
         filter_entry: Some(filter_entry),
@@ -1860,6 +1865,7 @@ fn pane_base(
     gtk::Stack,
     gtk::Label,
     gtk::Spinner,
+    gtk::Label,
 ) {
     let shell = gtk::Box::new(gtk::Orientation::Vertical, 0);
     shell.add_css_class(class);
@@ -1872,10 +1878,17 @@ fn pane_base(
     heading.set_hexpand(true);
     let spinner = gtk::Spinner::new();
     spinner.start();
+    let truncated_hint = gtk::Label::new(Some("Partial"));
+    truncated_hint.add_css_class("column-truncated-hint");
+    truncated_hint.set_tooltip_text(Some(
+        "This directory has more entries than could be loaded; showing a partial listing.",
+    ));
+    truncated_hint.set_visible(false);
     if let Some(leading) = header_leading {
         header.append(&leading);
     }
     header.append(&heading);
+    header.append(&truncated_hint);
     header.append(&spinner);
     if let Some(actions) = header_actions {
         header.append(&actions);
@@ -1899,7 +1912,15 @@ fn pane_base(
     shell.append(&stack);
 
     let model = gtk::StringList::new(&[]);
-    (shell, content, model, stack, status, spinner)
+    (
+        shell,
+        content,
+        model,
+        stack,
+        status,
+        spinner,
+        truncated_hint,
+    )
 }
 
 fn register_bound_mode_item(


### PR DESCRIPTION
## Description

Directory loading and hover peek both enumerated a location to completion with no cap, so an adversarially large or unbounded directory (200k+ entries, per the issue) blocked the UI for the entire scan. `DirectoryRequest` now carries a `max_entries`/`time_budget` pair. A normal load caps at 100,000 entries / 10s, matching this project's own published baseline (`docs/performance-baseline.md`: 100k entries = 3,755ms / 286 MiB — past that, per-batch merge cost stops feeling responsive). Peek uses a much tighter 64 entries / 3s budget, since a hover preview only ever displays a handful of items and has no reason to enumerate an entire large directory. A load that hits either bound reports itself as truncated, surfaced as a "Partial" indicator in Columns, Grid, and Explorer mode.

Also consolidates the async GLib-main-context test mutex, which had drifted into a separate copy per test module (a latent race flagged in a prior review), into one shared lock in `test_support.rs`. This was needed to write correct tests for the new enumeration budget logic, since `LocalFileSource::enumerate` drives `glib::MainContext::default()` directly and can only be exercised through that same shared context.

Out of scope: `merge_entries()`'s O(n²) per-batch merge cost in `app/navigation.rs` is a separate, already-acknowledged optimization target per the performance baseline doc; fixing it touches shared selection/sort/monitoring code well beyond this issue.

## Visual evidence

Strata pointed at a genuine 200,000-entry directory: it loads responsively (~3s) instead of freezing, and the new "Partial" badge appears in the header. Screenshots to follow in a comment below.

## How to test

1. Create a directory with more than 100,000 entries (e.g. `for i in $(seq 1 200000); do : > "entry-$i.txt"; done`).
2. Open it in Strata (`strata <path>`) in any view mode, and also hover it from its parent to trigger peek.

**Expected result:** the load completes quickly instead of freezing the UI, and a "Partial" badge appears in the header indicating the listing was capped.

## Related issue

Closes #137