### PR TITLE
docs: refresh Omarchy packages before installing Strata

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ Arch Linux and Omarchy are the primary supported environments. Current binaries 
 
 ### Omarchy
 
-Install Strata from the Omarchy Package Repository:
+The `strata` package is available on **Omarchy 4.0.2 or newer**. Update an
+older Omarchy installation before installing Strata from the Omarchy Package
+Repository:
 
 ```bash
 omarchy pkg add strata

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ omarchy pkg add strata
 
 Omarchy keeps this installation current through `omarchy update`. Strata still checks for stable releases and shows their notes, but detects that its executable is package-owned, hides the in-app release-channel selector, and does not replace it with the in-app updater. When an update is available, **Open Omarchy Update** launches the interactive updater in your configured terminal.
 
+For more frequent updates, prefer the [manual release installation](#manual-release-installation). Manual installations can select any release channel and receive stable releases as soon as they are published, while OPR installations follow the Omarchy repository's release schedule and stable channel.
+
 #### Switch a manual installation to OPR
 
 Close Strata, install the OPR package, and remove the per-user executable and desktop metadata that would otherwise take precedence over the package:


### PR DESCRIPTION
## Description

Tell Omarchy users to run `omarchy update` before installing Strata so their package database includes the recently added package. Also explain that manual installation provides immediate stable releases and access to every Strata release channel.

## Visual evidence

N/A — this is a text-only README correction.

## How to test

1. Open the README installation section.
2. Read and follow the Omarchy installation commands.

**Expected result:** The instructions refresh Omarchy before installing Strata and explain when manual installation is preferable.

## Related issue

Closes #206