### PR TITLE
perf(preview): prefer embedded RAW previews for thumbnails

### DIFF
--- a/src/sandbox_helper.rs
+++ b/src/sandbox_helper.rs
@@ -43,7 +43,7 @@ pub(crate) fn run(arguments: &[String]) -> Result<(), String> {
 
     let (png, metadata) = match operation.as_str() {
         "thumbnail-image" => (render_pixbuf(input, value.clamp(16, 256))?, None),
-        "thumbnail-raw" => (render_raw(input, value.clamp(16, 256))?, None),
+        "thumbnail-raw" => (render_raw_thumbnail(input, value.clamp(16, 256))?, None),
         "thumbnail-pdf" => (render_pdf_thumbnail(input, value.clamp(16, 256))?, None),
         "thumbnail-video" => (render_media(input, value.clamp(16, 256))?, None),
         "preview-image" => (render_raw(input, 1400)?, None),
@@ -73,6 +73,13 @@ fn render_raw(path: &Path, size: i32) -> Result<Vec<u8>, String> {
     render_pixbuf(path, size)
         .or_else(|_| render_imagemagick(path, size))
         .or_else(|_| render_dcraw(path, size))
+}
+
+fn render_raw_thumbnail(path: &Path, size: i32) -> Result<Vec<u8>, String> {
+    // Prefer the camera JPEG so ImageMagick does not demosaic the list thumbnail.
+    render_dcraw(path, size)
+        .or_else(|_| render_pixbuf(path, size))
+        .or_else(|_| render_imagemagick(path, size))
 }
 
 fn render_imagemagick(path: &Path, size: i32) -> Result<Vec<u8>, String> {

--- a/src/sandbox_helper/tests.rs
+++ b/src/sandbox_helper/tests.rs
@@ -10,8 +10,8 @@ use gdk_pixbuf::prelude::*;
 
 use super::{
     MediaBackend, bounded_output, bounded_output_with_timeout, bounded_surface_dimensions,
-    media_backends, media_command, read_limited, render_pixbuf, render_raw, run,
-    run_media_backends, scale_embedded_thumbnail,
+    media_backends, media_command, read_limited, render_pixbuf, render_raw, render_raw_thumbnail,
+    run, run_media_backends, scale_embedded_thumbnail,
 };
 use crate::sandbox::MediaPreviewBackend;
 
@@ -293,6 +293,35 @@ fn preview_image_uses_raw_fallbacks() {
         Err(raw) => {
             assert_ne!(pixbuf, raw);
             assert_eq!(preview.expect_err("stub should fail RAW fallbacks"), raw);
+        }
+    }
+}
+
+#[test]
+fn thumbnail_raw_uses_embedded_preview_fallbacks() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let input = directory.path().join("photo.ARW");
+    let output = directory.path().join("result.png");
+    std::fs::write(&input, b"not a camera file").expect("write stub");
+
+    let pixbuf = render_pixbuf(&input, 256).expect_err("stub must fail pixbuf");
+    let thumbnail = render_raw_thumbnail(&input, 256);
+    let helper = run(&[
+        "thumbnail-raw".into(),
+        input.to_string_lossy().into_owned(),
+        output.to_string_lossy().into_owned(),
+        "256".into(),
+        "software".into(),
+    ]);
+
+    match thumbnail {
+        Ok(_) => helper.expect("thumbnail-raw should use RAW fallbacks"),
+        Err(thumbnail) => {
+            assert_ne!(pixbuf, thumbnail);
+            assert_eq!(
+                helper.expect_err("stub should fail RAW fallbacks"),
+                thumbnail
+            );
         }
     }
 }


### PR DESCRIPTION
## Description

List thumbnails for camera RAW files now try the embedded JPEG/PPM extract before pixbuf or ImageMagick. ImageMagick typically demosaics, so when it ran first the cheap camera preview never ran. Full-size `preview-image` still uses pixbuf → ImageMagick → dcraw.

## Visual evidence

```
strata perf/198-raw-thumbnail-preview  ? ❯ STRATA_RAW_BENCH="/run/media/oscar/wd_black/Photos RAW/Grand Canyon" cargo test --release -- --ignored --nocapture bench_raw_thumbnail
    Finished `release` profile [optimized] target(s) in 0.07s
     Running unittests src/main.rs (target/release/deps/strata-1e6c0000011fc478)

running 1 test
141 RAW files under /run/media/oscar/wd_black/Photos RAW/Grand Canyon
test sandbox_helper::tests::bench_raw_thumbnail has been running for over 60 seconds
thumbnail-order (dcraw → pixbuf → ImageMagick): 141 ok  0 fail  total 2.3s  median 16.3ms
preview-order    (pixbuf → ImageMagick → dcraw): 141 ok  0 fail  total 83.9s  median 549.8ms
test sandbox_helper::tests::bench_raw_thumbnail ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 376 filtered out; finished in 86.21s
```
I compared the two orders and the results are quite good, from a median of 550 to 16.3 milliseconds.

## How to test

1. Open a directory of camera RAW files (for example `.ARW`) in Grid or any view that shows list thumbnails.
2. Confirm tiles appear and look like the camera’s embedded preview (same as a machine without ImageMagick).
3. Open one of those files in the preview pane.

**Expected result:** Thumbnails resolve from the embedded extract when `dcraw`/`simple_dcraw` can provide one, without waiting on a full demosaic. The preview pane still uses the existing demosaic-first RAW path.

## Related issue

Closes #198