### PR TITLE
feat(browser): add open in terminal to context menus and keybind

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -2901,6 +2901,6 @@ menubutton.grid-thumbnail-menu > button:focus-visible {
 
 @media (prefers-reduced-motion: reduce) {
   * {
-    transition-duration: 1ms !important;
+    transition-duration: 1ms;
   }
 }

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -6,6 +6,7 @@ use std::{
     future::Future,
     path::Path,
     pin::Pin,
+    process::Command,
     rc::Rc,
     time::{Duration, Instant},
 };
@@ -812,6 +813,24 @@ impl BrowserView {
         } else if let Some(depth) = self.state.browser.active_depth() {
             self.state.browser.select_all(depth);
         }
+    }
+
+    pub fn open_terminal(&self) {
+        let mode = self.view_mode();
+        let depth = if mode == BrowserMode::Columns {
+            new_folder_destination_depth(
+                self.state.hovered_column.get(),
+                self.state.focused_column_depth(),
+                self.state.browser.active_depth(),
+                self.state.columns.borrow().len(),
+            )
+        } else {
+            self.state.browser.active_depth()
+        };
+        let Some(location) = depth.and_then(|depth| self.state.browser.location_at(depth)) else {
+            return;
+        };
+        launch_terminal(&location, &self.state.overlay);
     }
 
     pub fn show_location_properties(&self, location: &Location) {
@@ -5136,11 +5155,13 @@ pub(super) fn install_folder_context_menu(
     let new_file = context_menu_option("New File", None);
     let paste = context_menu_option("Paste", Some("Ctrl+V"));
     let select_all = context_menu_option("Select All", Some("Ctrl+A"));
+    let open_terminal = context_menu_option("Open in Terminal", Some("F4"));
     let properties = context_menu_option("Properties", None);
     content.append(&new_folder);
     content.append(&new_file);
     content.append(&paste);
     content.append(&select_all);
+    content.append(&open_terminal);
     content.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
     content.append(&properties);
 
@@ -5199,12 +5220,24 @@ pub(super) fn install_folder_context_menu(
     });
     let weak = Rc::downgrade(state);
     let properties_popover = popover.downgrade();
+    let properties_location = location.clone();
     properties.connect_clicked(move |_| {
         if let Some(popover) = properties_popover.upgrade() {
             popover.popdown();
         }
         if let Some(state) = weak.upgrade() {
-            state.show_folder_properties(&location);
+            state.show_folder_properties(&properties_location);
+        }
+    });
+    let weak = Rc::downgrade(state);
+    let terminal_popover = popover.downgrade();
+    let terminal_location = location.clone();
+    open_terminal.connect_clicked(move |_| {
+        if let Some(popover) = terminal_popover.upgrade() {
+            popover.popdown();
+        }
+        if let Some(state) = weak.upgrade() {
+            launch_terminal(&terminal_location, &state.overlay);
         }
     });
 
@@ -5228,6 +5261,7 @@ pub(super) fn install_folder_context_menu(
                 .contains_type(gtk::gdk::FileList::static_type())
         }));
         select_all.set_sensitive(selection.n_items() > 0);
+        open_terminal.set_sensitive(can_open_terminal(&location));
         if popover_for_click.parent().is_none()
             && let Some(parent) = gesture.widget()
         {
@@ -5283,6 +5317,8 @@ pub(super) fn install_item_context_menu(
 
     let single = gtk::Box::new(gtk::Orientation::Vertical, 0);
     let open = item_context_option(crate::assets::icons::EXTERNAL_LINK, "Open", "↵");
+    let open_terminal =
+        item_context_option(crate::assets::icons::TERMINAL, "Open in Terminal", "F4");
     let preview = item_context_option(crate::assets::icons::EYE, "Quick preview", "Space");
     let restore = item_context_option(crate::assets::icons::FOLDER, "Restore", "");
     restore.set_visible(in_trash);
@@ -5306,6 +5342,7 @@ pub(super) fn install_item_context_menu(
     let extract = item_context_option(crate::assets::icons::FILE_ARCHIVE, "Extract here", "");
     let extract_to = item_context_option(crate::assets::icons::FILE_ARCHIVE, "Extract to…", "");
     single.append(&open);
+    single.append(&open_terminal);
     single.append(&preview);
     single.append(&restore);
     single.append(&extract);
@@ -5395,6 +5432,20 @@ pub(super) fn install_item_context_menu(
             && !entry.is_directory()
         {
             state.browser.preview(depth, position);
+        }
+    });
+    let weak = Rc::downgrade(state);
+    let terminal_target = target.clone();
+    let terminal_popover = popover.downgrade();
+    open_terminal.connect_clicked(move |_| {
+        if let Some(popover) = terminal_popover.upgrade() {
+            popover.popdown();
+        }
+        let Some((_, entry)) = terminal_target.borrow().clone() else {
+            return;
+        };
+        if let Some(state) = weak.upgrade() {
+            launch_terminal(&entry.location, &state.overlay);
         }
     });
     let weak = Rc::downgrade(state);
@@ -5519,6 +5570,7 @@ pub(super) fn install_item_context_menu(
         target.replace(Some((resolved_position, entry.clone())));
         let entries = state.browser.selected_entries();
         preview.set_visible(entry_supports_quick_preview(&entry));
+        open_terminal.set_visible(entry.is_directory() && can_open_terminal(&entry.location));
         pin.set_visible(entry.is_directory() && !is_trash_location(&entry.location));
         pin.set_sensitive(
             state
@@ -7663,6 +7715,41 @@ pub(super) fn open_location(location: &Location, parent: &impl IsA<gtk::Widget>)
             "file open location"
         );
         show_error_dialog(parent, "Unable to open file", &error.to_string());
+    }
+}
+
+fn can_open_terminal(location: &Location) -> bool {
+    location.native_path().is_some() && !is_trash_location(location)
+}
+
+pub(super) fn launch_terminal(location: &Location, parent: &impl IsA<gtk::Widget>) {
+    let Some(path) = location.native_path() else {
+        show_error_dialog(
+            parent,
+            "Unable to open terminal",
+            "This location is not a local folder",
+        );
+        return;
+    };
+    if is_trash_location(location) {
+        show_error_dialog(
+            parent,
+            "Unable to open terminal",
+            "Terminal cannot be opened in Trash",
+        );
+        return;
+    }
+    let path = path.to_path_buf();
+    tracing::debug!(
+        location = %location.diagnostic_path(),
+        "opening terminal"
+    );
+    let result = Command::new("xdg-terminal-exec")
+        .arg(format!("--dir={}", path.display()))
+        .spawn();
+    if let Err(error) = result {
+        tracing::warn!(%error, "unable to launch terminal");
+        show_error_dialog(parent, "Unable to open terminal", &error.to_string());
     }
 }
 

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -3,10 +3,11 @@
 use std::{
     cell::{Cell, RefCell},
     collections::HashSet,
+    ffi::OsString,
     future::Future,
     path::Path,
     pin::Pin,
-    process::Command,
+    process::{Command, Stdio},
     rc::Rc,
     time::{Duration, Instant},
 };
@@ -817,18 +818,23 @@ impl BrowserView {
     }
 
     pub fn open_terminal(&self) {
-        let mode = self.view_mode();
-        let depth = if mode == BrowserMode::Columns {
-            new_folder_destination_depth(
-                self.state.hovered_column.get(),
-                self.state.focused_column_depth(),
-                self.state.browser.active_depth(),
-                self.state.columns.borrow().len(),
-            )
-        } else {
-            self.state.browser.active_depth()
-        };
-        let Some(location) = depth.and_then(|depth| self.state.browser.location_at(depth)) else {
+        self.state.sync_mode_selection();
+        let selected = self.state.browser.selected_entries();
+        let location = selected_terminal_location(&selected).or_else(|| {
+            let mode = self.view_mode();
+            let depth = if mode == BrowserMode::Columns {
+                new_folder_destination_depth(
+                    self.state.hovered_column.get(),
+                    self.state.focused_column_depth(),
+                    self.state.browser.active_depth(),
+                    self.state.columns.borrow().len(),
+                )
+            } else {
+                self.state.browser.active_depth()
+            };
+            depth.and_then(|depth| self.state.browser.location_at(depth))
+        });
+        let Some(location) = location else {
             return;
         };
         launch_terminal(&location, &self.state.overlay);
@@ -5167,7 +5173,7 @@ pub(super) fn install_folder_context_menu(
     let new_file = context_menu_option("New File", None);
     let paste = context_menu_option("Paste", Some("Ctrl+V"));
     let select_all = context_menu_option("Select All", Some("Ctrl+A"));
-    let open_terminal = context_menu_option("Open in Terminal", Some("F4"));
+    let open_terminal = context_menu_option("Open in Terminal", Some("Ctrl+T"));
     let properties = context_menu_option("Properties", None);
     content.append(&new_folder);
     content.append(&new_file);
@@ -5330,7 +5336,7 @@ pub(super) fn install_item_context_menu(
     let single = gtk::Box::new(gtk::Orientation::Vertical, 0);
     let open = item_context_option(crate::assets::icons::EXTERNAL_LINK, "Open", "↵");
     let open_terminal =
-        item_context_option(crate::assets::icons::TERMINAL, "Open in Terminal", "F4");
+        item_context_option(crate::assets::icons::TERMINAL, "Open in Terminal", "Ctrl+T");
     let preview = item_context_option(crate::assets::icons::EYE, "Quick preview", "Space");
     let restore = item_context_option(crate::assets::icons::FOLDER, "Restore", "");
     restore.set_visible(in_trash);
@@ -7734,6 +7740,19 @@ fn can_open_terminal(location: &Location) -> bool {
     location.native_path().is_some() && !is_trash_location(location)
 }
 
+fn selected_terminal_location(entries: &[FileEntry]) -> Option<Location> {
+    let [entry] = entries else {
+        return None;
+    };
+    entry.is_directory().then(|| entry.location.clone())
+}
+
+fn terminal_directory_argument(path: &Path) -> OsString {
+    let mut argument = OsString::from("--dir=");
+    argument.push(path);
+    argument
+}
+
 pub(super) fn launch_terminal(location: &Location, parent: &impl IsA<gtk::Widget>) {
     let Some(path) = location.native_path() else {
         show_error_dialog(
@@ -7757,7 +7776,10 @@ pub(super) fn launch_terminal(location: &Location, parent: &impl IsA<gtk::Widget
         "opening terminal"
     );
     let result = Command::new("xdg-terminal-exec")
-        .arg(format!("--dir={}", path.display()))
+        .arg(terminal_directory_argument(&path))
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .spawn();
     if let Err(error) = result {
         tracing::warn!(%error, "unable to launch terminal");

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -3,6 +3,41 @@
 use super::*;
 
 #[test]
+fn terminal_shortcut_prefers_one_selected_directory() {
+    let entry = |name: &str, kind| FileEntry {
+        location: Location::local(format!("/fixture/{name}")),
+        native_name: name.into(),
+        display_name: name.into(),
+        kind,
+        size: crate::model::MetadataValue::Unknown,
+        modified_unix_seconds: crate::model::MetadataValue::Unknown,
+    };
+    let directory = entry("selected", crate::model::EntryKind::Directory);
+    let file = entry("notes.txt", crate::model::EntryKind::File);
+
+    assert_eq!(
+        selected_terminal_location(std::slice::from_ref(&directory)),
+        Some(directory.location.clone())
+    );
+    assert_eq!(selected_terminal_location(&[directory, file.clone()]), None);
+    assert_eq!(selected_terminal_location(&[file]), None);
+    assert_eq!(selected_terminal_location(&[]), None);
+}
+
+#[cfg(unix)]
+#[test]
+fn terminal_directory_argument_preserves_native_path_bytes() {
+    use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
+
+    let path = Path::new(OsStr::from_bytes(b"/tmp/non-utf8-\xff"));
+
+    assert_eq!(
+        terminal_directory_argument(path).as_encoded_bytes(),
+        b"--dir=/tmp/non-utf8-\xff"
+    );
+}
+
+#[test]
 fn global_activity_uses_the_latest_active_label() {
     let mut activity = GlobalActivityState::default();
     let connecting = activity.begin("Connecting…");

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -1101,7 +1101,11 @@ fn keybindings_page() -> gtk::Widget {
     }
 
     append_heading(&content, "APPLICATION");
-    for (label, keys) in [("Search", "Ctrl + K"), ("Open settings", "Ctrl + ,")] {
+    for (label, keys) in [
+        ("Search", "Ctrl + K"),
+        ("Open terminal", "Ctrl + T"),
+        ("Open settings", "Ctrl + ,"),
+    ] {
         append_keybinding(&content, label, keys);
     }
 

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -296,6 +296,14 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
     window.add_action(&search_action);
     application.set_accels_for_action("win.search", &["<Control>k"]);
 
+    let terminal_view = browser.clone();
+    let terminal_action = gio::SimpleAction::new("open-terminal", None);
+    terminal_action.connect_activate(move |_, _| {
+        terminal_view.open_terminal();
+    });
+    window.add_action(&terminal_action);
+    application.set_accels_for_action("win.open-terminal", &["F4", "<Primary><Alt>t"]);
+
     let update_button = sidebar.update_notice.clone();
     let update_area = sidebar.update_area.clone();
     let update_label = sidebar.update_label.clone();
@@ -585,6 +593,10 @@ fn install_keyboard_navigation(
         }
         if control && key == gtk::gdk::Key::h {
             browser.toggle_hidden();
+            return glib::Propagation::Stop;
+        }
+        if key == gtk::gdk::Key::F4 {
+            view.open_terminal();
             return glib::Propagation::Stop;
         }
         let column_popover = focused

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -302,7 +302,7 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
         terminal_view.open_terminal();
     });
     window.add_action(&terminal_action);
-    application.set_accels_for_action("win.open-terminal", &["F4", "<Primary><Alt>t"]);
+    application.set_accels_for_action("win.open-terminal", &["<Primary>t"]);
 
     let update_button = sidebar.update_notice.clone();
     let update_area = sidebar.update_area.clone();
@@ -595,7 +595,7 @@ fn install_keyboard_navigation(
             browser.toggle_hidden();
             return glib::Propagation::Stop;
         }
-        if key == gtk::gdk::Key::F4 {
+        if is_open_terminal_shortcut(key, modifiers) {
             view.open_terminal();
             return glib::Propagation::Stop;
         }
@@ -714,6 +714,13 @@ fn install_keyboard_navigation(
         glib::Propagation::Stop
     });
     window.add_controller(keys);
+}
+
+fn is_open_terminal_shortcut(key: gtk::gdk::Key, modifiers: gtk::gdk::ModifierType) -> bool {
+    modifiers.contains(gtk::gdk::ModifierType::CONTROL_MASK)
+        && !modifiers
+            .intersects(gtk::gdk::ModifierType::SHIFT_MASK | gtk::gdk::ModifierType::ALT_MASK)
+        && matches!(key, gtk::gdk::Key::t | gtk::gdk::Key::T)
 }
 
 fn is_sidebar_focus_shortcut(key: gtk::gdk::Key, modifiers: gtk::gdk::ModifierType) -> bool {

--- a/src/ui/window/tests.rs
+++ b/src/ui/window/tests.rs
@@ -3,10 +3,10 @@
 use std::path::Path;
 
 use super::{
-    MouseHistoryAction, PinStatus, is_sidebar_focus_shortcut, is_smb_location,
-    is_standard_place_location, mouse_history_action, parse_pinned_places, pin_status,
-    remove_pinned_place, reorder_places, serialize_pinned_places, should_show_standard_place,
-    vim_focus_direction,
+    MouseHistoryAction, PinStatus, is_open_terminal_shortcut, is_sidebar_focus_shortcut,
+    is_smb_location, is_standard_place_location, mouse_history_action, parse_pinned_places,
+    pin_status, remove_pinned_place, reorder_places, serialize_pinned_places,
+    should_show_standard_place, vim_focus_direction,
 };
 
 #[test]
@@ -16,6 +16,26 @@ fn mouse_history_buttons_map_to_navigation_actions() {
     for button in [1, 2, 3, 4, 5, 6, 7, 10] {
         assert_eq!(mouse_history_action(button), None);
     }
+}
+
+#[test]
+fn open_terminal_shortcut_requires_only_control() {
+    let control = gtk::gdk::ModifierType::CONTROL_MASK;
+    let shift = gtk::gdk::ModifierType::SHIFT_MASK;
+    let alt = gtk::gdk::ModifierType::ALT_MASK;
+
+    assert!(is_open_terminal_shortcut(gtk::gdk::Key::t, control));
+    assert!(is_open_terminal_shortcut(gtk::gdk::Key::T, control));
+    assert!(!is_open_terminal_shortcut(
+        gtk::gdk::Key::t,
+        gtk::gdk::ModifierType::empty()
+    ));
+    assert!(!is_open_terminal_shortcut(
+        gtk::gdk::Key::t,
+        control | shift
+    ));
+    assert!(!is_open_terminal_shortcut(gtk::gdk::Key::t, control | alt));
+    assert!(!is_open_terminal_shortcut(gtk::gdk::Key::F4, control));
 }
 
 #[test]


### PR DESCRIPTION
## Description

Add **Open in Terminal** to folder and directory context menus. `Ctrl+T` opens the selected directory when exactly one folder is selected, otherwise it opens the hovered/current pane. The shortcut is also listed under Settings → Keybindings.

Terminal launch uses `xdg-terminal-exec --dir=<path>`, preserves native path bytes, blocks non-native and Trash locations, and detaches standard streams so terminal warnings do not leak into Strata output. This also removes an unrelated GTK CSS parser warning emitted at startup.

## Visual evidence

The folder and directory context menus show **Open in Terminal — Ctrl+T**, and Settings → Keybindings lists **Open terminal — Ctrl + T**.

## How to test

1. Hover a pane and press `Ctrl+T`; verify the terminal opens in that pane.
2. Select one directory and press `Ctrl+T`; verify the terminal opens in the selected directory.
3. Use **Open in Terminal** from folder and directory context menus.
4. Start Strata from a terminal and verify opening terminals does not add terminal-process warnings to Strata output.
5. Navigate to Trash or a non-native location and verify terminal launch remains blocked.

**Expected result:** the terminal opens in the intended local directory without polluting Strata console output.

Closes #160
Closes #162