### PR TITLE
fix(test): eliminate cancellation race and lock cascade

### DIFF
--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -363,7 +363,7 @@ fn cancelled_replacement_move_tracks_the_modified_source_and_target_roots()
     let context = glib::MainContext::default();
     let watcher = context.spawn_local(async move {
         while !committed_marker.exists() {
-            glib::timeout_future(Duration::from_millis(1)).await;
+            glib::timeout_future(Duration::ZERO).await;
         }
         cancel_after_commit.cancel();
     });

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -2,11 +2,30 @@
 
 #![cfg(test)]
 
-use std::sync::Mutex;
+use std::sync::{LockResult, Mutex, MutexGuard};
+
+pub(crate) struct TestMutex(Mutex<()>);
+
+impl TestMutex {
+    pub(crate) const fn new() -> Self {
+        Self(Mutex::new(()))
+    }
+
+    pub(crate) fn lock(&self) -> LockResult<MutexGuard<'_, ()>> {
+        match self.0.lock() {
+            Ok(guard) => Ok(guard),
+            Err(error) => {
+                self.0.clear_poison();
+                Ok(error.into_inner())
+            }
+        }
+    }
+}
 
 /// Serializes tests that drive `glib::MainContext::default()` directly, since it is a
 /// process-wide singleton and concurrent access from the test harness's per-test threads panics
 /// with a GLib thread-affinity error. A single shared lock, not one static per module: two
 /// separate locks each covering only their own module's tests do not prevent a test in one
-/// module from racing a test in another, since neither knows about the other's lock.
-pub(crate) static ASYNC_MAIN_CONTEXT_DEFAULT: Mutex<()> = Mutex::new(());
+/// module from racing a test in another, since neither knows about the other's lock. Poisoning is
+/// cleared because the mutex protects no state and should not turn one failure into a cascade.
+pub(crate) static ASYNC_MAIN_CONTEXT_DEFAULT: TestMutex = TestMutex::new();


### PR DESCRIPTION
## Description

Make the post-commit cancellation watcher poll without a 1 ms race window. Recover the stateless main-context serialization mutex after a panic so one real failure does not create many poisoned-lock failures.

## Visual evidence

N/A — test-only, non-visual change.

## How to test

1. Repeatedly run `cargo test --all-features --bin strata adapters::local_operations::tests::cancelled_replacement_move_tracks_the_modified_source_and_target_roots -- --exact`.
2. Run the complete Rust test suite.

**Expected result:** The cancellation test consistently observes cancellation, and serialized tests can continue after an unrelated panic.

## Related issue

Closes #193