### PR TITLE
fix(ui): remove header outer-edge padding

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -20,7 +20,7 @@ headerbar {
   border-bottom: 1px solid alpha(@theme_border, 0.6);
   box-shadow: none;
   min-height: 54px;
-  padding: 0 8px;
+  padding: 0;
 }
 
 .location-control {


### PR DESCRIPTION
## Description

Remove the header bar's horizontal padding so the sidebar toggle and close button sit flush with their respective window edges.

## Visual evidence

**Before (from the issue):**

<img width="967" height="117" alt="Header controls inset from the window edges" src="https://github.com/user-attachments/assets/0ea506f2-7dea-43f6-9b7c-1056996d53b2" />

**After:** Manually verified at 125% display scale; both outer button hit areas now align with the header boundaries. A screenshot is available locally but cannot be attached through the CLI.

## How to test

1. Launch Strata and inspect the main header bar.
2. Hover the sidebar toggle and close button.

**Expected result:** The outer edge of each button's hover area is flush with its corresponding window edge, with no header padding outside it.

## Related issue

Closes #156
