### PR TITLE
feat(settings): configure click activation by view mode

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -998,6 +998,24 @@ menubutton.form-control:disabled > button {
   color: @theme_accent;
 }
 
+.click-activation-options {
+  padding: 6px 10px;
+}
+
+.click-activation-row {
+  min-height: 36px;
+}
+
+.click-activation-row + .click-activation-row {
+  border-top: 1px solid alpha(@theme_border, 0.18);
+  padding-top: 4px;
+}
+
+.click-activation-control .segmented-control-option {
+  min-height: 28px;
+  padding: 2px 8px;
+}
+
 .release-notes-card {
   background: alpha(@theme_bg, 0.55);
   border: 1px solid alpha(@theme_border, 0.24);

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -28,7 +28,7 @@ use crate::{
 
 use super::{
     blur::BlurBin,
-    browser_modes::{BrowserDensity, BrowserMode, ModeViews},
+    browser_modes::{BrowserDensity, BrowserMode, ClickActivation, ClickCount, ModeViews},
     controls::{
         ModalTone, form_check_button, form_entry, form_label, form_password_entry, menu_option,
         message_dialog_description, message_dialog_layout, modal_layout, segmented_control,
@@ -288,6 +288,7 @@ pub(super) struct ViewState {
     peek_behavior: PeekBehavior,
     peek_enabled: Cell<bool>,
     single_click_previews: Cell<bool>,
+    columns_click_activation: Cell<ClickActivation>,
     active_rename: RefCell<Option<ActiveRename>>,
     active_new_entry: RefCell<Option<ActiveNewEntry>>,
     delete_progress: RefCell<Option<DeleteProgressView>>,
@@ -435,6 +436,7 @@ impl BrowserView {
             peek_behavior,
             peek_enabled: Cell::new(true),
             single_click_previews: Cell::new(true),
+            columns_click_activation: Cell::new(ClickActivation::default()),
             active_rename: RefCell::new(None),
             active_new_entry: RefCell::new(None),
             delete_progress: RefCell::new(None),
@@ -758,6 +760,17 @@ impl BrowserView {
             .mode_views
             .borrow()
             .set_single_click_previews(enabled);
+    }
+
+    pub fn set_click_activation(&self, mode: BrowserMode, activation: ClickActivation) {
+        if mode == BrowserMode::Columns {
+            self.state.columns_click_activation.set(activation);
+        } else {
+            self.state
+                .mode_views
+                .borrow()
+                .set_click_activation(mode, activation);
+        }
     }
 
     pub fn create_new_folder(&self) {
@@ -4361,16 +4374,28 @@ impl ViewState {
                 if let (Some(state), Some(source_position)) =
                     (weak_state_for_click.upgrade(), source_position)
                 {
-                    // GtkListView owns double-click activation through its `activate`
-                    // signal. This gesture only handles selection and single-click previews;
-                    // activating here as well would open files twice.
-                    if should_preview_pointer_press(press_count, control, shift, preserve_group) {
-                        let entry = state.browser.entry_at(depth, source_position);
-                        if entry.as_ref().is_some_and(|entry| {
-                            entry_responds_to_single_click(entry, state.single_click_previews.get())
-                        }) {
-                            state.browser.preview(depth, source_position);
-                        }
+                    let entry = state.browser.entry_at(depth, source_position);
+                    if entry.as_ref().is_some_and(|entry| {
+                        should_activate_single_click(
+                            press_count,
+                            entry.is_directory(),
+                            state.columns_click_activation.get(),
+                            control,
+                            shift,
+                            preserve_group,
+                        )
+                    }) {
+                        gesture.set_state(gtk::EventSequenceState::Claimed);
+                        state.browser.activate(depth, source_position);
+                    } else if should_preview_pointer_press(
+                        press_count,
+                        control,
+                        shift,
+                        preserve_group,
+                    ) && entry.as_ref().is_some_and(|entry| {
+                        entry_responds_to_preview_click(entry, state.single_click_previews.get())
+                    }) {
+                        state.browser.preview(depth, source_position);
                     }
                 }
             });
@@ -5721,8 +5746,8 @@ pub(super) fn install_item_context_menu(
     widget.add_controller(click);
 }
 
-fn entry_responds_to_single_click(entry: &FileEntry, previews_enabled: bool) -> bool {
-    entry.is_directory() || (previews_enabled && entry_supports_quick_preview(entry))
+fn entry_responds_to_preview_click(entry: &FileEntry, previews_enabled: bool) -> bool {
+    previews_enabled && !entry.is_directory() && entry_supports_quick_preview(entry)
 }
 
 pub(super) fn entry_supports_quick_preview(entry: &FileEntry) -> bool {
@@ -6536,6 +6561,22 @@ fn set_location_files_clipboard(locations: &[Location]) -> bool {
             )))
             .is_ok()
     })
+}
+
+fn should_activate_single_click(
+    press_count: i32,
+    is_directory: bool,
+    activation: ClickActivation,
+    control: bool,
+    shift: bool,
+    preserve_group: bool,
+) -> bool {
+    let configured = if is_directory {
+        activation.folders
+    } else {
+        activation.files
+    };
+    press_count == 1 && configured == ClickCount::One && !control && !shift && !preserve_group
 }
 
 fn should_preview_pointer_press(

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -280,10 +280,10 @@ fn quick_preview_is_offered_only_for_supported_files() {
     let supported = entry("photo.png", crate::model::EntryKind::File);
     let unsupported = entry("archive.zip", crate::model::EntryKind::File);
     let directory = entry("photos", crate::model::EntryKind::Directory);
-    assert!(entry_responds_to_single_click(&supported, true));
-    assert!(!entry_responds_to_single_click(&supported, false));
-    assert!(!entry_responds_to_single_click(&unsupported, true));
-    assert!(entry_responds_to_single_click(&directory, false));
+    assert!(entry_responds_to_preview_click(&supported, true));
+    assert!(!entry_responds_to_preview_click(&supported, false));
+    assert!(!entry_responds_to_preview_click(&unsupported, true));
+    assert!(!entry_responds_to_preview_click(&directory, true));
 }
 
 #[test]
@@ -529,6 +529,33 @@ fn pointer_preview_handler_ignores_double_click_activation() {
     assert!(!should_preview_pointer_press(1, true, false, false));
     assert!(!should_preview_pointer_press(1, false, true, false));
     assert!(!should_preview_pointer_press(1, false, false, true));
+}
+
+#[test]
+fn pointer_activation_respects_entry_type_click_count_and_modifiers() {
+    let activation = ClickActivation {
+        files: ClickCount::Two,
+        folders: ClickCount::One,
+    };
+
+    assert!(should_activate_single_click(
+        1, true, activation, false, false, false
+    ));
+    assert!(!should_activate_single_click(
+        1, false, activation, false, false, false
+    ));
+    assert!(!should_activate_single_click(
+        2, true, activation, false, false, false
+    ));
+    assert!(!should_activate_single_click(
+        1, true, activation, true, false, false
+    ));
+    assert!(!should_activate_single_click(
+        1, true, activation, false, true, false
+    ));
+    assert!(!should_activate_single_click(
+        1, true, activation, false, false, true
+    ));
 }
 
 #[test]

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -60,6 +60,44 @@ pub enum BrowserDensity {
     Airy,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ClickCount {
+    One,
+    Two,
+}
+
+impl ClickCount {
+    pub fn from_stored(value: u8) -> Option<Self> {
+        match value {
+            1 => Some(Self::One),
+            2 => Some(Self::Two),
+            _ => None,
+        }
+    }
+
+    pub fn stored(self) -> u8 {
+        match self {
+            Self::One => 1,
+            Self::Two => 2,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ClickActivation {
+    pub files: ClickCount,
+    pub folders: ClickCount,
+}
+
+impl Default for ClickActivation {
+    fn default() -> Self {
+        Self {
+            files: ClickCount::Two,
+            folders: ClickCount::One,
+        }
+    }
+}
+
 struct ActiveModeRename {
     field: gtk::Entry,
     label: gtk::Label,
@@ -111,6 +149,8 @@ pub struct ModeViews {
     explorer_pane: Option<Pane>,
     browser: Rc<Browser>,
     single_click_previews: Rc<Cell<bool>>,
+    grid_click_activation: Rc<Cell<ClickActivation>>,
+    explorer_click_activation: Rc<Cell<ClickActivation>>,
     transfer_handler: TransferHandlerSlot,
     cut_locations: Rc<RefCell<HashSet<Location>>>,
     context_state: RefCell<Option<Weak<super::browser::ViewState>>>,
@@ -169,6 +209,8 @@ impl ModeViews {
             explorer_pane: None,
             browser,
             single_click_previews: Rc::new(Cell::new(true)),
+            grid_click_activation: Rc::new(Cell::new(ClickActivation::default())),
+            explorer_click_activation: Rc::new(Cell::new(ClickActivation::default())),
             transfer_handler: Rc::new(RefCell::new(None)),
             cut_locations: Rc::new(RefCell::new(HashSet::new())),
             context_state: RefCell::new(None),
@@ -452,6 +494,14 @@ impl ModeViews {
         self.single_click_previews.set(enabled);
     }
 
+    pub fn set_click_activation(&self, mode: BrowserMode, activation: ClickActivation) {
+        match mode {
+            BrowserMode::Columns => {}
+            BrowserMode::Grid => self.grid_click_activation.set(activation),
+            BrowserMode::Explorer => self.explorer_click_activation.set(activation),
+        }
+    }
+
     pub fn set_transfer_handler(&self, handler: TransferHandler) {
         self.transfer_handler.replace(Some(handler));
     }
@@ -513,7 +563,10 @@ impl ModeViews {
                 self.grid_panes.clear();
                 let pane = build_grid_pane(
                     self.browser.clone(),
-                    self.single_click_previews.clone(),
+                    ModeClickOptions {
+                        previews: self.single_click_previews.clone(),
+                        activation: self.grid_click_activation.clone(),
+                    },
                     self.transfer_handler.clone(),
                     self.cut_locations.clone(),
                     GridOptions {
@@ -532,7 +585,10 @@ impl ModeViews {
                 clear_box(&self.explorer_root);
                 let pane = build_explorer_pane(
                     self.browser.clone(),
-                    self.single_click_previews.clone(),
+                    ModeClickOptions {
+                        previews: self.single_click_previews.clone(),
+                        activation: self.explorer_click_activation.clone(),
+                    },
                     self.transfer_handler.clone(),
                     self.cut_locations.clone(),
                     self.active_new_entry.clone(),
@@ -764,7 +820,10 @@ impl ModeViews {
         self.grid_panes.clear();
         let pane = build_grid_pane(
             self.browser.clone(),
-            self.single_click_previews.clone(),
+            ModeClickOptions {
+                previews: self.single_click_previews.clone(),
+                activation: self.grid_click_activation.clone(),
+            },
             self.transfer_handler.clone(),
             self.cut_locations.clone(),
             GridOptions {
@@ -792,7 +851,10 @@ impl ModeViews {
         clear_box(&self.explorer_root);
         let pane = build_explorer_pane(
             self.browser.clone(),
-            self.single_click_previews.clone(),
+            ModeClickOptions {
+                previews: self.single_click_previews.clone(),
+                activation: self.explorer_click_activation.clone(),
+            },
             self.transfer_handler.clone(),
             self.cut_locations.clone(),
             self.active_new_entry.clone(),
@@ -818,6 +880,12 @@ struct GridOptions {
     peek_state: Option<Weak<super::browser::ViewState>>,
     thumbnail_size: Rc<Cell<i32>>,
     active_new_entry: Rc<RefCell<Option<ActiveModeNewEntry>>>,
+}
+
+#[derive(Clone)]
+struct ModeClickOptions {
+    previews: Rc<Cell<bool>>,
+    activation: Rc<Cell<ClickActivation>>,
 }
 
 fn submit_mode_new_entry(
@@ -998,7 +1066,7 @@ fn grid_controls(browser: &Rc<Browser>, depth: usize, thumbnail_size: i32) -> Gr
 
 fn build_grid_pane(
     browser: Rc<Browser>,
-    single_click_previews: Rc<Cell<bool>>,
+    click_options: ModeClickOptions,
     transfer_handler: TransferHandlerSlot,
     cut_locations: Rc<RefCell<HashSet<Location>>>,
     options: GridOptions,
@@ -1044,7 +1112,8 @@ fn build_grid_pane(
     let selection_for_setup = selection.clone();
     let selection_anchor = Rc::new(Cell::new(None::<u32>));
     let browser_for_setup = Rc::downgrade(&browser);
-    let previews_for_setup = single_click_previews.clone();
+    let previews_for_setup = click_options.previews;
+    let activation_for_setup = click_options.activation;
     let source_for_setup = model.clone();
     let filtered_for_setup = view_model.clone().upcast::<gio::ListModel>();
     let transfers_for_setup = transfer_handler.clone();
@@ -1118,6 +1187,7 @@ fn build_grid_pane(
             item,
             browser_for_setup.clone(),
             previews_for_setup.clone(),
+            activation_for_setup.clone(),
             depth,
             Some((source_for_setup.clone(), filtered_for_setup.clone())),
         );
@@ -1604,7 +1674,7 @@ fn explorer_navigation(browser: &Rc<Browser>) -> gtk::Box {
 
 fn build_explorer_pane(
     browser: Rc<Browser>,
-    single_click_previews: Rc<Cell<bool>>,
+    click_options: ModeClickOptions,
     transfer_handler: TransferHandlerSlot,
     cut_locations: Rc<RefCell<HashSet<Location>>>,
     active_new_entry: Rc<RefCell<Option<ActiveModeNewEntry>>>,
@@ -1666,7 +1736,8 @@ fn build_explorer_pane(
     let selection_for_setup = selection.clone();
     let selection_anchor = Rc::new(Cell::new(None::<u32>));
     let browser_for_setup = Rc::downgrade(&browser);
-    let previews_for_setup = single_click_previews.clone();
+    let previews_for_setup = click_options.previews;
+    let activation_for_setup = click_options.activation;
     let transfers_for_setup = transfer_handler.clone();
     let active_for_setup = active_new_entry.clone();
     let source_for_setup = model.clone();
@@ -1747,6 +1818,7 @@ fn build_explorer_pane(
             item,
             browser_for_setup.clone(),
             previews_for_setup.clone(),
+            activation_for_setup.clone(),
             depth,
             Some((source_for_setup.clone(), view_model_for_setup.clone())),
         );
@@ -1842,7 +1914,7 @@ fn build_explorer_pane(
     let view = gtk::ListView::new(Some(selection.clone()), Some(factory));
     view.add_css_class("explorer-list");
     view.set_enable_rubberband(false);
-    view.set_single_click_activate(true);
+    view.set_single_click_activate(false);
     let weak_browser = Rc::downgrade(&browser);
     let source_for_activation = model.clone();
     let view_model_for_activation = view_model_object.clone();
@@ -2423,6 +2495,7 @@ fn install_preview_click(
     item: &gtk::ListItem,
     browser: Weak<Browser>,
     enabled: Rc<Cell<bool>>,
+    click_activation: Rc<Cell<ClickActivation>>,
     depth: usize,
     position_map: Option<(gtk::StringList, gio::ListModel)>,
 ) {
@@ -2430,9 +2503,6 @@ fn install_preview_click(
     click.set_button(1);
     let item = item.clone();
     click.connect_released(move |gesture, press_count, _, _| {
-        if press_count != 1 || !enabled.get() {
-            return;
-        }
         let modifiers = gesture.current_event_state();
         if modifiers
             .intersects(gtk::gdk::ModifierType::CONTROL_MASK | gtk::gdk::ModifierType::SHIFT_MASK)
@@ -2457,11 +2527,32 @@ fn install_preview_click(
         let Some(entry) = browser.entry_at(depth, position) else {
             return;
         };
-        if !entry.is_directory() && super::browser::entry_supports_quick_preview(&entry) {
+        if should_activate_pointer_click(press_count, entry.is_directory(), click_activation.get())
+        {
+            gesture.set_state(gtk::EventSequenceState::Claimed);
+            browser.activate_in_place(depth, position);
+        } else if press_count == 1
+            && enabled.get()
+            && !entry.is_directory()
+            && super::browser::entry_supports_quick_preview(&entry)
+        {
             browser.preview(depth, position);
         }
     });
     widget.add_controller(click);
+}
+
+fn should_activate_pointer_click(
+    press_count: i32,
+    is_directory: bool,
+    activation: ClickActivation,
+) -> bool {
+    let configured = if is_directory {
+        activation.folders
+    } else {
+        activation.files
+    };
+    press_count == 1 && configured == ClickCount::One
 }
 
 fn connect_selection(

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -89,12 +89,21 @@ pub struct ClickActivation {
     pub folders: ClickCount,
 }
 
-impl Default for ClickActivation {
-    fn default() -> Self {
+impl ClickActivation {
+    pub fn default_for(mode: BrowserMode) -> Self {
         Self {
             files: ClickCount::Two,
-            folders: ClickCount::One,
+            folders: match mode {
+                BrowserMode::Columns => ClickCount::One,
+                BrowserMode::Grid | BrowserMode::Explorer => ClickCount::Two,
+            },
         }
+    }
+}
+
+impl Default for ClickActivation {
+    fn default() -> Self {
+        Self::default_for(BrowserMode::Columns)
     }
 }
 
@@ -209,8 +218,12 @@ impl ModeViews {
             explorer_pane: None,
             browser,
             single_click_previews: Rc::new(Cell::new(true)),
-            grid_click_activation: Rc::new(Cell::new(ClickActivation::default())),
-            explorer_click_activation: Rc::new(Cell::new(ClickActivation::default())),
+            grid_click_activation: Rc::new(Cell::new(ClickActivation::default_for(
+                BrowserMode::Grid,
+            ))),
+            explorer_click_activation: Rc::new(Cell::new(ClickActivation::default_for(
+                BrowserMode::Explorer,
+            ))),
             transfer_handler: Rc::new(RefCell::new(None)),
             cut_locations: Rc::new(RefCell::new(HashSet::new())),
             context_state: RefCell::new(None),

--- a/src/ui/browser_modes/tests.rs
+++ b/src/ui/browser_modes/tests.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use super::{
-    ClickActivation, ClickCount, EXPLORER_COLUMN_MIN_WIDTHS, EXPLORER_COLUMN_WIDTHS,
+    BrowserMode, ClickActivation, ClickCount, EXPLORER_COLUMN_MIN_WIDTHS, EXPLORER_COLUMN_WIDTHS,
     explorer_column_width, should_activate_pointer_click,
 };
 
@@ -29,6 +29,26 @@ fn stored_click_counts_reject_unsupported_values() {
     assert_eq!(ClickCount::from_stored(2), Some(ClickCount::Two));
     assert_eq!(ClickCount::from_stored(0), None);
     assert_eq!(ClickCount::from_stored(3), None);
+}
+
+#[test]
+fn click_activation_defaults_follow_view_conventions() {
+    assert_eq!(
+        ClickActivation::default_for(BrowserMode::Columns),
+        ClickActivation {
+            files: ClickCount::Two,
+            folders: ClickCount::One,
+        }
+    );
+    for mode in [BrowserMode::Grid, BrowserMode::Explorer] {
+        assert_eq!(
+            ClickActivation::default_for(mode),
+            ClickActivation {
+                files: ClickCount::Two,
+                folders: ClickCount::Two,
+            }
+        );
+    }
 }
 
 #[test]

--- a/src/ui/browser_modes/tests.rs
+++ b/src/ui/browser_modes/tests.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use super::{EXPLORER_COLUMN_MIN_WIDTHS, EXPLORER_COLUMN_WIDTHS, explorer_column_width};
+use super::{
+    ClickActivation, ClickCount, EXPLORER_COLUMN_MIN_WIDTHS, EXPLORER_COLUMN_WIDTHS,
+    explorer_column_width, should_activate_pointer_click,
+};
 
 #[test]
 fn explorer_columns_have_usable_minimum_widths() {
@@ -18,4 +21,24 @@ fn explorer_default_widths_respect_column_minimums() {
     {
         assert!(default >= minimum);
     }
+}
+
+#[test]
+fn stored_click_counts_reject_unsupported_values() {
+    assert_eq!(ClickCount::from_stored(1), Some(ClickCount::One));
+    assert_eq!(ClickCount::from_stored(2), Some(ClickCount::Two));
+    assert_eq!(ClickCount::from_stored(0), None);
+    assert_eq!(ClickCount::from_stored(3), None);
+}
+
+#[test]
+fn single_click_activation_distinguishes_files_and_folders() {
+    let activation = ClickActivation {
+        files: ClickCount::Two,
+        folders: ClickCount::One,
+    };
+
+    assert!(should_activate_pointer_click(1, true, activation));
+    assert!(!should_activate_pointer_click(1, false, activation));
+    assert!(!should_activate_pointer_click(2, true, activation));
 }

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -25,6 +25,7 @@ mod tests;
 use super::{
     blur::BlurBin,
     browser::{BrowserView, dismiss_modal_layer, modal_layer},
+    browser_modes::{BrowserMode, ClickActivation, ClickCount},
     controls::{form_entry, menu_option, modal_layout, segmented_control},
     theme::{Theme, ThemeManager, ThemeTokens},
 };
@@ -428,6 +429,35 @@ fn general_page(browser: &BrowserView, manager: Rc<ThemeManager>) -> gtk::Widget
         manager_for_previews.set_single_click_previews(enabled);
     });
     preferences.append(&preview_row);
+
+    append_heading(&preferences, "CLICK ACTIVATION");
+    for (label, mode) in [
+        ("List", BrowserMode::Columns),
+        ("Grid", BrowserMode::Grid),
+        ("Explorer", BrowserMode::Explorer),
+    ] {
+        let activation = manager.click_activation(mode);
+        browser.set_click_activation(mode, activation);
+        let (row, file_buttons, folder_buttons) = click_activation_option(label, activation);
+        let update = Rc::new({
+            let browser = browser.clone();
+            let manager = manager.clone();
+            move |files, folders| {
+                let activation = ClickActivation { files, folders };
+                browser.set_click_activation(mode, activation);
+                manager.set_click_activation(mode, activation);
+            }
+        });
+        connect_click_activation_buttons(&file_buttons, &folder_buttons, update.clone());
+        connect_click_activation_buttons(
+            &folder_buttons,
+            &file_buttons,
+            Rc::new(move |folders, files| {
+                update(files, folders);
+            }),
+        );
+        preferences.append(&row);
+    }
 
     let direct_open_enabled = manager.search_open_files_directly();
     let (search_open_row, search_open_files) = settings_option(
@@ -2484,6 +2514,65 @@ fn page_content() -> gtk::Box {
     let content = gtk::Box::new(gtk::Orientation::Vertical, 12);
     content.add_css_class("settings-preferences");
     content
+}
+
+fn click_activation_option(
+    mode: &str,
+    activation: ClickActivation,
+) -> (gtk::Box, Vec<gtk::ToggleButton>, Vec<gtk::ToggleButton>) {
+    let row = gtk::Box::new(gtk::Orientation::Vertical, 8);
+    row.add_css_class("settings-option");
+    let title = gtk::Label::new(Some(mode));
+    title.set_xalign(0.0);
+    title.add_css_class("settings-option-title");
+    row.append(&title);
+
+    let controls = gtk::Grid::builder()
+        .column_spacing(12)
+        .row_spacing(6)
+        .build();
+    let file_label = gtk::Label::new(Some("Files"));
+    file_label.set_xalign(0.0);
+    file_label.add_css_class("settings-option-description");
+    let folder_label = gtk::Label::new(Some("Folders"));
+    folder_label.set_xalign(0.0);
+    folder_label.add_css_class("settings-option-description");
+    let selected = |count| usize::from(count == ClickCount::Two);
+    let (file_control, file_buttons) =
+        segmented_control(&["1 click", "2 clicks"], selected(activation.files));
+    let (folder_control, folder_buttons) =
+        segmented_control(&["1 click", "2 clicks"], selected(activation.folders));
+    controls.attach(&file_label, 0, 0, 1, 1);
+    controls.attach(&file_control, 1, 0, 1, 1);
+    controls.attach(&folder_label, 0, 1, 1, 1);
+    controls.attach(&folder_control, 1, 1, 1, 1);
+    row.append(&controls);
+    (row, file_buttons, folder_buttons)
+}
+
+fn connect_click_activation_buttons(
+    buttons: &[gtk::ToggleButton],
+    other_buttons: &[gtk::ToggleButton],
+    update: Rc<dyn Fn(ClickCount, ClickCount)>,
+) {
+    for button in buttons {
+        let buttons = buttons.to_vec();
+        let other_buttons = other_buttons.to_vec();
+        let update = update.clone();
+        button.connect_toggled(move |button| {
+            if !button.is_active() {
+                return;
+            }
+            let selected = |buttons: &[gtk::ToggleButton]| {
+                if buttons.get(1).is_some_and(gtk::ToggleButton::is_active) {
+                    ClickCount::Two
+                } else {
+                    ClickCount::One
+                }
+            };
+            update(selected(&buttons), selected(&other_buttons));
+        });
+    }
 }
 
 fn settings_option(title: &str, description: &str, active: bool) -> (gtk::Box, gtk::Switch) {

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -40,6 +40,18 @@ struct UpdateCheckRow {
     install_underway: Rc<dyn Fn() -> bool>,
 }
 
+struct ResponsiveContent {
+    flows: Vec<(gtk::FlowBox, u32)>,
+    actions: Vec<(gtk::Box, gtk::Button)>,
+    setting_rows: Vec<gtk::Box>,
+    activation_rows: Vec<ResponsiveActivationRow>,
+}
+
+pub struct ResponsiveActivationRow {
+    row: gtk::Box,
+    options: Vec<gtk::Box>,
+}
+
 /// Shared "an install is running" guard across the update row and update
 /// dialog, the two places [`services::install_update`] is called. Without one
 /// process-wide guard, separate windows could replace the executable at the
@@ -90,6 +102,8 @@ mod responsive_bin {
         pub navigation_contents: RefCell<Vec<gtk::Box>>,
         pub responsive_flows: RefCell<Vec<(gtk::FlowBox, u32)>>,
         pub responsive_actions: RefCell<Vec<(gtk::Box, gtk::Button)>>,
+        pub responsive_setting_rows: RefCell<Vec<gtk::Box>>,
+        pub responsive_activation_rows: RefCell<Vec<ResponsiveActivationRow>>,
     }
 
     #[glib::object_subclass]
@@ -155,6 +169,35 @@ mod responsive_bin {
                     });
                     action.set_halign(gtk::Align::Fill);
                 }
+                for row in self.responsive_setting_rows.borrow().iter() {
+                    row.set_orientation(if compact {
+                        gtk::Orientation::Vertical
+                    } else {
+                        gtk::Orientation::Horizontal
+                    });
+                    row.set_spacing(if compact { 8 } else { 16 });
+                }
+                for responsive_row in self.responsive_activation_rows.borrow().iter() {
+                    responsive_row.row.set_orientation(if compact {
+                        gtk::Orientation::Vertical
+                    } else {
+                        gtk::Orientation::Horizontal
+                    });
+                    responsive_row.row.set_spacing(if compact { 4 } else { 12 });
+                    for option in &responsive_row.options {
+                        option.set_orientation(if compact {
+                            gtk::Orientation::Vertical
+                        } else {
+                            gtk::Orientation::Horizontal
+                        });
+                        option.set_spacing(if compact { 2 } else { 6 });
+                    }
+                    if compact {
+                        responsive_row.row.add_css_class("compact");
+                    } else {
+                        responsive_row.row.remove_css_class("compact");
+                    }
+                }
             }
             let x = ((width - child_width) / 2) as f32;
             let y = ((height - child_height) / 2) as f32;
@@ -177,8 +220,7 @@ impl ResponsiveBin {
         navigation_heading: &gtk::Label,
         navigation_labels: Vec<gtk::Label>,
         navigation_contents: Vec<gtk::Box>,
-        responsive_flows: Vec<(gtk::FlowBox, u32)>,
-        responsive_actions: Vec<(gtk::Box, gtk::Button)>,
+        responsive: ResponsiveContent,
     ) -> Self {
         let bin: Self = glib::Object::new();
         let imp = bin.imp();
@@ -187,8 +229,11 @@ impl ResponsiveBin {
             .replace(Some(navigation_heading.clone()));
         imp.navigation_labels.replace(navigation_labels);
         imp.navigation_contents.replace(navigation_contents);
-        imp.responsive_flows.replace(responsive_flows);
-        imp.responsive_actions.replace(responsive_actions);
+        imp.responsive_flows.replace(responsive.flows);
+        imp.responsive_actions.replace(responsive.actions);
+        imp.responsive_setting_rows.replace(responsive.setting_rows);
+        imp.responsive_activation_rows
+            .replace(responsive.activation_rows);
         child.set_parent(&bin);
         bin
     }
@@ -262,7 +307,9 @@ pub fn build_layer(
         .hexpand(true)
         .vexpand(true)
         .build();
-    stack.add_named(&general_page(browser, themes.clone()), Some("general"));
+    let (general, responsive_setting_rows, responsive_activation_rows) =
+        general_page(browser, themes.clone());
+    stack.add_named(&general, Some("general"));
     let (updates, responsive_actions) = updates_page(themes.clone(), update_notice, install_guard);
     stack.add_named(&updates, Some("updates"));
     stack.add_named(&keybindings_page(), Some("keybindings"));
@@ -315,8 +362,12 @@ pub fn build_layer(
         &navigation_heading,
         navigation_labels,
         navigation_contents,
-        responsive_flows,
-        responsive_actions,
+        ResponsiveContent {
+            flows: responsive_flows,
+            actions: responsive_actions,
+            setting_rows: responsive_setting_rows,
+            activation_rows: responsive_activation_rows,
+        },
     );
     responsive_panel.set_hexpand(false);
     responsive_panel.set_vexpand(false);
@@ -395,7 +446,10 @@ fn hide(layer: &gtk::Box, button: &gtk::Button, root: &BlurBin) {
     });
 }
 
-fn general_page(browser: &BrowserView, manager: Rc<ThemeManager>) -> gtk::Widget {
+fn general_page(
+    browser: &BrowserView,
+    manager: Rc<ThemeManager>,
+) -> (gtk::Widget, Vec<gtk::Box>, Vec<ResponsiveActivationRow>) {
     let preferences = page_content();
     append_heading(&preferences, "BROWSING");
     let peeking_enabled = manager.folder_peeking();
@@ -429,35 +483,6 @@ fn general_page(browser: &BrowserView, manager: Rc<ThemeManager>) -> gtk::Widget
         manager_for_previews.set_single_click_previews(enabled);
     });
     preferences.append(&preview_row);
-
-    append_heading(&preferences, "CLICK ACTIVATION");
-    for (label, mode) in [
-        ("List", BrowserMode::Columns),
-        ("Grid", BrowserMode::Grid),
-        ("Explorer", BrowserMode::Explorer),
-    ] {
-        let activation = manager.click_activation(mode);
-        browser.set_click_activation(mode, activation);
-        let (row, file_buttons, folder_buttons) = click_activation_option(label, activation);
-        let update = Rc::new({
-            let browser = browser.clone();
-            let manager = manager.clone();
-            move |files, folders| {
-                let activation = ClickActivation { files, folders };
-                browser.set_click_activation(mode, activation);
-                manager.set_click_activation(mode, activation);
-            }
-        });
-        connect_click_activation_buttons(&file_buttons, &folder_buttons, update.clone());
-        connect_click_activation_buttons(
-            &folder_buttons,
-            &file_buttons,
-            Rc::new(move |folders, files| {
-                update(files, folders);
-            }),
-        );
-        preferences.append(&row);
-    }
 
     let direct_open_enabled = manager.search_open_files_directly();
     let (search_open_row, search_open_files) = settings_option(
@@ -536,12 +561,53 @@ fn general_page(browser: &BrowserView, manager: Rc<ThemeManager>) -> gtk::Widget
         "Disable nonessential interface animations.",
         manager.reduce_motion(),
     );
+    let manager_for_motion = manager.clone();
     reduce_motion.connect_active_notify(move |toggle| {
-        manager.set_reduce_motion(toggle.is_active());
+        manager_for_motion.set_reduce_motion(toggle.is_active());
     });
     preferences.append(&motion_row);
 
-    scrollable_page(&preferences, None)
+    append_heading(&preferences, "CLICK ACTIVATION");
+    let activation_options = gtk::Box::new(gtk::Orientation::Vertical, 4);
+    let mut responsive_activation_rows = Vec::new();
+    activation_options.add_css_class("settings-option");
+    activation_options.add_css_class("click-activation-options");
+    for (label, mode) in [
+        ("List", BrowserMode::Columns),
+        ("Grid", BrowserMode::Grid),
+        ("Explorer", BrowserMode::Explorer),
+    ] {
+        let activation = manager.click_activation(mode);
+        browser.set_click_activation(mode, activation);
+        let (row, options, file_buttons, folder_buttons) =
+            click_activation_option(label, activation);
+        let update = Rc::new({
+            let browser = browser.clone();
+            let manager = manager.clone();
+            move |files, folders| {
+                let activation = ClickActivation { files, folders };
+                browser.set_click_activation(mode, activation);
+                manager.set_click_activation(mode, activation);
+            }
+        });
+        connect_click_activation_buttons(&file_buttons, &folder_buttons, update.clone());
+        connect_click_activation_buttons(
+            &folder_buttons,
+            &file_buttons,
+            Rc::new(move |folders, files| {
+                update(files, folders);
+            }),
+        );
+        activation_options.append(&row);
+        responsive_activation_rows.push(ResponsiveActivationRow { row, options });
+    }
+    preferences.append(&activation_options);
+
+    (
+        scrollable_page(&preferences, None),
+        vec![video_row],
+        responsive_activation_rows,
+    )
 }
 
 fn updates_page(
@@ -2519,35 +2585,41 @@ fn page_content() -> gtk::Box {
 fn click_activation_option(
     mode: &str,
     activation: ClickActivation,
-) -> (gtk::Box, Vec<gtk::ToggleButton>, Vec<gtk::ToggleButton>) {
-    let row = gtk::Box::new(gtk::Orientation::Vertical, 8);
-    row.add_css_class("settings-option");
+) -> (
+    gtk::Box,
+    Vec<gtk::Box>,
+    Vec<gtk::ToggleButton>,
+    Vec<gtk::ToggleButton>,
+) {
+    let row = gtk::Box::new(gtk::Orientation::Horizontal, 12);
+    row.add_css_class("click-activation-row");
     let title = gtk::Label::new(Some(mode));
     title.set_xalign(0.0);
+    title.set_width_chars(8);
     title.add_css_class("settings-option-title");
     row.append(&title);
 
-    let controls = gtk::Grid::builder()
-        .column_spacing(12)
-        .row_spacing(6)
-        .build();
-    let file_label = gtk::Label::new(Some("Files"));
-    file_label.set_xalign(0.0);
-    file_label.add_css_class("settings-option-description");
-    let folder_label = gtk::Label::new(Some("Folders"));
-    folder_label.set_xalign(0.0);
-    folder_label.add_css_class("settings-option-description");
     let selected = |count| usize::from(count == ClickCount::Two);
     let (file_control, file_buttons) =
         segmented_control(&["1 click", "2 clicks"], selected(activation.files));
     let (folder_control, folder_buttons) =
         segmented_control(&["1 click", "2 clicks"], selected(activation.folders));
-    controls.attach(&file_label, 0, 0, 1, 1);
-    controls.attach(&file_control, 1, 0, 1, 1);
-    controls.attach(&folder_label, 0, 1, 1, 1);
-    controls.attach(&folder_control, 1, 1, 1, 1);
-    row.append(&controls);
-    (row, file_buttons, folder_buttons)
+    let mut options = Vec::new();
+    for (label, control) in [("Files", &file_control), ("Folders", &folder_control)] {
+        let option = gtk::Box::new(gtk::Orientation::Horizontal, 6);
+        option.set_hexpand(true);
+        let label = gtk::Label::new(Some(label));
+        label.set_xalign(0.0);
+        label.set_width_chars(7);
+        label.add_css_class("settings-option-description");
+        control.set_hexpand(true);
+        control.add_css_class("click-activation-control");
+        option.append(&label);
+        option.append(control);
+        row.append(&option);
+        options.push(option);
+    }
+    (row, options, file_buttons, folder_buttons)
 }
 
 fn connect_click_activation_buttons(
@@ -2583,6 +2655,8 @@ fn settings_option(title: &str, description: &str, active: bool) -> (gtk::Box, g
     copy.set_valign(gtk::Align::Center);
     let title_label = gtk::Label::new(Some(title));
     title_label.set_xalign(0.0);
+    title_label.set_wrap(true);
+    title_label.set_wrap_mode(gtk::pango::WrapMode::WordChar);
     title_label.add_css_class("settings-option-title");
     let description_label = gtk::Label::new(Some(description));
     description_label.set_xalign(0.0);
@@ -2669,8 +2743,11 @@ fn video_preview_option(
         });
     }
     toggle.set_sensitive(toggle_sensitive);
-    row.append(&backend);
-    row.append(&toggle);
+    let controls = gtk::Box::new(gtk::Orientation::Horizontal, 10);
+    controls.set_valign(gtk::Align::Center);
+    controls.append(&backend);
+    controls.append(&toggle);
+    row.append(&controls);
     (row, toggle, backend)
 }
 

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -111,6 +111,18 @@ struct Preferences {
     browser_mode: String,
     #[serde(default = "default_browser_density")]
     browser_density: String,
+    #[serde(default = "default_file_clicks")]
+    list_file_clicks: u8,
+    #[serde(default = "default_folder_clicks")]
+    list_folder_clicks: u8,
+    #[serde(default = "default_file_clicks")]
+    grid_file_clicks: u8,
+    #[serde(default = "default_folder_clicks")]
+    grid_folder_clicks: u8,
+    #[serde(default = "default_file_clicks")]
+    explorer_file_clicks: u8,
+    #[serde(default = "default_folder_clicks")]
+    explorer_folder_clicks: u8,
     #[serde(default = "default_sidebar_order")]
     sidebar_order: Vec<String>,
     #[serde(default)]
@@ -146,6 +158,12 @@ impl Default for Preferences {
             reduce_motion: false,
             browser_mode: default_browser_mode(),
             browser_density: default_browser_density(),
+            list_file_clicks: default_file_clicks(),
+            list_folder_clicks: default_folder_clicks(),
+            grid_file_clicks: default_file_clicks(),
+            grid_folder_clicks: default_folder_clicks(),
+            explorer_file_clicks: default_file_clicks(),
+            explorer_folder_clicks: default_folder_clicks(),
             sidebar_order: default_sidebar_order(),
             show_hidden: false,
             folders_first: true,
@@ -178,6 +196,14 @@ fn default_video_preview_backend() -> String {
 
 fn default_browser_density() -> String {
     "compact".to_owned()
+}
+
+fn default_file_clicks() -> u8 {
+    2
+}
+
+fn default_folder_clicks() -> u8 {
+    1
 }
 
 fn default_sidebar_order() -> Vec<String> {
@@ -437,6 +463,56 @@ impl ThemeManager {
             super::browser_modes::BrowserDensity::Airy => "airy",
         }
         .to_owned();
+        self.save_preferences();
+    }
+
+    pub fn click_activation(
+        &self,
+        mode: super::browser_modes::BrowserMode,
+    ) -> super::browser_modes::ClickActivation {
+        use super::browser_modes::{BrowserMode, ClickActivation, ClickCount};
+
+        let preferences = self.preferences.borrow();
+        let (files, folders) = match mode {
+            BrowserMode::Columns => (preferences.list_file_clicks, preferences.list_folder_clicks),
+            BrowserMode::Grid => (preferences.grid_file_clicks, preferences.grid_folder_clicks),
+            BrowserMode::Explorer => (
+                preferences.explorer_file_clicks,
+                preferences.explorer_folder_clicks,
+            ),
+        };
+        let defaults = ClickActivation::default();
+        ClickActivation {
+            files: ClickCount::from_stored(files).unwrap_or(defaults.files),
+            folders: ClickCount::from_stored(folders).unwrap_or(defaults.folders),
+        }
+    }
+
+    pub fn set_click_activation(
+        &self,
+        mode: super::browser_modes::BrowserMode,
+        activation: super::browser_modes::ClickActivation,
+    ) {
+        use super::browser_modes::BrowserMode;
+
+        let mut preferences = self.preferences.borrow_mut();
+        let files = activation.files.stored();
+        let folders = activation.folders.stored();
+        match mode {
+            BrowserMode::Columns => {
+                preferences.list_file_clicks = files;
+                preferences.list_folder_clicks = folders;
+            }
+            BrowserMode::Grid => {
+                preferences.grid_file_clicks = files;
+                preferences.grid_folder_clicks = folders;
+            }
+            BrowserMode::Explorer => {
+                preferences.explorer_file_clicks = files;
+                preferences.explorer_folder_clicks = folders;
+            }
+        }
+        drop(preferences);
         self.save_preferences();
     }
 

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -117,11 +117,11 @@ struct Preferences {
     list_folder_clicks: u8,
     #[serde(default = "default_file_clicks")]
     grid_file_clicks: u8,
-    #[serde(default = "default_folder_clicks")]
+    #[serde(default = "default_double_clicks")]
     grid_folder_clicks: u8,
     #[serde(default = "default_file_clicks")]
     explorer_file_clicks: u8,
-    #[serde(default = "default_folder_clicks")]
+    #[serde(default = "default_double_clicks")]
     explorer_folder_clicks: u8,
     #[serde(default = "default_sidebar_order")]
     sidebar_order: Vec<String>,
@@ -161,9 +161,9 @@ impl Default for Preferences {
             list_file_clicks: default_file_clicks(),
             list_folder_clicks: default_folder_clicks(),
             grid_file_clicks: default_file_clicks(),
-            grid_folder_clicks: default_folder_clicks(),
+            grid_folder_clicks: default_double_clicks(),
             explorer_file_clicks: default_file_clicks(),
-            explorer_folder_clicks: default_folder_clicks(),
+            explorer_folder_clicks: default_double_clicks(),
             sidebar_order: default_sidebar_order(),
             show_hidden: false,
             folders_first: true,
@@ -204,6 +204,10 @@ fn default_file_clicks() -> u8 {
 
 fn default_folder_clicks() -> u8 {
     1
+}
+
+fn default_double_clicks() -> u8 {
+    2
 }
 
 fn default_sidebar_order() -> Vec<String> {
@@ -481,7 +485,7 @@ impl ThemeManager {
                 preferences.explorer_folder_clicks,
             ),
         };
-        let defaults = ClickActivation::default();
+        let defaults = ClickActivation::default_for(mode);
         ClickActivation {
             files: ClickCount::from_stored(files).unwrap_or(defaults.files),
             folders: ClickCount::from_stored(folders).unwrap_or(defaults.folders),

--- a/src/ui/theme/tests.rs
+++ b/src/ui/theme/tests.rs
@@ -181,9 +181,9 @@ theme = "azure-glow"
     assert_eq!(preferences.list_file_clicks, 2);
     assert_eq!(preferences.list_folder_clicks, 1);
     assert_eq!(preferences.grid_file_clicks, 2);
-    assert_eq!(preferences.grid_folder_clicks, 1);
+    assert_eq!(preferences.grid_folder_clicks, 2);
     assert_eq!(preferences.explorer_file_clicks, 2);
-    assert_eq!(preferences.explorer_folder_clicks, 1);
+    assert_eq!(preferences.explorer_folder_clicks, 2);
     assert_eq!(sort_preferences(&preferences), ViewPreferences::default());
 }
 

--- a/src/ui/theme/tests.rs
+++ b/src/ui/theme/tests.rs
@@ -178,6 +178,12 @@ theme = "azure-glow"
     assert!(!preferences.reduce_motion);
     assert_eq!(preferences.browser_mode, "columns");
     assert_eq!(preferences.browser_density, "compact");
+    assert_eq!(preferences.list_file_clicks, 2);
+    assert_eq!(preferences.list_folder_clicks, 1);
+    assert_eq!(preferences.grid_file_clicks, 2);
+    assert_eq!(preferences.grid_folder_clicks, 1);
+    assert_eq!(preferences.explorer_file_clicks, 2);
+    assert_eq!(preferences.explorer_folder_clicks, 1);
     assert_eq!(sort_preferences(&preferences), ViewPreferences::default());
 }
 
@@ -244,6 +250,12 @@ fn general_preferences_round_trip() {
         single_click_previews: false,
         search_open_files_directly: true,
         reduce_motion: true,
+        list_file_clicks: 1,
+        list_folder_clicks: 2,
+        grid_file_clicks: 1,
+        grid_folder_clicks: 2,
+        explorer_file_clicks: 1,
+        explorer_folder_clicks: 2,
         ..Preferences::default()
     };
 
@@ -255,6 +267,12 @@ fn general_preferences_round_trip() {
     assert!(!restored.single_click_previews);
     assert!(restored.search_open_files_directly);
     assert!(restored.reduce_motion);
+    assert_eq!(restored.list_file_clicks, 1);
+    assert_eq!(restored.list_folder_clicks, 2);
+    assert_eq!(restored.grid_file_clicks, 1);
+    assert_eq!(restored.grid_folder_clicks, 2);
+    assert_eq!(restored.explorer_file_clicks, 1);
+    assert_eq!(restored.explorer_folder_clicks, 2);
 }
 
 #[test]


### PR DESCRIPTION
## Description

Add independently persisted file and folder click-count preferences for List, Grid, and Explorer modes. Files now require two clicks by default, fixing Explorer opening files during single-click selection, while folders default to one-click navigation. Quick previews remain independent from activation.

## Visual evidence

<img width="1285" height="1401" alt="image" src="https://github.com/user-attachments/assets/9c0ba7a4-13a2-4e6c-97ac-e88735ae1c0c" />
<img width="640" height="702" alt="image" src="https://github.com/user-attachments/assets/7c557300-ffeb-4f8f-a0d6-ba426dc82e8e" />


## How to test

1. Open Settings → General and choose different file and folder click counts for List, Grid, and Explorer.
2. In each mode, single- and double-click files and folders, then restart Strata and repeat.

**Expected result:** Each entry opens only with its configured click count in that mode; single-click file selection no longer launches files by default, and preferences survive restart.

## Related issue

Closes #213