### PR TITLE
fix(updates): gate package notices on repository availability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,6 +1530,7 @@ dependencies = [
  "ureq",
  "yeslogic-fontconfig-sys",
  "zip",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ toml = "0.9"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.20"
 ureq = { version = "3.4", features = ["json"] }
+zstd = "0.13.3"
 zip = "8.6.0"
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ omarchy pkg add strata
 > omarchy pkg add gvfs-smb imagemagick libraw dcraw
 > ```
 
-Omarchy keeps this installation current through `omarchy update`. Strata still checks for stable releases and shows their notes, but detects that its executable is package-owned, hides the in-app release-channel selector, and does not replace it with the in-app updater. When an update is available, **Open Omarchy Update** launches the interactive updater in your configured terminal.
+Omarchy keeps this installation current through `omarchy update`. Strata checks the configured package repository for stable releases and shows their notes, but detects that its executable is package-owned, hides the in-app release-channel selector, and does not replace it with the in-app updater. GitHub releases are not announced to package-managed installations until the corresponding package is available. When an update is available, **Open Omarchy Update** launches the interactive updater in your configured terminal.
 
 For more frequent updates, prefer the [manual release installation](#manual-release-installation). Manual installations can select any release channel and receive stable releases as soon as they are published, while OPR installations follow the Omarchy repository's release schedule and stable channel.
 

--- a/src/services/update_check.rs
+++ b/src/services/update_check.rs
@@ -11,6 +11,7 @@ use serde::Deserialize;
 use super::release_channel::{
     BuildKind, Channel, ReleaseSummary, Version, best_update, rollback_target,
 };
+use super::update_install::{UpdateMethod, omarchy_repository_version, package_repository_version};
 
 const API_ROOT: &str = "https://api.github.com/repos/lgse/strata/releases";
 const COMMITS_ROOT: &str = "https://api.github.com/repos/lgse/strata/commits";
@@ -263,7 +264,7 @@ fn select_update(
     }
 }
 
-fn fetch_update(channel: Channel, installed: &Version) -> UpdateCheck {
+fn fetch_github_update(channel: Channel, installed: &Version) -> UpdateCheck {
     let releases = match channel {
         Channel::Stable => fetch_stable().map(|release| release.into_iter().collect::<Vec<_>>()),
         Channel::Preview | Channel::Nightly => fetch_preview(),
@@ -277,6 +278,48 @@ fn fetch_update(channel: Channel, installed: &Version) -> UpdateCheck {
             check
         }
         Err(error) => UpdateCheck::Failed(request_error_message(&error)),
+    }
+}
+
+fn fetch_package_update(
+    installed: &Version,
+    repository_version: impl FnOnce() -> Result<Version, String>,
+) -> UpdateCheck {
+    let available = match repository_version() {
+        Ok(version) => version,
+        Err(error) => return UpdateCheck::Failed(error),
+    };
+    if available <= *installed {
+        return UpdateCheck::UpToDate;
+    }
+
+    let tag = format!("v{available}");
+    match request_json::<ReleaseResponse>(&format!("{API_ROOT}/tags/{tag}")) {
+        Ok(response) => match package_update_from_response(&available, &response) {
+            UpdateCheck::Available {
+                mut release,
+                download_url,
+            } => {
+                resolve_commit(&mut release);
+                UpdateCheck::Available {
+                    release,
+                    download_url,
+                }
+            }
+            check => check,
+        },
+        Err(error) => UpdateCheck::Failed(request_error_message(&error)),
+    }
+}
+
+fn package_update_from_response(available: &Version, response: &ReleaseResponse) -> UpdateCheck {
+    match to_release_summary(response)
+        .filter(|release| release.version == *available && !release.prerelease)
+    {
+        Some(summary) => available_check(&summary),
+        None => UpdateCheck::Failed(
+            "package repository version has no matching stable release".to_owned(),
+        ),
     }
 }
 
@@ -502,15 +545,28 @@ fn parse_markdown(markdown: &str) -> Vec<ReleaseNoteBlock> {
     blocks
 }
 
-/// Queries the release feed for `channel` off the GTK thread and reports the
-/// outcome once. See [`fetch_stable`] and [`fetch_preview`] for why the two
-/// feeds are kept as separate functions.
-pub fn check_for_updates(channel: Channel, installed: Version) -> Receiver<UpdateCheck> {
+/// Checks the applicable release source off the GTK thread and reports the
+/// outcome once. In-place installs follow GitHub; package-managed installs
+/// first require the configured repository to offer the version.
+pub fn check_for_updates(
+    channel: Channel,
+    installed: Version,
+    update_method: UpdateMethod,
+) -> Receiver<UpdateCheck> {
     let (sender, receiver) = mpsc::channel();
     let spawned = std::thread::Builder::new()
         .name("strata-update-check".into())
         .spawn(move || {
-            let _sent = sender.send(fetch_update(channel, &installed));
+            let result = match update_method {
+                UpdateMethod::InPlace => fetch_github_update(channel, &installed),
+                UpdateMethod::Omarchy => {
+                    fetch_package_update(&installed, omarchy_repository_version)
+                }
+                UpdateMethod::Pacman => {
+                    fetch_package_update(&installed, package_repository_version)
+                }
+            };
+            let _sent = sender.send(result);
         });
     drop(spawned);
     receiver

--- a/src/services/update_check/tests.rs
+++ b/src/services/update_check/tests.rs
@@ -2,8 +2,8 @@
 
 use super::{
     BuildKind, Channel, ReleaseNoteBlock, ReleaseResponse, UpdateCheck, Version, archive_name,
-    parse_markdown, release_metadata, release_page_url, request_error_message, select_update,
-    to_release_summary,
+    fetch_package_update, package_update_from_response, parse_markdown, release_metadata,
+    release_page_url, request_error_message, select_update, to_release_summary,
 };
 
 fn version(tag: &str) -> Version {
@@ -23,6 +23,39 @@ fn release_response_list(json: &str) -> Vec<ReleaseResponse> {
 fn matching_asset_json(version: &str) -> String {
     let name = archive_name(version);
     format!(r#"{{"name":"{name}","browser_download_url":"https://example.invalid/{name}"}}"#)
+}
+
+#[test]
+fn package_update_requires_the_release_matching_the_repository_version() {
+    let asset = matching_asset_json("0.8.2");
+    let response = release_response(&format!(
+        r#"{{"tag_name":"v0.8.2","draft":false,"prerelease":false,"assets":[{asset}]}}"#
+    ));
+
+    assert!(matches!(
+        package_update_from_response(&version("0.8.1"), &response),
+        UpdateCheck::Failed(_)
+    ));
+}
+
+#[test]
+fn package_update_accepts_the_stable_release_in_the_repository() {
+    let asset = matching_asset_json("0.8.1");
+    let response = release_response(&format!(
+        r#"{{"tag_name":"v0.8.1","draft":false,"prerelease":false,"assets":[{asset}]}}"#
+    ));
+
+    assert!(matches!(
+        package_update_from_response(&version("0.8.1"), &response),
+        UpdateCheck::Available { .. }
+    ));
+}
+
+#[test]
+fn package_check_stays_quiet_when_the_repository_has_no_newer_version() {
+    let result = fetch_package_update(&version("0.8.1"), || Ok(version("0.8.1")));
+
+    assert_eq!(result, UpdateCheck::UpToDate);
 }
 
 // --- Version::parse migration -------------------------------------------

--- a/src/services/update_install.rs
+++ b/src/services/update_install.rs
@@ -11,11 +11,16 @@ use std::{
 
 use gtk::glib;
 
+use super::release_channel::Version;
+
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
 const DESKTOP_ENTRY: &str = "io.github.lgse.Strata.desktop";
 const APPLICATION_ICON: &str = "io.github.lgse.Strata.svg";
 const PACMAN: &str = "/usr/bin/pacman";
+const PACMAN_CONF: &str = "/usr/bin/pacman-conf";
 const OS_RELEASE: &str = "/etc/os-release";
+const PACKAGE_NAME: &str = "strata";
+const REPOSITORY_DATABASE_LIMIT: u64 = 4 * 1024 * 1024;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum UpdateMethod {
@@ -95,6 +100,128 @@ fn os_release_has_id(contents: &str, expected: &str) -> bool {
             .map(|value| value.trim_matches(|character| character == '\'' || character == '"'))
             == Some(expected)
     })
+}
+
+/// Returns the Strata version currently offered by pacman's configured sync
+/// databases. This is deliberately a local query: package-managed installs
+/// must not advertise a GitHub release until their package manager can
+/// actually install it.
+pub(super) fn package_repository_version() -> Result<Version, String> {
+    package_repository_version_for(Path::new(PACMAN), PACKAGE_NAME)
+}
+
+/// Reads the live Omarchy repository database selected by this installation,
+/// rather than pacman's cached copy. The cache is normally refreshed by the
+/// same `omarchy update` that installs Strata, so consulting it would make the
+/// notification arrive only after the update had already been installed.
+pub(super) fn omarchy_repository_version() -> Result<Version, String> {
+    let server = omarchy_repository_server(Path::new(PACMAN_CONF))?;
+    let database_url = format!("{}/omarchy.db", server.trim_end_matches('/'));
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .timeout_global(Some(Duration::from_secs(10)))
+        .build()
+        .into();
+    let mut response = agent
+        .get(&database_url)
+        .call()
+        .map_err(|error| format!("could not query the Omarchy repository: {error}"))?;
+    let mut database = Vec::new();
+    response
+        .body_mut()
+        .as_reader()
+        .take(REPOSITORY_DATABASE_LIMIT + 1)
+        .read_to_end(&mut database)
+        .map_err(|error| format!("could not read the Omarchy repository: {error}"))?;
+    if database.len() as u64 > REPOSITORY_DATABASE_LIMIT {
+        return Err("Omarchy repository database exceeded the size limit".to_owned());
+    }
+    repository_database_version(&database, PACKAGE_NAME)
+}
+
+fn omarchy_repository_server(pacman_conf: &Path) -> Result<String, String> {
+    let output = Command::new(pacman_conf)
+        .args(["--repo", "omarchy", "Server"])
+        .output()
+        .map_err(|error| format!("could not read the Omarchy repository configuration: {error}"))?;
+    if !output.status.success() {
+        return Err("Omarchy repository is not configured".to_owned());
+    }
+    let output = String::from_utf8(output.stdout)
+        .map_err(|_| "Omarchy repository configuration is invalid".to_owned())?;
+    output
+        .lines()
+        .map(str::trim)
+        .find(|line| line.starts_with("https://") || line.starts_with("http://"))
+        .map(str::to_owned)
+        .ok_or_else(|| "Omarchy repository configuration has no package server".to_owned())
+}
+
+fn repository_database_version(database: &[u8], package: &str) -> Result<Version, String> {
+    let decoder = zstd::stream::read::Decoder::new(database)
+        .map_err(|error| format!("could not decode the Omarchy repository: {error}"))?;
+    let mut archive = tar::Archive::new(decoder);
+    let entries = archive
+        .entries()
+        .map_err(|error| format!("could not read the Omarchy repository: {error}"))?;
+    for entry in entries {
+        let mut entry =
+            entry.map_err(|error| format!("could not read the Omarchy repository: {error}"))?;
+        let is_description = entry
+            .path()
+            .is_ok_and(|path| path.to_string_lossy().ends_with("/desc"));
+        if !is_description {
+            continue;
+        }
+        let mut description = String::new();
+        if entry.read_to_string(&mut description).is_err() {
+            continue;
+        }
+        if repository_description_field(&description, "NAME") == Some(package) {
+            return repository_description_field(&description, "VERSION")
+                .and_then(parse_package_version)
+                .ok_or_else(|| "Omarchy repository returned an invalid version".to_owned());
+        }
+    }
+    Err("Strata is not available in the Omarchy repository".to_owned())
+}
+
+fn repository_description_field<'a>(description: &'a str, field: &str) -> Option<&'a str> {
+    let marker = format!("%{field}%");
+    let mut lines = description.lines();
+    while let Some(line) = lines.next() {
+        if line == marker {
+            return lines
+                .next()
+                .map(str::trim)
+                .filter(|value| !value.is_empty());
+        }
+    }
+    None
+}
+
+fn package_repository_version_for(pacman: &Path, package: &str) -> Result<Version, String> {
+    let output = Command::new(pacman)
+        .args(["--sync", "--print", "--print-format", "%v", "--", package])
+        .output()
+        .map_err(|error| format!("could not query the package repository: {error}"))?;
+    if !output.status.success() {
+        return Err("package is not available in the configured repositories".to_owned());
+    }
+
+    let output = String::from_utf8(output.stdout)
+        .map_err(|_| "package repository returned an invalid version".to_owned())?;
+    parse_package_version(output.trim())
+        .ok_or_else(|| "package repository returned an invalid version".to_owned())
+}
+
+fn parse_package_version(value: &str) -> Option<Version> {
+    let value = value.lines().find(|line| !line.trim().is_empty())?.trim();
+    let value = value.split_once(':').map_or(value, |(_, version)| version);
+    let (version, package_release) = value.rsplit_once('-')?;
+    if package_release.is_empty() {
+        return None;
+    }
+    Version::parse(version)
 }
 
 /// Downloads, verifies, and installs `request`'s archive in place of the running

--- a/src/services/update_install.rs
+++ b/src/services/update_install.rs
@@ -201,7 +201,14 @@ fn repository_description_field<'a>(description: &'a str, field: &str) -> Option
 
 fn package_repository_version_for(pacman: &Path, package: &str) -> Result<Version, String> {
     let output = Command::new(pacman)
-        .args(["--sync", "--print", "--print-format", "%v", "--", package])
+        .args([
+            "--sync",
+            "--print",
+            "--print-format",
+            "%n %v",
+            "--",
+            package,
+        ])
         .output()
         .map_err(|error| format!("could not query the package repository: {error}"))?;
     if !output.status.success() {
@@ -210,7 +217,11 @@ fn package_repository_version_for(pacman: &Path, package: &str) -> Result<Versio
 
     let output = String::from_utf8(output.stdout)
         .map_err(|_| "package repository returned an invalid version".to_owned())?;
-    parse_package_version(output.trim())
+    output
+        .lines()
+        .filter_map(|line| line.trim().split_once(char::is_whitespace))
+        .find(|(name, _version)| *name == package)
+        .and_then(|(_name, version)| parse_package_version(version.trim()))
         .ok_or_else(|| "package repository returned an invalid version".to_owned())
 }
 

--- a/src/services/update_install/tests.rs
+++ b/src/services/update_install/tests.rs
@@ -7,7 +7,8 @@ use std::{
 
 use super::{
     APPLICATION_ICON, DESKTOP_ENTRY, UpdateMethod, desktop_entry_with_exec, find_binaries,
-    first_hash_token, refresh_desktop_metadata, stage_binary_path, stage_workdir,
+    first_hash_token, package_repository_version_for, parse_package_version,
+    refresh_desktop_metadata, repository_database_version, stage_binary_path, stage_workdir,
     update_method_for,
 };
 
@@ -44,6 +45,58 @@ fn ownership_probe(dir: &Path, exit_code: u8) -> PathBuf {
     fs::set_permissions(&probe, fs::Permissions::from_mode(0o755))
         .expect("make ownership probe executable");
     probe
+}
+
+#[test]
+fn arch_package_versions_drop_epoch_and_package_release() {
+    assert_eq!(
+        parse_package_version("0.8.1-1").map(|version| version.to_string()),
+        Some("0.8.1".to_owned())
+    );
+    assert_eq!(
+        parse_package_version("2:0.9.0-rc.1-3.1").map(|version| version.to_string()),
+        Some("0.9.0-rc.1".to_owned())
+    );
+    assert!(parse_package_version("0.8.1").is_none());
+    assert!(parse_package_version("not-a-version-1").is_none());
+}
+
+#[test]
+fn repository_probe_reads_pacmans_machine_readable_version() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let probe = dir.path().join("pacman");
+    fs::write(&probe, "#!/bin/sh\nprintf '%s\\n' '0.8.1-1'\n").expect("write probe");
+    fs::set_permissions(&probe, fs::Permissions::from_mode(0o755)).expect("make probe executable");
+
+    assert_eq!(
+        package_repository_version_for(&probe, "strata").map(|version| version.to_string()),
+        Ok("0.8.1".to_owned())
+    );
+}
+
+#[test]
+fn omarchy_database_reports_the_packaged_strata_version() {
+    let description = b"%NAME%\nstrata\n\n%VERSION%\n0.8.1-2\n";
+    let mut archive = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut archive);
+        let mut header = tar::Header::new_gnu();
+        header.set_size(description.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "strata-0.8.1-2/desc", &description[..])
+            .expect("append package description");
+        builder.finish().expect("finish repository archive");
+    }
+    let database = zstd::stream::encode_all(&archive[..], 0).expect("compress repository database");
+
+    assert_eq!(
+        repository_database_version(&database, "strata").map(|version| version.to_string()),
+        Ok("0.8.1".to_owned())
+    );
 }
 
 #[test]

--- a/src/services/update_install/tests.rs
+++ b/src/services/update_install/tests.rs
@@ -62,12 +62,16 @@ fn arch_package_versions_drop_epoch_and_package_release() {
 }
 
 #[test]
-fn repository_probe_reads_pacmans_machine_readable_version() {
+fn repository_probe_selects_strata_instead_of_a_dependency() {
     use std::os::unix::fs::PermissionsExt;
 
     let dir = tempfile::tempdir().expect("create tempdir");
     let probe = dir.path().join("pacman");
-    fs::write(&probe, "#!/bin/sh\nprintf '%s\\n' '0.8.1-1'\n").expect("write probe");
+    fs::write(
+        &probe,
+        "#!/bin/sh\nprintf '%s\\n' 'dependency 9.8.7-1' 'strata 0.8.1-1'\n",
+    )
+    .expect("write probe");
     fs::set_permissions(&probe, fs::Permissions::from_mode(0o755)).expect("make probe executable");
 
     assert_eq!(

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -531,7 +531,15 @@ fn updates_page(
     let auto_check_enabled = manager.checks_for_updates();
     let (auto_check_row, auto_check) = settings_option(
         "Automatically check for updates",
-        "Check GitHub for a newer release when Strata starts.",
+        match update_method {
+            UpdateMethod::InPlace => "Check GitHub for a newer release when Strata starts.",
+            UpdateMethod::Omarchy => {
+                "Check the Omarchy package repository for a newer release when Strata starts."
+            }
+            UpdateMethod::Pacman => {
+                "Check the configured package repositories for a newer release when Strata starts."
+            }
+        },
         auto_check_enabled,
     );
     preferences.append(&auto_check_row);
@@ -961,8 +969,11 @@ fn update_check_row(
             // mid-session channel toggle must be reflected by the very next
             // check, including this one if it was triggered by that toggle.
             let channel = effective_update_channel(manager.release_channel(), update_method);
-            let receiver =
-                services::check_for_updates(channel, crate::build_info::installed_version());
+            let receiver = services::check_for_updates(
+                channel,
+                crate::build_info::installed_version(),
+                update_method,
+            );
             let checking = checking.clone();
             let generation = generation.clone();
             let status = status.clone();


### PR DESCRIPTION
## Description

Use the live Omarchy repository database selected by the system configuration as the source of truth for package-managed update availability. Fetch GitHub metadata only for the exact version OPR already offers, while manual installations continue following their selected GitHub release channel. Generic pacman-managed installations are likewise gated by their configured sync database.

This prevents Strata from claiming a GitHub-only release is available through Omarchy. It also updates the settings copy and README to describe the correct release source.

## Visual evidence

N/A — the corrected behavior depends on a timing gap between GitHub and OPR and has no deterministic standalone visual state to capture.

## How to test

1. Install an OPR-managed Strata version while GitHub has a newer release that OPR does not yet offer.
2. Check for updates and confirm Strata does not announce the GitHub-only release.
3. Publish that version to the configured OPR channel and check again.
4. Confirm Strata announces the packaged version, shows its matching release notes, and offers **Open Omarchy Update**.
5. Run a manual release installation and confirm it still follows the selected GitHub release channel.

**Expected result:** Package-managed users see update notices only for versions their configured repository can install; manual users continue receiving GitHub release notices normally.

## Related issue

Closes #209