### PR TITLE
fix(ui): close appearance and sort dropdowns on option select

### DIFF
--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -6542,6 +6542,13 @@ pub(super) fn column_sort_menu(browser: &Rc<Browser>, depth: usize) -> gtk::Menu
     let preferences = browser.column_preferences(depth).unwrap_or_default();
     let selected_checks: Rc<RefCell<Vec<(SortKey, gtk::Image)>>> =
         Rc::new(RefCell::new(Vec::new()));
+    let popover = gtk::Popover::builder()
+        .has_arrow(false)
+        .halign(gtk::Align::End)
+        .position(gtk::PositionType::Bottom)
+        .build();
+    popover.add_css_class("column-popover");
+    let popover_weak = popover.downgrade();
     for (label, key) in [
         ("Name", SortKey::Name),
         ("Size", SortKey::Size),
@@ -6552,12 +6559,16 @@ pub(super) fn column_sort_menu(browser: &Rc<Browser>, depth: usize) -> gtk::Menu
         selected_checks.borrow_mut().push((key, check));
         let checks = selected_checks.clone();
         let weak_browser = Rc::downgrade(browser);
+        let popover_weak = popover_weak.clone();
         option.connect_clicked(move |_| {
             for (check_key, check) in checks.borrow().iter() {
                 check.set_visible(*check_key == key);
             }
             if let Some(browser) = weak_browser.upgrade() {
                 browser.set_sort_key(depth, key);
+            }
+            if let Some(popover) = popover_weak.upgrade() {
+                popover.popdown();
             }
         });
         content.append(&option);
@@ -6570,6 +6581,7 @@ pub(super) fn column_sort_menu(browser: &Rc<Browser>, depth: usize) -> gtk::Menu
     let weak_browser = Rc::downgrade(browser);
     let folders_enabled_for_click = folders_enabled.clone();
     let folders_check_for_click = folders_check.clone();
+    let popover_weak = popover_weak.clone();
     folders_first.connect_clicked(move |_| {
         let enabled = !folders_enabled_for_click.get();
         folders_enabled_for_click.set(enabled);
@@ -6577,16 +6589,13 @@ pub(super) fn column_sort_menu(browser: &Rc<Browser>, depth: usize) -> gtk::Menu
         if let Some(browser) = weak_browser.upgrade() {
             browser.set_folders_first(depth, enabled);
         }
+        if let Some(popover) = popover_weak.upgrade() {
+            popover.popdown();
+        }
     });
     content.append(&folders_first);
 
-    let popover = gtk::Popover::builder()
-        .child(&content)
-        .has_arrow(false)
-        .halign(gtk::Align::End)
-        .position(gtk::PositionType::Bottom)
-        .build();
-    popover.add_css_class("column-popover");
+    popover.set_child(Some(&content));
     let keys = gtk::EventControllerKey::new();
     keys.set_propagation_phase(gtk::PropagationPhase::Capture);
     let dismissed_popover = popover.clone();

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -771,6 +771,17 @@ fn build_appearance_menu(
 ) -> gtk::MenuButton {
     let content = gtk::Box::new(gtk::Orientation::Vertical, 0);
     content.add_css_class("appearance-menu");
+    let popover = gtk::Popover::builder()
+        .has_arrow(false)
+        .halign(gtk::Align::End)
+        .position(gtk::PositionType::Bottom)
+        .build();
+    popover.add_css_class("appearance-popover");
+    let button = gtk::MenuButton::builder()
+        .tooltip_text("Appearance")
+        .popover(&popover)
+        .build();
+    let popover_weak = popover.downgrade();
     append_menu_heading(&content, "VIEW");
     let current_mode = view.view_mode();
     let (list, list_check, _) = appearance_option(
@@ -801,12 +812,16 @@ fn build_appearance_menu(
         let grid_check = grid_check.clone();
         let explorer_check = explorer_check.clone();
         let preferences = preferences.clone();
+        let popover_weak = popover_weak.clone();
         button.connect_clicked(move |_| {
             view.set_view_mode(mode);
             preferences.set_browser_mode(mode);
             list_check.set_visible(mode == BrowserMode::Columns);
             grid_check.set_visible(mode == BrowserMode::Grid);
             explorer_check.set_visible(mode == BrowserMode::Explorer);
+            if let Some(popover) = popover_weak.upgrade() {
+                popover.popdown();
+            }
         });
     }
     content.append(&list);
@@ -834,20 +849,28 @@ fn build_appearance_menu(
         let compact_check = compact_check.clone();
         let airy_check = airy_check.clone();
         let preferences = preferences.clone();
+        let popover_weak = popover_weak.clone();
         compact.connect_clicked(move |_| {
             view.set_density(BrowserDensity::Compact);
             preferences.set_browser_density(BrowserDensity::Compact);
             compact_check.set_visible(true);
             airy_check.set_visible(false);
+            if let Some(popover) = popover_weak.upgrade() {
+                popover.popdown();
+            }
         });
     }
     {
         let view = view.clone();
+        let popover_weak = popover_weak.clone();
         airy.connect_clicked(move |_| {
             view.set_density(BrowserDensity::Airy);
             preferences.set_browser_density(BrowserDensity::Airy);
             compact_check.set_visible(false);
             airy_check.set_visible(true);
+            if let Some(popover) = popover_weak.upgrade() {
+                popover.popdown();
+            }
         });
     }
     content.append(&compact);
@@ -878,24 +901,18 @@ fn build_appearance_menu(
         );
     });
     let weak_controller = Rc::downgrade(controller);
+    let popover_weak = popover_weak.clone();
     hidden.connect_clicked(move |_| {
         if let Some(controller) = weak_controller.upgrade() {
             controller.toggle_hidden();
         }
+        if let Some(popover) = popover_weak.upgrade() {
+            popover.popdown();
+        }
     });
     content.append(&hidden);
 
-    let popover = gtk::Popover::builder()
-        .child(&content)
-        .has_arrow(false)
-        .halign(gtk::Align::End)
-        .position(gtk::PositionType::Bottom)
-        .build();
-    popover.add_css_class("appearance-popover");
-    let button = gtk::MenuButton::builder()
-        .tooltip_text("Appearance")
-        .popover(&popover)
-        .build();
+    popover.set_child(Some(&content));
     let icon = crate::assets::text_icon(crate::assets::icons::LIST, 20);
     button.set_child(Some(&icon));
     button.add_css_class("header-action");


### PR DESCRIPTION
## Summary
- Appearance dropdown (view mode, density, hidden files) now closes when an option is selected
- Column sort menu (sort by field, folders first) now closes when an option is selected
- Both use the same `popover.popdown()` pattern as the existing context menus

#### Test plan
- [x] Open appearance dropdown, select List/Grid/Explorer — popover closes
- [x] Open appearance dropdown, select Compact/Airy — popover closes
- [x] Open appearance dropdown, toggle Hidden files — popover closes
- [x] Open column sort menu, select a sort field — popover closes
- [x] Open column sort menu, toggle Folders first — popover closes
<img width="960" height="518" alt="screenrecording-2026-09-02_16-16-17" src="https://github.com/user-attachments/assets/44c4baac-4a05-4c13-a700-cf9dd4b90c1e" />