### PR TITLE
fix(search): always search from home instead of the current folder

### DIFF
--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -270,34 +270,26 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
     let search_dialog = SearchDialog::new(activate_search_result, dismiss_search);
     window_overlay.add_overlay(&search_dialog.widget());
     let shown_search = search_dialog.clone();
-    let search_browser = controller.clone();
     let search_blurred_root = blurred_root.clone();
     search_button.connect_clicked(move |button| {
         if shown_search.is_visible() {
             shown_search.hide();
             return;
         }
-        let root = search_browser
-            .active_location()
-            .and_then(|location| location.native_path().map(std::path::Path::to_path_buf))
-            .unwrap_or_else(home_directory);
+        let root = home_directory();
         button.add_css_class("active");
         search_blurred_root.set_blurred(true);
         shown_search.show(root);
     });
     let search_action = gio::SimpleAction::new("search", None);
     let shortcut_search = search_dialog.clone();
-    let shortcut_browser = controller.clone();
     let shortcut_search_button = search_button.clone();
     let shortcut_search_root = blurred_root.clone();
     search_action.connect_activate(move |_, _| {
         if shortcut_search.is_visible() {
             shortcut_search.hide();
         } else {
-            let root = shortcut_browser
-                .active_location()
-                .and_then(|location| location.native_path().map(std::path::Path::to_path_buf))
-                .unwrap_or_else(home_directory);
+            let root = home_directory();
             shortcut_search_button.add_css_class("active");
             shortcut_search_root.set_blurred(true);
             shortcut_search.show(root);


### PR DESCRIPTION
## Description

The search dialog indexed the active column's folder instead of the whole home tree, so results were scoped to wherever the user happened to be browsing. Each column already has its own inline filter for narrowing within a folder, making the folder-scoped global search redundant and confusing — the status text said "search the whole tree" but only searched the current directory.

Always pass `home_directory()` as the search root and drop the now-unused browser clones that fetched the active location.

## Visual evidence

N/A — no visual change to the search dialog; only the search scope changes (broader results when browsing outside home).

## How to test

1. Navigate to a subfolder (e.g. `~/Documents/Projects`)
2. Press `Ctrl+K` or click the search button
3. Type a filename that exists outside the current folder but inside `~`
4. Verify the result appears

**Expected result:** Search returns matches from the entire home directory regardless of which folder is currently open.

## Related issue

N/A