### PR TITLE
fix(ui): consistent accent hover colors and unified accent icons

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -75,8 +75,6 @@ struct PrimaryIcon {
 thread_local! {
     static PRIMARY_ICON_COLOR: RefCell<String> = RefCell::new("#8bc9eb".to_owned());
     static PRIMARY_ICONS: RefCell<Vec<PrimaryIcon>> = const { RefCell::new(Vec::new()) };
-    static TEXT_ICON_COLOR: RefCell<String> = RefCell::new("#c9deed".to_owned());
-    static TEXT_ICONS: RefCell<Vec<PrimaryIcon>> = const { RefCell::new(Vec::new()) };
     static DANGER_ICON_COLOR: RefCell<String> = RefCell::new("#e5484d".to_owned());
     static DANGER_ICONS: RefCell<Vec<PrimaryIcon>> = const { RefCell::new(Vec::new()) };
     static ICON_TEXTURES: RefCell<HashMap<(String, String), gdk::Texture>> = RefCell::new(HashMap::new());
@@ -144,24 +142,6 @@ pub fn remove_primary_icon(image: &gtk::Image) {
             .borrow_mut()
             .retain(|icon| icon.image.upgrade().as_ref() != Some(image));
     });
-}
-
-pub fn text_icon(name: &str, pixel_size: i32) -> gtk::Image {
-    let image = gtk::Image::new();
-    image.set_pixel_size(pixel_size);
-    set_text_icon(&image, name);
-    image
-}
-
-pub fn set_text_icon(image: &gtk::Image, name: &str) {
-    let color = TEXT_ICON_COLOR.with(|color| color.borrow().clone());
-    apply_primary_icon(image, name, &color);
-    TEXT_ICONS.with(|icons| register_icon(icons, image, name));
-}
-
-pub fn set_text_icon_color(color: &str) {
-    TEXT_ICON_COLOR.with(|current| current.replace(color.to_owned()));
-    TEXT_ICONS.with(|icons| recolor_registered_icons(icons, color));
 }
 
 pub fn danger_icon(name: &str, pixel_size: i32) -> gtk::Image {

--- a/src/style.css
+++ b/src/style.css
@@ -55,14 +55,14 @@ headerbar .sidebar-toggle:hover,
 headerbar button.header-action:hover,
 headerbar menubutton.header-action > button:hover,
 headerbar button.header-action.active {
-  background: alpha(@theme_muted, 0.62);
+  background: alpha(@theme_accent, 0.15);
 }
 
 headerbar .sidebar-toggle:active,
 headerbar button.header-action:active,
 headerbar menubutton.header-action > button:active,
 headerbar menubutton.header-action > button:checked {
-  background: alpha(@theme_muted, 0.8);
+  background: alpha(@theme_accent, 0.22);
   transform: scale(0.97);
 }
 
@@ -80,11 +80,6 @@ headerbar menubutton.header-action > button {
   color: @theme_text;
 }
 
-headerbar button.header-action image,
-headerbar menubutton.header-action > button image {
-  opacity: 0.42;
-}
-
 headerbar button.header-action:hover,
 headerbar button.header-action:active,
 headerbar button.header-action.active,
@@ -94,17 +89,6 @@ headerbar menubutton.header-action > button:active,
 headerbar menubutton.header-action > button:checked,
 headerbar menubutton.header-action > button:focus-visible {
   color: @theme_text;
-}
-
-headerbar button.header-action:hover image,
-headerbar button.header-action:active image,
-headerbar button.header-action.active image,
-headerbar button.header-action:focus-visible image,
-headerbar menubutton.header-action > button:hover image,
-headerbar menubutton.header-action > button:active image,
-headerbar menubutton.header-action > button:checked image,
-headerbar menubutton.header-action > button:focus-visible image {
-  opacity: 1;
 }
 
 .appearance-popover contents {
@@ -146,7 +130,7 @@ headerbar menubutton.header-action > button:focus-visible image {
 }
 
 .appearance-option:hover {
-  background: alpha(@theme_muted, 0.5);
+  background: alpha(@theme_accent, 0.15);
   color: @theme_text;
 }
 
@@ -201,7 +185,7 @@ headerbar menubutton.header-action > button:focus-visible image {
 }
 
 .location-action:active {
-  background: alpha(@theme_muted, 0.78);
+  background: alpha(@theme_accent, 0.22);
   transform: scale(0.97);
 }
 
@@ -218,7 +202,7 @@ headerbar menubutton.header-action > button:focus-visible image {
 }
 
 .breadcrumb:hover {
-  background: alpha(@theme_muted, 0.62);
+  background: alpha(@theme_accent, 0.15);
   color: @theme_text;
 }
 
@@ -260,7 +244,7 @@ headerbar menubutton.header-action > button:focus-visible image {
 }
 
 .copy-path:hover {
-  background: alpha(@theme_muted, 0.72);
+  background: alpha(@theme_accent, 0.15);
 }
 
 .breadcrumb-separator,
@@ -345,7 +329,7 @@ headerbar menubutton.header-action > button:focus-visible image {
 }
 
 .search-result:hover {
-  background: alpha(@theme_muted, 0.38);
+  background: alpha(@theme_accent, 0.15);
 }
 
 .search-result:selected,
@@ -531,12 +515,12 @@ headerbar menubutton.header-action > button:focus-visible image {
 }
 
 .action-dialog-close:hover {
-  background: alpha(@theme_muted, 0.56);
+  background: alpha(@theme_accent, 0.15);
   color: @theme_text;
 }
 
 .action-dialog-close:active {
-  background: alpha(@theme_muted, 0.78);
+  background: alpha(@theme_accent, 0.22);
   color: @theme_accent;
   transform: scale(0.97);
 }
@@ -574,12 +558,12 @@ headerbar menubutton.header-action > button:focus-visible image {
 }
 
 .action-dialog-cancel:hover {
-  background: alpha(@theme_muted, 0.62);
+  background: alpha(@theme_accent, 0.15);
   border-color: @theme_text;
 }
 
 .action-dialog-cancel:active {
-  background: alpha(@theme_muted, 0.82);
+  background: alpha(@theme_accent, 0.22);
   border-color: @theme_accent;
   color: @theme_accent;
   transform: scale(0.97);
@@ -777,12 +761,12 @@ dropdown.form-control > button {
 }
 
 dropdown.form-control > button:hover {
-  background: alpha(@theme_muted, 0.62);
+  background: alpha(@theme_accent, 0.15);
   border-color: alpha(@theme_accent, 0.68);
 }
 
 dropdown.form-control > button:active {
-  background: alpha(@theme_muted, 0.78);
+  background: alpha(@theme_accent, 0.22);
   transform: scale(0.97);
 }
 
@@ -848,8 +832,8 @@ dropdown.form-control:disabled > button {
 }
 
 .settings-navigation {
-  background: @theme_bg;
-  border-right: 1px solid alpha(@theme_border, 0.26);
+  background: @theme_surface;
+  border-right: 1px solid alpha(@theme_border, 0.6);
   border-radius: 7px 0 0 7px;
   min-width: 220px;
   padding: 18px 12px;
@@ -863,9 +847,9 @@ dropdown.form-control:disabled > button {
 .settings-navigation button {
   background: transparent;
   border: none;
-  border-radius: 5px;
+  border-radius: 6px;
   box-shadow: none;
-  color: @theme_dim_text;
+  color: @theme_text;
   min-height: 38px;
   padding: 5px 10px;
   transition: background 160ms ease-out, color 160ms ease-out, transform 160ms ease-out;
@@ -876,7 +860,7 @@ dropdown.form-control:disabled > button {
 }
 
 .settings-navigation button:hover {
-  background: alpha(@theme_muted, 0.62);
+  background: alpha(@theme_accent, 0.15);
   color: @theme_text;
 }
 
@@ -884,9 +868,10 @@ dropdown.form-control:disabled > button {
   transform: scale(0.97);
 }
 
-.settings-navigation button.settings-nav-active {
-  background: alpha(@theme_highlight, 0.82);
-  color: @theme_accent;
+.settings-navigation button.settings-nav-active,
+.settings-navigation button.settings-nav-active:hover {
+  background: alpha(@theme_accent, 0.18);
+  color: @theme_text;
 }
 
 .settings-page {
@@ -918,11 +903,11 @@ dropdown.form-control:disabled > button {
 }
 
 .settings-close:hover {
-  background: alpha(@theme_muted, 0.62);
+  background: alpha(@theme_accent, 0.15);
 }
 
 .settings-close:active {
-  background: alpha(@theme_muted, 0.82);
+  background: alpha(@theme_accent, 0.22);
   transform: scale(0.97);
 }
 
@@ -1163,7 +1148,7 @@ dropdown.form-control:disabled > button {
 }
 
 .about-repository:hover {
-  background: alpha(@theme_muted, 0.55);
+  background: alpha(@theme_accent, 0.15);
   color: @theme_text;
 }
 
@@ -1229,12 +1214,12 @@ switch:checked slider {
 }
 
 .sidebar-update:hover {
-  background: alpha(@theme_muted, 0.38);
+  background: alpha(@theme_accent, 0.15);
   color: @theme_accent;
 }
 
 .sidebar-update:active {
-  background: alpha(@theme_muted, 0.56);
+  background: alpha(@theme_accent, 0.22);
   color: @theme_accent;
   transform: scale(0.97);
 }
@@ -1267,7 +1252,7 @@ switch:checked slider {
 }
 
 .sidebar-row:hover {
-  background: alpha(@theme_muted, 0.38);
+  background: alpha(@theme_accent, 0.15);
 }
 
 .sidebar-row:active {
@@ -1359,13 +1344,13 @@ paned > separator {
 }
 
 .preview-header-action:hover {
-  background: alpha(@theme_muted, 0.62);
+  background: alpha(@theme_accent, 0.15);
   border-color: alpha(@theme_border, 0.42);
   color: @theme_accent;
 }
 
 .preview-header-action:active {
-  background: alpha(@theme_muted, 0.82);
+  background: alpha(@theme_accent, 0.22);
   border-color: @theme_accent;
   color: @theme_accent;
   transform: scale(0.97);
@@ -1500,11 +1485,11 @@ entry.preview-command-entry selection {
 }
 
 .preview-command-copy:hover {
-  background: alpha(@theme_muted, 0.72);
+  background: alpha(@theme_accent, 0.15);
 }
 
 .preview-command-copy:active {
-  background: alpha(@theme_muted, 0.9);
+  background: alpha(@theme_accent, 0.22);
   transform: scale(0.96);
 }
 
@@ -1570,6 +1555,10 @@ entry.preview-command-entry selection {
   padding: 6px 0;
 }
 
+.peek-popover row:hover .file-chevron {
+  opacity: 1;
+}
+
 .column-header {
   background: transparent;
   border-bottom: 1px solid alpha(@theme_border, 0.6);
@@ -1595,29 +1584,17 @@ button.column-header-action:hover,
 button.column-header-action:checked,
 menubutton.column-header-action > button:hover,
 menubutton.column-header-action > button:checked {
-  background: alpha(@theme_muted, 0.62);
+  background: alpha(@theme_accent, 0.22);
 }
 
 button.column-header-action:active,
 menubutton.column-header-action > button:active {
-  background: alpha(@theme_muted, 0.78);
+  background: alpha(@theme_accent, 0.22);
   transform: scale(0.97);
 }
 
 .column-header-action image {
   color: @theme_text;
-  opacity: 0.42;
-}
-
-button.column-header-action:hover image,
-button.column-header-action:active image,
-button.column-header-action:checked image,
-button.column-header-action:focus-visible image,
-menubutton.column-header-action > button:hover image,
-menubutton.column-header-action > button:active image,
-menubutton.column-header-action > button:checked image,
-menubutton.column-header-action > button:focus-visible image {
-  opacity: 1;
 }
 
 .column-filter {
@@ -1625,10 +1602,6 @@ menubutton.column-header-action > button:focus-visible image {
   border-bottom: 1px solid alpha(@theme_border, 0.6);
   min-height: 30px;
   padding: 0 11px;
-}
-
-.column-filter image {
-  opacity: 0.42;
 }
 
 .column-filter-entry,
@@ -1680,12 +1653,12 @@ menubutton.column-header-action > button:focus-visible image {
 }
 
 .column-menu-option:hover {
-  background: alpha(@theme_muted, 0.5);
+  background: alpha(@theme_accent, 0.15);
   color: @theme_text;
 }
 
 .column-menu-option:active {
-  background: alpha(@theme_muted, 0.78);
+  background: alpha(@theme_accent, 0.22);
   transform: scale(0.97);
 }
 
@@ -1740,7 +1713,7 @@ menubutton.column-header-action > button:focus-visible image {
 }
 
 .segmented-control-option:hover {
-  background: alpha(@theme_muted, 0.62);
+  background: alpha(@theme_accent, 0.15);
   color: @theme_text;
 }
 
@@ -1755,7 +1728,7 @@ menubutton.column-header-action > button:focus-visible image {
 }
 
 .segmented-control-option:active {
-  background: alpha(@theme_muted, 0.82);
+  background: alpha(@theme_accent, 0.22);
   color: @theme_accent;
   transform: scale(0.97);
 }
@@ -1810,7 +1783,7 @@ menubutton.column-header-action > button:focus-visible image {
 }
 
 .transfer-suggestion:active {
-  background: alpha(@theme_muted, 0.8);
+  background: alpha(@theme_accent, 0.22);
   color: @theme_accent;
   transform: scale(0.97);
 }
@@ -1913,13 +1886,13 @@ menubutton.column-header-action > button:focus-visible image {
 }
 
 .properties-action:hover {
-  background: alpha(@theme_muted, 0.52);
+  background: alpha(@theme_accent, 0.15);
   border-color: @theme_accent;
   color: @theme_accent;
 }
 
 .properties-action:active {
-  background: alpha(@theme_muted, 0.78);
+  background: alpha(@theme_accent, 0.22);
   border-color: @theme_accent;
   color: @theme_accent;
   transform: scale(0.97);
@@ -1990,12 +1963,12 @@ menubutton.column-header-action > button:focus-visible image {
 }
 
 .item-context-option:hover {
-  background: alpha(@theme_muted, 0.52);
+  background: alpha(@theme_accent, 0.15);
   color: @theme_text;
 }
 
 .item-context-option:active {
-  background: alpha(@theme_muted, 0.78);
+  background: alpha(@theme_accent, 0.22);
   transform: scale(0.97);
 }
 
@@ -2052,12 +2025,12 @@ menubutton.column-header-action > button:focus-visible image {
 }
 
 .folder-context-option:hover {
-  background: alpha(@theme_muted, 0.52);
+  background: alpha(@theme_accent, 0.15);
   color: @theme_text;
 }
 
 .folder-context-option:active {
-  background: alpha(@theme_muted, 0.78);
+  background: alpha(@theme_accent, 0.22);
   transform: scale(0.97);
 }
 
@@ -2143,7 +2116,7 @@ menubutton.column-header-action > button:focus-visible image {
 }
 
 .file-list row:hover {
-  background: alpha(@theme_muted, 0.65);
+  background: alpha(@theme_accent, 0.15);
   color: @theme_text;
 }
 
@@ -2222,7 +2195,7 @@ menubutton.column-header-action > button:focus-visible image {
 }
 
 .file-list row:selected {
-  background: alpha(@theme_muted, 0.65);
+  background: alpha(@theme_accent, 0.22);
   color: @theme_text;
   outline: none;
 }
@@ -2315,7 +2288,7 @@ entry.theme-search {
 
 .theme-search-clear:hover,
 .theme-search-clear:active {
-  background: alpha(@theme_muted, 0.62);
+  background: alpha(@theme_accent, 0.22);
 }
 
 .theme-search-clear:active {
@@ -2438,7 +2411,7 @@ entry.theme-search {
 }
 
 .add-theme-card:hover {
-  background: alpha(@theme_muted, 0.45);
+  background: alpha(@theme_accent, 0.15);
   border-color: @theme_accent;
   color: @theme_text;
 }
@@ -2623,11 +2596,11 @@ menubutton.grid-thumbnail-menu > button {
 }
 
 menubutton.grid-thumbnail-menu > button:hover {
-  background: alpha(@theme_muted, 0.62);
+  background: alpha(@theme_accent, 0.15);
 }
 
 menubutton.grid-thumbnail-menu > button:active {
-  background: alpha(@theme_muted, 0.82);
+  background: alpha(@theme_accent, 0.22);
   transform: scale(0.97);
 }
 
@@ -2667,17 +2640,17 @@ menubutton.grid-thumbnail-menu > button:focus-visible {
 }
 
 .file-grid > child:hover .grid-card {
-  background: alpha(@theme_muted, 0.62);
+  background: alpha(@theme_accent, 0.15);
 }
 
 .file-grid > child:selected {
   background: transparent;
-  color: @theme_accent;
+  color: @theme_text;
   outline: none;
 }
 
 .file-grid > child:selected .grid-card {
-  background: @theme_highlight;
+  background: alpha(@theme_accent, 0.22);
   outline: 1px solid alpha(@theme_accent, 0.9);
   outline-offset: -1px;
 }
@@ -2723,7 +2696,7 @@ menubutton.grid-thumbnail-menu > button:focus-visible {
 }
 
 .file-grid > child:selected .grid-card-label {
-  color: @theme_accent;
+  color: @theme_text;
 }
 
 .mode-grid-columns.density-airy .file-grid {
@@ -2771,12 +2744,12 @@ menubutton.grid-thumbnail-menu > button:focus-visible {
 }
 
 .explorer-heading-button:hover {
-  background: alpha(@theme_muted, 0.5);
+  background: alpha(@theme_accent, 0.15);
   color: @theme_text;
 }
 
 .explorer-heading-button:active {
-  background: alpha(@theme_muted, 0.72);
+  background: alpha(@theme_accent, 0.22);
   color: @theme_accent;
   transform: scale(0.97);
 }
@@ -2825,7 +2798,7 @@ menubutton.grid-thumbnail-menu > button:focus-visible {
 }
 
 .explorer-navigation-button:hover:not(:disabled) {
-  background: alpha(@theme_muted, 0.56);
+  background: alpha(@theme_accent, 0.15);
   color: @theme_text;
 }
 
@@ -2836,7 +2809,7 @@ menubutton.grid-thumbnail-menu > button:focus-visible {
 }
 
 .explorer-navigation-button:active {
-  background: alpha(@theme_muted, 0.78);
+  background: alpha(@theme_accent, 0.22);
   color: @theme_accent;
   transform: scale(0.97);
 }
@@ -2854,12 +2827,12 @@ menubutton.grid-thumbnail-menu > button:focus-visible {
 }
 
 .explorer-list row:hover {
-  background: alpha(@theme_muted, 0.62);
+  background: alpha(@theme_accent, 0.15);
 }
 
 .explorer-list row:selected {
-  background: @theme_highlight;
-  color: @theme_accent;
+  background: alpha(@theme_accent, 0.22);
+  color: @theme_text;
 }
 
 .explorer-row.drop-destination {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -3985,7 +3985,7 @@ impl ViewState {
         let filter_button = gtk::ToggleButton::builder()
             .tooltip_text("Filter this pane (Ctrl+F)")
             .build();
-        filter_button.set_child(Some(&crate::assets::text_icon(
+        filter_button.set_child(Some(&crate::assets::primary_icon(
             crate::assets::icons::FUNNEL,
             16,
         )));
@@ -4005,7 +4005,10 @@ impl ViewState {
             let close = gtk::Button::builder()
                 .tooltip_text("Close this pane")
                 .build();
-            close.set_child(Some(&crate::assets::text_icon(crate::assets::icons::X, 16)));
+            close.set_child(Some(&crate::assets::primary_icon(
+                crate::assets::icons::X,
+                16,
+            )));
             close.add_css_class("column-header-action");
             let weak_browser = Rc::downgrade(&self.browser);
             close.connect_clicked(move |_| {
@@ -5009,6 +5012,7 @@ fn peek_label_factory(entries: Rc<RefCell<Vec<FileEntry>>>) -> gtk::SignalListIt
             return;
         };
         let row = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+        row.add_css_class("file-row");
         let icon = gtk::Image::new();
         icon.add_css_class("file-icon");
         icon.set_pixel_size(17);
@@ -6488,7 +6492,7 @@ fn retain_untransferred(cut: &mut Vec<Location>, transferred: &[Location]) {
 }
 
 fn item_context_option(icon: &str, label: &str, accelerator: &str) -> gtk::Button {
-    item_context_option_with_icon(crate::assets::text_icon(icon, 15), label, accelerator)
+    item_context_option_with_icon(crate::assets::primary_icon(icon, 15), label, accelerator)
 }
 
 fn item_context_danger_option(icon: &str, label: &str, accelerator: &str) -> gtk::Button {
@@ -6634,7 +6638,7 @@ pub(super) fn column_sort_menu(browser: &Rc<Browser>, depth: usize) -> gtk::Menu
         .tooltip_text("Choose sort field")
         .popover(&popover)
         .build();
-    button.set_child(Some(&crate::assets::text_icon(
+    button.set_child(Some(&crate::assets::primary_icon(
         crate::assets::icons::SETTINGS_2,
         16,
     )));
@@ -6648,7 +6652,7 @@ pub(super) fn column_sort_direction_toggle(browser: &Rc<Browser>, depth: usize) 
         .unwrap_or_default()
         .sort_direction;
     let button = gtk::Button::new();
-    let icon = crate::assets::text_icon(crate::assets::icons::ARROW_UP_NARROW_WIDE, 16);
+    let icon = crate::assets::primary_icon(crate::assets::icons::ARROW_UP_NARROW_WIDE, 16);
     button.set_child(Some(&icon));
     button.add_css_class("column-header-action");
     sync_sort_direction_toggle(&button, &icon, direction);
@@ -6685,7 +6689,7 @@ pub(super) fn column_sort_direction_toggle(browser: &Rc<Browser>, depth: usize) 
 
 fn sync_sort_direction_toggle(button: &gtk::Button, icon: &gtk::Image, direction: SortDirection) {
     let descending = direction == SortDirection::Descending;
-    crate::assets::set_text_icon(
+    crate::assets::set_primary_icon(
         icon,
         if descending {
             crate::assets::icons::ARROW_DOWN_WIDE_NARROW
@@ -6711,7 +6715,7 @@ pub(super) fn empty_trash_button(browser: &Rc<Browser>) -> gtk::Button {
         .tooltip_text("Empty Trash")
         .visible(false)
         .build();
-    button.set_child(Some(&crate::assets::text_icon(
+    button.set_child(Some(&crate::assets::primary_icon(
         crate::assets::icons::TRASH,
         16,
     )));

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -875,7 +875,7 @@ fn filter_controls(tooltip: &str) -> (gtk::Entry, gtk::Revealer, gtk::ToggleButt
         .child(&row)
         .build();
     let button = gtk::ToggleButton::builder().tooltip_text(tooltip).build();
-    button.set_child(Some(&crate::assets::text_icon(
+    button.set_child(Some(&crate::assets::primary_icon(
         crate::assets::icons::FUNNEL,
         16,
     )));
@@ -940,7 +940,7 @@ fn grid_controls(browser: &Rc<Browser>, depth: usize, thumbnail_size: i32) -> Gr
         .build();
     thumbnail_menu.add_css_class("column-header-action");
     thumbnail_menu.add_css_class("grid-thumbnail-menu");
-    thumbnail_menu.set_child(Some(&crate::assets::text_icon(
+    thumbnail_menu.set_child(Some(&crate::assets::primary_icon(
         crate::assets::icons::PICTURES,
         16,
     )));
@@ -1371,7 +1371,7 @@ fn explorer_headings(
         let label = gtk::Label::new(Some(text));
         label.set_xalign(0.0);
         label.set_hexpand(true);
-        let arrow = crate::assets::text_icon(
+        let arrow = crate::assets::primary_icon(
             if preferences.sort_direction == SortDirection::Ascending {
                 crate::assets::icons::ARROW_UP
             } else {
@@ -1402,7 +1402,7 @@ fn explorer_headings(
             for (arrow_key, arrow) in arrows_for_click.borrow().iter() {
                 arrow.set_visible(*arrow_key == key);
                 if *arrow_key == key {
-                    crate::assets::set_text_icon(
+                    crate::assets::set_primary_icon(
                         arrow,
                         if direction == SortDirection::Ascending {
                             crate::assets::icons::ARROW_UP
@@ -1545,7 +1545,7 @@ fn explorer_navigation(browser: &Rc<Browser>) -> gtk::Box {
             .tooltip_text(tooltip)
             .sensitive(available)
             .build();
-        button.set_child(Some(&crate::assets::text_icon(icon, 16)));
+        button.set_child(Some(&crate::assets::primary_icon(icon, 16)));
         button.add_css_class("explorer-navigation-button");
         let weak_browser = Rc::downgrade(browser);
         button.connect_clicked(move |_| {

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -110,7 +110,7 @@ impl SearchDialog {
         let navigation = gtk::Label::new(Some("↑↓  navigate"));
         let open = gtk::Box::new(gtk::Orientation::Horizontal, 5);
         open.set_valign(gtk::Align::Center);
-        open.append(&crate::assets::text_icon(
+        open.append(&crate::assets::primary_icon(
             crate::assets::icons::CORNER_DOWN_LEFT,
             13,
         ));

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -215,8 +215,7 @@ pub fn build_layer(
     stack.add_named(&about_page(), Some("about"));
     page.append(&stack);
 
-    let nav_buttons: Rc<RefCell<Vec<(gtk::Button, gtk::Image, gtk::Image)>>> =
-        Rc::new(RefCell::new(Vec::new()));
+    let nav_buttons: Rc<RefCell<Vec<gtk::Button>>> = Rc::new(RefCell::new(Vec::new()));
     let mut navigation_labels = Vec::new();
     let mut navigation_contents = Vec::new();
     for (label, icon, name) in [
@@ -227,30 +226,24 @@ pub fn build_layer(
         ("About", icons::INFO, "about"),
     ] {
         let active = name == "general";
-        let (button, navigation_label, navigation_content, primary_icon, text_icon) =
-            navigation_button(icon, label, active);
+        let (button, navigation_label, navigation_content) = navigation_button(icon, label);
         navigation_labels.push(navigation_label);
         navigation_contents.push(navigation_content);
         if active {
             button.add_css_class("settings-nav-active");
         }
-        nav_buttons
-            .borrow_mut()
-            .push((button.clone(), primary_icon, text_icon));
+        nav_buttons.borrow_mut().push(button.clone());
         let buttons = nav_buttons.clone();
         let stack = stack.clone();
         let title = title.clone();
         let page_title = label.to_owned();
         button.connect_clicked(move |clicked| {
-            for (candidate, primary_icon, text_icon) in buttons.borrow().iter() {
-                let active = candidate == clicked;
-                if active {
+            for candidate in buttons.borrow().iter() {
+                if candidate == clicked {
                     candidate.add_css_class("settings-nav-active");
                 } else {
                     candidate.remove_css_class("settings-nav-active");
                 }
-                primary_icon.set_visible(active);
-                text_icon.set_visible(!active);
             }
             stack.set_visible_child_name(name);
             title.set_text(&page_title);
@@ -1254,7 +1247,7 @@ fn theme_page(manager: Rc<ThemeManager>) -> (gtk::Widget, Vec<(gtk::FlowBox, u32
     });
     theme_search.add_controller(search_keys);
     let clear_search = gtk::Button::builder()
-        .child(&crate::assets::text_icon(icons::X, 15))
+        .child(&crate::assets::primary_icon(icons::X, 15))
         .tooltip_text("Clear theme search")
         .halign(gtk::Align::End)
         .valign(gtk::Align::Center)
@@ -1692,27 +1685,19 @@ impl ColorField {
     }
 }
 
-fn navigation_button(
-    icon: &str,
-    label: &str,
-    active: bool,
-) -> (gtk::Button, gtk::Label, gtk::Box, gtk::Image, gtk::Image) {
+fn navigation_button(icon: &str, label: &str) -> (gtk::Button, gtk::Label, gtk::Box) {
     let content = gtk::Box::new(gtk::Orientation::Horizontal, 10);
-    let primary_icon = crate::assets::primary_icon(icon, 18);
-    primary_icon.set_visible(active);
-    let text_icon = crate::assets::text_icon(icon, 18);
-    text_icon.set_visible(!active);
+    let icon_image = crate::assets::primary_icon(icon, 18);
     let text = gtk::Label::new(Some(label));
     text.set_xalign(0.0);
-    content.append(&primary_icon);
-    content.append(&text_icon);
+    content.append(&icon_image);
     content.append(&text);
     let button = gtk::Button::builder()
         .child(&content)
         .tooltip_text(label)
         .build();
     button.set_has_frame(false);
-    (button, text, content, primary_icon, text_icon)
+    (button, text, content)
 }
 
 fn scrollable_page(content: &gtk::Box, class: Option<&str>) -> gtk::Widget {

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -414,7 +414,6 @@ impl ThemeManager {
     fn apply_tokens(&self, tokens: &ThemeTokens) {
         self.provider.load_from_string(&tokens_css(tokens));
         crate::assets::set_primary_icon_color(&tokens.accent);
-        crate::assets::set_text_icon_color(&tokens.text);
         crate::assets::set_danger_icon_color(&tokens.danger);
         install_source_style_scheme(tokens);
     }

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -108,20 +108,23 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
     let search_button = gtk::Button::builder()
         .tooltip_text("Search (Ctrl+K)")
         .build();
-    search_button.set_child(Some(&crate::assets::text_icon(
+    search_button.set_child(Some(&crate::assets::primary_icon(
         crate::assets::icons::SEARCH,
         20,
     )));
     search_button.add_css_class("header-action");
     let appearance = build_appearance_menu(&browser, &controller, theme_manager.clone());
     let settings = gtk::Button::builder().tooltip_text("Settings").build();
-    settings.set_child(Some(&crate::assets::text_icon(
+    settings.set_child(Some(&crate::assets::primary_icon(
         crate::assets::icons::SETTINGS,
         20,
     )));
     settings.add_css_class("header-action");
     let close_window = gtk::Button::builder().tooltip_text("Close window").build();
-    close_window.set_child(Some(&crate::assets::text_icon(crate::assets::icons::X, 20)));
+    close_window.set_child(Some(&crate::assets::primary_icon(
+        crate::assets::icons::X,
+        20,
+    )));
     close_window.add_css_class("header-action");
     let closing_window = window.clone();
     close_window.connect_clicked(move |_| closing_window.close());
@@ -896,11 +899,11 @@ fn build_appearance_menu(
         .tooltip_text("Appearance")
         .popover(&popover)
         .build();
-    let icon = crate::assets::text_icon(crate::assets::icons::LIST, 20);
+    let icon = crate::assets::primary_icon(crate::assets::icons::LIST, 20);
     button.set_child(Some(&icon));
     button.add_css_class("header-action");
     button.connect_active_notify(move |button| {
-        crate::assets::set_text_icon(
+        crate::assets::set_primary_icon(
             &icon,
             if button.is_active() {
                 crate::assets::icons::LIST_ACTIVE


### PR DESCRIPTION
## Summary

- Replace all `@theme_muted` hover/active backgrounds with `@theme_accent` across headerbar, sidebar, settings nav, breadcrumbs, dialogs, context menus, column headers, file list/grid/explorer rows, and peek popover
- Remove opacity dimming on header and column-header icons so all icons render at full accent color
- Switch all `text_icon` calls to `primary_icon` for consistent accent-colored icons across search, settings, browser modes, and window controls
- Remove dead `text_icon`/`set_text_icon`/`set_text_icon_color` and their thread-local statics from assets.rs
- Simplify settings nav from two swapped icons to one, driven by CSS active class
- Brighten settings sidebar: `@theme_surface` background, `@theme_text` labels, accent-tinted active state
- Reuse `.file-list` styles for peek popover rows; add `.file-row` class for matching padding; keep only chevron-on-hover as peek-specific CSS

Closes #169.

#### Manual verification

- [x] Hover any button in the headerbar — accent-tinted background, full-color icon
- [x] Hover file rows in list, grid, explorer, and peek popover — same accent hover color
- [x] Select a file in each view — same accent selected color
- [x] Open settings — sidebar matches main sidebar brightness, nav icons are accent-colored
- [x] Click through settings nav items — active state shows accent background
- [x] Hover context menu options, breadcrumbs, dialog buttons — accent hover throughout
- [x] Verify no icons appear lighter/dimmer than others
<img width="1182" height="865" alt="image" src="https://github.com/user-attachments/assets/8b1e6183-dbc6-449a-b506-489f2ed2adff" />
<img width="1888" height="758" alt="image" src="https://github.com/user-attachments/assets/cf20dd90-4036-4542-89d8-b1f946f2d238" />
<img width="1888" height="542" alt="image" src="https://github.com/user-attachments/assets/b71a670f-7d6a-4673-bb13-10752f203147" />
<img width="732" height="446" alt="image" src="https://github.com/user-attachments/assets/2fb500a3-847d-4603-b13f-0549d14dbe73" />