### PR TITLE
feat(columns): reselect open folder to close its child column

### DIFF
--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -1249,6 +1249,7 @@ impl Browser {
             return;
         };
         if entry.is_directory() && self.is_open_child(depth, &entry.location) {
+            self.close_column(depth + 1);
             return;
         }
         self.select(depth, position);
@@ -1272,6 +1273,7 @@ impl Browser {
             .entry_at(depth, position)
             .is_some_and(|entry| entry.is_directory() && self.is_open_child(depth, &entry.location))
         {
+            self.close_column(depth + 1);
             return;
         }
         self.select(depth, position);

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -1242,22 +1242,25 @@ fn single_click_action_descends_into_directories() {
 }
 
 #[test]
-fn activating_an_open_list_item_does_not_reload_its_pane() {
+fn activating_an_open_list_item_closes_its_child_column() {
     let browser = Browser::new(Rc::new(FakeFileSource));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
     browser.observe(move |event| observed.borrow_mut().push(event));
     browser.navigate(Location::local("/fixture"));
     browser.preview(0, 0);
+    assert_eq!(browser.active_depth(), Some(1));
     events.borrow_mut().clear();
 
     browser.preview(0, 0);
 
-    assert!(!events.borrow().iter().any(|event| matches!(
-        event,
-        BrowserEvent::ColumnsTruncated { .. } | BrowserEvent::ColumnAdded { .. }
-    )));
-    assert_eq!(browser.active_depth(), Some(1));
+    assert!(
+        events
+            .borrow()
+            .iter()
+            .any(|event| matches!(event, BrowserEvent::ColumnsTruncated { len: 1 }))
+    );
+    assert_eq!(browser.active_depth(), Some(0));
 }
 
 #[test]

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -1799,7 +1799,7 @@ fn build_explorer_pane(
     let view = gtk::ListView::new(Some(selection.clone()), Some(factory));
     view.add_css_class("explorer-list");
     view.set_enable_rubberband(false);
-    view.set_single_click_activate(false);
+    view.set_single_click_activate(true);
     let weak_browser = Rc::downgrade(&browser);
     let source_for_activation = model.clone();
     let view_model_for_activation = view_model_object.clone();
@@ -1811,7 +1811,7 @@ fn build_explorer_pane(
                 position,
             )
         {
-            browser.activate_in_place(depth, position);
+            browser.activate(depth, position);
         }
     });
     connect_selection(


### PR DESCRIPTION
## Summary

- Single-click a folder in column view to open it as the next column
- Single-click the same folder again to close its child column
- Explorer view now calls `activate` instead of `activate_in_place` so folders descend into child columns rather than replacing the path

Closes #140.

#### Manual verification

- [x] Single-click a folder — opens as next column
- [x] Single-click the same folder again — child column closes
- [x] X button on column header still works
<img width="960" height="540" alt="screenrecording-2026-09-02_17-43-00" src="https://github.com/user-attachments/assets/aed154f9-6259-40cd-a029-447a261e1b26" />