### PR TITLE
perf(hidden): toggle hidden files in-memory without re-enumerating

### DIFF
--- a/src/adapters/local_files.rs
+++ b/src/adapters/local_files.rs
@@ -122,6 +122,7 @@ fn entry_from_info(location: Location, info: gio::FileInfo) -> FileEntry {
             .modification_date_time()
             .map(|modified| MetadataValue::Known(modified.to_unix()))
             .unwrap_or(MetadataValue::Unavailable),
+        is_hidden: info_is_hidden(&info),
     }
 }
 
@@ -266,7 +267,6 @@ impl FileSource for LocalFileSource {
                     Ok(Ok(files)) => {
                         let mut entries: Vec<_> = files
                             .into_iter()
-                            .filter(|info| request.include_hidden || !info_is_hidden(info))
                             .filter_map(|info| {
                                 let child = directory.child(info.name());
                                 Some(entry_from_info(location_for_file(&child)?, info))
@@ -327,6 +327,7 @@ impl FileSource for LocalFileSource {
         include_hidden: bool,
         notify: Rc<dyn Fn(DirectoryChange)>,
     ) -> Option<LoadHandle> {
+        let _ = include_hidden;
         let path = location.native_path()?.to_path_buf();
         let file = gio::File::for_path(&path);
         let monitor = match file.monitor_directory(
@@ -405,7 +406,7 @@ impl FileSource for LocalFileSource {
             let cancelled = cancelled_for_change.clone();
             let source = glib::timeout_add_local_once(Duration::from_millis(100), move || {
                 timeout.take();
-                flush_monitor_changes(&pending, include_hidden, &notify, &cancelled);
+                flush_monitor_changes(&pending, &notify, &cancelled);
             });
             timeout_for_change.replace(Some(source));
         });
@@ -474,7 +475,6 @@ fn merge_pending_change(
 
 fn flush_monitor_changes(
     pending: &RefCell<HashMap<PathBuf, PendingMonitorChange>>,
-    include_hidden: bool,
     notify: &Rc<dyn Fn(DirectoryChange)>,
     cancelled: &Rc<Cell<bool>>,
 ) {
@@ -496,20 +496,12 @@ fn flush_monitor_changes(
             PendingMonitorChange::Remove(path) => {
                 notify(DirectoryChange::Remove(Location::local(path)));
             }
-            PendingMonitorChange::Upsert(path) => query_monitored_entry(
-                path,
-                include_hidden,
-                None,
-                notify.clone(),
-                cancelled.clone(),
-            ),
-            PendingMonitorChange::Move { from, to } => query_monitored_entry(
-                to,
-                include_hidden,
-                Some(from),
-                notify.clone(),
-                cancelled.clone(),
-            ),
+            PendingMonitorChange::Upsert(path) => {
+                query_monitored_entry(path, None, notify.clone(), cancelled.clone())
+            }
+            PendingMonitorChange::Move { from, to } => {
+                query_monitored_entry(to, Some(from), notify.clone(), cancelled.clone())
+            }
             PendingMonitorChange::Rescan => {}
         }
     }
@@ -517,7 +509,6 @@ fn flush_monitor_changes(
 
 fn query_monitored_entry(
     path: PathBuf,
-    include_hidden: bool,
     moved_from: Option<PathBuf>,
     notify: Rc<dyn Fn(DirectoryChange)>,
     cancelled: Rc<Cell<bool>>,
@@ -535,7 +526,7 @@ fn query_monitored_entry(
             return;
         }
         match result {
-            Ok(info) if include_hidden || !info_is_hidden(&info) => {
+            Ok(info) => {
                 let entry = entry_from_info(Location::local(path), info);
                 if let Some(from) = moved_from {
                     notify(DirectoryChange::Move {
@@ -544,11 +535,6 @@ fn query_monitored_entry(
                     });
                 } else {
                     notify(DirectoryChange::Upsert(entry));
-                }
-            }
-            Ok(_) => {
-                if let Some(from) = moved_from {
-                    notify(DirectoryChange::Remove(Location::local(from)));
                 }
             }
             Err(error) if error.matches(gio::IOErrorEnum::NotFound) => {

--- a/src/adapters/local_files/tests.rs
+++ b/src/adapters/local_files/tests.rs
@@ -387,7 +387,6 @@ fn enumerate_reports_truncated_once_the_entry_budget_is_exceeded() {
         id: RequestId(1),
         location: Location::local(&root),
         batch_size: 2,
-        include_hidden: true,
         max_entries: 3,
         time_budget: Duration::from_secs(10),
     });
@@ -418,7 +417,6 @@ fn enumerate_completes_untruncated_at_the_exact_entry_budget() {
         id: RequestId(1),
         location: Location::local(&root),
         batch_size: 2,
-        include_hidden: true,
         max_entries: 4,
         time_budget: Duration::from_secs(10),
     });
@@ -443,7 +441,6 @@ fn enumerate_reports_truncated_once_the_time_budget_is_exceeded() {
         id: RequestId(1),
         location: Location::local(&root),
         batch_size: 1,
-        include_hidden: true,
         max_entries: usize::MAX,
         time_budget: Duration::from_nanos(1),
     });
@@ -469,7 +466,6 @@ fn enumerate_completes_untruncated_within_budget() {
         id: RequestId(1),
         location: Location::local(&root),
         batch_size: 64,
-        include_hidden: true,
         max_entries: 100,
         time_budget: Duration::from_secs(10),
     });

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -48,6 +48,7 @@ fn file_entry(path: &std::path::Path) -> FileEntry {
         kind: EntryKind::File,
         size: MetadataValue::Unknown,
         modified_unix_seconds: MetadataValue::Unknown,
+        is_hidden: false,
     }
 }
 
@@ -497,6 +498,7 @@ fn test_file_entry(path: &Path) -> FileEntry {
         kind: EntryKind::File,
         size: MetadataValue::Unknown,
         modified_unix_seconds: MetadataValue::Unknown,
+        is_hidden: false,
     }
 }
 

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -238,6 +238,10 @@ impl Browser {
         self.observers.borrow_mut().clear();
     }
 
+    pub fn preferences(&self) -> ViewPreferences {
+        self.preferences.get()
+    }
+
     pub fn observe_preferences(&self, observer: impl Fn(ViewPreferences) + 'static) {
         self.preferences_observers
             .borrow_mut()
@@ -570,6 +574,7 @@ impl Browser {
         self.preferences.set(preferences);
         self.notify_preferences_observers();
 
+        self.close_peek();
         self.state
             .borrow_mut()
             .set_show_hidden(preferences.show_hidden);
@@ -1634,9 +1639,21 @@ impl Browser {
                             take_focus: false,
                         });
                     }
-                } else if state.apply_peek_batch(request_id, &entries) {
-                    drop(state);
-                    self.emit(BrowserEvent::PeekEntriesAdded { entries });
+                } else {
+                    let peek_entries: Vec<_> = if self.preferences.get().show_hidden {
+                        entries
+                    } else {
+                        entries
+                            .into_iter()
+                            .filter(|entry| !entry.is_hidden)
+                            .collect()
+                    };
+                    if state.apply_peek_batch(request_id, &peek_entries) {
+                        drop(state);
+                        self.emit(BrowserEvent::PeekEntriesAdded {
+                            entries: peek_entries,
+                        });
+                    }
                 }
             }
             DirectoryEvent::Finished {

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -73,6 +73,9 @@ pub enum BrowserEvent {
     ColumnReloaded {
         depth: usize,
     },
+    HiddenToggled {
+        show_hidden: bool,
+    },
     LoadFinished {
         depth: usize,
         truncated: bool,
@@ -479,7 +482,6 @@ impl Browser {
                 id: request_id,
                 location,
                 batch_size: 128,
-                include_hidden: self.preferences.get().show_hidden,
                 max_entries: PEEK_MAX_ENTRIES,
                 time_budget: PEEK_TIME_BUDGET,
             },
@@ -568,22 +570,12 @@ impl Browser {
         self.preferences.set(preferences);
         self.notify_preferences_observers();
 
-        let locations = {
-            let mut state = self.state.borrow_mut();
-            state.set_show_hidden(preferences.show_hidden);
-            state
-                .columns
-                .iter()
-                .map(|column| column.location.clone())
-                .collect::<Vec<_>>()
-        };
-        for (depth, location) in locations.into_iter().enumerate() {
-            self.refresh_column(depth);
-            let monitor = self.install_monitor(depth, location);
-            if let Some(slot) = self.monitors.borrow_mut().get_mut(depth) {
-                *slot = monitor;
-            }
-        }
+        self.state
+            .borrow_mut()
+            .set_show_hidden(preferences.show_hidden);
+        self.emit(BrowserEvent::HiddenToggled {
+            show_hidden: preferences.show_hidden,
+        });
     }
 
     fn apply_column_preferences(
@@ -1431,7 +1423,6 @@ impl Browser {
                 id: request_id,
                 location,
                 batch_size: 128,
-                include_hidden: self.preferences.get().show_hidden,
                 max_entries: MAX_DIRECTORY_ENTRIES,
                 time_budget: DIRECTORY_LOAD_TIME_BUDGET,
             },

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -17,6 +17,7 @@ fn deleted_trash_entries_refresh_the_trash_root() {
         kind: EntryKind::File,
         size: MetadataValue::Known(10),
         modified_unix_seconds: MetadataValue::Unknown,
+        is_hidden: false,
     };
 
     assert_eq!(
@@ -74,7 +75,7 @@ struct TrackingFileSource {
 }
 
 struct RecordingFileSource {
-    include_hidden: Rc<RefCell<Vec<bool>>>,
+    request_count: Rc<Cell<usize>>,
 }
 
 type WatchCallback = Rc<dyn Fn(DirectoryChange)>;
@@ -98,6 +99,7 @@ impl FileSource for WatchingFileSource {
                 kind: EntryKind::Directory,
                 size: MetadataValue::Unknown,
                 modified_unix_seconds: MetadataValue::Unknown,
+                is_hidden: false,
             }],
         });
         emit(DirectoryEvent::Finished {
@@ -125,12 +127,10 @@ impl FileSource for RecordingFileSource {
 
     fn enumerate(
         &self,
-        request: DirectoryRequest,
+        _request: DirectoryRequest,
         _emit: Rc<dyn Fn(DirectoryEvent)>,
     ) -> LoadHandle {
-        self.include_hidden
-            .borrow_mut()
-            .push(request.include_hidden);
+        self.request_count.set(self.request_count.get() + 1);
         LoadHandle::new(|| {})
     }
 }
@@ -173,6 +173,7 @@ impl FileSource for RetryFileSource {
                     kind: EntryKind::Directory,
                     size: MetadataValue::Unknown,
                     modified_unix_seconds: MetadataValue::Unknown,
+                    is_hidden: false,
                 }],
             });
             emit(DirectoryEvent::Finished {
@@ -227,6 +228,7 @@ impl FileSource for FilePreviewSource {
                 kind: EntryKind::File,
                 size: MetadataValue::Known(12),
                 modified_unix_seconds: MetadataValue::Known(1),
+                is_hidden: false,
             }],
         });
         emit(DirectoryEvent::Finished {
@@ -250,6 +252,7 @@ impl FileSource for RestoredSortingSource {
             kind: EntryKind::File,
             size: MetadataValue::Known(size),
             modified_unix_seconds: MetadataValue::Unknown,
+            is_hidden: false,
         };
         emit(DirectoryEvent::Batch {
             request_id: request.id,
@@ -278,6 +281,7 @@ impl FileSource for FakeFileSource {
                 kind: EntryKind::Directory,
                 size: MetadataValue::Unknown,
                 modified_unix_seconds: MetadataValue::Unknown,
+                is_hidden: false,
             }],
         });
         emit(DirectoryEvent::Finished {
@@ -305,6 +309,7 @@ impl FileSource for TrashFileSource {
                 kind: EntryKind::File,
                 size: MetadataValue::Unknown,
                 modified_unix_seconds: MetadataValue::Unknown,
+                is_hidden: false,
             }],
         });
         emit(DirectoryEvent::Finished {
@@ -583,6 +588,7 @@ fn renaming_on_a_remote_location_refreshes_the_open_column() {
             kind: EntryKind::File,
             size: MetadataValue::Known(1),
             modified_unix_seconds: MetadataValue::Unknown,
+            is_hidden: false,
         },
         "new-name.txt".to_owned(),
     );
@@ -705,6 +711,7 @@ fn filesystem_notifications_update_the_affected_column_incrementally() {
         kind: EntryKind::File,
         size: MetadataValue::Known(4),
         modified_unix_seconds: MetadataValue::Known(1),
+        is_hidden: false,
     }));
 
     assert!(events.borrow().iter().any(|event| matches!(
@@ -791,9 +798,9 @@ fn retrying_a_failed_column_preserves_navigation_history() {
 
 #[test]
 fn hidden_file_preference_is_applied_to_reloaded_requests() {
-    let include_hidden = Rc::new(RefCell::new(Vec::new()));
+    let request_count = Rc::new(Cell::new(0));
     let browser = Browser::new(Rc::new(RecordingFileSource {
-        include_hidden: include_hidden.clone(),
+        request_count: request_count.clone(),
     }));
     let observed_preferences = Rc::new(Cell::new(None));
     let observed = observed_preferences.clone();
@@ -802,7 +809,8 @@ fn hidden_file_preference_is_applied_to_reloaded_requests() {
     browser.navigate(Location::local("/fixture"));
     browser.toggle_hidden();
 
-    assert_eq!(*include_hidden.borrow(), vec![false, true]);
+    // Toggling hidden files no longer re-enumerates; it only re-filters in-memory state.
+    assert_eq!(request_count.get(), 1);
     assert_eq!(
         observed_preferences.get(),
         Some(ViewPreferences {

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -1413,3 +1413,92 @@ fn escape_closes_a_peek_before_the_deepest_column() {
             .any(|event| matches!(event, BrowserEvent::ColumnsTruncated { len: 1 }))
     );
 }
+
+struct MixedPeekFileSource;
+
+impl FileSource for MixedPeekFileSource {
+    fn validate_location(&self, _location: &Location) -> Result<(), LocationValidationError> {
+        Ok(())
+    }
+
+    fn enumerate(&self, request: DirectoryRequest, emit: Rc<dyn Fn(DirectoryEvent)>) -> LoadHandle {
+        emit(DirectoryEvent::Batch {
+            request_id: request.id,
+            entries: vec![
+                FileEntry {
+                    location: Location::local("/fixture/.dotfile"),
+                    native_name: OsString::from(".dotfile"),
+                    display_name: ".dotfile".into(),
+                    kind: EntryKind::File,
+                    size: MetadataValue::Unknown,
+                    modified_unix_seconds: MetadataValue::Unknown,
+                    is_hidden: true,
+                },
+                FileEntry {
+                    location: Location::local("/fixture/normal.txt"),
+                    native_name: OsString::from("normal.txt"),
+                    display_name: "normal.txt".into(),
+                    kind: EntryKind::File,
+                    size: MetadataValue::Unknown,
+                    modified_unix_seconds: MetadataValue::Unknown,
+                    is_hidden: false,
+                },
+            ],
+        });
+        emit(DirectoryEvent::Finished {
+            request_id: request.id,
+            truncated: false,
+        });
+        LoadHandle::new(|| {})
+    }
+}
+
+#[test]
+fn peek_filters_hidden_entries_before_item_limit() {
+    let browser = Browser::new(Rc::new(MixedPeekFileSource));
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let observed = events.clone();
+    browser.observe(move |event| observed.borrow_mut().push(event));
+    browser.navigate(Location::local("/fixture"));
+    browser.begin_peek(0, Location::local("/fixture/peek_target"));
+
+    let peek_batch = events.borrow().iter().find_map(|event| match event {
+        BrowserEvent::PeekEntriesAdded { entries } => Some(entries.clone()),
+        _ => None,
+    });
+    let entries = peek_batch.expect("peek batch emitted");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].display_name, "normal.txt");
+
+    events.borrow_mut().clear();
+    browser.toggle_hidden();
+    browser.begin_peek(0, Location::local("/fixture/peek_target"));
+
+    let peek_batch = events.borrow().iter().find_map(|event| match event {
+        BrowserEvent::PeekEntriesAdded { entries } => Some(entries.clone()),
+        _ => None,
+    });
+    let entries = peek_batch.expect("peek batch emitted");
+    assert_eq!(entries.len(), 2);
+}
+
+#[test]
+fn new_columns_inherit_show_hidden_preference() {
+    let preferences = ViewPreferences {
+        show_hidden: true,
+        ..Default::default()
+    };
+    let browser = Browser::with_preferences(Rc::new(FakeFileSource), preferences);
+    browser.navigate(Location::local("/fixture"));
+
+    assert_eq!(
+        browser.column_preferences(0).map(|p| p.show_hidden),
+        Some(true)
+    );
+
+    browser.descend(0, Location::local("/fixture/child"));
+    assert_eq!(
+        browser.column_preferences(1).map(|p| p.show_hidden),
+        Some(true)
+    );
+}

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -268,12 +268,18 @@ impl NavigationState {
             }
         }
         if column.select_first_on_load && !column.entries.is_empty() {
-            let location = column.entries[0].location.clone();
-            column.selected = Some(0);
-            column.selected_locations.clear();
-            column.selected_locations.insert(location.clone());
-            column.selection_anchor = Some(location);
-            column.select_first_on_load = false;
+            let first_visible = column
+                .entries
+                .iter()
+                .position(|entry| preferences.show_hidden || !entry.is_hidden);
+            if let Some(position) = first_visible {
+                let location = column.entries[position].location.clone();
+                column.selected = Some(position);
+                column.selected_locations.clear();
+                column.selected_locations.insert(location.clone());
+                column.selection_anchor = Some(location);
+                column.select_first_on_load = false;
+            }
         }
         Some((depth, insertions))
     }
@@ -381,6 +387,30 @@ impl NavigationState {
         self.preferences.show_hidden = show_hidden;
         for column in &mut self.columns {
             column.preferences.show_hidden = show_hidden;
+            if !show_hidden {
+                if let Some(selected) = column.selected
+                    && column.entries.get(selected).is_some_and(|e| e.is_hidden)
+                {
+                    let nearest_visible = (selected + 1..column.entries.len())
+                        .find(|&i| !column.entries[i].is_hidden)
+                        .or_else(|| (0..selected).rev().find(|&i| !column.entries[i].is_hidden));
+                    column.selected = nearest_visible;
+                    column.selected_locations.clear();
+                    if let Some(pos) = nearest_visible {
+                        let loc = column.entries[pos].location.clone();
+                        column.selected_locations.insert(loc.clone());
+                        column.selection_anchor = Some(loc);
+                    } else {
+                        column.selection_anchor = None;
+                    }
+                }
+                column.selected_locations.retain(|loc| {
+                    column
+                        .entries
+                        .iter()
+                        .any(|entry| &entry.location == loc && !entry.is_hidden)
+                });
+            }
         }
     }
 
@@ -564,15 +594,34 @@ impl NavigationState {
         if column.entries.is_empty() {
             return None;
         }
-        let last = column.entries.len() - 1;
-        let current = column
-            .selected
-            .unwrap_or(if direction < 0 { last } else { 0 });
-        let focused = if direction < 0 {
-            current.saturating_sub(1)
+
+        let show_hidden = column.preferences.show_hidden;
+        let is_visible = |entry: &FileEntry| show_hidden || !entry.is_hidden;
+
+        let first_visible = column.entries.iter().position(is_visible)?;
+        let last_visible = column.entries.iter().rposition(is_visible)?;
+
+        let current = column.selected.unwrap_or(if direction < 0 {
+            last_visible
         } else {
-            (current + 1).min(last)
+            first_visible
+        });
+
+        let focused = if direction < 0 {
+            column.entries[..current]
+                .iter()
+                .rposition(is_visible)
+                .unwrap_or(current)
+        } else if current + 1 < column.entries.len() {
+            column.entries[current + 1..]
+                .iter()
+                .position(is_visible)
+                .map(|offset| current + 1 + offset)
+                .unwrap_or(current)
+        } else {
+            current
         };
+
         let anchor = column
             .selection_anchor
             .as_ref()
@@ -588,13 +637,16 @@ impl NavigationState {
         }
         let start = anchor.min(focused);
         let end = anchor.max(focused);
-        column.selected_locations = column.entries[start..=end]
+        let selected_positions: Vec<usize> = (start..=end)
+            .filter(|&index| is_visible(&column.entries[index]))
+            .collect();
+        column.selected_locations = selected_positions
             .iter()
-            .map(|entry| entry.location.clone())
+            .map(|&index| column.entries[index].location.clone())
             .collect();
         column.selected = Some(focused);
         self.active_column = Some(depth);
-        Some((depth, focused, (start..=end).collect()))
+        Some((depth, focused, selected_positions))
     }
 
     pub fn selected_positions(&self, depth: usize) -> Vec<usize> {
@@ -638,13 +690,67 @@ impl NavigationState {
             return None;
         }
 
-        let last = column.entries.len() - 1;
+        let show_hidden = column.preferences.show_hidden;
+        let is_visible = |entry: &FileEntry| show_hidden || !entry.is_hidden;
+
+        if !column.entries.iter().any(is_visible) {
+            column.selected = None;
+            column.selected_locations.clear();
+            column.selection_anchor = None;
+            return None;
+        }
+
         let position = match (column.selected, direction.cmp(&0)) {
-            (None, std::cmp::Ordering::Less) => last,
-            (None, _) => 0,
-            (Some(position), std::cmp::Ordering::Less) => position.saturating_sub(1),
-            (Some(position), std::cmp::Ordering::Greater) => (position + 1).min(last),
-            (Some(position), std::cmp::Ordering::Equal) => position,
+            (None, std::cmp::Ordering::Less) => column.entries.iter().rposition(is_visible)?,
+            (None, _) => column.entries.iter().position(is_visible)?,
+            (Some(current), std::cmp::Ordering::Less) => column.entries[..current]
+                .iter()
+                .rposition(is_visible)
+                .unwrap_or_else(|| {
+                    if is_visible(&column.entries[current]) {
+                        current
+                    } else {
+                        column
+                            .entries
+                            .iter()
+                            .position(is_visible)
+                            .unwrap_or(current)
+                    }
+                }),
+            (Some(current), std::cmp::Ordering::Greater) => {
+                if current + 1 < column.entries.len() {
+                    column.entries[current + 1..]
+                        .iter()
+                        .position(is_visible)
+                        .map(|offset| current + 1 + offset)
+                        .unwrap_or_else(|| {
+                            if is_visible(&column.entries[current]) {
+                                current
+                            } else {
+                                column
+                                    .entries
+                                    .iter()
+                                    .rposition(is_visible)
+                                    .unwrap_or(current)
+                            }
+                        })
+                } else if is_visible(&column.entries[current]) {
+                    current
+                } else {
+                    column
+                        .entries
+                        .iter()
+                        .rposition(is_visible)
+                        .unwrap_or(current)
+                }
+            }
+            (Some(current), std::cmp::Ordering::Equal) => {
+                if is_visible(&column.entries[current]) {
+                    current
+                } else {
+                    column.entries.iter().position(is_visible)?
+                }
+            }
         };
         column.selected = Some(position);
         column.selected_locations.clear();

--- a/src/app/navigation/tests.rs
+++ b/src/app/navigation/tests.rs
@@ -374,6 +374,64 @@ fn parent_removes_the_deepest_committed_column() {
     assert_eq!(parent.locations(), &[location("/home")]);
 }
 
+fn hidden_entry(path: &str, name: &str) -> FileEntry {
+    FileEntry {
+        location: location(path),
+        native_name: OsString::from(name),
+        display_name: name.into(),
+        kind: EntryKind::Directory,
+        size: MetadataValue::Unknown,
+        modified_unix_seconds: MetadataValue::Unknown,
+        is_hidden: true,
+    }
+}
+
+#[test]
+fn keyboard_selection_skips_hidden_entries_when_hidden_files_are_not_shown() {
+    let mut state = NavigationState::default();
+    state.navigate(location("/home"), RequestId(1));
+    state.apply_batch(
+        RequestId(1),
+        vec![
+            named_entry("/home/alpha", "alpha"),
+            hidden_entry("/home/bravo", "bravo"),
+            named_entry("/home/charlie", "charlie"),
+        ],
+    );
+
+    assert_eq!(state.move_selection(1), Some((0, 0)));
+    assert_eq!(state.move_selection(1), Some((0, 2)));
+    assert_eq!(state.move_selection(1), Some((0, 2)));
+    assert_eq!(state.move_selection(-1), Some((0, 0)));
+    assert_eq!(state.move_selection(-1), Some((0, 0)));
+
+    state.set_show_hidden(true);
+    assert_eq!(state.move_selection(1), Some((0, 1)));
+    assert_eq!(state.move_selection(1), Some((0, 2)));
+}
+
+#[test]
+fn keyboard_selection_extension_skips_hidden_entries() {
+    let mut state = NavigationState::default();
+    state.navigate(location("/home"), RequestId(1));
+    state.apply_batch(
+        RequestId(1),
+        vec![
+            named_entry("/home/alpha", "alpha"),
+            hidden_entry("/home/bravo", "bravo"),
+            named_entry("/home/charlie", "charlie"),
+        ],
+    );
+    assert!(state.select(0, 0));
+
+    assert_eq!(
+        state.extend_selection(1).map(|(_, _, range)| range),
+        Some(vec![0, 2])
+    );
+    assert_eq!(state.selected_entries().len(), 2);
+    assert!(!state.selected_entries().iter().any(|e| e.is_hidden));
+}
+
 #[test]
 fn keyboard_selection_is_bounded_and_tracks_the_active_column() {
     let mut state = NavigationState::default();

--- a/src/app/navigation/tests.rs
+++ b/src/app/navigation/tests.rs
@@ -24,6 +24,7 @@ fn named_entry(path: &str, name: &str) -> FileEntry {
         kind: EntryKind::Directory,
         size: MetadataValue::Unknown,
         modified_unix_seconds: MetadataValue::Unknown,
+        is_hidden: false,
     }
 }
 

--- a/src/app/peek/tests.rs
+++ b/src/app/peek/tests.rs
@@ -13,6 +13,7 @@ fn entry() -> FileEntry {
         kind: EntryKind::Directory,
         size: MetadataValue::Unknown,
         modified_unix_seconds: MetadataValue::Unknown,
+        is_hidden: false,
     }
 }
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -237,6 +237,7 @@ pub struct FileEntry {
     pub kind: EntryKind,
     pub size: MetadataValue<u64>,
     pub modified_unix_seconds: MetadataValue<i64>,
+    pub is_hidden: bool,
 }
 
 impl FileEntry {

--- a/src/services/file_source.rs
+++ b/src/services/file_source.rs
@@ -15,7 +15,6 @@ pub struct DirectoryRequest {
     pub id: RequestId,
     pub location: Location,
     pub batch_size: usize,
-    pub include_hidden: bool,
     /// Caps how many entries a single load will retain/render, bounding worst-case time and
     /// memory on an adversarially large or unbounded directory.
     pub max_entries: usize,

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -77,6 +77,8 @@ struct ColumnView {
     new_entry_row: gtk::Box,
     new_entry_icon: gtk::Image,
     new_entry_entry: gtk::Entry,
+    show_hidden: Rc<Cell<bool>>,
+    filter: gtk::CustomFilter,
 }
 
 struct ActiveRename {
@@ -3581,6 +3583,13 @@ impl ViewState {
                     column.presentation.show_loading();
                 }
             }
+            BrowserEvent::HiddenToggled { show_hidden } => {
+                for column in self.columns.borrow().iter() {
+                    column.show_hidden.set(show_hidden);
+                    column.filter.changed(gtk::FilterChange::Different);
+                }
+                self.mode_views.borrow().set_show_hidden(show_hidden);
+            }
             BrowserEvent::LoadFinished { depth, truncated } => {
                 if let Some(column) = self.columns.borrow().get(depth) {
                     if column.selection.model().is_none() {
@@ -4025,17 +4034,8 @@ impl ViewState {
         let entry_count = Rc::new(Cell::new(0));
         let model = gtk::StringList::new(&[]);
         let filter_query = Rc::new(RefCell::new(String::new()));
-        let query = filter_query.clone();
-        let filter = gtk::CustomFilter::new(move |item| {
-            let Some(item) = item.downcast_ref::<gtk::StringObject>() else {
-                return false;
-            };
-            let query = query.borrow();
-            query.is_empty()
-                || model_display_name(&item.string())
-                    .to_lowercase()
-                    .contains(query.as_str())
-        });
+        let show_hidden = Rc::new(Cell::new(false));
+        let filter = entry_filter(show_hidden.clone(), filter_query.clone());
         let filtered_model = gtk::FilterListModel::new(Some(model.clone()), Some(filter.clone()));
         let selection = gtk::MultiSelection::new(Some(filtered_model.clone()));
         let syncing_selection = Rc::new(Cell::new(false));
@@ -4046,6 +4046,7 @@ impl ViewState {
         let filtered_for_selection = filtered_model.clone();
         let syncing_selection_changed = syncing_selection.clone();
         let focused_filtered_changed = focused_filtered.clone();
+        let filter_for_column = filter.clone();
         selection.connect_selection_changed(move |selection, position, count| {
             if syncing_selection_changed.get() {
                 return;
@@ -4756,6 +4757,8 @@ impl ViewState {
             new_entry_row,
             new_entry_icon,
             new_entry_entry,
+            show_hidden,
+            filter: filter_for_column,
         });
 
         self.refresh_active_path_rows();
@@ -6880,7 +6883,8 @@ fn entry_model_value(entry: &FileEntry) -> String {
     } else {
         'f'
     };
-    format!("{kind}\t{}", entry.display_name)
+    let hidden = if entry.is_hidden { 'h' } else { 'v' };
+    format!("{kind}{hidden}\t{}", entry.display_name)
 }
 
 fn model_display_name(value: &str) -> &str {
@@ -6888,7 +6892,31 @@ fn model_display_name(value: &str) -> &str {
 }
 
 fn model_is_directory(value: &str) -> bool {
-    value.starts_with("d\t")
+    value.starts_with("d")
+}
+
+pub(super) fn model_is_hidden(value: &str) -> bool {
+    value.as_bytes().get(1) == Some(&b'h')
+}
+
+pub(super) fn entry_filter(
+    show_hidden: Rc<Cell<bool>>,
+    filter_query: Rc<RefCell<String>>,
+) -> gtk::CustomFilter {
+    gtk::CustomFilter::new(move |item| {
+        let Some(item) = item.downcast_ref::<gtk::StringObject>() else {
+            return false;
+        };
+        let value = item.string();
+        if !show_hidden.get() && model_is_hidden(&value) {
+            return false;
+        }
+        let query = filter_query.borrow();
+        query.is_empty()
+            || model_display_name(&value)
+                .to_lowercase()
+                .contains(query.as_str())
+    })
 }
 
 pub(super) fn entry_icon(entry: &FileEntry) -> &'static str {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -4034,7 +4034,11 @@ impl ViewState {
         let entry_count = Rc::new(Cell::new(0));
         let model = gtk::StringList::new(&[]);
         let filter_query = Rc::new(RefCell::new(String::new()));
-        let show_hidden = Rc::new(Cell::new(false));
+        let initial_show_hidden = self
+            .browser
+            .column_preferences(depth)
+            .map_or_else(|| self.browser.preferences().show_hidden, |p| p.show_hidden);
+        let show_hidden = Rc::new(Cell::new(initial_show_hidden));
         let filter = entry_filter(show_hidden.clone(), filter_query.clone());
         let filtered_model = gtk::FilterListModel::new(Some(model.clone()), Some(filter.clone()));
         let selection = gtk::MultiSelection::new(Some(filtered_model.clone()));
@@ -6873,7 +6877,7 @@ pub(super) fn rename_stem_end(name: &str) -> i32 {
     name[..end].chars().count().min(i32::MAX as usize) as i32
 }
 
-fn entry_model_value(entry: &FileEntry) -> String {
+pub(super) fn entry_model_value(entry: &FileEntry) -> String {
     let kind = if entry.is_broken_symbolic_link() {
         'x'
     } else if entry.is_directory() {

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1037,3 +1037,37 @@ fn trash_summary_does_not_stop_enumerating_siblings_after_one_branch_is_depth_tr
          not just the first next_files_future batch"
     );
 }
+
+#[test]
+fn entry_model_value_encodes_hidden_state_and_preserves_display_name() {
+    let visible = FileEntry {
+        location: Location::local("/fixture/photo"),
+        native_name: "photo".into(),
+        display_name: "photo".into(),
+        kind: crate::model::EntryKind::File,
+        size: crate::model::MetadataValue::Unknown,
+        modified_unix_seconds: crate::model::MetadataValue::Unknown,
+        is_hidden: false,
+    };
+    let hidden = FileEntry {
+        location: Location::local("/fixture/.config"),
+        native_name: ".config".into(),
+        display_name: ".config".into(),
+        kind: crate::model::EntryKind::Directory,
+        size: crate::model::MetadataValue::Unknown,
+        modified_unix_seconds: crate::model::MetadataValue::Unknown,
+        is_hidden: true,
+    };
+
+    let encoded_visible = entry_model_value(&visible);
+    let encoded_hidden = entry_model_value(&hidden);
+
+    assert_eq!(encoded_visible, "fv\tphoto");
+    assert_eq!(encoded_hidden, "dh\t.config");
+
+    assert!(!model_is_hidden(&encoded_visible));
+    assert!(model_is_hidden(&encoded_hidden));
+
+    assert_eq!(model_display_name(&encoded_visible), "photo");
+    assert_eq!(model_display_name(&encoded_hidden), ".config");
+}

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -11,6 +11,7 @@ fn terminal_shortcut_prefers_one_selected_directory() {
         kind,
         size: crate::model::MetadataValue::Unknown,
         modified_unix_seconds: crate::model::MetadataValue::Unknown,
+        is_hidden: false,
     };
     let directory = entry("selected", crate::model::EntryKind::Directory);
     let file = entry("notes.txt", crate::model::EntryKind::File);
@@ -183,6 +184,7 @@ fn delete_confirmation_labels_distinguish_files_and_folders() {
         kind: crate::model::EntryKind::File,
         size: crate::model::MetadataValue::Known(10),
         modified_unix_seconds: crate::model::MetadataValue::Unknown,
+        is_hidden: false,
     };
     let mut folder = file.clone();
     folder.kind = crate::model::EntryKind::Directory;
@@ -255,6 +257,7 @@ fn quick_preview_is_offered_only_for_supported_files() {
         kind,
         size: crate::model::MetadataValue::Unknown,
         modified_unix_seconds: crate::model::MetadataValue::Unknown,
+        is_hidden: false,
     };
 
     assert!(entry_supports_quick_preview(&entry(
@@ -356,6 +359,7 @@ fn multi_selection_summary_lists_at_most_three_names() {
         kind: crate::model::EntryKind::File,
         size: crate::model::MetadataValue::Unknown,
         modified_unix_seconds: crate::model::MetadataValue::Unknown,
+        is_hidden: false,
     };
 
     assert_eq!(

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -543,12 +543,13 @@ impl ModeViews {
             BrowserEvent::EntriesInserted { depth, insertions } => {
                 for pane in self.panes_at(*depth) {
                     for insertion in insertions {
-                        let values: Vec<_> = insertion
+                        let values: Vec<String> = insertion
                             .entries
                             .iter()
-                            .map(|entry| entry.display_name.as_str())
+                            .map(super::browser::entry_model_value)
                             .collect();
-                        pane.model.splice(insertion.position as u32, 0, &values);
+                        let values_ref: Vec<&str> = values.iter().map(String::as_str).collect();
+                        pane.model.splice(insertion.position as u32, 0, &values_ref);
                     }
                     if !pane.spinner.is_spinning() {
                         show_count(pane);
@@ -577,13 +578,17 @@ impl ModeViews {
             BrowserEvent::EntriesSpliced { depth, splices, .. } => {
                 for pane in self.panes_at(*depth) {
                     for splice in splices {
-                        let values: Vec<_> = splice
+                        let values: Vec<String> = splice
                             .entries
                             .iter()
-                            .map(|entry| entry.display_name.as_str())
+                            .map(super::browser::entry_model_value)
                             .collect();
-                        pane.model
-                            .splice(splice.position as u32, splice.removed as u32, &values);
+                        let values_ref: Vec<&str> = values.iter().map(String::as_str).collect();
+                        pane.model.splice(
+                            splice.position as u32,
+                            splice.removed as u32,
+                            &values_ref,
+                        );
                     }
                     show_count(pane);
                 }
@@ -1010,7 +1015,10 @@ fn build_grid_pane(
     }
     content.append(&controls.filter_revealer);
     let filter_query = Rc::new(RefCell::new(String::new()));
-    let show_hidden = Rc::new(Cell::new(false));
+    let initial_show_hidden = browser
+        .column_preferences(depth)
+        .map_or_else(|| browser.preferences().show_hidden, |p| p.show_hidden);
+    let show_hidden = Rc::new(Cell::new(initial_show_hidden));
     let filter = super::browser::entry_filter(show_hidden.clone(), filter_query.clone());
     let filtered_model = gtk::FilterListModel::new(Some(model.clone()), Some(filter.clone()));
     let filter_for_pane = filter.clone();
@@ -1604,7 +1612,10 @@ fn build_explorer_pane(
     }
     content.append(&filter_revealer);
     let filter_query = Rc::new(RefCell::new(String::new()));
-    let show_hidden = Rc::new(Cell::new(false));
+    let initial_show_hidden = browser
+        .column_preferences(depth)
+        .map_or_else(|| browser.preferences().show_hidden, |p| p.show_hidden);
+    let show_hidden = Rc::new(Cell::new(initial_show_hidden));
     let filter = super::browser::entry_filter(show_hidden.clone(), filter_query.clone());
     let filtered_model = gtk::FilterListModel::new(Some(model.clone()), Some(filter.clone()));
     let filter_for_pane = filter.clone();
@@ -2490,11 +2501,12 @@ fn refresh_cut_pane(pane: &Pane, browser: &Browser, cuts: &[Location]) {
 }
 
 fn replace_entries(pane: &Pane, entries: &[FileEntry]) {
-    let values: Vec<_> = entries
+    let values: Vec<String> = entries
         .iter()
-        .map(|entry| entry.display_name.as_str())
+        .map(super::browser::entry_model_value)
         .collect();
-    pane.model.splice(0, pane.model.n_items(), &values);
+    let values_ref: Vec<&str> = values.iter().map(String::as_str).collect();
+    pane.model.splice(0, pane.model.n_items(), &values_ref);
     show_count(pane);
 }
 

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -96,6 +96,8 @@ struct Pane {
     empty_trash_button: Option<gtk::Button>,
     new_entry_placeholder: Option<gtk::StringList>,
     new_entry_is_directory: Option<Rc<Cell<bool>>>,
+    show_hidden: Rc<Cell<bool>>,
+    filter: gtk::CustomFilter,
 }
 
 pub struct ModeViews {
@@ -177,6 +179,13 @@ impl ModeViews {
 
     pub fn widget(&self) -> gtk::Stack {
         self.stack.clone()
+    }
+
+    pub fn set_show_hidden(&self, show_hidden: bool) {
+        for pane in self.all_panes() {
+            pane.show_hidden.set(show_hidden);
+            pane.filter.changed(gtk::FilterChange::Different);
+        }
     }
 
     pub fn mode(&self) -> BrowserMode {
@@ -666,6 +675,13 @@ impl ModeViews {
         }
     }
 
+    fn all_panes(&self) -> Vec<&Pane> {
+        self.grid_panes
+            .iter()
+            .chain(self.explorer_pane.as_ref())
+            .collect()
+    }
+
     fn panes_at(&self, depth: usize) -> Vec<&Pane> {
         match self.mode {
             BrowserMode::Columns => Vec::new(),
@@ -994,15 +1010,10 @@ fn build_grid_pane(
     }
     content.append(&controls.filter_revealer);
     let filter_query = Rc::new(RefCell::new(String::new()));
-    let query = filter_query.clone();
-    let filter = gtk::CustomFilter::new(move |item| {
-        let Some(item) = item.downcast_ref::<gtk::StringObject>() else {
-            return false;
-        };
-        let query = query.borrow();
-        query.is_empty() || item.string().to_lowercase().contains(query.as_str())
-    });
+    let show_hidden = Rc::new(Cell::new(false));
+    let filter = super::browser::entry_filter(show_hidden.clone(), filter_query.clone());
     let filtered_model = gtk::FilterListModel::new(Some(model.clone()), Some(filter.clone()));
+    let filter_for_pane = filter.clone();
     let new_entry_placeholder = gtk::StringList::new(&[]);
     let new_entry_is_directory = Rc::new(Cell::new(true));
     let flattened_models = gio::ListStore::new::<gio::ListModel>();
@@ -1275,6 +1286,8 @@ fn build_grid_pane(
         empty_trash_button: controls.empty_trash_button,
         new_entry_placeholder: Some(new_entry_placeholder),
         new_entry_is_directory: Some(new_entry_is_directory),
+        show_hidden,
+        filter: filter_for_pane,
     }
 }
 
@@ -1591,15 +1604,10 @@ fn build_explorer_pane(
     }
     content.append(&filter_revealer);
     let filter_query = Rc::new(RefCell::new(String::new()));
-    let query = filter_query.clone();
-    let filter = gtk::CustomFilter::new(move |item| {
-        let Some(item) = item.downcast_ref::<gtk::StringObject>() else {
-            return false;
-        };
-        let query = query.borrow();
-        query.is_empty() || item.string().to_lowercase().contains(query.as_str())
-    });
+    let show_hidden = Rc::new(Cell::new(false));
+    let filter = super::browser::entry_filter(show_hidden.clone(), filter_query.clone());
     let filtered_model = gtk::FilterListModel::new(Some(model.clone()), Some(filter.clone()));
+    let filter_for_pane = filter.clone();
     filter_entry.connect_changed(move |entry| {
         *filter_query.borrow_mut() = entry.text().to_lowercase();
         filter.changed(gtk::FilterChange::Different);
@@ -1864,6 +1872,8 @@ fn build_explorer_pane(
         empty_trash_button: is_trash.then_some(empty_trash),
         new_entry_placeholder: Some(new_entry_placeholder),
         new_entry_is_directory: Some(new_entry_is_directory),
+        show_hidden,
+        filter: filter_for_pane,
     }
 }
 

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -251,6 +251,7 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
                 kind: EntryKind::File,
                 size: MetadataValue::Unknown,
                 modified_unix_seconds: MetadataValue::Unknown,
+                is_hidden: false,
             });
         }
     });


### PR DESCRIPTION
## Summary

- Store `is_hidden` on `FileEntry` at enumeration time
- Keep all entries in memory; filter hidden files at the UI level via `CustomFilter`
- `toggle_hidden` flips a boolean and calls `filter.changed()` — no disk re-enumeration, no monitor reinstallation
- Extracted shared `entry_filter()` helper to avoid duplicated filter closures across columns, grid, and explorer panes

## Why

Toggling hidden files re-enumerated every open column from disk AND tore down + reinstalled every directory monitor, all sequential on the main thread. For 5 open columns that's 5 disk reads + 5 monitor recreations — the freeze users see.

The fix keeps all entries (including hidden ones) in memory and lets GTK's virtualized `FilterListModel` hide/show them instantly. The `is_hidden` flag is encoded in the model value (`"dh\t.config"` vs `"dv\tREADME.md"`) so the filter closure can check it in O(1) without a side lookup.

Memory cost: ~132 bytes per hidden entry, bounded by the existing 100k `MAX_DIRECTORY_ENTRIES` cap. Negligible — a single thumbnail uses more RAM.

## Manual verification

1. Open a directory with several columns
2. Toggle "Show Hidden Files" on and off repeatedly
3. Toggle is instant with no freeze

## Expected result

Hidden files appear/disappear instantly on toggle with no UI freeze.

Closes #200