### PR TITLE
feat(selection): start marquee drags from chrome beside file panes

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1283,6 +1283,15 @@ switch:checked slider {
   border-right: 1px solid alpha(@theme_border, 0.6);
 }
 
+.sidebar-scroll scrollbar.vertical {
+  min-width: 10px;
+}
+
+.sidebar-scroll scrollbar.vertical slider {
+  margin: 3px;
+  min-width: 4px;
+}
+
 .sidebar {
   background: @theme_surface;
   padding: 8px 7px;

--- a/src/style.css
+++ b/src/style.css
@@ -1283,21 +1283,35 @@ switch:checked slider {
   border-right: 1px solid alpha(@theme_border, 0.6);
 }
 
-.sidebar-scroll scrollbar.vertical,
-.sidebar-scroll scrollbar.vertical:hover,
-.sidebar-scroll scrollbar.vertical.hovering,
-.sidebar-scroll scrollbar.vertical.dragging {
+.fixed-scrollbar scrollbar,
+.fixed-scrollbar scrollbar:hover,
+.fixed-scrollbar scrollbar.hovering,
+.fixed-scrollbar scrollbar.dragging {
   background: transparent;
   border: none;
-  min-width: 5px;
   padding: 0;
   transition: none;
 }
 
-.sidebar-scroll scrollbar.vertical > range > trough > slider {
+.fixed-scrollbar scrollbar.vertical {
+  min-width: 5px;
+}
+
+.fixed-scrollbar scrollbar.horizontal {
+  min-height: 5px;
+}
+
+.fixed-scrollbar scrollbar > range > trough > slider {
   border-width: 1px;
   margin: 0;
+}
+
+.fixed-scrollbar scrollbar.vertical > range > trough > slider {
   min-width: 3px;
+}
+
+.fixed-scrollbar scrollbar.horizontal > range > trough > slider {
+  min-height: 3px;
 }
 
 .sidebar {

--- a/src/style.css
+++ b/src/style.css
@@ -1283,13 +1283,21 @@ switch:checked slider {
   border-right: 1px solid alpha(@theme_border, 0.6);
 }
 
-.sidebar-scroll scrollbar.vertical {
-  min-width: 10px;
+.sidebar-scroll scrollbar.vertical,
+.sidebar-scroll scrollbar.vertical:hover,
+.sidebar-scroll scrollbar.vertical.hovering,
+.sidebar-scroll scrollbar.vertical.dragging {
+  background: transparent;
+  border: none;
+  min-width: 5px;
+  padding: 0;
+  transition: none;
 }
 
-.sidebar-scroll scrollbar.vertical slider {
-  margin: 3px;
-  min-width: 4px;
+.sidebar-scroll scrollbar.vertical > range > trough > slider {
+  border-width: 1px;
+  margin: 0;
+  min-width: 3px;
 }
 
 .sidebar {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -68,7 +68,7 @@ struct ColumnView {
     selection: gtk::MultiSelection,
     syncing_selection: Rc<Cell<bool>>,
     list: gtk::ListView,
-    marquee: gtk::Box,
+    marquee: super::marquee::Marquee,
     bound_rows: Rc<RefCell<Vec<BoundRow>>>,
     entry_count: Rc<Cell<usize>>,
     spinner: gtk::Spinner,
@@ -448,6 +448,27 @@ impl BrowserView {
             auto_refresh: RefCell::new(None),
             browser,
         });
+
+        // Columns are laid out from the start edge, so the blank strip beside the last
+        // one is the natural place to begin a marquee that runs into it.
+        let weak_state = Rc::downgrade(&state);
+        super::marquee::install_shared_origin_surface(
+            &state.scroller,
+            move |surface, picked, x, _| {
+                if picked.is::<gtk::Scrollbar>()
+                    || picked.ancestor(gtk::Scrollbar::static_type()).is_some()
+                {
+                    return None;
+                }
+                let state = weak_state.upgrade()?;
+                let laid_out = state.columns_widget.compute_bounds(surface)?;
+                if x < f64::from(laid_out.x() + laid_out.width()) {
+                    return None;
+                }
+                let columns = state.columns.borrow();
+                columns.last().map(|column| column.marquee.clone())
+            },
+        );
 
         let weak_state = Rc::downgrade(&state);
         state.mode_views.borrow().set_transfer_handler(Rc::new(
@@ -4469,117 +4490,6 @@ impl ViewState {
         list.set_single_click_activate(false);
         list.set_vexpand(true);
 
-        let marquee_box = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-        marquee_box.add_css_class("file-marquee");
-        marquee_box.set_can_target(false);
-        marquee_box.set_halign(gtk::Align::Start);
-        marquee_box.set_valign(gtk::Align::Start);
-        marquee_box.set_visible(false);
-        self.overlay.add_overlay(&marquee_box);
-
-        let marquee_active = Rc::new(Cell::new(false));
-        let marquee_origin = Rc::new(Cell::new((0.0, 0.0)));
-        let marquee_initial = Rc::new(RefCell::new(gtk::Bitset::new_empty()));
-        let marquee_modifiers = Rc::new(Cell::new((false, false)));
-        let marquee = gtk::GestureDrag::new();
-        marquee.set_button(1);
-        marquee.set_propagation_phase(gtk::PropagationPhase::Capture);
-        let active_for_begin = marquee_active.clone();
-        let origin_for_begin = marquee_origin.clone();
-        let initial_for_begin = marquee_initial.clone();
-        let modifiers_for_begin = marquee_modifiers.clone();
-        let selection_for_begin = selection.clone();
-        let marquee_box_for_begin = marquee_box.clone();
-        marquee.connect_drag_begin(move |gesture, x, y| {
-            let starts_on_row = gesture
-                .widget()
-                .and_then(|widget| widget.pick(x, y, gtk::PickFlags::DEFAULT))
-                .is_some_and(is_file_row_target);
-            let force_marquee = gesture
-                .current_event_state()
-                .contains(gtk::gdk::ModifierType::ALT_MASK);
-            let can_start = force_marquee || !starts_on_row;
-            active_for_begin.set(can_start);
-            if !can_start {
-                return;
-            }
-            gesture.set_state(gtk::EventSequenceState::Claimed);
-            marquee_box_for_begin.set_visible(true);
-            origin_for_begin.set((x, y));
-            initial_for_begin.replace(selection_for_begin.selection().copy());
-            let modifiers = gesture.current_event_state();
-            modifiers_for_begin.set((
-                modifiers.contains(gtk::gdk::ModifierType::CONTROL_MASK),
-                modifiers.contains(gtk::gdk::ModifierType::SHIFT_MASK),
-            ));
-        });
-        let active_for_update = marquee_active.clone();
-        let origin_for_update = marquee_origin.clone();
-        let initial_for_update = marquee_initial.clone();
-        let modifiers_for_update = marquee_modifiers.clone();
-        let selection_for_marquee = selection.clone();
-        let rows_for_marquee = bound_rows.clone();
-        let list_for_marquee = list.clone();
-        let overlay_for_marquee = self.overlay.clone();
-        let marquee_box_for_update = marquee_box.clone();
-        marquee.connect_drag_update(move |_, offset_x, offset_y| {
-            if !active_for_update.get() {
-                return;
-            }
-            let (origin_x, origin_y) = origin_for_update.get();
-            let current_x = origin_x + offset_x;
-            let current_y = origin_y + offset_y;
-            let left = origin_x.min(current_x);
-            let right = origin_x.max(current_x);
-            let top = origin_y.min(current_y);
-            let bottom = origin_y.max(current_y);
-            if let Some(list_bounds) = list_for_marquee.compute_bounds(&overlay_for_marquee) {
-                marquee_box_for_update
-                    .set_margin_start((f64::from(list_bounds.x()) + left).round().max(0.0) as i32);
-                marquee_box_for_update
-                    .set_margin_top((f64::from(list_bounds.y()) + top).round().max(0.0) as i32);
-                marquee_box_for_update.set_size_request(
-                    (right - left).round().max(1.0) as i32,
-                    (bottom - top).round().max(1.0) as i32,
-                );
-            }
-            let initial = initial_for_update.borrow();
-            let (control, shift) = modifiers_for_update.get();
-            let selected = if control || shift {
-                initial.copy()
-            } else {
-                gtk::Bitset::new_empty()
-            };
-            rows_for_marquee.borrow_mut().retain(|bound| {
-                let (Some(item), Some(row)) = (bound.item.upgrade(), bound.row.upgrade()) else {
-                    return false;
-                };
-                let Some(bounds) = row.compute_bounds(&list_for_marquee) else {
-                    return true;
-                };
-                let intersects = f64::from(bounds.x()) < right
-                    && f64::from(bounds.x() + bounds.width()) > left
-                    && f64::from(bounds.y()) < bottom
-                    && f64::from(bounds.y() + bounds.height()) > top;
-                let position = item.position();
-                if intersects && position != gtk::INVALID_LIST_POSITION {
-                    if control && initial.contains(position) {
-                        selected.remove(position);
-                    } else {
-                        selected.add(position);
-                    }
-                }
-                true
-            });
-            let mask = gtk::Bitset::new_range(0, selection_for_marquee.n_items());
-            selection_for_marquee.set_selection(&selected, &mask);
-        });
-        let active_for_end = marquee_active.clone();
-        let marquee_box_for_end = marquee_box.clone();
-        marquee.connect_drag_end(move |_, _, _| {
-            active_for_end.set(false);
-            marquee_box_for_end.set_visible(false);
-        });
         let clear_selection = gtk::GestureClick::new();
         clear_selection.set_button(1);
         let background_press = Rc::new(Cell::new((0.0, 0.0)));
@@ -4599,7 +4509,6 @@ impl ViewState {
                 mouse_selection_anchor_for_background.set(None);
             }
         });
-        list.add_controller(marquee);
         list.add_controller(clear_selection);
         let selection_keys = gtk::EventControllerKey::new();
         selection_keys.set_propagation_phase(gtk::PropagationPhase::Capture);
@@ -4638,6 +4547,26 @@ impl ViewState {
             .hscrollbar_policy(gtk::PolicyType::Never)
             .vexpand(true)
             .build();
+        let rows_for_marquee = bound_rows.clone();
+        let marquee = super::marquee::install(super::marquee::MarqueeSetup {
+            view: list.clone().upcast(),
+            scroll: scroll.clone(),
+            overlay: self.overlay.clone(),
+            selection: selection.clone(),
+            visit_items: Rc::new(move |visit| {
+                rows_for_marquee.borrow_mut().retain(|bound| {
+                    let (Some(item), Some(row)) = (bound.item.upgrade(), bound.row.upgrade())
+                    else {
+                        return false;
+                    };
+                    visit(item.position(), row.upcast_ref());
+                    true
+                });
+            }),
+            is_item: Rc::new(|widget| is_file_row_target(widget.clone())),
+        });
+        marquee.add_origin_surface(&header);
+
         let retry = gtk::Button::with_label("Retry");
         retry.add_css_class("retry-button");
         let weak_browser = Rc::downgrade(&self.browser);
@@ -4789,7 +4718,7 @@ impl ViewState {
             selection,
             syncing_selection,
             list,
-            marquee: marquee_box,
+            marquee,
             bound_rows,
             entry_count,
             spinner,
@@ -5034,7 +4963,7 @@ impl ViewState {
                 .animation_generation
                 .set(column.animation_generation.get().saturating_add(1));
             self.columns_widget.remove(&column.shell);
-            self.overlay.remove_overlay(&column.marquee);
+            self.overlay.remove_overlay(&column.marquee.band());
         }
         let retained = self
             .columns

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -452,23 +452,15 @@ impl BrowserView {
         // Columns are laid out from the start edge, so the blank strip beside the last
         // one is the natural place to begin a marquee that runs into it.
         let weak_state = Rc::downgrade(&state);
-        super::marquee::install_shared_origin_surface(
-            &state.scroller,
-            move |surface, picked, x, _| {
-                if picked.is::<gtk::Scrollbar>()
-                    || picked.ancestor(gtk::Scrollbar::static_type()).is_some()
-                {
-                    return None;
-                }
-                let state = weak_state.upgrade()?;
-                let laid_out = state.columns_widget.compute_bounds(surface)?;
-                if x < f64::from(laid_out.x() + laid_out.width()) {
-                    return None;
-                }
-                let columns = state.columns.borrow();
-                columns.last().map(|column| column.marquee.clone())
-            },
-        );
+        super::marquee::install_shared_origin_surface(&state.scroller, move |surface, _, x, _| {
+            let state = weak_state.upgrade()?;
+            let laid_out = state.columns_widget.compute_bounds(surface)?;
+            if x < f64::from(laid_out.x() + laid_out.width()) {
+                return None;
+            }
+            let columns = state.columns.borrow();
+            columns.last().map(|column| column.marquee.clone())
+        });
 
         let weak_state = Rc::downgrade(&state);
         state.mode_views.borrow().set_transfer_handler(Rc::new(
@@ -580,6 +572,25 @@ impl BrowserView {
             .iter()
             .map(|column| column.shell.width().max(COLUMN_WIDTH))
             .fold(0, i32::saturating_add)
+    }
+
+    /// Lets a marquee drag begin on blank chrome beside the file panes — the sidebar —
+    /// and run into whichever view the current mode shows. The pane nearest the start
+    /// edge is the target, since that is the one such a drag runs into.
+    pub(super) fn add_marquee_origin(&self, surface: &impl IsA<gtk::Widget>) {
+        let weak_state = Rc::downgrade(&self.state);
+        super::marquee::install_shared_origin_surface(surface, move |_, _, _, _| {
+            let state = weak_state.upgrade()?;
+            let mode = state.mode_views.borrow().mode();
+            if mode == BrowserMode::Columns {
+                return state
+                    .columns
+                    .borrow()
+                    .first()
+                    .map(|column| column.marquee.clone());
+            }
+            state.mode_views.borrow().leading_marquee()
+        });
     }
 
     pub fn view_mode(&self) -> BrowserMode {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -343,6 +343,7 @@ impl BrowserView {
             .hexpand(true)
             .vexpand(true)
             .build();
+        scroller.add_css_class("fixed-scrollbar");
         let overlay = gtk::Overlay::new();
 
         let location_entry = gtk::Entry::builder()
@@ -4588,6 +4589,7 @@ impl ViewState {
             .hscrollbar_policy(gtk::PolicyType::Never)
             .vexpand(true)
             .build();
+        scroll.add_css_class("fixed-scrollbar");
         let rows_for_marquee = bound_rows.clone();
         let marquee = super::marquee::install(super::marquee::MarqueeSetup {
             view: list.clone().upcast(),

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -94,6 +94,7 @@ struct Pane {
     truncated_hint: gtk::Image,
     view: gtk::Widget,
     bound_items: Rc<RefCell<Vec<BoundModeItem>>>,
+    marquee: super::marquee::Marquee,
     filter_entry: Option<gtk::Entry>,
     filter_button: Option<gtk::ToggleButton>,
     empty_trash_button: Option<gtk::Button>,
@@ -184,6 +185,17 @@ impl ModeViews {
 
     pub fn mode(&self) -> BrowserMode {
         self.mode
+    }
+
+    /// The marquee of the pane nearest the window's start edge, so chrome outside the
+    /// panes can run a drag into whichever view the current mode shows.
+    pub(super) fn leading_marquee(&self) -> Option<super::marquee::Marquee> {
+        let pane = match self.mode {
+            BrowserMode::Columns => return None,
+            BrowserMode::Grid => self.grid_panes.first(),
+            BrowserMode::Explorer => self.explorer_pane.as_ref(),
+        }?;
+        Some(pane.marquee.clone())
     }
 
     pub fn selected_positions(&self) -> Option<(usize, Vec<usize>)> {
@@ -1276,6 +1288,7 @@ fn build_grid_pane(
         truncated_hint,
         view: view.upcast(),
         bound_items,
+        marquee,
         filter_entry: Some(controls.filter_entry),
         filter_button: Some(controls.filter_button),
         empty_trash_button: controls.empty_trash_button,
@@ -1891,6 +1904,7 @@ fn build_explorer_pane(
         truncated_hint,
         view: view.upcast(),
         bound_items,
+        marquee,
         filter_entry: Some(filter_entry),
         filter_button: Some(filter_button),
         empty_trash_button: is_trash.then_some(empty_trash),

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -185,6 +185,7 @@ impl ModeViews {
             .hexpand(true)
             .vexpand(true)
             .build();
+        grid_scroll.add_css_class("fixed-scrollbar");
 
         let explorer_root = gtk::Box::new(gtk::Orientation::Vertical, 0);
         explorer_root.add_css_class("mode-explorer");
@@ -1366,6 +1367,7 @@ fn build_grid_pane(
         .child(&view)
         .vexpand(true)
         .build();
+    scroll.add_css_class("fixed-scrollbar");
     let (collection, marquee) = collection_with_marquee(
         view.upcast_ref(),
         scroll,
@@ -1972,6 +1974,7 @@ fn build_explorer_pane(
         .hscrollbar_policy(gtk::PolicyType::Never)
         .vexpand(true)
         .build();
+    scroll.add_css_class("fixed-scrollbar");
     let table = gtk::Box::new(gtk::Orientation::Vertical, 0);
     table.set_vexpand(true);
     table.append(&headings);
@@ -1992,6 +1995,7 @@ fn build_explorer_pane(
         .hexpand(true)
         .vexpand(true)
         .build();
+    table_scroll.add_css_class("fixed-scrollbar");
     content.append(&table_scroll);
     Pane {
         depth,

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -987,7 +987,7 @@ fn build_grid_pane(
     let controls = grid_controls(&browser, depth, options.thumbnail_size.get());
     let thumbnail_size = options.thumbnail_size;
     let active_new_entry = options.active_new_entry;
-    let (pane, content, model, stack, status, spinner, truncated_hint) = pane_base(
+    let (pane, header, content, model, stack, status, spinner, truncated_hint) = pane_base(
         title,
         "grid-pane",
         Some(controls.leading.clone().upcast()),
@@ -1252,13 +1252,15 @@ fn build_grid_pane(
         .child(&view)
         .vexpand(true)
         .build();
-    content.append(&collection_with_marquee(
+    let (collection, marquee) = collection_with_marquee(
         view.upcast_ref(),
         scroll,
         &selection,
         bound_items.clone(),
         "grid-card",
-    ));
+    );
+    content.append(&collection);
+    marquee.add_origin_surface(&header);
     let shell = pane;
     Pane {
         depth,
@@ -1604,7 +1606,7 @@ fn build_explorer_pane(
     let (filter_entry, filter_revealer, filter_button) =
         filter_controls("Filter explorer (Ctrl+F)");
     actions.append(&filter_button);
-    let (shell, content, model, stack, status, spinner, truncated_hint) = pane_base(
+    let (shell, header, content, model, stack, status, spinner, truncated_hint) = pane_base(
         title,
         "explorer-pane",
         Some(navigation.upcast()),
@@ -1854,13 +1856,16 @@ fn build_explorer_pane(
     let table = gtk::Box::new(gtk::Orientation::Vertical, 0);
     table.set_vexpand(true);
     table.append(&headings);
-    table.append(&collection_with_marquee(
+    let (collection, marquee) = collection_with_marquee(
         view.upcast_ref(),
         scroll,
         &selection,
         bound_items.clone(),
         "explorer-row",
-    ));
+    );
+    table.append(&collection);
+    marquee.add_origin_surface(&header);
+    marquee.add_origin_surface(&headings);
     let table_scroll = gtk::ScrolledWindow::builder()
         .child(&table)
         .hscrollbar_policy(gtk::PolicyType::Automatic)
@@ -1897,6 +1902,7 @@ fn pane_base(
     header_leading: Option<gtk::Widget>,
     header_actions: Option<gtk::Widget>,
 ) -> (
+    gtk::Box,
     gtk::Box,
     gtk::Box,
     gtk::StringList,
@@ -1951,6 +1957,7 @@ fn pane_base(
     let model = gtk::StringList::new(&[]);
     (
         shell,
+        header,
         content,
         model,
         stack,
@@ -1981,121 +1988,30 @@ fn collection_with_marquee(
     selection: &gtk::MultiSelection,
     bound_items: Rc<RefCell<Vec<BoundModeItem>>>,
     item_class: &'static str,
-) -> gtk::Overlay {
+) -> (gtk::Overlay, super::marquee::Marquee) {
     let overlay = gtk::Overlay::new();
     overlay.set_child(Some(&scroll));
     overlay.set_hexpand(true);
     overlay.set_vexpand(true);
-    let marquee_box = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-    marquee_box.add_css_class("file-marquee");
-    marquee_box.set_can_target(false);
-    marquee_box.set_halign(gtk::Align::Start);
-    marquee_box.set_valign(gtk::Align::Start);
-    marquee_box.set_visible(false);
-    overlay.add_overlay(&marquee_box);
 
-    let active = Rc::new(Cell::new(false));
-    let origin = Rc::new(Cell::new((0.0, 0.0)));
-    let initial = Rc::new(RefCell::new(gtk::Bitset::new_empty()));
-    let modifiers = Rc::new(Cell::new((false, false)));
-    let marquee = gtk::GestureDrag::new();
-    marquee.set_button(1);
-    marquee.set_propagation_phase(gtk::PropagationPhase::Capture);
-    let active_for_begin = active.clone();
-    let origin_for_begin = origin.clone();
-    let initial_for_begin = initial.clone();
-    let modifiers_for_begin = modifiers.clone();
-    let selection_for_begin = selection.clone();
-    let marquee_for_begin = marquee_box.clone();
-    marquee.connect_drag_begin(move |gesture, x, y| {
-        let starts_on_item = gesture
-            .widget()
-            .and_then(|widget| widget.pick(x, y, gtk::PickFlags::DEFAULT))
-            .is_some_and(|widget| widget_or_ancestor_has_class(&widget, item_class));
-        let force_marquee = gesture
-            .current_event_state()
-            .contains(gtk::gdk::ModifierType::ALT_MASK);
-        let can_start = force_marquee || !starts_on_item;
-        active_for_begin.set(can_start);
-        if !can_start {
-            return;
-        }
-        gesture.set_state(gtk::EventSequenceState::Claimed);
-        marquee_for_begin.set_visible(true);
-        origin_for_begin.set((x, y));
-        initial_for_begin.replace(selection_for_begin.selection().copy());
-        let state = gesture.current_event_state();
-        modifiers_for_begin.set((
-            state.contains(gtk::gdk::ModifierType::CONTROL_MASK),
-            state.contains(gtk::gdk::ModifierType::SHIFT_MASK),
-        ));
+    let items_for_visit = bound_items.clone();
+    let marquee = super::marquee::install(super::marquee::MarqueeSetup {
+        view: view.clone(),
+        scroll,
+        overlay: overlay.clone(),
+        selection: selection.clone(),
+        visit_items: Rc::new(move |visit| {
+            items_for_visit.borrow_mut().retain(|bound| {
+                let (Some(item), Some(widget)) = (bound.item.upgrade(), bound.widget.upgrade())
+                else {
+                    return false;
+                };
+                visit(item.position(), &widget);
+                true
+            });
+        }),
+        is_item: Rc::new(|widget| widget_or_ancestor_has_class(widget, item_class)),
     });
-
-    let active_for_update = active.clone();
-    let view_for_update = view.clone();
-    let overlay_for_update = overlay.clone();
-    let marquee_for_update = marquee_box.clone();
-    let selection_for_update = selection.clone();
-    let items_for_update = bound_items.clone();
-    marquee.connect_drag_update(move |_, offset_x, offset_y| {
-        if !active_for_update.get() {
-            return;
-        }
-        let (origin_x, origin_y) = origin.get();
-        let current_x = origin_x + offset_x;
-        let current_y = origin_y + offset_y;
-        let left = origin_x.min(current_x);
-        let right = origin_x.max(current_x);
-        let top = origin_y.min(current_y);
-        let bottom = origin_y.max(current_y);
-        if let Some(view_bounds) = view_for_update.compute_bounds(&overlay_for_update) {
-            marquee_for_update
-                .set_margin_start((f64::from(view_bounds.x()) + left).round().max(0.0) as i32);
-            marquee_for_update
-                .set_margin_top((f64::from(view_bounds.y()) + top).round().max(0.0) as i32);
-            marquee_for_update.set_size_request(
-                (right - left).round().max(1.0) as i32,
-                (bottom - top).round().max(1.0) as i32,
-            );
-        }
-        let initial = initial.borrow();
-        let (control, shift) = modifiers.get();
-        let selected = if control || shift {
-            initial.copy()
-        } else {
-            gtk::Bitset::new_empty()
-        };
-        items_for_update.borrow_mut().retain(|bound| {
-            let (Some(item), Some(widget)) = (bound.item.upgrade(), bound.widget.upgrade()) else {
-                return false;
-            };
-            let Some(bounds) = widget.compute_bounds(&view_for_update) else {
-                return true;
-            };
-            let intersects = f64::from(bounds.x()) < right
-                && f64::from(bounds.x() + bounds.width()) > left
-                && f64::from(bounds.y()) < bottom
-                && f64::from(bounds.y() + bounds.height()) > top;
-            let position = item.position();
-            if intersects && position != gtk::INVALID_LIST_POSITION {
-                if control && initial.contains(position) {
-                    selected.remove(position);
-                } else {
-                    selected.add(position);
-                }
-            }
-            true
-        });
-        let mask = gtk::Bitset::new_range(0, selection_for_update.n_items());
-        selection_for_update.set_selection(&selected, &mask);
-    });
-    let active_for_end = active;
-    let marquee_for_end = marquee_box;
-    marquee.connect_drag_end(move |_, _, _| {
-        active_for_end.set(false);
-        marquee_for_end.set_visible(false);
-    });
-    view.add_controller(marquee);
 
     let clear = gtk::GestureClick::new();
     clear.set_button(1);
@@ -2116,7 +2032,7 @@ fn collection_with_marquee(
         }
     });
     view.add_controller(clear);
-    overlay
+    (overlay, marquee)
 }
 
 fn descendant_with_class(widget: &gtk::Widget, class: &str) -> Option<gtk::Widget> {

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -1825,7 +1825,10 @@ fn build_explorer_pane(
     let view = gtk::ListView::new(Some(selection.clone()), Some(factory));
     view.add_css_class("explorer-list");
     view.set_enable_rubberband(false);
-    view.set_single_click_activate(true);
+    // GTK's single-click activation also selects rows on hover, which replaces any
+    // multi-selection as soon as the pointer crosses a row. Explorer activates on a
+    // double click instead, matching the grid and column views.
+    view.set_single_click_activate(false);
     let weak_browser = Rc::downgrade(&browser);
     let source_for_activation = model.clone();
     let view_model_for_activation = view_model_object.clone();

--- a/src/ui/marquee.rs
+++ b/src/ui/marquee.rs
@@ -1,0 +1,473 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+use std::time::Duration;
+
+use gtk::glib;
+use gtk::graphene;
+use gtk::prelude::*;
+
+/// Distance from a viewport edge at which a marquee drag starts scrolling.
+const AUTO_SCROLL_MARGIN: f64 = 28.0;
+/// Largest scroll step, in pixels, applied per auto-scroll frame.
+const AUTO_SCROLL_MAX_STEP: f64 = 24.0;
+const AUTO_SCROLL_INTERVAL: Duration = Duration::from_millis(16);
+
+/// Visits every bound item of a collection view as `(position, widget)`, dropping
+/// entries whose widgets have been recycled.
+pub(super) type ItemVisitor = Rc<dyn Fn(&mut dyn FnMut(u32, &gtk::Widget))>;
+pub(super) type ItemPredicate = Rc<dyn Fn(&gtk::Widget) -> bool>;
+
+pub(super) struct MarqueeSetup {
+    pub view: gtk::Widget,
+    pub scroll: gtk::ScrolledWindow,
+    pub overlay: gtk::Overlay,
+    pub selection: gtk::MultiSelection,
+    pub visit_items: ItemVisitor,
+    pub is_item: ItemPredicate,
+}
+
+#[derive(Clone)]
+pub(super) struct Marquee {
+    state: Rc<MarqueeState>,
+}
+
+struct MarqueeState {
+    view: gtk::Widget,
+    scroll: gtk::ScrolledWindow,
+    overlay: gtk::Overlay,
+    band: gtk::Box,
+    selection: gtk::MultiSelection,
+    visit_items: ItemVisitor,
+    is_item: ItemPredicate,
+    active: Cell<bool>,
+    /// Anchor in the view's own coordinates, so it stays glued to the content
+    /// while the list scrolls underneath the pointer.
+    anchor: Cell<(f64, f64)>,
+    /// Last pointer position in the scrolled window's coordinates, which do not
+    /// move while the content scrolls.
+    pointer: Cell<(f64, f64)>,
+    initial: RefCell<gtk::Bitset>,
+    modifiers: Cell<(bool, bool)>,
+    auto_scroll: RefCell<Option<glib::SourceId>>,
+}
+
+/// Installs marquee selection on `setup.view` and returns a handle that can grant
+/// the same drag to surrounding chrome via [`Marquee::add_origin_surface`].
+pub(super) fn install(setup: MarqueeSetup) -> Marquee {
+    let band = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    band.add_css_class("file-marquee");
+    band.set_can_target(false);
+    band.set_halign(gtk::Align::Start);
+    band.set_valign(gtk::Align::Start);
+    band.set_visible(false);
+    setup.overlay.add_overlay(&band);
+
+    let view = setup.view;
+    let state = Rc::new(MarqueeState {
+        view: view.clone(),
+        scroll: setup.scroll,
+        overlay: setup.overlay,
+        band,
+        selection: setup.selection,
+        visit_items: setup.visit_items,
+        is_item: setup.is_item,
+        active: Cell::new(false),
+        anchor: Cell::new((0.0, 0.0)),
+        pointer: Cell::new((0.0, 0.0)),
+        initial: RefCell::new(gtk::Bitset::new_empty()),
+        modifiers: Cell::new((false, false)),
+        auto_scroll: RefCell::new(None),
+    });
+
+    let gesture = gtk::GestureDrag::new();
+    gesture.set_button(1);
+    gesture.set_propagation_phase(gtk::PropagationPhase::Capture);
+    let state_for_begin = state.clone();
+    gesture.connect_drag_begin(move |gesture, x, y| {
+        let starts_on_item = gesture
+            .widget()
+            .and_then(|widget| widget.pick(x, y, gtk::PickFlags::DEFAULT))
+            .is_some_and(|widget| (state_for_begin.is_item)(&widget));
+        let force = gesture
+            .current_event_state()
+            .contains(gtk::gdk::ModifierType::ALT_MASK);
+        if !force && starts_on_item {
+            state_for_begin.active.set(false);
+            return;
+        }
+        gesture.set_state(gtk::EventSequenceState::Claimed);
+        state_for_begin.begin((x, y), gesture.current_event_state());
+    });
+    connect_drag_progress(&gesture, &state, &view);
+    view.add_controller(gesture);
+
+    Marquee { state }
+}
+
+impl Marquee {
+    pub(super) fn band(&self) -> gtk::Box {
+        self.state.band.clone()
+    }
+
+    /// Lets a marquee drag begin on `surface` — chrome beside the collection view,
+    /// such as a pane header or a column-heading strip — and carry into the view.
+    /// Only presses landing on the surface itself qualify, so the controls it hosts
+    /// keep their own drags.
+    pub(super) fn add_origin_surface(&self, surface: &impl IsA<gtk::Widget>) {
+        let surface = surface.clone().upcast::<gtk::Widget>();
+        let gesture = gtk::GestureDrag::new();
+        gesture.set_button(1);
+        let state_for_begin = self.state.clone();
+        let surface_for_begin = surface.clone();
+        gesture.connect_drag_begin(move |gesture, x, y| {
+            state_for_begin.active.set(false);
+            let accepted = surface_for_begin
+                .pick(x, y, gtk::PickFlags::DEFAULT)
+                .is_some_and(|picked| is_inert_chrome(&surface_for_begin, &picked));
+            if !accepted || !state_for_begin.view.is_mapped() {
+                return;
+            }
+            let Some(anchor) = translate(&surface_for_begin, &state_for_begin.view, (x, y)) else {
+                return;
+            };
+            gesture.set_state(gtk::EventSequenceState::Claimed);
+            state_for_begin.begin(anchor, gesture.current_event_state());
+        });
+        connect_drag_progress(&gesture, &self.state, &surface);
+        surface.add_controller(gesture);
+    }
+}
+
+/// Chrome such as a pane header can begin a marquee drag, but only where the press
+/// lands on the container itself rather than on a button, entry, or other control.
+fn is_inert_chrome(surface: &gtk::Widget, picked: &gtk::Widget) -> bool {
+    let mut current = Some(picked.clone());
+    while let Some(widget) = current {
+        if widget.eq(surface) {
+            return true;
+        }
+        if widget.is::<gtk::Button>()
+            || widget.is::<gtk::Editable>()
+            || widget.is::<gtk::Range>()
+            || widget.is::<gtk::Scrollbar>()
+        {
+            return false;
+        }
+        current = widget.parent();
+    }
+    false
+}
+
+/// Lets one long-lived surface — such as the blank area beside the last open
+/// column — begin a marquee drag on whichever collection view `resolve` picks for
+/// the press position. Unlike [`Marquee::add_origin_surface`] the surface outlives
+/// the views it feeds, so the target is resolved per drag.
+pub(super) fn install_shared_origin_surface(
+    surface: &impl IsA<gtk::Widget>,
+    resolve: impl Fn(&gtk::Widget, &gtk::Widget, f64, f64) -> Option<Marquee> + 'static,
+) {
+    let surface = surface.clone().upcast::<gtk::Widget>();
+    let target: Rc<RefCell<Option<Rc<MarqueeState>>>> = Rc::new(RefCell::new(None));
+    let gesture = gtk::GestureDrag::new();
+    gesture.set_button(1);
+    let target_for_begin = target.clone();
+    let surface_for_begin = surface.clone();
+    gesture.connect_drag_begin(move |gesture, x, y| {
+        target_for_begin.replace(None);
+        let Some(picked) = surface_for_begin.pick(x, y, gtk::PickFlags::DEFAULT) else {
+            return;
+        };
+        let Some(marquee) = resolve(&surface_for_begin, &picked, x, y) else {
+            return;
+        };
+        let state = marquee.state;
+        if !state.view.is_mapped() {
+            return;
+        }
+        let Some(anchor) = translate(&surface_for_begin, &state.view, (x, y)) else {
+            return;
+        };
+        gesture.set_state(gtk::EventSequenceState::Claimed);
+        state.begin(anchor, gesture.current_event_state());
+        target_for_begin.replace(Some(state));
+    });
+    let target_for_update = target.clone();
+    let surface_for_update = surface.clone();
+    gesture.connect_drag_update(move |gesture, offset_x, offset_y| {
+        let Some((start_x, start_y)) = gesture.start_point() else {
+            return;
+        };
+        if let Some(state) = target_for_update.borrow().as_ref() {
+            state.drag_to(
+                &surface_for_update,
+                (start_x + offset_x, start_y + offset_y),
+            );
+        }
+    });
+    gesture.connect_drag_end(move |_, _, _| {
+        if let Some(state) = target.borrow_mut().take() {
+            state.end();
+        }
+    });
+    surface.add_controller(gesture);
+}
+
+/// Wires update/end handling for a drag whose coordinates are expressed in
+/// `origin`'s space.
+fn connect_drag_progress(
+    gesture: &gtk::GestureDrag,
+    state: &Rc<MarqueeState>,
+    origin: &gtk::Widget,
+) {
+    let state_for_update = state.clone();
+    let origin_for_update = origin.clone();
+    gesture.connect_drag_update(move |gesture, offset_x, offset_y| {
+        let Some((start_x, start_y)) = gesture.start_point() else {
+            return;
+        };
+        state_for_update.drag_to(&origin_for_update, (start_x + offset_x, start_y + offset_y));
+    });
+    let state_for_end = state.clone();
+    gesture.connect_drag_end(move |_, _, _| state_for_end.end());
+}
+
+impl MarqueeState {
+    fn begin(&self, anchor: (f64, f64), modifiers: gtk::gdk::ModifierType) {
+        self.active.set(true);
+        self.anchor.set(anchor);
+        self.pointer
+            .set(translate(&self.view, &self.scroll, anchor).unwrap_or_default());
+        self.initial.replace(self.selection.selection().copy());
+        self.modifiers.set((
+            modifiers.contains(gtk::gdk::ModifierType::CONTROL_MASK),
+            modifiers.contains(gtk::gdk::ModifierType::SHIFT_MASK),
+        ));
+    }
+
+    fn end(&self) {
+        self.active.set(false);
+        self.stop_auto_scroll();
+        self.band.set_visible(false);
+    }
+
+    fn refresh(&self) {
+        let Some((current_x, current_y)) = translate(&self.scroll, &self.view, self.pointer.get())
+        else {
+            return;
+        };
+        let (anchor_x, anchor_y) = self.anchor.get();
+        let left = anchor_x.min(current_x);
+        let right = anchor_x.max(current_x);
+        let top = anchor_y.min(current_y);
+        let bottom = anchor_y.max(current_y);
+        self.place_band(left, top, right, bottom);
+        self.apply_selection(left, top, right, bottom);
+    }
+
+    fn place_band(&self, left: f64, top: f64, right: f64, bottom: f64) {
+        let Some(view_bounds) = self.view.compute_bounds(&self.overlay) else {
+            return;
+        };
+        let placement = band_placement(
+            f64::from(view_bounds.x()) + left,
+            f64::from(view_bounds.y()) + top,
+            right - left,
+            bottom - top,
+            f64::from(self.overlay.width()),
+            f64::from(self.overlay.height()),
+        );
+        let Some((x, y, width, height)) = placement else {
+            self.band.set_visible(false);
+            return;
+        };
+        self.band.set_visible(true);
+        self.band.set_margin_start(x);
+        self.band.set_margin_top(y);
+        self.band.set_size_request(width, height);
+    }
+
+    fn apply_selection(&self, left: f64, top: f64, right: f64, bottom: f64) {
+        let initial = self.initial.borrow();
+        let (control, shift) = self.modifiers.get();
+        let selected = if control || shift {
+            initial.copy()
+        } else {
+            gtk::Bitset::new_empty()
+        };
+        let view = self.view.clone();
+        (self.visit_items)(&mut |position, widget| {
+            if position == gtk::INVALID_LIST_POSITION {
+                return;
+            }
+            let Some(bounds) = widget.compute_bounds(&view) else {
+                return;
+            };
+            if !intersects(&bounds, left, top, right, bottom) {
+                return;
+            }
+            if control && initial.contains(position) {
+                selected.remove(position);
+            } else {
+                selected.add(position);
+            }
+        });
+        let mask = gtk::Bitset::new_range(0, self.selection.n_items());
+        self.selection.set_selection(&selected, &mask);
+    }
+
+    fn stop_auto_scroll(&self) {
+        if let Some(source) = self.auto_scroll.borrow_mut().take() {
+            source.remove();
+        }
+    }
+
+    /// Applies one frame of edge scrolling, reporting whether the timer should keep
+    /// running.
+    fn auto_scroll_frame(&self) -> bool {
+        if !self.active.get() {
+            return false;
+        }
+        let (step_x, step_y) = self.auto_scroll_steps();
+        if step_x == 0.0 && step_y == 0.0 {
+            return false;
+        }
+        if advance(&self.scroll.hadjustment(), step_x) | advance(&self.scroll.vadjustment(), step_y)
+        {
+            self.refresh();
+        }
+        true
+    }
+
+    fn auto_scroll_steps(&self) -> (f64, f64) {
+        let (x, y) = self.pointer.get();
+        (
+            self.scrollable_step(
+                &self.scroll.hadjustment(),
+                x,
+                f64::from(self.scroll.width()),
+            ),
+            self.scrollable_step(
+                &self.scroll.vadjustment(),
+                y,
+                f64::from(self.scroll.height()),
+            ),
+        )
+    }
+
+    /// An axis the view cannot scroll never contributes a step, so a drag that hangs
+    /// far off a fixed edge does not keep the auto-scroll timer alive.
+    fn scrollable_step(&self, adjustment: &gtk::Adjustment, position: f64, size: f64) -> f64 {
+        if adjustment.upper() - adjustment.lower() <= adjustment.page_size() {
+            return 0.0;
+        }
+        auto_scroll_step(position, size)
+    }
+
+    /// Records a pointer position given in `origin`'s coordinates and refreshes the
+    /// band, the selection, and edge auto-scrolling.
+    fn drag_to(self: &Rc<Self>, origin: &gtk::Widget, point: (f64, f64)) {
+        if !self.active.get() {
+            return;
+        }
+        let Some(pointer) = translate(origin, &self.scroll, point) else {
+            return;
+        };
+        self.pointer.set(pointer);
+        self.refresh();
+        if self.auto_scroll_steps() == (0.0, 0.0) {
+            self.stop_auto_scroll();
+            return;
+        }
+        if self.auto_scroll.borrow().is_some() {
+            return;
+        }
+        let state = self.clone();
+        let source = glib::timeout_add_local(AUTO_SCROLL_INTERVAL, move || {
+            if state.auto_scroll_frame() {
+                return glib::ControlFlow::Continue;
+            }
+            state.auto_scroll.borrow_mut().take();
+            glib::ControlFlow::Break
+        });
+        self.auto_scroll.replace(Some(source));
+    }
+}
+
+fn advance(adjustment: &gtk::Adjustment, step: f64) -> bool {
+    if step == 0.0 {
+        return false;
+    }
+    let upper = (adjustment.upper() - adjustment.page_size()).max(adjustment.lower());
+    let target = (adjustment.value() + step).clamp(adjustment.lower(), upper);
+    if (target - adjustment.value()).abs() < f64::EPSILON {
+        return false;
+    }
+    adjustment.set_value(target);
+    true
+}
+
+fn translate(
+    from: &impl IsA<gtk::Widget>,
+    to: &impl IsA<gtk::Widget>,
+    point: (f64, f64),
+) -> Option<(f64, f64)> {
+    let point = graphene::Point::new(point.0 as f32, point.1 as f32);
+    from.as_ref()
+        .compute_point(to, &point)
+        .map(|point| (f64::from(point.x()), f64::from(point.y())))
+}
+
+/// A band with zero area still resolves against the item under it, so a press
+/// that has not moved yet behaves like a click.
+fn intersects(bounds: &graphene::Rect, left: f64, top: f64, right: f64, bottom: f64) -> bool {
+    f64::from(bounds.x()) < right
+        && f64::from(bounds.x() + bounds.width()) > left
+        && f64::from(bounds.y()) < bottom
+        && f64::from(bounds.y() + bounds.height()) > top
+}
+
+/// Scroll step for a pointer coordinate inside a viewport `size` pixels long.
+/// Negative values scroll towards the start, positive towards the end.
+fn auto_scroll_step(position: f64, size: f64) -> f64 {
+    if size <= AUTO_SCROLL_MARGIN * 2.0 {
+        return 0.0;
+    }
+    let overshoot = if position < AUTO_SCROLL_MARGIN {
+        position - AUTO_SCROLL_MARGIN
+    } else if position > size - AUTO_SCROLL_MARGIN {
+        position - (size - AUTO_SCROLL_MARGIN)
+    } else {
+        return 0.0;
+    };
+    (overshoot / AUTO_SCROLL_MARGIN).clamp(-1.0, 1.0) * AUTO_SCROLL_MAX_STEP
+}
+
+/// Clips a band rectangle to the overlay it is drawn in, returning `None` when
+/// none of it remains visible.
+fn band_placement(
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+    overlay_width: f64,
+    overlay_height: f64,
+) -> Option<(i32, i32, i32, i32)> {
+    let left = x.max(0.0);
+    let top = y.max(0.0);
+    let right = (x + width).min(overlay_width);
+    let bottom = (y + height).min(overlay_height);
+    if right < left || bottom < top {
+        return None;
+    }
+    Some((
+        left.round() as i32,
+        top.round() as i32,
+        (right - left).round().max(1.0) as i32,
+        (bottom - top).round().max(1.0) as i32,
+    ))
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/ui/marquee.rs
+++ b/src/ui/marquee.rs
@@ -160,10 +160,11 @@ fn is_inert_chrome(surface: &gtk::Widget, picked: &gtk::Widget) -> bool {
     false
 }
 
-/// Lets one long-lived surface — such as the blank area beside the last open
-/// column — begin a marquee drag on whichever collection view `resolve` picks for
+/// Lets one long-lived surface — the blank area beside the last open column, or the
+/// sidebar — begin a marquee drag on whichever collection view `resolve` picks for
 /// the press position. Unlike [`Marquee::add_origin_surface`] the surface outlives
-/// the views it feeds, so the target is resolved per drag.
+/// the views it feeds, so the target is resolved per drag. Presses landing on a
+/// control the surface hosts are filtered out before `resolve` is consulted.
 pub(super) fn install_shared_origin_surface(
     surface: &impl IsA<gtk::Widget>,
     resolve: impl Fn(&gtk::Widget, &gtk::Widget, f64, f64) -> Option<Marquee> + 'static,
@@ -179,6 +180,9 @@ pub(super) fn install_shared_origin_surface(
         let Some(picked) = surface_for_begin.pick(x, y, gtk::PickFlags::DEFAULT) else {
             return;
         };
+        if !is_inert_chrome(&surface_for_begin, &picked) {
+            return;
+        }
         let Some(marquee) = resolve(&surface_for_begin, &picked, x, y) else {
             return;
         };

--- a/src/ui/marquee/tests.rs
+++ b/src/ui/marquee/tests.rs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use super::*;
+
+#[test]
+fn pointer_inside_the_viewport_does_not_scroll() {
+    assert_eq!(auto_scroll_step(200.0, 400.0), 0.0);
+    assert_eq!(auto_scroll_step(AUTO_SCROLL_MARGIN, 400.0), 0.0);
+}
+
+#[test]
+fn pointer_near_an_edge_scrolls_towards_it() {
+    assert!(auto_scroll_step(4.0, 400.0) < 0.0);
+    assert!(auto_scroll_step(396.0, 400.0) > 0.0);
+}
+
+#[test]
+fn scroll_speed_saturates_beyond_the_viewport() {
+    assert_eq!(auto_scroll_step(-500.0, 400.0), -AUTO_SCROLL_MAX_STEP);
+    assert_eq!(auto_scroll_step(900.0, 400.0), AUTO_SCROLL_MAX_STEP);
+}
+
+#[test]
+fn short_viewports_never_auto_scroll() {
+    assert_eq!(auto_scroll_step(0.0, AUTO_SCROLL_MARGIN), 0.0);
+}
+
+#[test]
+fn band_starting_above_the_view_is_clipped_to_the_overlay() {
+    assert_eq!(
+        band_placement(10.0, -40.0, 100.0, 90.0, 400.0, 300.0),
+        Some((10, 0, 100, 50))
+    );
+}
+
+#[test]
+fn band_extending_past_the_overlay_is_clipped_to_it() {
+    assert_eq!(
+        band_placement(350.0, 250.0, 200.0, 200.0, 400.0, 300.0),
+        Some((350, 250, 50, 50))
+    );
+}
+
+#[test]
+fn band_entirely_outside_the_overlay_is_hidden() {
+    assert_eq!(
+        band_placement(-200.0, 10.0, 100.0, 50.0, 400.0, 300.0),
+        None
+    );
+    assert_eq!(band_placement(10.0, 400.0, 100.0, 50.0, 400.0, 300.0), None);
+}
+
+#[test]
+fn items_touching_the_band_are_captured() {
+    let bounds = graphene::Rect::new(0.0, 100.0, 300.0, 24.0);
+    assert!(intersects(&bounds, 10.0, 90.0, 40.0, 110.0));
+    assert!(!intersects(&bounds, 10.0, 0.0, 40.0, 90.0));
+}
+
+#[test]
+fn an_unmoved_band_still_captures_the_item_under_it() {
+    let bounds = graphene::Rect::new(0.0, 100.0, 300.0, 24.0);
+    assert!(intersects(&bounds, 20.0, 110.0, 20.0, 110.0));
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4,6 +4,7 @@ mod blur;
 mod browser;
 mod browser_modes;
 mod controls;
+mod marquee;
 mod motion;
 mod preview;
 mod search;

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -1816,6 +1816,7 @@ fn build_sidebar(view: BrowserView, theme_manager: Rc<super::theme::ThemeManager
         .vexpand(true)
         .build();
     scroller.add_css_class("sidebar-scroll");
+    scroller.add_css_class("fixed-scrollbar");
 
     let update_content = gtk::Box::new(gtk::Orientation::Horizontal, 8);
     let dot = gtk::Label::new(Some("●"));

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -166,6 +166,7 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
         Rc::new(move |location| pin_status(&pinned_places.borrow(), location)),
     );
     sidebar.widget.set_size_request(MIN_SIDEBAR_WIDTH, -1);
+    browser.add_marquee_origin(&sidebar.widget);
     content.set_start_child(Some(&sidebar.widget));
     content.set_end_child(Some(&browser.widget()));
     let animation_generation = Rc::new(Cell::new(0));

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -1812,7 +1812,6 @@ fn build_sidebar(view: BrowserView, theme_manager: Rc<super::theme::ThemeManager
         .child(&widget)
         .hscrollbar_policy(gtk::PolicyType::Never)
         .vscrollbar_policy(gtk::PolicyType::Automatic)
-        .overlay_scrolling(false)
         .width_request(SIDEBAR_WIDTH)
         .vexpand(true)
         .build();

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -1812,6 +1812,7 @@ fn build_sidebar(view: BrowserView, theme_manager: Rc<super::theme::ThemeManager
         .child(&widget)
         .hscrollbar_policy(gtk::PolicyType::Never)
         .vscrollbar_policy(gtk::PolicyType::Automatic)
+        .overlay_scrolling(false)
         .width_request(SIDEBAR_WIDTH)
         .vexpand(true)
         .build();


### PR DESCRIPTION
## Description

Marquee selection had to begin on empty space inside a file pane. A directory long
enough to fill and scroll the viewport leaves no such space, so mouse-only
multi-selection was impractical in Explorer.

The two near-identical marquee implementations (columns view in `ui::browser`,
grid/explorer panes in `ui::browser_modes`) now live in a shared `ui::marquee`
module, which also supports starting a drag on inert chrome outside a pane and
carrying it into the pane:

- **Sidebar** — blank panel space, in every mode. This is the most reachable
  origin, since the sidebar sits beside all three views. It targets the pane
  nearest the start edge: the explorer or grid pane, or the first open column.
- **Explorer** — the pane header and the column-heading strip.
- **Grid** — the pane header.
- **Columns** — each column header, plus the blank strip beside the last open
  column; a drag there targets the last column.

A press landing on a button, entry, slider, or scrollbar is left to that control,
so navigation, sorting, column resizing, scrollbars, and the sidebar's own place
rows (which are buttons) keep their existing behaviour. GTK keeps the event
sequence on the originating widget once the gesture is claimed, so the drag
continues into the file list without further routing.

Two supporting changes make cross-pane drags behave:

- The anchor is stored in the view's own coordinates and the pointer in the
  scrolled window's, so the band stays glued to the content while the list moves.
- Holding the pointer near a viewport edge auto-scrolls the list, with the band
  and selection recomputed each frame. Axes the view cannot scroll contribute
  nothing, so the timer does not spin against a fixed edge.

The band is also clipped to its overlay instead of only being clamped at the
origin, so a drag beginning above or beside the view no longer paints outside it.

### Explorer now activates on double click

Please review this part specifically — it is a deliberate behaviour change.

Explorer set `single_click_activate(true)`. GTK bundles two behaviours into that
property: "activate rows on single click **and select them on hover**". The hover
half replaced the whole selection with whatever row the pointer crossed, which
discarded a marquee the instant the drag ended.

This was not caused by this branch and was not limited to the marquee — on `main`,
hover-select already made Ctrl+Click and Shift+Click multi-selection unusable in
Explorer, since moving the pointer collapsed the selection to one row. GTK offers
no way to keep single-click activation without hover selection, so Explorer now
activates on a double click, matching the grid and column views which already do.

## Visual evidence

N/A — the change is an interaction rather than a new visual element, and I have no
screen capture tooling on this machine. Happy to add a recording before merge.

## How to test

1. Open a directory with enough entries to fill and scroll the viewport, in Explorer.
2. Press blank sidebar space (the area below the last place) and drag right into the
   rows. Repeat from the pane header and from the column-heading strip.
3. Keep dragging past the bottom edge of the list.
4. Repeat step 2 in Grid, and in List from the blank strip right of the last column.
5. Ctrl+Click and Shift+Click several rows in Explorer, then move the pointer across
   the list.
6. Confirm the untouched paths: click a heading to sort, drag a column resize handle,
   drag the scrollbar, drag a row to move a file, click a sidebar place to navigate,
   drag a sidebar place to reorder it, and double-click a folder in Explorer to open it.

**Expected result:** a rubber band appears from the press point and selects every row
it crosses; step 3 scrolls the list and keeps extending the selection; the step 5
selection survives pointer movement; everything in step 6 behaves as before, except
that Explorer now opens on a double click.

## Related issue

Closes #189