### PR TITLE
feat(sidebar): allow pinned folders to be reordered

### DIFF
--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -80,6 +80,8 @@ struct Preferences {
     browser_mode: String,
     #[serde(default = "default_browser_density")]
     browser_density: String,
+    #[serde(default = "default_sidebar_order")]
+    sidebar_order: Vec<String>,
     #[serde(default)]
     show_hidden: bool,
     #[serde(default = "default_enabled")]
@@ -109,6 +111,7 @@ impl Default for Preferences {
             reduce_motion: false,
             browser_mode: default_browser_mode(),
             browser_density: default_browser_density(),
+            sidebar_order: default_sidebar_order(),
             show_hidden: false,
             folders_first: true,
             sort_key: default_sort_key(),
@@ -138,6 +141,16 @@ fn default_video_preview_backend() -> String {
 
 fn default_browser_density() -> String {
     "compact".to_owned()
+}
+
+fn default_sidebar_order() -> Vec<String> {
+    vec![
+        "desktop".to_owned(),
+        "documents".to_owned(),
+        "downloads".to_owned(),
+        "pictures".to_owned(),
+        "videos".to_owned(),
+    ]
 }
 
 fn default_sort_key() -> String {
@@ -347,6 +360,15 @@ impl ThemeManager {
             super::browser_modes::BrowserDensity::Airy => "airy",
         }
         .to_owned();
+        self.save_preferences();
+    }
+
+    pub fn sidebar_order(&self) -> Vec<String> {
+        self.preferences.borrow().sidebar_order.clone()
+    }
+
+    pub fn set_sidebar_order(&self, order: Vec<String>) {
+        self.preferences.borrow_mut().sidebar_order = order;
         self.save_preferences();
     }
 

--- a/src/ui/theme/tests.rs
+++ b/src/ui/theme/tests.rs
@@ -371,3 +371,39 @@ fn video_preview_backends_round_trip_and_invalid_values_fall_back() {
         MediaPreviewBackend::Automatic
     );
 }
+
+#[test]
+fn sidebar_order_defaults_to_the_canonical_place_list() {
+    let preferences = Preferences::default();
+    assert_eq!(
+        preferences.sidebar_order,
+        ["desktop", "documents", "downloads", "pictures", "videos"]
+    );
+}
+
+#[test]
+fn sidebar_order_round_trips_through_toml() {
+    let preferences = Preferences {
+        sidebar_order: vec!["videos".to_owned(), "desktop".to_owned()],
+        ..Preferences::default()
+    };
+    let serialized = toml::to_string(&preferences).expect("preferences should serialize");
+    let restored: Preferences =
+        toml::from_str(&serialized).expect("preferences should deserialize");
+    assert_eq!(restored.sidebar_order, ["videos", "desktop"]);
+}
+
+#[test]
+fn legacy_preferences_without_sidebar_order_default_to_the_canonical_list() {
+    let preferences: Preferences = toml::from_str(
+        r#"
+mode = "theme"
+theme = "azure-glow"
+"#,
+    )
+    .expect("legacy preferences without sidebar_order should remain valid");
+    assert_eq!(
+        preferences.sidebar_order,
+        ["desktop", "documents", "downloads", "pictures", "videos"]
+    );
+}

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -1244,37 +1244,20 @@ impl SidebarState {
         self.widget.append(&row);
     }
 
-    fn append_reorderable_place(
+    fn make_reorderable(
         self: &Rc<Self>,
-        id: &'static str,
-        icon: &str,
-        name: &str,
-        location: Location,
+        row: &gtk::Button,
+        payload: impl Fn() -> String + 'static,
+        on_drop: impl Fn(&Rc<Self>, &str, bool) -> bool + 'static,
     ) {
-        let row = sidebar_button(icon, name);
         row.add_css_class("reorderable");
         row.set_cursor_from_name(Some("grab"));
-        row.set_tooltip_text(Some(&location.display_path()));
-        self.place_rows
-            .borrow_mut()
-            .push((location.clone(), row.clone()));
-        let weak_browser = Rc::downgrade(&self.browser);
-        let sidebar = self.widget.clone();
-        let selected_row = row.clone();
-        row.connect_clicked(move |_| {
-            select_sidebar_row(&sidebar, &selected_row);
-            if let Some(browser) = weak_browser.upgrade() {
-                browser.navigate(location.clone());
-            }
-        });
 
         let drag = gtk::DragSource::builder()
             .actions(gtk::gdk::DragAction::MOVE)
             .build();
         drag.connect_prepare(move |_, _, _| {
-            Some(gtk::gdk::ContentProvider::for_value(
-                &id.to_string().to_value(),
-            ))
+            Some(gtk::gdk::ContentProvider::for_value(&payload().to_value()))
         });
         let dragged_row = row.clone();
         drag.connect_drag_begin(move |_, _| {
@@ -1295,17 +1278,50 @@ impl SidebarState {
             let Ok(source) = value.get::<String>() else {
                 return false;
             };
-            if source.starts_with(PINNED_DRAG_PREFIX) {
-                return false;
-            }
             let after = y >= f64::from(target_row.height()) / 2.0;
             if let Some(state) = weak_state.upgrade() {
-                state.reorder_place(&source, id, after);
-                return true;
+                return on_drop(&state, &source, after);
             }
             false
         });
         row.add_controller(drop);
+    }
+
+    fn append_reorderable_place(
+        self: &Rc<Self>,
+        id: &'static str,
+        icon: &str,
+        name: &str,
+        location: Location,
+    ) {
+        let row = sidebar_button(icon, name);
+        row.set_tooltip_text(Some(&location.display_path()));
+        self.place_rows
+            .borrow_mut()
+            .push((location.clone(), row.clone()));
+        let weak_browser = Rc::downgrade(&self.browser);
+        let sidebar = self.widget.clone();
+        let selected_row = row.clone();
+        row.connect_clicked(move |_| {
+            select_sidebar_row(&sidebar, &selected_row);
+            if let Some(browser) = weak_browser.upgrade() {
+                browser.navigate(location.clone());
+            }
+        });
+
+        self.make_reorderable(
+            &row,
+            // Standard rows drag their stable id, so a pinned row's numeric
+            // payload is rejected by the standard-place drop handler.
+            move || id.to_string(),
+            move |state, source, after| {
+                if source.starts_with(PINNED_DRAG_PREFIX) {
+                    return false;
+                }
+                state.reorder_place(source, id, after);
+                true
+            },
+        );
         self.widget.append(&row);
     }
 
@@ -1512,47 +1528,17 @@ impl SidebarState {
     }
 
     fn make_pinned_row_reorderable(self: &Rc<Self>, row: &gtk::Button, index: usize) {
-        row.add_css_class("reorderable");
-        row.set_cursor_from_name(Some("grab"));
-
-        let drag = gtk::DragSource::builder()
-            .actions(gtk::gdk::DragAction::MOVE)
-            .build();
-        drag.connect_prepare(move |_, _, _| {
-            Some(gtk::gdk::ContentProvider::for_value(
-                &format!("{PINNED_DRAG_PREFIX}{index}").to_value(),
-            ))
-        });
-        let dragged_row = row.clone();
-        drag.connect_drag_begin(move |_, _| {
-            dragged_row.add_css_class("dragging");
-            dragged_row.set_cursor_from_name(Some("grabbing"));
-        });
-        let dragged_row = row.clone();
-        drag.connect_drag_end(move |_, _, _| {
-            dragged_row.remove_css_class("dragging");
-            dragged_row.set_cursor_from_name(Some("grab"));
-        });
-        row.add_controller(drag);
-
-        let drop = gtk::DropTarget::new(String::static_type(), gtk::gdk::DragAction::MOVE);
-        let weak_state = Rc::downgrade(self);
-        let target_row = row.clone();
-        drop.connect_drop(move |_, value, _, y| {
-            let Ok(source) = value.get::<String>() else {
-                return false;
-            };
-            let Some(source) = parse_pinned_drag_source(&source) else {
-                return false;
-            };
-            let after = y >= f64::from(target_row.height()) / 2.0;
-            if let Some(state) = weak_state.upgrade() {
+        self.make_reorderable(
+            row,
+            move || format!("{PINNED_DRAG_PREFIX}{index}"),
+            move |state, source, after| {
+                let Some(source) = parse_pinned_drag_source(source) else {
+                    return false;
+                };
                 state.reorder_pinned_place(source, index, after);
-                return true;
-            }
-            false
-        });
-        row.add_controller(drop);
+                true
+            },
+        );
     }
 
     fn append_place(&self, icon: &str, name: &str, location: Location) -> gtk::Button {
@@ -1612,6 +1598,10 @@ fn reorder_pinned_places(
         return false;
     }
     let place = places.remove(source);
+    // `source` is a pre-removal index, but `target` must remap onto the shrunken
+    // vector: any target that sat after `source` slides left by one. Since
+    // `destination == source` is checked in post-removal coordinates, a match
+    // means re-inserting into the original slot — a no-op worth reporting.
     let target = target - usize::from(target > source);
     let destination = (target + usize::from(after)).min(places.len());
     if destination == source {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -30,6 +30,7 @@ const SIDEBAR_WIDTH: i32 = 208;
 const MIN_SIDEBAR_WIDTH: i32 = 176;
 const SIDEBAR_TRANSITION: Duration = Duration::from_millis(300);
 const PINNED_DRAG_PREFIX: &str = "pinned:";
+const STANDARD_PLACE_IDS: &[&str] = &["desktop", "documents", "downloads", "pictures", "videos"];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum MouseHistoryAction {
@@ -155,7 +156,7 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
     content.set_resize_start_child(false);
     content.set_position(SIDEBAR_WIDTH);
     content.set_vexpand(true);
-    let sidebar = build_sidebar(browser.clone());
+    let sidebar = build_sidebar(browser.clone(), theme_manager.clone());
     let weak_sidebar = Rc::downgrade(&sidebar.state);
     let pinned_places = sidebar.state.pinned_places.clone();
     browser.set_pin_handlers(
@@ -1035,6 +1036,7 @@ struct SidebarState {
     view: BrowserView,
     browser: Rc<Browser>,
     volume_monitor: gio::VolumeMonitor,
+    theme_manager: Rc<super::theme::ThemeManager>,
     place_order: RefCell<Vec<&'static str>>,
     pinned_places: Rc<RefCell<Vec<(Location, String)>>>,
     place_rows: RefCell<Vec<(Location, gtk::Button)>>,
@@ -1328,6 +1330,13 @@ impl SidebarState {
     fn reorder_place(self: &Rc<Self>, source: &str, target: &str, after: bool) {
         let changed = reorder_places(&mut self.place_order.borrow_mut(), source, target, after);
         if changed {
+            let order = self
+                .place_order
+                .borrow()
+                .iter()
+                .map(|place| (*place).to_owned())
+                .collect();
+            self.theme_manager.set_sidebar_order(order);
             self.rebuild();
         }
     }
@@ -1662,6 +1671,25 @@ fn should_show_standard_place(id: &str, path: &std::path::Path, home: &std::path
     id != "desktop" || path != home
 }
 
+fn resolve_place_order(persisted: &[String]) -> Vec<&'static str> {
+    let mut order: Vec<&'static str> = Vec::new();
+    for id in persisted {
+        if let Some(canonical) = STANDARD_PLACE_IDS
+            .iter()
+            .find(|&&known| known == id.as_str())
+            && !order.contains(canonical)
+        {
+            order.push(*canonical);
+        }
+    }
+    for &id in STANDARD_PLACE_IDS {
+        if !order.contains(&id) {
+            order.push(id);
+        }
+    }
+    order
+}
+
 fn standard_place(id: &str) -> Option<(&'static str, &'static str, glib::UserDirectory)> {
     match id {
         "desktop" => Some((
@@ -1753,7 +1781,7 @@ fn sidebar_update_label(release: &ReleaseMetadata) -> String {
     }
 }
 
-fn build_sidebar(view: BrowserView) -> SidebarView {
+fn build_sidebar(view: BrowserView, theme_manager: Rc<super::theme::ThemeManager>) -> SidebarView {
     let widget = gtk::Box::new(gtk::Orientation::Vertical, 2);
     widget.add_css_class("sidebar");
     let scroller = gtk::ScrolledWindow::builder()
@@ -1794,18 +1822,14 @@ fn build_sidebar(view: BrowserView) -> SidebarView {
     shell.append(&scroller);
     shell.append(&update_area);
     let volume_monitor = gio::VolumeMonitor::get();
+    let place_order = resolve_place_order(&theme_manager.sidebar_order());
     let state = Rc::new(SidebarState {
         widget,
         browser: view.browser(),
         view,
         volume_monitor,
-        place_order: RefCell::new(vec![
-            "desktop",
-            "documents",
-            "downloads",
-            "pictures",
-            "videos",
-        ]),
+        theme_manager,
+        place_order: RefCell::new(place_order),
         pinned_places: Rc::new(RefCell::new(load_pinned_places())),
         place_rows: RefCell::new(Vec::new()),
     });

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -29,6 +29,7 @@ use super::{
 const SIDEBAR_WIDTH: i32 = 208;
 const MIN_SIDEBAR_WIDTH: i32 = 176;
 const SIDEBAR_TRANSITION: Duration = Duration::from_millis(300);
+const PINNED_DRAG_PREFIX: &str = "pinned:";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum MouseHistoryAction {
@@ -1089,14 +1090,15 @@ impl SidebarState {
             .pinned_places
             .borrow()
             .iter()
-            .filter(|(location, _)| !is_standard_place_location(location))
-            .cloned()
+            .enumerate()
+            .filter(|(_, (location, _))| !is_standard_place_location(location))
+            .map(|(index, (location, name))| (index, location.clone(), name.clone()))
             .collect::<Vec<_>>();
         if !pinned.is_empty() {
             self.append_separator();
             self.append_heading("PINNED");
-            for (location, name) in pinned {
-                self.append_pinned_place(&name, location);
+            for (index, location, name) in pinned {
+                self.append_pinned_place(index, &name, location);
             }
         }
 
@@ -1293,6 +1295,9 @@ impl SidebarState {
             let Ok(source) = value.get::<String>() else {
                 return false;
             };
+            if source.starts_with(PINNED_DRAG_PREFIX) {
+                return false;
+            }
             let after = y >= f64::from(target_row.height()) / 2.0;
             if let Some(state) = weak_state.upgrade() {
                 state.reorder_place(&source, id, after);
@@ -1307,6 +1312,15 @@ impl SidebarState {
     fn reorder_place(self: &Rc<Self>, source: &str, target: &str, after: bool) {
         let changed = reorder_places(&mut self.place_order.borrow_mut(), source, target, after);
         if changed {
+            self.rebuild();
+        }
+    }
+
+    fn reorder_pinned_place(self: &Rc<Self>, source: usize, target: usize, after: bool) {
+        let changed =
+            reorder_pinned_places(&mut self.pinned_places.borrow_mut(), source, target, after);
+        if changed {
+            save_pinned_places(&self.pinned_places.borrow());
             self.rebuild();
         }
     }
@@ -1441,8 +1455,9 @@ impl SidebarState {
         row.add_controller(context);
     }
 
-    fn append_pinned_place(self: &Rc<Self>, name: &str, location: Location) {
+    fn append_pinned_place(self: &Rc<Self>, index: usize, name: &str, location: Location) {
         let row = self.append_place(crate::assets::icons::FOLDER, name, location.clone());
+        self.make_pinned_row_reorderable(&row, index);
         let menu = gtk::Box::new(gtk::Orientation::Vertical, 0);
         menu.add_css_class("folder-context-menu");
         let unpin = sidebar_context_option(crate::assets::icons::PIN, "Unpin", false);
@@ -1496,6 +1511,50 @@ impl SidebarState {
         row.add_controller(context);
     }
 
+    fn make_pinned_row_reorderable(self: &Rc<Self>, row: &gtk::Button, index: usize) {
+        row.add_css_class("reorderable");
+        row.set_cursor_from_name(Some("grab"));
+
+        let drag = gtk::DragSource::builder()
+            .actions(gtk::gdk::DragAction::MOVE)
+            .build();
+        drag.connect_prepare(move |_, _, _| {
+            Some(gtk::gdk::ContentProvider::for_value(
+                &format!("{PINNED_DRAG_PREFIX}{index}").to_value(),
+            ))
+        });
+        let dragged_row = row.clone();
+        drag.connect_drag_begin(move |_, _| {
+            dragged_row.add_css_class("dragging");
+            dragged_row.set_cursor_from_name(Some("grabbing"));
+        });
+        let dragged_row = row.clone();
+        drag.connect_drag_end(move |_, _, _| {
+            dragged_row.remove_css_class("dragging");
+            dragged_row.set_cursor_from_name(Some("grab"));
+        });
+        row.add_controller(drag);
+
+        let drop = gtk::DropTarget::new(String::static_type(), gtk::gdk::DragAction::MOVE);
+        let weak_state = Rc::downgrade(self);
+        let target_row = row.clone();
+        drop.connect_drop(move |_, value, _, y| {
+            let Ok(source) = value.get::<String>() else {
+                return false;
+            };
+            let Some(source) = parse_pinned_drag_source(&source) else {
+                return false;
+            };
+            let after = y >= f64::from(target_row.height()) / 2.0;
+            if let Some(state) = weak_state.upgrade() {
+                state.reorder_pinned_place(source, index, after);
+                return true;
+            }
+            false
+        });
+        row.add_controller(drop);
+    }
+
     fn append_place(&self, icon: &str, name: &str, location: Location) -> gtk::Button {
         let row = sidebar_button(icon, name);
         row.set_tooltip_text(Some(&location.display_path()));
@@ -1541,6 +1600,30 @@ fn reorder_places(order: &mut Vec<&'static str>, source: &str, target: &str, aft
     };
     order.insert(target_index + usize::from(after), source);
     true
+}
+
+fn reorder_pinned_places(
+    places: &mut Vec<(Location, String)>,
+    source: usize,
+    target: usize,
+    after: bool,
+) -> bool {
+    if source == target || source >= places.len() || target >= places.len() {
+        return false;
+    }
+    let place = places.remove(source);
+    let target = target - usize::from(target > source);
+    let destination = (target + usize::from(after)).min(places.len());
+    if destination == source {
+        places.insert(source, place);
+        return false;
+    }
+    places.insert(destination, place);
+    true
+}
+
+fn parse_pinned_drag_source(source: &str) -> Option<usize> {
+    source.strip_prefix(PINNED_DRAG_PREFIX)?.parse().ok()
 }
 
 fn pin_status(places: &[(Location, String)], location: &Location) -> PinStatus {

--- a/src/ui/window/tests.rs
+++ b/src/ui/window/tests.rs
@@ -6,9 +6,9 @@ use crate::services::{BuildKind, ReleaseMetadata};
 
 use super::{
     MouseHistoryAction, PinStatus, is_open_terminal_shortcut, is_sidebar_focus_shortcut,
-    is_smb_location, is_standard_place_location, mouse_history_action, parse_pinned_places,
-    pin_status, remove_pinned_place, reorder_places, serialize_pinned_places,
-    should_show_standard_place, sidebar_update_label, vim_focus_direction,
+    is_smb_location, is_standard_place_location, mouse_history_action, parse_pinned_drag_source,
+    parse_pinned_places, pin_status, remove_pinned_place, reorder_pinned_places, reorder_places,
+    serialize_pinned_places, should_show_standard_place, sidebar_update_label, vim_focus_direction,
 };
 
 fn release(version: &str, kind: BuildKind) -> ReleaseMetadata {
@@ -135,6 +135,74 @@ fn invalid_place_reorders_leave_the_order_unchanged() {
     assert!(!reorder_places(&mut places, "desktop", "missing", false));
     assert!(!reorder_places(&mut places, "desktop", "desktop", false));
     assert_eq!(places, original);
+}
+
+fn pinned(paths: &[&str]) -> Vec<(crate::model::Location, String)> {
+    paths
+        .iter()
+        .map(|path| {
+            (
+                crate::model::Location::local(format!("/home/user/{path}")),
+                (*path).to_owned(),
+            )
+        })
+        .collect()
+}
+
+fn pinned_names(places: &[(crate::model::Location, String)]) -> Vec<&str> {
+    places.iter().map(|(_, name)| name.as_str()).collect()
+}
+
+#[test]
+fn pinned_places_can_move_before_an_earlier_place() {
+    let mut places = pinned(&["Projects", "Notes", "Archive"]);
+
+    assert!(reorder_pinned_places(&mut places, 2, 0, false));
+    assert_eq!(pinned_names(&places), ["Archive", "Projects", "Notes"]);
+}
+
+#[test]
+fn pinned_places_can_move_after_a_later_place() {
+    let mut places = pinned(&["Projects", "Notes", "Archive"]);
+
+    assert!(reorder_pinned_places(&mut places, 0, 2, true));
+    assert_eq!(pinned_names(&places), ["Notes", "Archive", "Projects"]);
+}
+
+#[test]
+fn pinned_reorders_that_keep_the_position_are_ignored() {
+    let original = pinned(&["Projects", "Notes", "Archive"]);
+    let mut places = original.clone();
+
+    assert!(!reorder_pinned_places(&mut places, 1, 1, false));
+    assert!(!reorder_pinned_places(&mut places, 1, 0, true));
+    assert!(!reorder_pinned_places(&mut places, 1, 2, false));
+    assert_eq!(places, original);
+}
+
+#[test]
+fn out_of_range_pinned_reorders_leave_the_order_unchanged() {
+    let original = pinned(&["Projects", "Notes"]);
+    let mut places = original.clone();
+
+    assert!(!reorder_pinned_places(&mut places, 5, 0, false));
+    assert!(!reorder_pinned_places(&mut places, 0, 5, true));
+    assert_eq!(places, original);
+}
+
+#[test]
+fn pinned_reorders_leave_the_other_places_untouched() {
+    let mut places = pinned(&["Documents", "Projects", "Notes"]);
+
+    assert!(reorder_pinned_places(&mut places, 2, 1, false));
+    assert_eq!(pinned_names(&places), ["Documents", "Notes", "Projects"]);
+}
+
+#[test]
+fn only_pinned_drag_payloads_resolve_to_a_pinned_place() {
+    assert_eq!(parse_pinned_drag_source("pinned:3"), Some(3));
+    assert_eq!(parse_pinned_drag_source("documents"), None);
+    assert_eq!(parse_pinned_drag_source("pinned:documents"), None);
 }
 
 #[test]

--- a/src/ui/window/tests.rs
+++ b/src/ui/window/tests.rs
@@ -5,10 +5,11 @@ use std::path::Path;
 use crate::services::{BuildKind, ReleaseMetadata};
 
 use super::{
-    MouseHistoryAction, PinStatus, is_open_terminal_shortcut, is_sidebar_focus_shortcut,
-    is_smb_location, is_standard_place_location, mouse_history_action, parse_pinned_drag_source,
-    parse_pinned_places, pin_status, remove_pinned_place, reorder_pinned_places, reorder_places,
-    serialize_pinned_places, should_show_standard_place, sidebar_update_label, vim_focus_direction,
+    MouseHistoryAction, PinStatus, STANDARD_PLACE_IDS, is_open_terminal_shortcut,
+    is_sidebar_focus_shortcut, is_smb_location, is_standard_place_location, mouse_history_action,
+    parse_pinned_drag_source, parse_pinned_places, pin_status, remove_pinned_place,
+    reorder_pinned_places, reorder_places, resolve_place_order, serialize_pinned_places,
+    should_show_standard_place, sidebar_update_label, standard_place, vim_focus_direction,
 };
 
 fn release(version: &str, kind: BuildKind) -> ReleaseMetadata {
@@ -135,6 +136,56 @@ fn invalid_place_reorders_leave_the_order_unchanged() {
     assert!(!reorder_places(&mut places, "desktop", "missing", false));
     assert!(!reorder_places(&mut places, "desktop", "desktop", false));
     assert_eq!(places, original);
+}
+
+fn persisted_order(ids: &[&str]) -> Vec<String> {
+    ids.iter().map(|id| (*id).to_owned()).collect()
+}
+
+#[test]
+fn every_reorderable_place_id_is_a_known_standard_place() {
+    for id in STANDARD_PLACE_IDS {
+        assert!(
+            standard_place(id).is_some(),
+            "{id} must be a standard place"
+        );
+    }
+}
+
+#[test]
+fn a_persisted_place_order_is_restored_exactly() {
+    let order = resolve_place_order(&persisted_order(&["videos", "downloads", "desktop"]));
+    assert_eq!(
+        order,
+        vec!["videos", "downloads", "desktop", "documents", "pictures"]
+    );
+}
+
+#[test]
+fn unknown_persisted_place_ids_are_dropped() {
+    let order = resolve_place_order(&persisted_order(&["desktop", "archive", "videos"]));
+    assert_eq!(
+        order,
+        vec!["desktop", "videos", "documents", "downloads", "pictures"]
+    );
+}
+
+#[test]
+fn missing_places_are_appended_in_default_order() {
+    let order = resolve_place_order(&persisted_order(&["pictures"]));
+    assert_eq!(
+        order,
+        vec!["pictures", "desktop", "documents", "downloads", "videos"]
+    );
+}
+
+#[test]
+fn duplicate_persisted_place_ids_are_deduplicated() {
+    let order = resolve_place_order(&persisted_order(&["desktop", "desktop", "videos"]));
+    assert_eq!(
+        order,
+        vec!["desktop", "videos", "documents", "downloads", "pictures"]
+    );
 }
 
 fn pinned(paths: &[&str]) -> Vec<(crate::model::Location, String)> {


### PR DESCRIPTION
## Description

Pinned folders could only be arranged by unpinning and re-pinning them. They are now reorderable by drag and drop, using the same interaction, cursor, and drop styling as the standard folders (Desktop, Documents, Downloads, …).

Reordering stays inside the Pinned section: the drag payload is namespaced with a `pinned:` prefix, so a standard row rejects a pinned payload and a pinned row rejects a standard one. Rows carry their index into the stored bookmark list, so bookmarks hidden from the Pinned section (those that resolve to standard folders) keep their place in the file. The new order is written back to the GTK bookmarks file, so it is restored on the next launch.

## Visual evidence

N/A — no new elements or styling. The rows reuse the existing `.sidebar-row.reorderable` drag/drop appearance, so before/after screenshots are identical outside of the drag itself.

## How to test

1. Pin at least three folders (right-click a folder in the file list → Pin).
2. Drag a pinned row above and below other pinned rows; drop on the upper half of a row to place it before, the lower half to place it after.
3. Try dragging a pinned row onto a standard folder row, and a standard folder row onto a pinned row.
4. Restart Strata.

**Expected result:** Pinned rows reorder to the drop position and the Pinned section keeps its own order; cross-section drags do nothing; the order from step 2 is still in place after the restart.

## Related issue

Closes #184
