### PR TITLE
fix(ci): authorize organization release actor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,8 @@ env:
 jobs:
   prepare:
     name: Determine release version
-    if: github.actor == github.repository_owner
+    # Organization-owned repositories expose the organization, not a human owner.
+    if: github.actor == vars.RELEASE_ACTOR
     runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Description

Use the repository `RELEASE_ACTOR` variable to authorize release dispatches instead of comparing a human actor with the organization login. The variable is configured as `l0gicgate`, preserving the restriction against collaborator-published releases.

## Visual evidence

N/A — workflow-only change.

## How to test

1. Dispatch the Release workflow from `main` as the account named by `RELEASE_ACTOR`.
2. Confirm the prepare and build jobs run and the protected `release` environment still requires approval before publication.

**Expected result:** The authorized maintainer can publish a release; other actors cannot pass the prepare-job condition.

## Related issue

Closes #158