### PR TITLE
fix(preview): keep sandbox input extensions so RAW files decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Plain-text and source previews are different: they stay in process because they 
 | UI and runtime | Rust 2024, GTK 4.12+, GIO/GLib, Cairo, GtkSourceView 5, Poppler GLib, GDK Pixbuf, GStreamer, and Fontconfig |
 | Filesystems | Native Linux paths (including non-UTF-8 names) and GIO/GVfs locations; remote protocol availability depends on installed GVfs backends |
 | Preview boundary | Bubblewrap is mandatory for native parser-backed previews; helpers have no network and fail closed. Plain text is read in process with a 1 MiB cap. |
-| Optional preview tools | `ffmpegthumbnailer`/`ffmpeg` for video; ImageMagick and LibRaw-compatible `dcraw_emu`/`dcraw` expand camera RAW support |
+| Optional preview tools | `ffmpegthumbnailer`/`ffmpeg` for video; ImageMagick and `dcraw`/`simple_dcraw` expand camera RAW support |
 | Hardware acceleration | Media-only VA-API or Vulkan attempts with software VP8/WebM fallback; GPU and codec support depend on host drivers/plugins |
 | Scale targets | Virtualized browser models and bounded asynchronous updates are tested with deterministic directories up to 100,000 entries |
 | Packaging | Dynamically linked release archive with SHA-256 digest, GitHub build-provenance attestation, and `SOURCE_COMMIT` |

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Plain-text and source previews are different: they stay in process because they 
 | UI and runtime | Rust 2024, GTK 4.12+, GIO/GLib, Cairo, GtkSourceView 5, Poppler GLib, GDK Pixbuf, GStreamer, and Fontconfig |
 | Filesystems | Native Linux paths (including non-UTF-8 names) and GIO/GVfs locations; remote protocol availability depends on installed GVfs backends |
 | Preview boundary | Bubblewrap is mandatory for native parser-backed previews; helpers have no network and fail closed. Plain text is read in process with a 1 MiB cap. |
-| Optional preview tools | `ffmpegthumbnailer`/`ffmpeg` for video; ImageMagick and `dcraw`/`simple_dcraw` expand camera RAW support |
+| Optional preview tools | `ffmpegthumbnailer`/`ffmpeg` for video; ImageMagick, classic `dcraw`, and LibRaw `simple_dcraw` expand camera RAW support |
 | Hardware acceleration | Media-only VA-API or Vulkan attempts with software VP8/WebM fallback; GPU and codec support depend on host drivers/plugins |
 | Scale targets | Virtualized browser models and bounded asynchronous updates are tested with deterministic directories up to 100,000 entries |
 | Packaging | Dynamically linked release archive with SHA-256 digest, GitHub build-provenance attestation, and `SOURCE_COMMIT` |

--- a/docs/preview-sandbox.md
+++ b/docs/preview-sandbox.md
@@ -8,7 +8,7 @@ The following providers run in a short-lived helper process:
 
 - GDK Pixbuf image and camera RAW loaders;
 - Poppler PDF thumbnail and page rendering;
-- ImageMagick and `dcraw`/`dcraw_emu` RAW fallbacks; and
+- ImageMagick and `dcraw`/`simple_dcraw` RAW fallbacks; and
 - `ffmpegthumbnailer` media thumbnails.
 
 Image previews are normalized to PNG by the helper. Video previews are limited to the first 30 seconds, at most 1280 pixels on either axis, and at most 30 frames per second. They are normalized by VA-API first, Vulkan second, or the software VP8 fallback. Hardware paths produce H.264/AAC MP4; the software path produces VP8/Opus WebM. This keeps GStreamer from parsing the selected untrusted file directly. Plain-text previews remain in-process and are limited to 1 MB; they do not invoke a native format parser.

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -362,8 +362,9 @@ fn sandbox_command(
         "/etc/ImageMagick-6",
         "--ro-bind",
     ]);
+    let sandbox_input = sandbox_input_path(input);
     command.arg(executable).arg("/app/strata");
-    command.arg("--ro-bind").arg(input).arg("/input");
+    command.arg("--ro-bind").arg(input).arg(&sandbox_input);
     if operation != ParseOperation::PreviewMedia {
         command.arg("--bind").arg(output).arg("/output");
     }
@@ -391,7 +392,7 @@ fn sandbox_command(
         "/app/strata",
         "--preview-helper",
         operation.argument(),
-        "/input",
+        &sandbox_input,
     ]);
     if operation == ParseOperation::PreviewMedia {
         command.arg("/dev/stdout");
@@ -400,6 +401,18 @@ fn sandbox_command(
     }
     command.arg(value.to_string());
     command
+}
+
+fn sandbox_input_path(input: &Path) -> String {
+    match input.extension().and_then(|extension| extension.to_str()) {
+        Some(extension)
+            if (1..=8).contains(&extension.len())
+                && extension.bytes().all(|byte| byte.is_ascii_alphanumeric()) =>
+        {
+            format!("/input.{extension}")
+        }
+        _ => "/input".to_owned(),
+    }
 }
 
 pub(crate) fn gpu_devices(dev: &Path) -> Vec<PathBuf> {

--- a/src/sandbox/tests.rs
+++ b/src/sandbox/tests.rs
@@ -10,8 +10,8 @@ use std::{
 
 use super::{
     Cancellation, MAX_RASTER_INPUT_BYTES, MEDIA_WALL_TIME_LIMIT, ParseOperation, PrivateOutput,
-    WALL_TIME_LIMIT, gpu_devices, parse, sandbox_command, spawn_renderer, valid_output,
-    wait_for_renderer, wait_for_renderer_output,
+    WALL_TIME_LIMIT, gpu_devices, parse, sandbox_command, sandbox_input_path, spawn_renderer,
+    valid_output, wait_for_renderer, wait_for_renderer_output,
 };
 
 fn limit_from(arguments: &[String], flag: &str) -> u64 {
@@ -79,7 +79,7 @@ fn sandbox_exposes_only_runtime_input_and_private_output() {
 
     assert!(joined.contains("--unshare-all"));
     assert!(joined.contains("--clearenv"));
-    assert!(joined.contains("--ro-bind /home/alice/Downloads/untrusted.pdf /input"));
+    assert!(joined.contains("--ro-bind /home/alice/Downloads/untrusted.pdf /input.pdf"));
     assert!(joined.contains("--bind /tmp/private-output /output"));
     assert!(joined.contains("--as=2147483648"));
     assert!(joined.contains("--cpu=10"));
@@ -119,7 +119,21 @@ fn media_previews_use_bounded_streaming_instead_of_driver_wide_resource_limits()
     assert!(!joined.contains("MALLOC_ARENA_MAX"));
     assert!(joined.contains("--size 536870912 --tmpfs /tmp"));
     assert!(!joined.contains("--bind /tmp/private-output /output"));
-    assert!(joined.contains("preview-media /input /dev/stdout"));
+    assert!(joined.contains("preview-media /input.mkv /dev/stdout"));
+}
+
+#[test]
+fn sandbox_input_keeps_a_safe_filename_extension() {
+    assert_eq!(
+        sandbox_input_path(Path::new("/photos/DSC01986.ARW")),
+        "/input.ARW"
+    );
+    assert_eq!(sandbox_input_path(Path::new("/tmp/no-extension")), "/input");
+    assert_eq!(sandbox_input_path(Path::new("/tmp/photo.ar-w")), "/input");
+    assert_eq!(
+        sandbox_input_path(Path::new("/tmp/toolongextension.abcdefghij")),
+        "/input"
+    );
 }
 
 #[test]
@@ -182,7 +196,7 @@ fn media_sandbox_exposes_only_supplied_gpu_devices_and_sysfs() {
     assert!(joined.contains("--ro-bind /sys /sys"));
     assert!(!joined.contains("--cpu=10"));
     assert!(!joined.contains("--bind /tmp/private-output /output"));
-    assert!(joined.contains("preview-media /input /dev/stdout"));
+    assert!(joined.contains("preview-media /input.mkv /dev/stdout"));
 }
 
 #[test]

--- a/src/sandbox_helper.rs
+++ b/src/sandbox_helper.rs
@@ -128,10 +128,13 @@ fn render_simple_dcraw(path: &Path, size: i32) -> Result<Vec<u8>, String> {
         return Err("simple_dcraw failed".to_owned());
     }
     for thumb in ["/tmp/raw-thumb.thumb.jpg", "/tmp/raw-thumb.thumb.ppm"] {
-        let Ok(data) = fs::read(thumb) else {
+        let Ok(file) = fs::File::open(thumb) else {
             continue;
         };
-        if data.is_empty() || data.len() as u64 > MAX_OUTPUT_BYTES {
+        let Ok(data) = read_limited(file, MAX_OUTPUT_BYTES) else {
+            continue;
+        };
+        if data.is_empty() {
             continue;
         }
         if let Ok(png) = scale_embedded_thumbnail(&data, size) {
@@ -538,31 +541,38 @@ fn render_media(path: &Path, size: i32) -> Result<Vec<u8>, String> {
     }
 }
 
+fn read_limited(reader: impl Read, max_bytes: u64) -> io::Result<Vec<u8>> {
+    let mut data = Vec::new();
+    reader
+        .take(max_bytes.saturating_add(1))
+        .read_to_end(&mut data)?;
+    if data.len() as u64 > max_bytes {
+        return Err(io::Error::other(
+            "Preview provider output exceeded its limit",
+        ));
+    }
+    Ok(data)
+}
+
 fn bounded_output(command: &mut Command, max_bytes: u64) -> io::Result<Output> {
     let mut child = command
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()?;
-    let mut stdout = Vec::new();
     let read = child
         .stdout
         .take()
-        .ok_or_else(|| io::Error::other("Unable to capture provider output"))?
-        .take(max_bytes.saturating_add(1))
-        .read_to_end(&mut stdout);
-    if let Err(error) = read {
-        let _killed = child.kill();
-        let _waited = child.wait();
-        return Err(error);
-    }
-    if stdout.len() as u64 > max_bytes {
-        let _killed = child.kill();
-        let _waited = child.wait();
-        return Err(io::Error::other(
-            "Preview provider output exceeded its limit",
-        ));
-    }
+        .ok_or_else(|| io::Error::other("Unable to capture provider output"))
+        .and_then(|stdout| read_limited(stdout, max_bytes));
+    let stdout = match read {
+        Ok(stdout) => stdout,
+        Err(error) => {
+            let _killed = child.kill();
+            let _waited = child.wait();
+            return Err(error);
+        }
+    };
     let status = child.wait()?;
     Ok(Output {
         status,

--- a/src/sandbox_helper.rs
+++ b/src/sandbox_helper.rs
@@ -44,7 +44,7 @@ pub(crate) fn run(arguments: &[String]) -> Result<(), String> {
         "thumbnail-raw" => (render_raw(input, value.clamp(16, 256))?, None),
         "thumbnail-pdf" => (render_pdf_thumbnail(input, value.clamp(16, 256))?, None),
         "thumbnail-video" => (render_media(input, value.clamp(16, 256))?, None),
-        "preview-image" => (render_pixbuf(input, 1400)?, None),
+        "preview-image" => (render_raw(input, 1400)?, None),
         "preview-pdf" => {
             let (png, page, pages) = render_pdf_page(input, value)?;
             (png, Some(format!("{page} {pages}")))
@@ -93,42 +93,77 @@ fn render_imagemagick(path: &Path, size: i32) -> Result<Vec<u8>, String> {
     Err("No RAW image renderer succeeded".to_owned())
 }
 
+// LibRaw's dcraw_emu does not support `-e`; `-c` is a threshold, not stdout.
 fn render_dcraw(path: &Path, size: i32) -> Result<Vec<u8>, String> {
-    for executable in ["dcraw_emu", "dcraw"] {
-        let output = bounded_output(
-            Command::new(executable).args(["-e", "-c"]).arg(path),
-            MAX_OUTPUT_BYTES,
-        );
-        let Ok(output) = output else {
+    let classic = bounded_output(
+        Command::new("dcraw").args(["-e", "-c"]).arg(path),
+        MAX_OUTPUT_BYTES,
+    );
+    if let Ok(output) = classic
+        && output.status.success()
+        && !output.stdout.is_empty()
+        && let Ok(png) = scale_embedded_thumbnail(&output.stdout, size)
+    {
+        return Ok(png);
+    }
+    render_simple_dcraw(path, size)
+}
+
+fn render_simple_dcraw(path: &Path, size: i32) -> Result<Vec<u8>, String> {
+    use std::os::unix::fs::symlink;
+
+    // Writes `<file>.thumb.jpg` next to the input, which is a read-only bind.
+    let staging = Path::new("/tmp/raw-thumb");
+    let _ = fs::remove_file(staging);
+    symlink(path, staging).map_err(|error| error.to_string())?;
+    let status = Command::new("simple_dcraw")
+        .arg("-e")
+        .arg(staging)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|error| error.to_string())?;
+    if !status.success() {
+        return Err("simple_dcraw failed".to_owned());
+    }
+    for thumb in ["/tmp/raw-thumb.thumb.jpg", "/tmp/raw-thumb.thumb.ppm"] {
+        let Ok(data) = fs::read(thumb) else {
             continue;
         };
-        if !output.status.success() || output.stdout.is_empty() {
+        if data.is_empty() || data.len() as u64 > MAX_OUTPUT_BYTES {
             continue;
         }
-        let loader = gdk_pixbuf::PixbufLoader::new();
-        if loader.write(&output.stdout).is_err() || loader.close().is_err() {
-            continue;
-        }
-        let Some(pixbuf) = loader.pixbuf() else {
-            continue;
-        };
-        let width = pixbuf.width().max(1);
-        let height = pixbuf.height().max(1);
-        let scale = (f64::from(size) / f64::from(width))
-            .min(f64::from(size) / f64::from(height))
-            .min(1.0);
-        let Some(scaled) = pixbuf.scale_simple(
-            (f64::from(width) * scale).round().max(1.0) as i32,
-            (f64::from(height) * scale).round().max(1.0) as i32,
-            gdk_pixbuf::InterpType::Bilinear,
-        ) else {
-            continue;
-        };
-        if let Ok(png) = scaled.save_to_bufferv("png", &[]) {
+        if let Ok(png) = scale_embedded_thumbnail(&data, size) {
             return Ok(png);
         }
     }
-    Err("No embedded RAW thumbnail could be decoded".to_owned())
+    Err("simple_dcraw produced no thumbnail".to_owned())
+}
+
+fn scale_embedded_thumbnail(data: &[u8], size: i32) -> Result<Vec<u8>, String> {
+    let loader = gdk_pixbuf::PixbufLoader::new();
+    loader
+        .write(data)
+        .and_then(|()| loader.close())
+        .map_err(|error| error.to_string())?;
+    let pixbuf = loader
+        .pixbuf()
+        .ok_or_else(|| "Unable to decode embedded RAW thumbnail".to_owned())?;
+    let width = pixbuf.width().max(1);
+    let height = pixbuf.height().max(1);
+    let scale = (f64::from(size) / f64::from(width))
+        .min(f64::from(size) / f64::from(height))
+        .min(1.0);
+    pixbuf
+        .scale_simple(
+            (f64::from(width) * scale).round().max(1.0) as i32,
+            (f64::from(height) * scale).round().max(1.0) as i32,
+            gdk_pixbuf::InterpType::Bilinear,
+        )
+        .ok_or_else(|| "Unable to scale embedded RAW thumbnail".to_owned())?
+        .save_to_bufferv("png", &[])
+        .map_err(|error| error.to_string())
 }
 
 fn render_pdf_thumbnail(path: &Path, size: i32) -> Result<Vec<u8>, String> {

--- a/src/sandbox_helper/tests.rs
+++ b/src/sandbox_helper/tests.rs
@@ -10,7 +10,8 @@ use gdk_pixbuf::prelude::*;
 
 use super::{
     MediaBackend, bounded_output, bounded_output_with_timeout, bounded_surface_dimensions,
-    media_backends, media_command, run_media_backends, scale_embedded_thumbnail,
+    media_backends, media_command, render_pixbuf, render_raw, run, run_media_backends,
+    scale_embedded_thumbnail,
 };
 
 fn arguments(backend: &MediaBackend) -> String {
@@ -213,4 +214,29 @@ fn embedded_thumbnails_scale_to_the_requested_size() {
     let scaled = loader.pixbuf().expect("decode scaled png");
 
     assert_eq!((scaled.width(), scaled.height()), (32, 24));
+}
+
+#[test]
+fn preview_image_uses_raw_fallbacks() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let input = directory.path().join("photo.ARW");
+    let output = directory.path().join("result.png");
+    std::fs::write(&input, b"not a camera file").expect("write stub");
+
+    let pixbuf = render_pixbuf(&input, 1400).expect_err("stub must fail pixbuf");
+    let raw = render_raw(&input, 1400);
+    let preview = run(&[
+        "preview-image".into(),
+        input.to_string_lossy().into_owned(),
+        output.to_string_lossy().into_owned(),
+        "1400".into(),
+    ]);
+
+    match raw {
+        Ok(_) => preview.expect("preview-image should use RAW fallbacks"),
+        Err(raw) => {
+            assert_ne!(pixbuf, raw);
+            assert_eq!(preview.expect_err("stub should fail RAW fallbacks"), raw);
+        }
+    }
 }

--- a/src/sandbox_helper/tests.rs
+++ b/src/sandbox_helper/tests.rs
@@ -10,8 +10,8 @@ use gdk_pixbuf::prelude::*;
 
 use super::{
     MediaBackend, bounded_output, bounded_output_with_timeout, bounded_surface_dimensions,
-    media_backends, media_command, render_pixbuf, render_raw, run, run_media_backends,
-    scale_embedded_thumbnail,
+    media_backends, media_command, read_limited, render_pixbuf, render_raw, run,
+    run_media_backends, scale_embedded_thumbnail,
 };
 
 fn arguments(backend: &MediaBackend) -> String {
@@ -146,6 +146,20 @@ fn provider_output_is_bounded_without_buffering_stderr() {
     .expect("discard provider stderr");
     assert_eq!(noisy.stdout, b"ok");
     assert!(noisy.stderr.is_empty());
+}
+
+#[test]
+fn file_reads_stop_before_exceeding_the_output_limit() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let path = directory.path().join("thumb.jpg");
+
+    std::fs::write(&path, b"1234").expect("write exact");
+    let exact = read_limited(std::fs::File::open(&path).expect("open exact"), 4)
+        .expect("read file at the limit");
+    assert_eq!(exact, b"1234");
+
+    std::fs::write(&path, vec![0_u8; 1025]).expect("write oversized");
+    assert!(read_limited(std::fs::File::open(&path).expect("open oversized"), 1024).is_err());
 }
 
 #[test]

--- a/src/sandbox_helper/tests.rs
+++ b/src/sandbox_helper/tests.rs
@@ -6,9 +6,11 @@ use std::{
     time::{Duration, Instant},
 };
 
+use gdk_pixbuf::prelude::*;
+
 use super::{
     MediaBackend, bounded_output, bounded_output_with_timeout, bounded_surface_dimensions,
-    media_backends, media_command, run_media_backends,
+    media_backends, media_command, run_media_backends, scale_embedded_thumbnail,
 };
 
 fn arguments(backend: &MediaBackend) -> String {
@@ -193,4 +195,22 @@ fn media_commands_select_the_backend_and_preserve_limits() {
         assert!(command.contains("-b:v 2M -maxrate 3M -bufsize 4M"));
         assert!(command.ends_with("pipe:1"));
     }
+}
+
+#[test]
+fn embedded_thumbnails_scale_to_the_requested_size() {
+    let source = gdk_pixbuf::Pixbuf::new(gdk_pixbuf::Colorspace::Rgb, false, 8, 80, 60)
+        .expect("allocate thumbnail");
+    source.fill(0x3366_99ff);
+    let jpeg = source
+        .save_to_bufferv("jpeg", &[])
+        .expect("encode thumbnail");
+
+    let png = scale_embedded_thumbnail(&jpeg, 32).expect("scale thumbnail");
+    let loader = gdk_pixbuf::PixbufLoader::new();
+    loader.write(&png).expect("load scaled png");
+    loader.close().expect("finish scaled png");
+    let scaled = loader.pixbuf().expect("decode scaled png");
+
+    assert_eq!((scaled.width(), scaled.height()), (32, 24));
 }


### PR DESCRIPTION
## Description

The sandbox bind-mounted every file as extensionless `/input`, so ImageMagick treated Sony `.ARW` (TIFF-container RAW) as TIFF and failed. The preview pane also skipped the ImageMagick/dcraw fallbacks that thumbnails already had, and the last fallback called LibRaw's `dcraw_emu` with classic `dcraw -e -c` flags.

Keep a sanitized original extension (`/input.ARW`), run `preview-image` through `render_raw`, and extract embedded thumbnails with classic `dcraw` or LibRaw `simple_dcraw`.

## Visual evidence

<img width="1125" height="683" alt="image" src="https://github.com/user-attachments/assets/37599dc1-3e9e-4dda-a87f-fe6666453c96" />
<img width="1105" height="895" alt="image" src="https://github.com/user-attachments/assets/4160f937-1086-48b8-949a-e412c8441185" />

Closes #165