### PR TITLE
ci(release): publish manual prerelease builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,17 @@ jobs:
       - name: Run tests
         run: cargo test --all-targets --all-features
 
+  release-scripts:
+    name: Release workflow scripts
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Test release version calculation
+        run: python3 -m unittest discover -s scripts -p 'test_*.py'
+
   repository-policy:
     name: Dependency and spelling policy
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,21 @@ on:
           - patch
           - minor
           - major
+      mode:
+        description: Release channel to publish
+        required: true
+        default: stable
+        type: choice
+        options:
+          - stable
+          - alpha
+          - beta
+          - rc
+          - nightly
+      source:
+        description: PR number, branch, tag, or commit to publish (prereleases only; blank uses main)
+        required: false
+        type: string
 
 concurrency:
   group: release
@@ -32,6 +47,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       source_sha: ${{ steps.source.outputs.sha }}
+      checkout_ref: ${{ steps.source.outputs.checkout_ref }}
 
     steps:
       - name: Require the default branch
@@ -48,41 +64,70 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          fetch-depth: 0
 
-      - name: Record source commit
+      - name: Resolve source commit
         id: source
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        env:
+          MODE: ${{ inputs.mode }}
+          SOURCE: ${{ inputs.source }}
+        run: |
+          if [[ "$MODE" == "stable" && -n "$SOURCE" ]]; then
+            echo "Stable releases must use the current default-branch tip." >&2
+            exit 1
+          fi
+
+          if [[ -z "$SOURCE" ]]; then
+            sha="$(git rev-parse HEAD)"
+            checkout_ref="$sha"
+          elif [[ "$SOURCE" =~ ^[0-9]+$ ]]; then
+            checkout_ref="refs/pull/${SOURCE}/head"
+            git fetch --no-tags origin "$checkout_ref"
+            sha="$(git rev-parse FETCH_HEAD)"
+          else
+            git fetch --no-tags origin "$SOURCE"
+            sha="$(git rev-parse FETCH_HEAD)"
+            checkout_ref="$sha"
+          fi
+
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "checkout_ref=$checkout_ref" >> "$GITHUB_OUTPUT"
 
       - name: Calculate version
         id: version
         env:
           BUMP: ${{ inputs.bump }}
+          MODE: ${{ inputs.mode }}
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
         run: |
-          python3 - <<'PY'
-          import os
-          import pathlib
-          import re
+          current_version="$(git show "$SOURCE_SHA:Cargo.toml" | grep -m1 -oP '^version = "\K\d+\.\d+\.\d+(?=")')"
+          tags="$(git tag -l 'v*')"
+          version="$(python3 scripts/release_version.py \
+            --current-version "$current_version" \
+            --bump "$BUMP" \
+            --mode "$MODE" \
+            --date "$(date --utc +%Y%m%d)" \
+            --tags "$tags")"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
-          manifest = pathlib.Path("Cargo.toml").read_text()
-          match = re.search(r'^version = "(\d+)\.(\d+)\.(\d+)"$', manifest, re.MULTILINE)
-          if match is None:
-              raise SystemExit("Cargo.toml must contain a plain major.minor.patch package version")
-
-          major, minor, patch = map(int, match.groups())
-          bump = os.environ["BUMP"]
-          if bump == "major":
-              major, minor, patch = major + 1, 0, 0
-          elif bump == "minor":
-              minor, patch = minor + 1, 0
-          elif bump == "patch":
-              patch += 1
-          else:
-              raise SystemExit(f"unsupported version bump: {bump}")
-
-          version = f"{major}.{minor}.{patch}"
-          with open(os.environ["GITHUB_OUTPUT"], "a") as output:
-              output.write(f"version={version}\n")
-          PY
+      - name: Guard against superseding an untested RC
+        if: inputs.mode == 'stable'
+        env:
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          # VERSION is the plain core version for a stable release. If an RC
+          # already exists for this core version, a stable release must not
+          # silently supersede it unless the RC's commit is already part of
+          # this release's history -- otherwise a stable tag could publish
+          # over an RC whose changes were never folded in and never tested
+          # as stable.
+          for tag in $(git tag -l "v${VERSION}-rc.*"); do
+            if ! git merge-base --is-ancestor "$tag" "$SOURCE_SHA"; then
+              echo "Tag $tag targets a commit not reachable from $SOURCE_SHA (the release source). A stable release must not silently supersede an untested RC." >&2
+              exit 1
+            fi
+          done
 
   build:
     name: Build ${{ matrix.target }}
@@ -101,13 +146,36 @@ jobs:
       - name: Check out source commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.prepare.outputs.source_sha }}
+          ref: ${{ needs.prepare.outputs.checkout_ref }}
           persist-credentials: false
+
+      - name: Verify source commit
+        env:
+          SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+        run: test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
 
       - name: Set release version
         env:
+          MODE: ${{ inputs.mode }}
           VERSION: ${{ needs.prepare.outputs.version }}
         run: |
+          if [[ "$MODE" != "stable" ]]; then
+            # Fail closed when targeting source older than release-channel
+            # support; otherwise the archive tag and binary identity diverge.
+            if ! grep -q 'STRATA_RELEASE_TAG' build.rs; then
+              echo "The selected source does not support prerelease build metadata." >&2
+              exit 1
+            fi
+
+            # Prerelease identity is injected at build time instead of being
+            # written into Cargo.toml, which remains the stable version line.
+            {
+              echo "STRATA_RELEASE_TAG=v${VERSION}"
+              echo "STRATA_BUILD_KIND=${MODE}"
+            } >> "$GITHUB_ENV"
+            exit 0
+          fi
+
           python3 - <<'PY'
           import os
           import pathlib
@@ -196,9 +264,14 @@ jobs:
       - name: Check out source commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.prepare.outputs.source_sha }}
+          ref: ${{ needs.prepare.outputs.checkout_ref }}
           fetch-depth: 0
           ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
+
+      - name: Verify source commit
+        env:
+          SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+        run: test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
 
       - name: Download binaries
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -214,9 +287,27 @@ jobs:
       - name: Commit version and push tag
         env:
           BRANCH: ${{ github.event.repository.default_branch }}
+          MODE: ${{ inputs.mode }}
           SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
           VERSION: ${{ needs.prepare.outputs.version }}
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if [[ "$MODE" != "stable" ]]; then
+            # A prerelease run tags the source commit but never pushes a
+            # version-bump commit to the default branch.
+            git fetch origin --tags
+            if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+              echo "Tag v$VERSION already exists." >&2
+              exit 1
+            fi
+
+            git tag -a "v$VERSION" -m "Strata v$VERSION"
+            git push origin "v$VERSION"
+            exit 0
+          fi
+
           git fetch origin "$BRANCH" --tags
           if [[ "$(git rev-parse "origin/$BRANCH")" != "$SOURCE_SHA" ]]; then
             echo "The default branch changed while release binaries were building. Run the workflow again." >&2
@@ -244,8 +335,6 @@ jobs:
               path.write_text(text)
           PY
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add Cargo.toml Cargo.lock
           git commit -m "chore: release v$VERSION"
           git tag -a "v$VERSION" -m "Strata v$VERSION"
@@ -254,5 +343,13 @@ jobs:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
+          MODE: ${{ inputs.mode }}
           VERSION: ${{ needs.prepare.outputs.version }}
-        run: gh release create "v$VERSION" dist/* --verify-tag --generate-notes --title "Strata v$VERSION"
+        run: |
+          if [[ "$MODE" != "stable" ]]; then
+            # --prerelease keeps /releases/latest pointing at the last final
+            # release, which is the endpoint a Stable user polls.
+            gh release create "v$VERSION" dist/* --verify-tag --generate-notes --prerelease --title "Strata v$VERSION"
+          else
+            gh release create "v$VERSION" dist/* --verify-tag --generate-notes --title "Strata v$VERSION"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 .idea/
 .vscode/
 .DS_Store
+
+__pycache__/
+*.py[cod]

--- a/scripts/release_version.py
+++ b/scripts/release_version.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Compute the next release version for `.github/workflows/release.yml`.
+
+This is the only non-trivial logic in the release workflow, extracted so it
+can be unit tested (see `scripts/test_release_version.py`) rather than living
+as an inline, untestable Python heredoc.
+
+Stable, alpha, beta, RC, and nightly publication modes are supported. Stable
+bumps the core `major.minor.patch` version from `Cargo.toml`. Staged
+prereleases use numeric ordinals. Nightlies use the supplied UTC date and add
+a numeric suffix only when another nightly already exists for that date.
+Prerelease identity stays out of `Cargo.toml` and is injected at build time.
+
+The script prints the resulting version (without a leading `v`) to stdout on
+success, e.g. `0.5.1` or `0.5.0-rc.1`. On failure it prints a message to
+stderr and exits non-zero.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import re
+import sys
+
+CORE_PATTERN = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+BUMP_LEVELS = ("major", "minor", "patch")
+MODES = ("stable", "alpha", "beta", "rc", "nightly")
+
+
+class VersionError(ValueError):
+    """Raised for any invalid input or a version collision."""
+
+
+def parse_core(version: str) -> tuple[int, int, int]:
+    """Parses a plain `major.minor.patch` string, as found in `Cargo.toml`."""
+    match = CORE_PATTERN.match(version.strip())
+    if match is None:
+        raise VersionError(
+            f"current version must be a plain major.minor.patch: {version!r}"
+        )
+    major, minor, patch = (int(part) for part in match.groups())
+    return major, minor, patch
+
+
+def bump_core(version: str, bump: str) -> tuple[int, int, int]:
+    """Bumps a parsed core version by one `major`, `minor`, or `patch` step."""
+    major, minor, patch = parse_core(version)
+    if bump == "major":
+        return major + 1, 0, 0
+    if bump == "minor":
+        return major, minor + 1, 0
+    if bump == "patch":
+        return major, minor, patch + 1
+    raise VersionError(f"unsupported version bump: {bump!r}")
+
+
+def format_core(core: tuple[int, int, int]) -> str:
+    major, minor, patch = core
+    return f"{major}.{minor}.{patch}"
+
+
+def split_tags(raw_tags: str) -> list[str]:
+    """Splits a whitespace-separated tag list, as produced by `git tag -l`."""
+    return [tag for tag in raw_tags.split() if tag]
+
+
+def next_prerelease_ordinal(
+    core: str, kind: str, existing_tags: list[str]
+) -> int:
+    """Finds the next numeric ordinal for one prerelease kind and core."""
+    if kind not in ("alpha", "beta", "rc"):
+        raise VersionError(f"unsupported prerelease kind: {kind!r}")
+    prefix = f"v{core}-{kind}."
+    highest = 0
+    for tag in existing_tags:
+        if not tag.startswith(prefix):
+            continue
+        suffix = tag[len(prefix) :]
+        if suffix.isdigit():
+            highest = max(highest, int(suffix))
+    return highest + 1
+
+
+def nightly_version(core: str, release_date: str, existing_tags: list[str]) -> str:
+    """Builds a dated nightly version, disambiguating repeated same-day runs."""
+    try:
+        parsed_date = datetime.datetime.strptime(release_date, "%Y%m%d")
+    except ValueError as error:
+        raise VersionError(
+            f"nightly date must be a valid YYYYMMDD date: {release_date!r}"
+        ) from error
+    if parsed_date.strftime("%Y%m%d") != release_date:
+        raise VersionError(
+            f"nightly date must be a valid YYYYMMDD date: {release_date!r}"
+        )
+
+    base = f"{core}-nightly.{release_date}"
+    prefix = f"v{base}"
+    suffixes = [0]
+    for tag in existing_tags:
+        if tag == prefix:
+            suffixes.append(0)
+        elif tag.startswith(f"{prefix}.") and tag[len(prefix) + 1 :].isdigit():
+            suffixes.append(int(tag[len(prefix) + 1 :]))
+    if len(suffixes) == 1:
+        return base
+    return f"{base}.{max(suffixes) + 1}"
+
+
+def ensure_tag_available(tag: str, existing_tags: list[str]) -> None:
+    """Fails if `tag` is already present in `existing_tags`.
+
+    Mirrors the workflow's stable-release guard and applies to every
+    prerelease stage: a computed tag must never overwrite an existing one.
+    """
+    if tag in existing_tags:
+        raise VersionError(f"tag {tag} already exists")
+
+
+def compute_next_version(
+    current_version: str,
+    bump: str,
+    mode: str,
+    existing_tags: list[str],
+    release_date: str | None = None,
+) -> str:
+    """Computes the next release version, without a leading `v`.
+
+    `existing_tags` is every tag already published (as full tag names, e.g.
+    `v0.5.0` or `v0.5.0-rc.2`), used to reject a collision and find the next
+    ordinal for prerelease modes.
+    """
+    if mode not in MODES:
+        raise VersionError(f"unsupported mode: {mode!r}")
+
+    core = format_core(bump_core(current_version, bump))
+
+    if mode == "stable":
+        tag = f"v{core}"
+        ensure_tag_available(tag, existing_tags)
+        return core
+
+    if mode == "nightly":
+        if release_date is None:
+            raise VersionError("nightly mode requires a release date")
+        version = nightly_version(core, release_date, existing_tags)
+    else:
+        ordinal = next_prerelease_ordinal(core, mode, existing_tags)
+        version = f"{core}-{mode}.{ordinal}"
+    ensure_tag_available(f"v{version}", existing_tags)
+    return version
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--current-version",
+        required=True,
+        help="the current plain major.minor.patch version, from Cargo.toml",
+    )
+    parser.add_argument("--bump", required=True, choices=BUMP_LEVELS)
+    parser.add_argument("--mode", required=True, choices=MODES)
+    parser.add_argument(
+        "--date",
+        help="UTC release date as YYYYMMDD (required for nightly mode)",
+    )
+    parser.add_argument(
+        "--tags",
+        default="",
+        help="every existing tag, whitespace-separated (e.g. `git tag -l 'v*'` output)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    try:
+        version = compute_next_version(
+            args.current_version,
+            args.bump,
+            args.mode,
+            split_tags(args.tags),
+            args.date,
+        )
+    except VersionError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    print(version)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/test_release_version.py
+++ b/scripts/test_release_version.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Tests for `scripts/release_version.py`.
+
+Run with:
+
+    python3 scripts/test_release_version.py
+
+or, to run every script test in the repo the same way CI does:
+
+    python3 -m unittest discover -s scripts -p 'test_*.py'
+
+Stdlib `unittest` only -- no dependencies, matching the script it tests.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from release_version import (
+    VersionError,
+    compute_next_version,
+    ensure_tag_available,
+    next_prerelease_ordinal,
+    nightly_version,
+    split_tags,
+)
+
+
+class BumpStableTests(unittest.TestCase):
+    """Each bump level for `stable`, behaviour unchanged from the original
+    inline heredoc."""
+
+    def test_patch(self) -> None:
+        self.assertEqual(
+            compute_next_version("0.5.0", "patch", "stable", []), "0.5.1"
+        )
+
+    def test_minor(self) -> None:
+        self.assertEqual(
+            compute_next_version("0.5.7", "minor", "stable", []), "0.6.0"
+        )
+
+    def test_major(self) -> None:
+        self.assertEqual(
+            compute_next_version("0.5.7", "major", "stable", []), "1.0.0"
+        )
+
+    def test_rejects_tag_collision(self) -> None:
+        with self.assertRaisesRegex(VersionError, "already exists"):
+            compute_next_version("0.5.0", "patch", "stable", ["v0.5.1"])
+
+    def test_unrelated_existing_tags_do_not_interfere(self) -> None:
+        self.assertEqual(
+            compute_next_version(
+                "0.5.0", "patch", "stable", ["v0.4.0", "v0.5.0", "v0.5.0-rc.1"]
+            ),
+            "0.5.1",
+        )
+
+
+class PrereleaseOrdinalTests(unittest.TestCase):
+    """Ordinal selection for alpha, beta, and RC publication modes."""
+
+    def test_each_stage_has_an_independent_ordinal(self) -> None:
+        tags = ["v0.5.1-alpha.2", "v0.5.1-beta.3", "v0.5.1-rc.4"]
+        self.assertEqual(
+            compute_next_version("0.5.0", "patch", "alpha", tags),
+            "0.5.1-alpha.3",
+        )
+        self.assertEqual(
+            compute_next_version("0.5.0", "patch", "beta", tags),
+            "0.5.1-beta.4",
+        )
+        self.assertEqual(
+            compute_next_version("0.5.0", "patch", "rc", tags),
+            "0.5.1-rc.5",
+        )
+
+    def test_first_rc_for_a_core_with_no_existing_rc_tags(self) -> None:
+        self.assertEqual(
+            compute_next_version("0.5.0", "patch", "rc", []), "0.5.1-rc.1"
+        )
+
+    def test_first_rc_ignores_other_cores_and_other_kinds(self) -> None:
+        self.assertEqual(
+            compute_next_version(
+                "0.5.0",
+                "patch",
+                "rc",
+                ["v0.5.0", "v0.4.0-rc.3", "v0.5.1-nightly.20260101"],
+            ),
+            "0.5.1-rc.1",
+        )
+
+    def test_rc_2_after_rc_1(self) -> None:
+        self.assertEqual(
+            compute_next_version("0.5.0", "patch", "rc", ["v0.5.1-rc.1"]),
+            "0.5.1-rc.2",
+        )
+
+    def test_rc_10_ordering_after_rc_9_is_numeric_not_lexicographic(self) -> None:
+        # A lexicographic comparison would sort "rc.10" before "rc.9" (the
+        # string "1" < "9"), and could pick 10 as the max and produce
+        # `rc.11` while never having "seen" `rc.9`, or worse, treat `rc.9`
+        # as the max and collide by reissuing `rc.10`. Numeric comparison
+        # must pick 10 as the max regardless of insertion order.
+        tags = [f"v0.5.1-rc.{n}" for n in range(1, 11)]  # rc.1 .. rc.10
+        self.assertEqual(
+            compute_next_version("0.5.0", "patch", "rc", tags), "0.5.1-rc.11"
+        )
+
+    def test_next_rc_ordinal_numeric_ordering_directly(self) -> None:
+        self.assertEqual(
+            next_prerelease_ordinal(
+                "0.5.1", "rc", ["v0.5.1-rc.9", "v0.5.1-rc.10"]
+            ),
+            11,
+        )
+        self.assertEqual(
+            next_prerelease_ordinal(
+                "0.5.1", "rc", ["v0.5.1-rc.10", "v0.5.1-rc.9"]
+            ),
+            11,
+        )
+
+    def test_non_numeric_or_mismatched_suffixes_are_ignored(self) -> None:
+        self.assertEqual(
+            next_prerelease_ordinal(
+                "0.5.1",
+                "rc",
+                ["v0.5.1-rc.abc", "v0.5.1-rc.", "v0.5.2-rc.9"],
+            ),
+            1,
+        )
+
+
+class NightlyVersionTests(unittest.TestCase):
+    def test_first_nightly_uses_the_utc_date_without_a_suffix(self) -> None:
+        self.assertEqual(
+            compute_next_version("0.7.0", "minor", "nightly", [], "20260904"),
+            "0.8.0-nightly.20260904",
+        )
+
+    def test_repeated_same_day_nightlies_get_numeric_suffixes(self) -> None:
+        tags = [
+            "v0.8.0-nightly.20260904",
+            "v0.8.0-nightly.20260904.1",
+            "v0.8.0-nightly.20260904.2",
+        ]
+        self.assertEqual(
+            compute_next_version(
+                "0.7.0", "minor", "nightly", tags, "20260904"
+            ),
+            "0.8.0-nightly.20260904.3",
+        )
+
+    def test_other_dates_and_cores_do_not_affect_the_suffix(self) -> None:
+        self.assertEqual(
+            nightly_version(
+                "0.8.0",
+                "20260904",
+                [
+                    "v0.8.0-nightly.20260903.9",
+                    "v0.9.0-nightly.20260904.9",
+                ],
+            ),
+            "0.8.0-nightly.20260904",
+        )
+
+    def test_nightly_requires_a_real_calendar_date(self) -> None:
+        for release_date in ["", "20261301", "20260230", "2026-09-04"]:
+            with self.subTest(release_date=release_date):
+                with self.assertRaises(VersionError):
+                    compute_next_version(
+                        "0.7.0", "minor", "nightly", [], release_date
+                    )
+
+    def test_nightly_requires_the_date_argument(self) -> None:
+        with self.assertRaises(VersionError):
+            compute_next_version("0.7.0", "minor", "nightly", [])
+
+
+class TagCollisionTests(unittest.TestCase):
+    """Rejection when the computed tag already exists, mirroring the
+    stable guard. RC's `N = max + 1` scan can never organically reproduce
+    an existing tag, so this exercises the shared guard function directly
+    -- the same one `compute_next_version` calls for every mode -- as
+    defense in depth against a manually created or out-of-band tag."""
+
+    def test_ensure_tag_available_raises_on_duplicate(self) -> None:
+        with self.assertRaisesRegex(VersionError, "v0.5.1-rc.3 already exists"):
+            ensure_tag_available("v0.5.1-rc.3", ["v0.5.1-rc.3"])
+
+    def test_ensure_tag_available_passes_when_absent(self) -> None:
+        ensure_tag_available("v0.5.1-rc.3", ["v0.5.1-rc.1", "v0.5.1-rc.2"])
+
+
+class InputValidationTests(unittest.TestCase):
+    def test_rejects_non_plain_current_version(self) -> None:
+        with self.assertRaises(VersionError):
+            compute_next_version("0.5.0-rc.1", "patch", "stable", [])
+
+    def test_rejects_unsupported_bump(self) -> None:
+        with self.assertRaises(VersionError):
+            compute_next_version("0.5.0", "sideways", "stable", [])
+
+    def test_rejects_unsupported_mode(self) -> None:
+        with self.assertRaises(VersionError):
+            compute_next_version("0.5.0", "patch", "canary", [])
+
+    def test_rejects_unsupported_prerelease_kind(self) -> None:
+        with self.assertRaises(VersionError):
+            next_prerelease_ordinal("0.5.1", "preview", [])
+
+
+class SplitTagsTests(unittest.TestCase):
+    def test_splits_on_any_whitespace(self) -> None:
+        self.assertEqual(
+            split_tags("v0.5.0\nv0.5.1-rc.1\n\nv0.4.0"),
+            ["v0.5.0", "v0.5.1-rc.1", "v0.4.0"],
+        )
+
+    def test_empty_input_yields_no_tags(self) -> None:
+        self.assertEqual(split_tags(""), [])
+        self.assertEqual(split_tags("   \n  "), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Extend the protected manual Release workflow so maintainers can publish alpha, beta, RC, and nightly GitHub prereleases from an exact branch, tag, commit, or pull request. This lands independently of the updater UI so PR #97 can be exercised through a real RC before it is merged.

Prerelease builds retain the stable `Cargo.toml` version and receive their exact release tag/build kind through build-time metadata. Stable releases remain restricted to the current default-branch tip. Nightlies use UTC-dated tags and add a numeric suffix for repeated same-day runs. Version calculation is extracted into a unit-tested Python script and fails closed when selected source code lacks prerelease metadata support.

## Visual evidence

N/A — workflow-only change with no application UI changes.

## How to test

1. After merging, open **Actions → Release**, run it from `main`, choose `patch`, `rc`, and enter `97` as the source.
2. Confirm it resolves PR #97's exact head SHA, builds both architectures, creates `v0.7.1-rc.1` as a GitHub prerelease, and does not modify `main`.
3. Run it with `nightly` and source `97` to exercise manual nightly publication.

**Expected result:** RC publication produces the next numeric `rc.N` tag; nightly publication produces `v0.7.1-nightly.YYYYMMDD` (or `.N` for another run that day). Both releases are marked prerelease, package the selected immutable source revision, and leave `/releases/latest` and the stable manifest version unchanged.

## Related issue

Part of #61
