### PR TITLE
feat(preview): preview extensionless dotfiles as text

### DIFF
--- a/src/adapters/local_preview.rs
+++ b/src/adapters/local_preview.rs
@@ -9,7 +9,7 @@ use crate::{
     sandbox::{Cancellation, MediaPreviewBackend, ParseOperation},
     services::{
         LoadHandle, Preview, PreviewContent, PreviewEvent, PreviewProvider, PreviewRequest,
-        content_family, has_plain_text_extension,
+        content_family, has_plain_text_extension, is_non_executable_extensionless_dotfile,
     },
 };
 
@@ -36,7 +36,7 @@ impl PreviewProvider for LocalPreviewProvider {
             let file = file_for_location(&entry.location);
             let info = match file
                 .query_info_future(
-                    "standard::content-type",
+                    "standard::content-type,unix::mode",
                     gio::FileQueryInfoFlags::NONE,
                     glib::Priority::DEFAULT,
                 )
@@ -56,10 +56,14 @@ impl PreviewProvider for LocalPreviewProvider {
                 .content_type()
                 .map(|value| value.to_string())
                 .unwrap_or_else(|| "application/octet-stream".to_owned());
+            let unix_mode = info
+                .has_attribute(gio::FILE_ATTRIBUTE_UNIX_MODE)
+                .then(|| info.attribute_uint32(gio::FILE_ATTRIBUTE_UNIX_MODE));
             let mut content = content_family(&content_type);
             if matches!(content, PreviewContent::Unsupported)
                 && (gio::content_type_is_a(&content_type, "text/plain")
-                    || has_plain_text_extension(&entry.native_name))
+                    || has_plain_text_extension(&entry.native_name)
+                    || is_non_executable_extensionless_dotfile(&entry.native_name, unix_mode))
             {
                 content = PreviewContent::Text {
                     content: String::new(),

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -21,7 +21,10 @@ pub use operations::{
 pub use preview::{
     Preview, PreviewContent, PreviewEvent, PreviewProvider, PreviewRequest, PreviewRequestId,
 };
-pub(crate) use preview::{content_family, has_plain_text_extension};
+pub(crate) use preview::{
+    content_family, has_plain_text_extension, is_extensionless_dotfile,
+    is_non_executable_extensionless_dotfile,
+};
 // `best_update`, `rollback_target`, and `ReleaseSummary` are deliberately not
 // re-exported here: `rollback_target` is the never-downgrade bypass, and only
 // `update_check` (which imports them directly from `release_channel`) has any

--- a/src/services/preview.rs
+++ b/src/services/preview.rs
@@ -57,6 +57,18 @@ pub(crate) fn has_plain_text_extension(name: &OsStr) -> bool {
         .is_some_and(|extension| matches!(extension.to_ascii_lowercase().as_str(), "conf" | "ini"))
 }
 
+pub(crate) fn is_extensionless_dotfile(name: &OsStr) -> bool {
+    let bytes = name.as_encoded_bytes();
+    bytes.len() > 1 && bytes.starts_with(b".") && Path::new(name).extension().is_none()
+}
+
+pub(crate) fn is_non_executable_extensionless_dotfile(
+    name: &OsStr,
+    unix_mode: Option<u32>,
+) -> bool {
+    is_extensionless_dotfile(name) && unix_mode.is_some_and(|mode| mode & 0o111 == 0)
+}
+
 pub(crate) fn content_family(content_type: &str) -> PreviewContent {
     if content_type == "application/pdf" {
         PreviewContent::Pdf {

--- a/src/services/preview/tests.rs
+++ b/src/services/preview/tests.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use super::{PreviewContent, content_family, has_plain_text_extension};
+use super::{
+    PreviewContent, content_family, has_plain_text_extension, is_extensionless_dotfile,
+    is_non_executable_extensionless_dotfile,
+};
 
 #[test]
 fn recognizes_configuration_files_as_plain_text() {
@@ -13,6 +16,30 @@ fn recognizes_configuration_files_as_plain_text() {
     assert!(!has_plain_text_extension(std::ffi::OsStr::new(
         "archive.zip"
     )));
+}
+
+#[test]
+fn recognizes_extensionless_dotfiles() {
+    assert!(is_extensionless_dotfile(std::ffi::OsStr::new(".steampath")));
+    assert!(!is_extensionless_dotfile(std::ffi::OsStr::new("steampath")));
+    assert!(!is_extensionless_dotfile(std::ffi::OsStr::new(
+        ".settings.toml"
+    )));
+}
+
+#[test]
+fn recognizes_non_executable_extensionless_dotfiles() {
+    let name = std::ffi::OsStr::new(".steamid");
+
+    assert!(is_non_executable_extensionless_dotfile(
+        name,
+        Some(0o100644)
+    ));
+    assert!(!is_non_executable_extensionless_dotfile(
+        name,
+        Some(0o100755)
+    ));
+    assert!(!is_non_executable_extensionless_dotfile(name, None));
 }
 
 #[test]

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -22,7 +22,7 @@ use crate::{
         ArchiveFormat, FileSource, LoadHandle, LocationValidationError, OperationProvider,
         PasteItem, PreviewContent, SearchEvent, TransferConflict, UriCredentials,
         backend_unavailable_message, content_family, has_plain_text_extension, index_tree,
-        sanitize_uri_credentials, validate_basename,
+        is_extensionless_dotfile, sanitize_uri_credentials, validate_basename,
     },
 };
 
@@ -5702,6 +5702,7 @@ pub(super) fn entry_supports_quick_preview(entry: &FileEntry) -> bool {
     !matches!(content_family(&content_type), PreviewContent::Unsupported)
         || gio::content_type_is_a(&content_type, "text/plain")
         || has_plain_text_extension(&entry.native_name)
+        || is_extensionless_dotfile(&entry.native_name)
 }
 
 struct TrashSummary {

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -268,6 +268,10 @@ fn quick_preview_is_offered_only_for_supported_files() {
         "notes.txt",
         crate::model::EntryKind::FileSymbolicLink,
     )));
+    assert!(entry_supports_quick_preview(&entry(
+        ".steampath",
+        crate::model::EntryKind::File,
+    )));
     assert!(!entry_supports_quick_preview(&entry(
         "archive.zip",
         crate::model::EntryKind::File,


### PR DESCRIPTION
## Description

Allow extensionless dotfiles to enter the quick-preview path, then use the file's Unix mode as a conservative fallback when MIME detection does not already identify text. Non-executable files such as `.steampath` and `.steamid` now use the existing bounded plain-text preview; executable files and files without mode metadata do not use the fallback.

## Visual evidence

N/A — the preview interface is unchanged; this enables the existing text preview for additional files.

## How to test

1. Create a non-executable extensionless dotfile containing text, such as `.steampath`, and show hidden files in Strata.
2. Select the file or press Space to preview it.

**Expected result:** The file contents appear in Strata's existing text preview. An otherwise unsupported executable dotfile does not use the new text fallback.

## Related issue

Closes #223
