### PR TITLE
fix(search): activate results on single click instead of double click

### DIFF
--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -89,7 +89,7 @@ impl SearchDialog {
         let list = gtk::ListBox::new();
         list.add_css_class("search-results");
         list.set_selection_mode(gtk::SelectionMode::Single);
-        list.set_activate_on_single_click(false);
+        list.set_activate_on_single_click(true);
         let scroller = gtk::ScrolledWindow::builder()
             .hscrollbar_policy(gtk::PolicyType::Never)
             .vscrollbar_policy(gtk::PolicyType::Automatic)


### PR DESCRIPTION
## Summary
- Search results list had `activate_on_single_click(false)` from the initial search dialog commit with no stated reason, forcing a double click to navigate.
- Changed to `true` so single-click navigates immediately, matching standard search dialog behavior.

#### Test plan
- [x] Open search, type a query, single-click a result — it navigates to the file
- [x] Keyboard navigation (arrow keys + Enter) still works