### PR TITLE
docs(branding): add approved logo assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <div align="center">
 
+<img src="docs/assets/logos/strata-tokyo-night.svg" alt="Strata logo" width="160">
+
 # Strata
 
 **Navigate every layer.** A fast, keyboard-first file manager for modern Linux desktops.

--- a/docs/assets/logos/README.md
+++ b/docs/assets/logos/README.md
@@ -1,6 +1,0 @@
-# Strata final logo assets
-
-The eight final SVG assets from the approved Strata logo gallery. All files use
-the angular interlocking S/hex mark with detached upper-right and lower-left
-accents. SVG backgrounds are transparent; white variants are intended for dark
-surfaces and black variants for light surfaces.

--- a/docs/assets/logos/README.md
+++ b/docs/assets/logos/README.md
@@ -1,0 +1,6 @@
+# Strata final logo assets
+
+The eight final SVG assets from the approved Strata logo gallery. All files use
+the angular interlocking S/hex mark with detached upper-right and lower-left
+accents. SVG backgrounds are transparent; white variants are intended for dark
+surfaces and black variants for light surfaces.

--- a/docs/assets/logos/strata-monokai-bw-black.svg
+++ b/docs/assets/logos/strata-monokai-bw-black.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 284 284" role="img" aria-labelledby="title">
+  <title id="title">Strata Monokai black logo</title>
+  
+  <path d="M38 82 142 22 174 40 70 100v24l104 62-32 18L38 142Z" fill="#000000"/>
+  <path d="M142 88l104 60v60l-104 60-32-18 104-60v-24l-104-60Z" fill="#000000"/>
+  <path d="M174 74l32-18 40 23v36l-72-41Z" fill="#000000"/>
+  <path d="M38 176l72 42-32 18-40-23Z" fill="#000000"/>
+</svg>

--- a/docs/assets/logos/strata-monokai-bw-white.svg
+++ b/docs/assets/logos/strata-monokai-bw-white.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 284 284" role="img" aria-labelledby="title">
+  <title id="title">Strata Monokai white logo</title>
+  
+  <path d="M38 82 142 22 174 40 70 100v24l104 62-32 18L38 142Z" fill="#FFFFFF"/>
+  <path d="M142 88l104 60v60l-104 60-32-18 104-60v-24l-104-60Z" fill="#FFFFFF"/>
+  <path d="M174 74l32-18 40 23v36l-72-41Z" fill="#FFFFFF"/>
+  <path d="M38 176l72 42-32 18-40-23Z" fill="#FFFFFF"/>
+</svg>

--- a/docs/assets/logos/strata-monokai-greyscale.svg
+++ b/docs/assets/logos/strata-monokai-greyscale.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 284 284" role="img" aria-labelledby="title">
+  <title id="title">Strata Monokai greyscale logo</title>
+  <defs><linearGradient id="main" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#FFFFFF"/><stop offset="1" stop-color="#E7E7E7"/></linearGradient><linearGradient id="grey" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#8B9098"/><stop offset="1" stop-color="#5C626B"/></linearGradient></defs>
+  <path d="M38 82 142 22 174 40 70 100v24l104 62-32 18L38 142Z" fill="url(#main)"/>
+  <path d="M142 88l104 60v60l-104 60-32-18 104-60v-24l-104-60Z" fill="url(#main)"/>
+  <path d="M174 74l32-18 40 23v36l-72-41Z" fill="url(#grey)"/>
+  <path d="M38 176l72 42-32 18-40-23Z" fill="url(#grey)"/>
+</svg>

--- a/docs/assets/logos/strata-monokai.svg
+++ b/docs/assets/logos/strata-monokai.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 284 284" role="img" aria-labelledby="title">
+  <title id="title">Strata Monokai logo</title>
+  <defs>
+    <linearGradient id="main" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#FFFFFF"/><stop offset="1" stop-color="#E7E7E2"/></linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#B6F400"/><stop offset="1" stop-color="#8FCE00"/></linearGradient>
+  </defs>
+  <path d="M38 82 142 22 174 40 70 100v24l104 62-32 18L38 142Z" fill="url(#main)"/>
+  <path d="M142 88l104 60v60l-104 60-32-18 104-60v-24l-104-60Z" fill="url(#main)"/>
+  <path d="M174 74l32-18 40 23v36l-72-41Z" fill="url(#accent)"/>
+  <path d="M38 176l72 42-32 18-40-23Z" fill="url(#accent)"/>
+</svg>

--- a/docs/assets/logos/strata-tokyo-night-bw-black.svg
+++ b/docs/assets/logos/strata-tokyo-night-bw-black.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 284 284" role="img" aria-labelledby="title">
+  <title id="title">Strata Tokyo Night black logo</title>
+  
+  <path d="M38 82 142 22 174 40 70 100v24l104 62-32 18L38 142Z" fill="#000000"/>
+  <path d="M142 88l104 60v60l-104 60-32-18 104-60v-24l-104-60Z" fill="#000000"/>
+  <path d="M174 74l32-18 40 23v36l-72-41Z" fill="#000000"/>
+  <path d="M38 176l72 42-32 18-40-23Z" fill="#000000"/>
+</svg>

--- a/docs/assets/logos/strata-tokyo-night-bw-white.svg
+++ b/docs/assets/logos/strata-tokyo-night-bw-white.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 284 284" role="img" aria-labelledby="title">
+  <title id="title">Strata Tokyo Night white logo</title>
+  
+  <path d="M38 82 142 22 174 40 70 100v24l104 62-32 18L38 142Z" fill="#FFFFFF"/>
+  <path d="M142 88l104 60v60l-104 60-32-18 104-60v-24l-104-60Z" fill="#FFFFFF"/>
+  <path d="M174 74l32-18 40 23v36l-72-41Z" fill="#FFFFFF"/>
+  <path d="M38 176l72 42-32 18-40-23Z" fill="#FFFFFF"/>
+</svg>

--- a/docs/assets/logos/strata-tokyo-night-greyscale.svg
+++ b/docs/assets/logos/strata-tokyo-night-greyscale.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 284 284" role="img" aria-labelledby="title">
+  <title id="title">Strata Tokyo Night greyscale logo</title>
+  <defs><linearGradient id="main" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#FFFFFF"/><stop offset="1" stop-color="#E7E7E7"/></linearGradient><linearGradient id="grey" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#8B9098"/><stop offset="1" stop-color="#5C626B"/></linearGradient></defs>
+  <path d="M38 82 142 22 174 40 70 100v24l104 62-32 18L38 142Z" fill="url(#main)"/>
+  <path d="M142 88l104 60v60l-104 60-32-18 104-60v-24l-104-60Z" fill="url(#main)"/>
+  <path d="M174 74l32-18 40 23v36l-72-41Z" fill="url(#grey)"/>
+  <path d="M38 176l72 42-32 18-40-23Z" fill="url(#grey)"/>
+</svg>

--- a/docs/assets/logos/strata-tokyo-night.svg
+++ b/docs/assets/logos/strata-tokyo-night.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 284 284" role="img" aria-labelledby="title">
+  <title id="title">Strata Tokyo Night logo</title>
+  <defs>
+    <linearGradient id="main" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#C7D2FF"/><stop offset="1" stop-color="#91A7E8"/></linearGradient>
+    <linearGradient id="top" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#9CCBFF"/><stop offset="1" stop-color="#62A8FF"/></linearGradient>
+    <linearGradient id="bottom" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#9D8CFF"/><stop offset="1" stop-color="#6674FF"/></linearGradient>
+  </defs>
+  <path d="M38 82 142 22 174 40 70 100v24l104 62-32 18L38 142Z" fill="url(#main)"/>
+  <path d="M142 88l104 60v60l-104 60-32-18 104-60v-24l-104-60Z" fill="url(#main)"/>
+  <path d="M174 74l32-18 40 23v36l-72-41Z" fill="url(#top)"/>
+  <path d="M38 176l72 42-32 18-40-23Z" fill="url(#bottom)"/>
+</svg>


### PR DESCRIPTION
## Description

Adds the eight approved Tokyo Night and Monokai SVG logo variants to a canonical `docs/assets/logos/` directory. The README now displays the Tokyo Night color logo above the project title.

## Visual evidence

**Before:** The README started with the Strata text heading and had no logo.

**After:**

<img src="https://raw.githubusercontent.com/lgse/strata/refs/heads/docs/185-add-logo-assets/docs/assets/logos/strata-tokyo-night.svg" alt="Tokyo Night Strata logo" width="160">

## How to test

1. Open `README.md` in a Markdown renderer.
2. Confirm the Tokyo Night logo appears above the Strata heading.
3. Browse `docs/assets/logos/` and open each of the eight SVG variants.

**Expected result:** The README renders the Tokyo Night logo, and every color, greyscale, black, and white variant renders with a transparent background.

## Related issue

Closes #185