### PR TITLE
docs: refresh Omarchy packages before installing Strata

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ Arch Linux and Omarchy are the primary supported environments. Current binaries 
 
 ### Omarchy
 
-The `strata` package is available on **Omarchy 4.0.2 or newer**. Update an
-older Omarchy installation before installing Strata from the Omarchy Package
-Repository:
+Update Omarchy to refresh its package database, then install Strata from the
+Omarchy Package Repository:
 
 ```bash
+omarchy update
 omarchy pkg add strata
 ```
 


### PR DESCRIPTION
## Description

Replace the incorrect Omarchy 4.0.2 requirement with an `omarchy update` step so the local package database includes the recently added Strata package. This follows up #207, which merged before the correction was pushed.

## Visual evidence

N/A — this is a text-only README correction.

## How to test

1. Open the README installation section.
2. Read and follow the Omarchy installation commands.

**Expected result:** The instructions refresh Omarchy before installing Strata and do not claim that Omarchy 4.0.2 is required.

## Related issue

Closes #206