### PR TITLE
feat(trash): remove move to trash confirmation and add undo via Ctrl+Z

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ strata                 # home directory
 strata ~/Documents     # a specific directory
 ```
 
-Useful shortcuts include <kbd>Ctrl</kbd>+<kbd>K</kbd> for recursive search, <kbd>Ctrl</kbd>+<kbd>L</kbd> for a path or URI, <kbd>Ctrl</kbd>+<kbd>F</kbd> to filter the current pane, <kbd>Space</kbd> for preview, <kbd>F2</kbd> to rename, and <kbd>Alt</kbd>+arrow keys for history and parent navigation.
+Useful shortcuts include <kbd>Ctrl</kbd>+<kbd>K</kbd> for recursive search, <kbd>Ctrl</kbd>+<kbd>L</kbd> for a path or URI, <kbd>Ctrl</kbd>+<kbd>F</kbd> to filter the current pane, <kbd>Ctrl</kbd>+<kbd>Z</kbd> to undo the latest move to Trash, <kbd>Space</kbd> for preview, <kbd>F2</kbd> to rename, and <kbd>Alt</kbd>+arrow keys for history and parent navigation.
 
 ### Desktop entry
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -161,7 +161,7 @@ Legend: **P0** blocks the milestone, **P1** is required for its exit criteria, *
 - [ ] **P0** Generalize partial-failure reporting and safe cancellation cleanup across operations
 - [ ] **P1** Cross-device move behavior
 - [ ] **P1** Disk-full, permissions, disappearing source, and read-only tests
-- [ ] **P2** Limited undo where behavior can be guaranteed
+- [x] **P2** Limited undo for the latest move to Trash
 - [ ] **P2** Future Undo/Redo operation history with toolbar buttons and configurable keyboard shortcuts
 - [ ] **P2** Bind Undo to `Ctrl+Z` and Redo to both `Ctrl+Shift+Z` and `Ctrl+Y`
 

--- a/src/adapters/local_files/tests.rs
+++ b/src/adapters/local_files/tests.rs
@@ -54,11 +54,11 @@ fn capture_directory_start_logs(locations: &[(RequestId, &Location)]) -> String 
         .with_writer(writer.clone())
         .finish();
 
-    tracing::subscriber::with_default(subscriber, || {
-        for (request_id, location) in locations {
-            log_directory_load_started(*request_id, location);
-        }
-    });
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("the logging subscriber should only be installed once");
+    for (request_id, location) in locations {
+        log_directory_load_started(*request_id, location);
+    }
     writer.output()
 }
 

--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -5,7 +5,7 @@ mod tests;
 
 use std::{
     cell::Cell,
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     ffi::{OsStr, OsString},
     future::Future,
     io,
@@ -34,7 +34,7 @@ use crate::{
         ArchiveFormat, CancelledOperation, CompressRequest, CreateDirectoryRequest,
         CreateFileRequest, DeleteRequest, ExtractRequest, LoadHandle, OperationEvent,
         OperationProvider, OperationRequestId, PasteRequest, RenameRequest, RestoreRequest,
-        TransferConflict, validate_basename,
+        RestoreSource, TransferConflict, validate_basename,
     },
 };
 
@@ -581,6 +581,169 @@ fn deletion_error_message(name: &str, permanent: bool, error: &glib::Error) -> S
     }
 }
 
+#[derive(Clone)]
+struct RestoreEntry {
+    source: Location,
+    display_name: String,
+    original_target: Option<Location>,
+    trash_info: Option<PathBuf>,
+}
+
+async fn trashed_entries_for_originals(
+    original_locations: &[Location],
+) -> Result<Vec<RestoreEntry>, glib::Error> {
+    let requested = original_locations
+        .iter()
+        .filter_map(|location| location.native_path().map(Path::to_path_buf))
+        .collect::<HashSet<_>>();
+    // GVfs can miss an item re-trashed under the same basename after a restore, so prefer the
+    // authoritative freedesktop.org metadata for the home trash before consulting trash:///.
+    let fallback_requested = requested.clone();
+    let mut fallback = gio::spawn_blocking(move || home_trash_entries(&fallback_requested))
+        .await
+        .map_err(|_| glib::Error::new(gio::IOErrorEnum::Failed, "Trash lookup task failed"))?;
+    if fallback.len() == requested.len() && requested.len() == original_locations.len() {
+        return Ok(original_locations
+            .iter()
+            .filter_map(|location| location.native_path())
+            .filter_map(|path| fallback.remove(path))
+            .collect());
+    }
+
+    let trash = gio::File::for_uri("trash:///");
+    let enumerator = trash
+        .enumerate_children_future(
+            "standard::name,standard::display-name,trash::orig-path,trash::deletion-date",
+            gio::FileQueryInfoFlags::NOFOLLOW_SYMLINKS,
+            glib::Priority::DEFAULT,
+        )
+        .await?;
+    let mut newest = HashMap::<PathBuf, (String, Location, String)>::new();
+    loop {
+        let infos = enumerator
+            .next_files_future(64, glib::Priority::DEFAULT)
+            .await?;
+        if infos.is_empty() {
+            break;
+        }
+        for info in infos {
+            let Some(original_path) = info.attribute_byte_string("trash::orig-path") else {
+                continue;
+            };
+            let original_path = PathBuf::from(original_path.as_str());
+            if !requested.contains(&original_path) {
+                continue;
+            }
+            let deletion_date = info
+                .attribute_string("trash::deletion-date")
+                .map(|value| value.to_string())
+                .unwrap_or_default();
+            let Some(location) = location_for_file(&trash.child(info.name())) else {
+                continue;
+            };
+            let candidate = (deletion_date, location, info.display_name().to_string());
+            match newest.get(&original_path) {
+                Some(current) if current.0 >= candidate.0 => {}
+                _ => {
+                    newest.insert(original_path, candidate);
+                }
+            }
+        }
+    }
+
+    if requested
+        .iter()
+        .any(|path| !fallback.contains_key(path) && !newest.contains_key(path))
+        || requested.len() != original_locations.len()
+    {
+        return Err(glib::Error::new(
+            gio::IOErrorEnum::NotFound,
+            "One or more recently trashed items are no longer available",
+        ));
+    }
+    Ok(original_locations
+        .iter()
+        .filter_map(|location| location.native_path())
+        .filter_map(|path| {
+            fallback.remove(path).or_else(|| {
+                newest
+                    .remove(path)
+                    .map(|(_, source, display_name)| RestoreEntry {
+                        source,
+                        display_name,
+                        original_target: None,
+                        trash_info: None,
+                    })
+            })
+        })
+        .collect())
+}
+
+fn home_trash_entries(requested: &HashSet<PathBuf>) -> HashMap<PathBuf, RestoreEntry> {
+    home_trash_entries_at(&glib::user_data_dir().join("Trash"), requested)
+}
+
+fn home_trash_entries_at(
+    trash_root: &Path,
+    requested: &HashSet<PathBuf>,
+) -> HashMap<PathBuf, RestoreEntry> {
+    let info_root = trash_root.join("info");
+    let files_root = trash_root.join("files");
+    let mut newest = HashMap::<PathBuf, (String, RestoreEntry)>::new();
+    let Ok(infos) = std::fs::read_dir(info_root) else {
+        return HashMap::new();
+    };
+    for info in infos.flatten() {
+        let info_path = info.path();
+        let Some(name) = info_path.file_name() else {
+            continue;
+        };
+        let bytes = name.as_bytes();
+        let Some(file_name) = bytes.strip_suffix(b".trashinfo") else {
+            continue;
+        };
+        let Ok(contents) = std::fs::read_to_string(&info_path) else {
+            continue;
+        };
+        let encoded_path = contents.lines().find_map(|line| line.strip_prefix("Path="));
+        let deletion_date = contents
+            .lines()
+            .find_map(|line| line.strip_prefix("DeletionDate="))
+            .unwrap_or_default();
+        let Some(original_path) =
+            encoded_path.and_then(|path| gio::File::for_uri(&format!("file://{path}")).path())
+        else {
+            continue;
+        };
+        if !requested.contains(&original_path) {
+            continue;
+        }
+        let source_path = files_root.join(OsString::from_vec(file_name.to_vec()));
+        if !source_path.exists() {
+            continue;
+        }
+        let entry = RestoreEntry {
+            source: Location::local(&source_path),
+            display_name: source_path
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "Trashed item".to_owned()),
+            original_target: Some(Location::local(&original_path)),
+            trash_info: Some(info_path),
+        };
+        match newest.get(&original_path) {
+            Some((current_date, _)) if current_date.as_str() >= deletion_date => {}
+            _ => {
+                newest.insert(original_path, (deletion_date.to_owned(), entry));
+            }
+        }
+    }
+    newest
+        .into_iter()
+        .map(|(path, (_, entry))| (path, entry))
+        .collect()
+}
+
 fn cancellation_handle(cancellable: gio::Cancellable) -> LoadHandle {
     LoadHandle::new(move || cancellable.cancel())
 }
@@ -1057,95 +1220,147 @@ impl OperationProvider for LocalOperationProvider {
         let cancellable = gio::Cancellable::new();
         let operation_cancellable = cancellable.clone();
         let _task = glib::MainContext::default().spawn_local(async move {
-            let total = request.entries.len();
+            let entries = match request.source {
+                RestoreSource::TrashEntries(entries) => entries
+                    .into_iter()
+                    .map(|entry| RestoreEntry {
+                        source: entry.location,
+                        display_name: entry.display_name,
+                        original_target: None,
+                        trash_info: None,
+                    })
+                    .collect(),
+                RestoreSource::OriginalLocations(locations) => {
+                    match trashed_entries_for_originals(&locations).await {
+                        Ok(entries) => entries,
+                        Err(error) => {
+                            emit(OperationEvent::Failed {
+                                request_id: request.id,
+                                message: format!("Unable to find items in Trash: {error}"),
+                            });
+                            return;
+                        }
+                    }
+                }
+            };
+            let total = entries.len();
             let mut errors = Vec::new();
             let mut restored_locations = Vec::new();
             let mut failed_locations = Vec::new();
             let mut affected_locations = HashSet::from([Location::uri("trash:///")]);
-            for (index, entry) in request.entries.iter().enumerate() {
+            for (index, entry) in entries.iter().enumerate() {
                 if operation_cancellable.is_cancelled() {
                     emit(cancelled_event(
                         request.id,
                         restored_locations,
                         failed_locations,
-                        request.entries[index..]
+                        entries[index..]
                             .iter()
-                            .map(|entry| entry.location.clone())
+                            .map(|entry| entry.source.clone())
                             .collect(),
                         affected_locations,
                     ));
                     return;
                 }
-                let source = gio_file(&entry.location);
-                let result = match await_cancellable(
-                    &source,
-                    &operation_cancellable,
-                    |source, cancellable, result| {
-                        source.query_info_async(
-                            "trash::orig-path",
-                            gio::FileQueryInfoFlags::NONE,
-                            glib::Priority::DEFAULT,
-                            Some(cancellable),
-                            move |output| result.resolve(output),
-                        );
-                    },
-                )
-                .await
-                {
-                    Ok(info) => match info.attribute_byte_string("trash::orig-path") {
-                        Some(original_path) => {
-                            let target =
-                                gio::File::for_path(std::path::Path::new(original_path.as_str()));
-                            if let Some(parent) =
-                                location_for_file(&target).and_then(|location| location.parent())
-                            {
-                                affected_locations.insert(parent);
+                let source = gio_file(&entry.source);
+                let result = if let Some(original_target) = entry.original_target.clone() {
+                    let target = gio_file(&original_target);
+                    if let Some(parent) = original_target.parent() {
+                        affected_locations.insert(parent);
+                    }
+                    await_cancellable(
+                        &source,
+                        &operation_cancellable,
+                        move |source, cancellable, result| {
+                            source.move_async(
+                                &target,
+                                gio::FileCopyFlags::ALL_METADATA
+                                    | gio::FileCopyFlags::NOFOLLOW_SYMLINKS,
+                                glib::Priority::DEFAULT,
+                                Some(cancellable),
+                                None,
+                                move |output| result.resolve(output),
+                            );
+                        },
+                    )
+                    .await
+                } else {
+                    match await_cancellable(
+                        &source,
+                        &operation_cancellable,
+                        |source, cancellable, result| {
+                            source.query_info_async(
+                                "trash::orig-path",
+                                gio::FileQueryInfoFlags::NONE,
+                                glib::Priority::DEFAULT,
+                                Some(cancellable),
+                                move |output| result.resolve(output),
+                            );
+                        },
+                    )
+                    .await
+                    {
+                        Ok(info) => match info.attribute_byte_string("trash::orig-path") {
+                            Some(original_path) => {
+                                let target = gio::File::for_path(std::path::Path::new(
+                                    original_path.as_str(),
+                                ));
+                                if let Some(parent) = location_for_file(&target)
+                                    .and_then(|location| location.parent())
+                                {
+                                    affected_locations.insert(parent);
+                                }
+                                await_cancellable(
+                                    &source,
+                                    &operation_cancellable,
+                                    move |source, cancellable, result| {
+                                        source.move_async(
+                                            &target,
+                                            gio::FileCopyFlags::ALL_METADATA
+                                                | gio::FileCopyFlags::NOFOLLOW_SYMLINKS,
+                                            glib::Priority::DEFAULT,
+                                            Some(cancellable),
+                                            None,
+                                            move |output| result.resolve(output),
+                                        );
+                                    },
+                                )
+                                .await
                             }
-                            await_cancellable(
-                                &source,
-                                &operation_cancellable,
-                                move |source, cancellable, result| {
-                                    source.move_async(
-                                        &target,
-                                        gio::FileCopyFlags::ALL_METADATA
-                                            | gio::FileCopyFlags::NOFOLLOW_SYMLINKS,
-                                        glib::Priority::DEFAULT,
-                                        Some(cancellable),
-                                        None,
-                                        move |output| result.resolve(output),
-                                    );
-                                },
-                            )
-                            .await
-                        }
-                        None => Err(glib::Error::new(
-                            gio::IOErrorEnum::NotFound,
-                            "The original location is unavailable",
-                        )),
-                    },
-                    Err(error) => Err(error),
+                            None => Err(glib::Error::new(
+                                gio::IOErrorEnum::NotFound,
+                                "The original location is unavailable",
+                            )),
+                        },
+                        Err(error) => Err(error),
+                    }
                 };
                 let restored_location = if let Err(error) = result {
                     if was_cancelled(&error) {
-                        failed_locations.push(entry.location.clone());
+                        failed_locations.push(entry.source.clone());
                         emit(cancelled_event(
                             request.id,
                             restored_locations,
                             failed_locations,
-                            request.entries[index + 1..]
+                            entries[index + 1..]
                                 .iter()
-                                .map(|entry| entry.location.clone())
+                                .map(|entry| entry.source.clone())
                                 .collect(),
                             affected_locations,
                         ));
                         return;
                     }
                     errors.push(format!("{}: {error}", entry.display_name));
-                    failed_locations.push(entry.location.clone());
+                    failed_locations.push(entry.source.clone());
                     None
                 } else {
-                    restored_locations.push(entry.location.clone());
-                    Some(entry.location.clone())
+                    if let Some(info_path) = &entry.trash_info
+                        && let Err(error) = std::fs::remove_file(info_path)
+                    {
+                        tracing::warn!(%error, "unable to remove restored trash metadata");
+                    }
+                    restored_locations.push(entry.source.clone());
+                    Some(entry.source.clone())
                 };
                 emit(OperationEvent::RestoreProgress {
                     request_id: request.id,

--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -719,7 +719,7 @@ fn home_trash_entries_at(
             continue;
         }
         let source_path = files_root.join(OsString::from_vec(file_name.to_vec()));
-        if !source_path.exists() {
+        if std::fs::symlink_metadata(&source_path).is_err() {
             continue;
         }
         let entry = RestoreEntry {

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -24,15 +24,16 @@ use crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT;
 use super::{
     LocalOperationProvider, await_cancellable, copy_new_recursively, copy_recursively,
     deletion_error_message, deletion_error_summary, extract_7z_from_reader, extract_tar,
-    extract_zip_from_archive, operation_error_summary, replace_local, replace_local_with,
-    transfer_is_noop, validated_archive_path, validated_child, write_staged_archive,
+    extract_zip_from_archive, home_trash_entries_at, operation_error_summary, replace_local,
+    replace_local_with, transfer_is_noop, validated_archive_path, validated_child,
+    write_staged_archive,
 };
 use crate::{
     model::{EntryKind, FileEntry, Location, MetadataValue},
     services::{
         ArchiveFormat, CompressRequest, DeleteRequest, LoadHandle, OperationEvent,
         OperationProvider, OperationRequestId, PasteItem, PasteRequest, RestoreRequest,
-        TransferConflict,
+        RestoreSource, TransferConflict,
     },
 };
 
@@ -1200,6 +1201,40 @@ fn extraction_supports_nesting_and_regular_conflicts() -> Result<(), Box<dyn Err
 }
 
 #[test]
+fn home_trash_fallback_finds_entries_the_virtual_backend_has_not_refreshed()
+-> Result<(), Box<dyn Error>> {
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_nanos();
+    let fixture = std::env::temp_dir().join(format!("strata-home-trash-fallback-{unique}"));
+    let trash = fixture.join("Trash");
+    let original = fixture.join("original report.txt");
+    fs::create_dir_all(trash.join("files"))?;
+    fs::create_dir_all(trash.join("info"))?;
+    fs::write(trash.join("files/report.txt"), b"fixture")?;
+    let encoded = original.display().to_string().replace(' ', "%20");
+    fs::write(
+        trash.join("info/report.txt.trashinfo"),
+        format!("[Trash Info]\nPath={encoded}\nDeletionDate=2026-09-03T16:05:39\n"),
+    )?;
+
+    let entries = home_trash_entries_at(&trash, &HashSet::from([original.clone()]));
+
+    let entry = entries.get(&original).expect("fallback entry");
+    assert_eq!(
+        entry.source,
+        Location::local(trash.join("files/report.txt"))
+    );
+    assert_eq!(entry.original_target, Some(Location::local(&original)));
+    assert_eq!(
+        entry.trash_info.as_deref(),
+        Some(trash.join("info/report.txt.trashinfo").as_path())
+    );
+    fs::remove_dir_all(fixture)?;
+    Ok(())
+}
+
+#[test]
 fn cancelling_restore_before_io_reports_every_item_as_unattempted() -> Result<(), Box<dyn Error>> {
     let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
         .lock()
@@ -1210,7 +1245,7 @@ fn cancelling_restore_before_io_reports_every_item_as_unattempted() -> Result<()
     let operation = LocalOperationProvider.restore(
         RestoreRequest {
             id: OperationRequestId(9),
-            entries: entries.clone(),
+            source: RestoreSource::TrashEntries(entries.clone()),
         },
         Rc::new(move |event| emitted.borrow_mut().push(event)),
     );

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -1201,7 +1201,7 @@ fn extraction_supports_nesting_and_regular_conflicts() -> Result<(), Box<dyn Err
 }
 
 #[test]
-fn home_trash_fallback_finds_entries_the_virtual_backend_has_not_refreshed()
+fn home_trash_fallback_finds_broken_symlinks_the_virtual_backend_has_not_refreshed()
 -> Result<(), Box<dyn Error>> {
     let unique = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)?
@@ -1211,7 +1211,7 @@ fn home_trash_fallback_finds_entries_the_virtual_backend_has_not_refreshed()
     let original = fixture.join("original report.txt");
     fs::create_dir_all(trash.join("files"))?;
     fs::create_dir_all(trash.join("info"))?;
-    fs::write(trash.join("files/report.txt"), b"fixture")?;
+    std::os::unix::fs::symlink("missing-target", trash.join("files/report.txt"))?;
     let encoded = original.display().to_string().replace(' ', "%20");
     fs::write(
         trash.join("info/report.txt.trashinfo"),

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -180,22 +180,64 @@ type PreferencesObserver = Rc<dyn Fn(ViewPreferences)>;
 
 const MAX_INCREMENTAL_OPERATION_UPDATES: usize = 64;
 
+#[derive(Default)]
+struct TrashUndoState {
+    generation: u64,
+    locations: Vec<Location>,
+    claimed: bool,
+}
+
 // Undo follows the latest operation across every Strata window on the GTK main thread.
 thread_local! {
-    static PENDING_TRASH_UNDO: RefCell<Vec<Location>> = const { RefCell::new(Vec::new()) };
+    static PENDING_TRASH_UNDO: RefCell<TrashUndoState> = RefCell::new(TrashUndoState::default());
 }
 
 fn replace_pending_trash_undo(locations: Vec<Location>) {
-    PENDING_TRASH_UNDO.with(|pending| pending.replace(locations));
+    PENDING_TRASH_UNDO.with(|pending| {
+        let generation = pending.borrow().generation.saturating_add(1);
+        pending.replace(TrashUndoState {
+            generation,
+            locations,
+            claimed: false,
+        });
+    });
 }
 
-fn take_pending_trash_undo() -> Vec<Location> {
-    PENDING_TRASH_UNDO.with(RefCell::take)
+fn claim_pending_trash_undo() -> Option<(u64, Vec<Location>)> {
+    PENDING_TRASH_UNDO.with(|pending| {
+        let mut pending = pending.borrow_mut();
+        if pending.claimed || pending.locations.is_empty() {
+            return None;
+        }
+        pending.claimed = true;
+        Some((pending.generation, pending.locations.clone()))
+    })
+}
+
+fn mark_trash_undo_restored(generation: u64, location: &Location) {
+    PENDING_TRASH_UNDO.with(|pending| {
+        let mut pending = pending.borrow_mut();
+        if pending.generation == generation {
+            pending.locations.retain(|candidate| candidate != location);
+        }
+    });
+}
+
+fn finish_trash_undo(generation: u64, completed: bool) {
+    PENDING_TRASH_UNDO.with(|pending| {
+        let mut pending = pending.borrow_mut();
+        if pending.generation == generation {
+            if completed {
+                pending.locations.clear();
+            }
+            pending.claimed = false;
+        }
+    });
 }
 
 #[cfg(test)]
 fn pending_trash_undo() -> Vec<Location> {
-    PENDING_TRASH_UNDO.with(|pending| pending.borrow().clone())
+    PENDING_TRASH_UNDO.with(|pending| pending.borrow().locations.clone())
 }
 
 pub struct Browser {
@@ -213,6 +255,7 @@ pub struct Browser {
     deletion_operation: Cell<bool>,
     deletion_permanent: Cell<bool>,
     restoration_operation: Cell<bool>,
+    undo_restoration: RefCell<Option<(u64, Vec<Location>)>>,
     next_request: Cell<u64>,
     pending_sort: Cell<Option<(u64, usize)>>,
     preferences: Cell<ViewPreferences>,
@@ -242,6 +285,7 @@ impl Browser {
             deletion_operation: Cell::new(false),
             deletion_permanent: Cell::new(false),
             restoration_operation: Cell::new(false),
+            undo_restoration: RefCell::new(None),
             next_request: Cell::new(1),
             pending_sort: Cell::new(None),
             preferences: Cell::new(preferences),
@@ -931,7 +975,6 @@ impl Browser {
         };
         let total = entries.len();
         let request_id = self.begin_operation();
-        replace_pending_trash_undo(Vec::new());
         self.deletion_operation.set(true);
         self.deletion_permanent.set(permanent);
         self.emit(BrowserEvent::DeletionStarted { total });
@@ -974,17 +1017,18 @@ impl Browser {
         if self.current_operation.get().is_some() {
             return false;
         }
-        let locations = take_pending_trash_undo();
-        if locations.is_empty() {
+        let Some((generation, locations)) = claim_pending_trash_undo() else {
             return false;
-        }
+        };
         let Some(provider) = self.operation_provider.borrow().clone() else {
-            replace_pending_trash_undo(locations);
+            finish_trash_undo(generation, false);
             return false;
         };
         let total = locations.len();
         let request_id = self.begin_operation();
         self.restoration_operation.set(true);
+        self.undo_restoration
+            .replace(Some((generation, locations.clone())));
         self.emit(BrowserEvent::RestorationStarted { total });
         let load = provider.restore(
             RestoreRequest {
@@ -1075,6 +1119,9 @@ impl Browser {
 
     fn begin_operation(&self) -> OperationRequestId {
         self.operation_load.borrow_mut().take();
+        if let Some((generation, _)) = self.undo_restoration.take() {
+            finish_trash_undo(generation, false);
+        }
         self.transfer_operation.set(None);
         self.deletion_operation.set(false);
         self.deletion_permanent.set(false);
@@ -1154,6 +1201,15 @@ impl Browser {
                 ..
             } = &event
             {
+                if restored_location.is_some()
+                    && let Some((generation, locations)) =
+                        browser.undo_restoration.borrow().as_ref()
+                    && let Some(location) = completed
+                        .checked_sub(1)
+                        .and_then(|index| locations.get(index))
+                {
+                    mark_trash_undo_restored(*generation, location);
+                }
                 if *total <= MAX_INCREMENTAL_OPERATION_UPDATES
                     && let Some(location) = restored_location
                 {
@@ -1184,6 +1240,12 @@ impl Browser {
             let deleting = browser.deletion_operation.replace(false);
             let deletion_permanent = browser.deletion_permanent.replace(false);
             let restoring = browser.restoration_operation.replace(false);
+            if restoring && let Some((generation, _)) = browser.undo_restoration.take() {
+                finish_trash_undo(
+                    generation,
+                    matches!(&event, OperationEvent::Restored { .. }),
+                );
+            }
             if deleting && !deletion_permanent {
                 let locations = match &event {
                     OperationEvent::Deleted { locations, .. } => locations.clone(),

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -15,7 +15,7 @@ use crate::{
         ArchiveFormat, CompressRequest, CreateDirectoryRequest, CreateFileRequest, DeleteRequest,
         DirectoryChange, DirectoryEvent, DirectoryRequest, ExtractRequest, FileSource, LoadHandle,
         LocationValidationError, OperationEvent, OperationProvider, OperationRequestId, PasteItem,
-        PasteRequest, RenameRequest, RequestId, RestoreRequest, TransferConflict,
+        PasteRequest, RenameRequest, RequestId, RestoreRequest, RestoreSource, TransferConflict,
         validate_basename, validate_uri_credentials,
     },
 };
@@ -180,6 +180,24 @@ type PreferencesObserver = Rc<dyn Fn(ViewPreferences)>;
 
 const MAX_INCREMENTAL_OPERATION_UPDATES: usize = 64;
 
+// Undo follows the latest operation across every Strata window on the GTK main thread.
+thread_local! {
+    static PENDING_TRASH_UNDO: RefCell<Vec<Location>> = const { RefCell::new(Vec::new()) };
+}
+
+fn replace_pending_trash_undo(locations: Vec<Location>) {
+    PENDING_TRASH_UNDO.with(|pending| pending.replace(locations));
+}
+
+fn take_pending_trash_undo() -> Vec<Location> {
+    PENDING_TRASH_UNDO.with(RefCell::take)
+}
+
+#[cfg(test)]
+fn pending_trash_undo() -> Vec<Location> {
+    PENDING_TRASH_UNDO.with(|pending| pending.borrow().clone())
+}
+
 pub struct Browser {
     source: Rc<dyn FileSource>,
     state: RefCell<NavigationState>,
@@ -193,6 +211,7 @@ pub struct Browser {
     current_operation: Cell<Option<OperationRequestId>>,
     transfer_operation: Cell<Option<bool>>,
     deletion_operation: Cell<bool>,
+    deletion_permanent: Cell<bool>,
     restoration_operation: Cell<bool>,
     next_request: Cell<u64>,
     pending_sort: Cell<Option<(u64, usize)>>,
@@ -221,6 +240,7 @@ impl Browser {
             current_operation: Cell::new(None),
             transfer_operation: Cell::new(None),
             deletion_operation: Cell::new(false),
+            deletion_permanent: Cell::new(false),
             restoration_operation: Cell::new(false),
             next_request: Cell::new(1),
             pending_sort: Cell::new(None),
@@ -911,7 +931,9 @@ impl Browser {
         };
         let total = entries.len();
         let request_id = self.begin_operation();
+        replace_pending_trash_undo(Vec::new());
         self.deletion_operation.set(true);
+        self.deletion_permanent.set(permanent);
         self.emit(BrowserEvent::DeletionStarted { total });
         let load = provider.delete(
             DeleteRequest {
@@ -941,11 +963,38 @@ impl Browser {
         let load = provider.restore(
             RestoreRequest {
                 id: request_id,
-                entries,
+                source: RestoreSource::TrashEntries(entries),
             },
             self.operation_callback(request_id, false, HashSet::new()),
         );
         self.operation_load.replace(Some(load));
+    }
+
+    pub fn undo_last_trash(self: &Rc<Self>) -> bool {
+        if self.current_operation.get().is_some() {
+            return false;
+        }
+        let locations = take_pending_trash_undo();
+        if locations.is_empty() {
+            return false;
+        }
+        let Some(provider) = self.operation_provider.borrow().clone() else {
+            replace_pending_trash_undo(locations);
+            return false;
+        };
+        let total = locations.len();
+        let request_id = self.begin_operation();
+        self.restoration_operation.set(true);
+        self.emit(BrowserEvent::RestorationStarted { total });
+        let load = provider.restore(
+            RestoreRequest {
+                id: request_id,
+                source: RestoreSource::OriginalLocations(locations),
+            },
+            self.operation_callback(request_id, false, HashSet::new()),
+        );
+        self.operation_load.replace(Some(load));
+        true
     }
 
     pub fn compress(
@@ -1028,6 +1077,7 @@ impl Browser {
         self.operation_load.borrow_mut().take();
         self.transfer_operation.set(None);
         self.deletion_operation.set(false);
+        self.deletion_permanent.set(false);
         self.restoration_operation.set(false);
         let request_id = OperationRequestId(self.next_request.get());
         self.next_request
@@ -1132,7 +1182,21 @@ impl Browser {
             browser.current_operation.set(None);
             let moving = browser.transfer_operation.replace(None);
             let deleting = browser.deletion_operation.replace(false);
+            let deletion_permanent = browser.deletion_permanent.replace(false);
             let restoring = browser.restoration_operation.replace(false);
+            if deleting && !deletion_permanent {
+                let locations = match &event {
+                    OperationEvent::Deleted { locations, .. } => locations.clone(),
+                    OperationEvent::CompletedWithErrors {
+                        deleted_locations, ..
+                    } => deleted_locations.clone(),
+                    OperationEvent::Cancelled { result, .. } => result.completed.clone(),
+                    _ => Vec::new(),
+                };
+                if !locations.is_empty() {
+                    replace_pending_trash_undo(locations);
+                }
+            }
             if moving.is_some() {
                 let moved_locations = match &event {
                     OperationEvent::Pasted { locations, .. } if moving == Some(true) => {

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -520,7 +520,11 @@ impl OperationProvider for ImmediateOperationProvider {
     fn delete(&self, request: DeleteRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle {
         emit(OperationEvent::Deleted {
             request_id: request.id,
-            locations: Vec::new(),
+            locations: request
+                .entries
+                .into_iter()
+                .map(|entry| entry.location)
+                .collect(),
         });
         LoadHandle::new(|| {})
     }
@@ -548,6 +552,72 @@ impl OperationProvider for ImmediateOperationProvider {
         });
         LoadHandle::new(|| {})
     }
+}
+
+#[test]
+fn a_completed_trash_operation_can_be_undone_once() {
+    let browser = Browser::new(Rc::new(FakeFileSource));
+    browser.set_operation_provider(Rc::new(ImmediateOperationProvider));
+    let location = Location::local("/fixture/report.txt");
+    let entry = FileEntry {
+        location: location.clone(),
+        native_name: OsString::from("report.txt"),
+        display_name: "report.txt".into(),
+        kind: EntryKind::File,
+        size: MetadataValue::Unknown,
+        modified_unix_seconds: MetadataValue::Unknown,
+        is_hidden: false,
+    };
+
+    browser.delete(vec![entry], false);
+
+    assert_eq!(
+        pending_trash_undo().as_slice(),
+        std::slice::from_ref(&location)
+    );
+    assert!(browser.undo_last_trash());
+    assert!(!browser.undo_last_trash());
+}
+
+#[test]
+fn another_browser_can_undo_the_latest_trash_operation() {
+    let deleting_browser = Browser::new(Rc::new(FakeFileSource));
+    deleting_browser.set_operation_provider(Rc::new(ImmediateOperationProvider));
+    let undoing_browser = Browser::new(Rc::new(FakeFileSource));
+    undoing_browser.set_operation_provider(Rc::new(ImmediateOperationProvider));
+    let entry = FileEntry {
+        location: Location::local("/fixture/report.txt"),
+        native_name: OsString::from("report.txt"),
+        display_name: "report.txt".into(),
+        kind: EntryKind::File,
+        size: MetadataValue::Unknown,
+        modified_unix_seconds: MetadataValue::Unknown,
+        is_hidden: false,
+    };
+
+    deleting_browser.delete(vec![entry], false);
+
+    assert!(undoing_browser.undo_last_trash());
+    assert!(!deleting_browser.undo_last_trash());
+}
+
+#[test]
+fn permanent_delete_does_not_create_an_undo_operation() {
+    let browser = Browser::new(Rc::new(FakeFileSource));
+    browser.set_operation_provider(Rc::new(ImmediateOperationProvider));
+    let entry = FileEntry {
+        location: Location::local("/fixture/report.txt"),
+        native_name: OsString::from("report.txt"),
+        display_name: "report.txt".into(),
+        kind: EntryKind::File,
+        size: MetadataValue::Unknown,
+        modified_unix_seconds: MetadataValue::Unknown,
+        is_hidden: false,
+    };
+
+    browser.delete(vec![entry], true);
+
+    assert!(!browser.undo_last_trash());
 }
 
 #[test]

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -602,10 +602,10 @@ fn another_browser_can_undo_the_latest_trash_operation() {
 }
 
 #[test]
-fn permanent_delete_does_not_create_an_undo_operation() {
+fn permanent_delete_preserves_the_previous_trash_undo() {
     let browser = Browser::new(Rc::new(FakeFileSource));
     browser.set_operation_provider(Rc::new(ImmediateOperationProvider));
-    let entry = FileEntry {
+    let trashed = FileEntry {
         location: Location::local("/fixture/report.txt"),
         native_name: OsString::from("report.txt"),
         display_name: "report.txt".into(),
@@ -614,10 +614,33 @@ fn permanent_delete_does_not_create_an_undo_operation() {
         modified_unix_seconds: MetadataValue::Unknown,
         is_hidden: false,
     };
+    let permanently_deleted = FileEntry {
+        location: Location::local("/fixture/draft.txt"),
+        native_name: OsString::from("draft.txt"),
+        display_name: "draft.txt".into(),
+        ..trashed.clone()
+    };
 
-    browser.delete(vec![entry], true);
+    browser.delete(vec![trashed], false);
+    browser.delete(vec![permanently_deleted], true);
 
-    assert!(!browser.undo_last_trash());
+    assert!(browser.undo_last_trash());
+}
+
+#[test]
+fn failed_and_partial_undo_operations_can_be_retried() {
+    let first = Location::local("/fixture/first.txt");
+    let second = Location::local("/fixture/second.txt");
+    replace_pending_trash_undo(vec![first.clone(), second.clone()]);
+    let (generation, _) = claim_pending_trash_undo().expect("undo claim");
+
+    mark_trash_undo_restored(generation, &first);
+    finish_trash_undo(generation, false);
+
+    assert_eq!(pending_trash_undo(), vec![second.clone()]);
+    let (retry_generation, retry) = claim_pending_trash_undo().expect("retry claim");
+    assert_eq!(retry, vec![second]);
+    finish_trash_undo(retry_generation, true);
 }
 
 #[test]

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -16,7 +16,8 @@ pub use file_source::{
 pub use operations::{
     ArchiveFormat, CancelledOperation, CompressRequest, CreateDirectoryRequest, CreateFileRequest,
     DeleteRequest, ExtractRequest, OperationEvent, OperationProvider, OperationRequestId,
-    PasteItem, PasteRequest, RenameRequest, RestoreRequest, TransferConflict, validate_basename,
+    PasteItem, PasteRequest, RenameRequest, RestoreRequest, RestoreSource, TransferConflict,
+    validate_basename,
 };
 pub use preview::{
     Preview, PreviewContent, PreviewEvent, PreviewProvider, PreviewRequest, PreviewRequestId,

--- a/src/services/operations.rs
+++ b/src/services/operations.rs
@@ -75,9 +75,15 @@ pub struct DeleteRequest {
 }
 
 #[derive(Clone, Debug)]
+pub enum RestoreSource {
+    TrashEntries(Vec<FileEntry>),
+    OriginalLocations(Vec<Location>),
+}
+
+#[derive(Clone, Debug)]
 pub struct RestoreRequest {
     pub id: OperationRequestId,
-    pub entries: Vec<FileEntry>,
+    pub source: RestoreSource,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -95,6 +95,13 @@ struct ActiveNewEntry {
     field: gtk::Entry,
 }
 
+const FILE_PROGRESS_DELAY: Duration = Duration::from_millis(350);
+const IMMEDIATE_PROGRESS_ITEM_COUNT: usize = 16;
+
+fn should_show_progress_immediately(total: usize) -> bool {
+    total == 0 || total >= IMMEDIATE_PROGRESS_ITEM_COUNT
+}
+
 struct DeleteProgressView {
     layer: gtk::Box,
     overlay: gtk::Overlay,
@@ -292,6 +299,8 @@ pub(super) struct ViewState {
     active_rename: RefCell<Option<ActiveRename>>,
     active_new_entry: RefCell<Option<ActiveNewEntry>>,
     delete_progress: RefCell<Option<DeleteProgressView>>,
+    pending_file_progress: RefCell<Option<glib::SourceId>>,
+    file_operation_progress: Cell<(usize, usize)>,
     pin_handler: RefCell<Option<PinHandler>>,
     pin_status_handler: RefCell<Option<PinStatusHandler>>,
     pending_select: RefCell<Vec<String>>,
@@ -441,6 +450,8 @@ impl BrowserView {
             active_rename: RefCell::new(None),
             active_new_entry: RefCell::new(None),
             delete_progress: RefCell::new(None),
+            pending_file_progress: RefCell::new(None),
+            file_operation_progress: Cell::new((0, 0)),
             pin_handler: RefCell::new(None),
             pin_status_handler: RefCell::new(None),
             pending_select: RefCell::new(Vec::new()),
@@ -932,9 +943,12 @@ impl BrowserView {
             .or_else(|| self.state.browser.active_location())
             .as_ref()
             .is_some_and(is_trash_location);
-        self.state
-            .show_delete_confirmation(entries, permanent || in_trash);
+        self.state.request_delete(entries, permanent || in_trash);
         true
+    }
+
+    pub fn undo_last_trash(&self) -> bool {
+        self.state.browser.undo_last_trash()
     }
 
     pub fn show_filter(&self) -> bool {
@@ -1703,13 +1717,40 @@ impl ViewState {
 
     fn show_file_operation_progress(
         self: &Rc<Self>,
-        _total: usize,
+        total: usize,
         icon: &str,
         title_text: &str,
         subtitle_text: &str,
         on_cancel: Rc<dyn Fn()>,
     ) {
         self.dismiss_delete_progress();
+        self.file_operation_progress.set((0, total));
+        if should_show_progress_immediately(total) {
+            self.present_file_operation_progress(icon, title_text, subtitle_text, on_cancel);
+            return;
+        }
+
+        let weak = Rc::downgrade(self);
+        let icon = icon.to_owned();
+        let title_text = title_text.to_owned();
+        let subtitle_text = subtitle_text.to_owned();
+        let source = glib::timeout_add_local_once(FILE_PROGRESS_DELAY, move || {
+            let Some(state) = weak.upgrade() else {
+                return;
+            };
+            state.pending_file_progress.borrow_mut().take();
+            state.present_file_operation_progress(&icon, &title_text, &subtitle_text, on_cancel);
+        });
+        self.pending_file_progress.replace(Some(source));
+    }
+
+    fn present_file_operation_progress(
+        self: &Rc<Self>,
+        icon: &str,
+        title_text: &str,
+        subtitle_text: &str,
+        on_cancel: Rc<dyn Fn()>,
+    ) {
         let Some(window_overlay) = self
             .overlay
             .root()
@@ -1764,9 +1805,12 @@ impl ViewState {
             progress.layer.add_controller(escape);
         }
         cancel.grab_focus();
+        let (completed, total) = self.file_operation_progress.get();
+        self.update_delete_progress(completed, total);
     }
 
     fn update_delete_progress(&self, completed: usize, total: usize) {
+        self.file_operation_progress.set((completed, total));
         let progress_view = self.delete_progress.borrow();
         let Some(view) = progress_view.as_ref() else {
             return;
@@ -1797,10 +1841,13 @@ impl ViewState {
     }
 
     fn dismiss_delete_progress(&self) {
-        let Some(view) = self.delete_progress.take() else {
-            return;
-        };
-        dismiss_modal_layer(&view.layer, &view.overlay, view.blurred_root.as_ref());
+        if let Some(source) = self.pending_file_progress.take() {
+            source.remove();
+        }
+        self.file_operation_progress.set((0, 0));
+        if let Some(view) = self.delete_progress.take() {
+            dismiss_modal_layer(&view.layer, &view.overlay, view.blurred_root.as_ref());
+        }
     }
 
     /// The total item count isn't known upfront -- entries are deleted as they're enumerated,
@@ -2135,7 +2182,16 @@ impl ViewState {
         });
     }
 
-    fn show_delete_confirmation(self: &Rc<Self>, entries: Vec<FileEntry>, permanent: bool) {
+    fn request_delete(self: &Rc<Self>, entries: Vec<FileEntry>, permanent: bool) {
+        if permanent {
+            self.show_delete_confirmation(entries);
+        } else {
+            self.browser.delete(entries, false);
+            self.browser.focus_active();
+        }
+    }
+
+    fn show_delete_confirmation(self: &Rc<Self>, entries: Vec<FileEntry>) {
         let Some(window_overlay) = self
             .overlay
             .root()
@@ -2151,16 +2207,8 @@ impl ViewState {
         }
 
         let count = entries.len();
-        let title = if permanent {
-            format!("Permanently delete {}?", item_count_label(count))
-        } else {
-            format!("Move {} to trash?", item_count_label(count))
-        };
-        let confirm_label = if permanent {
-            format!("Permanently delete {}", item_count_label(count))
-        } else {
-            format!("Move {}", item_count_label(count))
-        };
+        let title = format!("Permanently delete {}?", item_count_label(count));
+        let confirm_label = format!("Permanently delete {}", item_count_label(count));
         let layout = message_dialog_layout(
             crate::assets::icons::TRASH,
             &title,
@@ -2207,11 +2255,9 @@ impl ViewState {
             .build();
         file_scroller.add_css_class("delete-confirmation-list");
         layout.body.append(&file_scroller);
-        let explanation = message_dialog_description(if permanent {
-            "These items will be permanently deleted. This action cannot be undone."
-        } else {
-            "The items will be moved to trash. You can restore them later."
-        });
+        let explanation = message_dialog_description(
+            "These items will be permanently deleted. This action cannot be undone.",
+        );
         layout.body.append(&explanation);
         let content = layout.content;
         let close = layout.close;
@@ -2250,7 +2296,7 @@ impl ViewState {
                 &confirmed_overlay,
                 confirmed_root.as_ref(),
             );
-            browser.delete(entries.clone(), permanent);
+            browser.delete(entries.clone(), true);
             browser.focus_active();
         });
         let keys = gtk::EventControllerKey::new();
@@ -6013,7 +6059,7 @@ fn connect_context_trash(
         }
         if let Some(state) = weak.upgrade() {
             let entries = context_entries(&state, &target);
-            state.show_delete_confirmation(entries, permanent);
+            state.request_delete(entries, permanent);
         }
     });
 }

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -198,6 +198,18 @@ fn delete_confirmation_labels_distinguish_files_and_folders() {
 }
 
 #[test]
+fn small_operations_delay_progress_while_large_or_unbounded_operations_show_it_immediately() {
+    assert!(!should_show_progress_immediately(1));
+    assert!(!should_show_progress_immediately(
+        IMMEDIATE_PROGRESS_ITEM_COUNT - 1
+    ));
+    assert!(should_show_progress_immediately(
+        IMMEDIATE_PROGRESS_ITEM_COUNT
+    ));
+    assert!(should_show_progress_immediately(0));
+}
+
+#[test]
 fn delete_confirmation_direction_keys_choose_an_action() {
     assert_eq!(
         delete_confirmation_focus_target(gtk::gdk::Key::Left),

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -616,6 +616,9 @@ fn install_keyboard_navigation(
             }
             return glib::Propagation::Proceed;
         }
+        if !text_has_focus && is_undo_trash_shortcut(key, modifiers) && view.undo_last_trash() {
+            return glib::Propagation::Stop;
+        }
         if alt
             && !control
             && !shift
@@ -785,6 +788,13 @@ fn install_keyboard_navigation(
         glib::Propagation::Stop
     });
     window.add_controller(keys);
+}
+
+fn is_undo_trash_shortcut(key: gtk::gdk::Key, modifiers: gtk::gdk::ModifierType) -> bool {
+    modifiers.contains(gtk::gdk::ModifierType::CONTROL_MASK)
+        && !modifiers
+            .intersects(gtk::gdk::ModifierType::SHIFT_MASK | gtk::gdk::ModifierType::ALT_MASK)
+        && matches!(key, gtk::gdk::Key::z | gtk::gdk::Key::Z)
 }
 
 fn is_open_terminal_shortcut(key: gtk::gdk::Key, modifiers: gtk::gdk::ModifierType) -> bool {

--- a/src/ui/window/tests.rs
+++ b/src/ui/window/tests.rs
@@ -6,10 +6,11 @@ use crate::services::{BuildKind, ReleaseMetadata};
 
 use super::{
     MouseHistoryAction, PinStatus, STANDARD_PLACE_IDS, is_open_terminal_shortcut,
-    is_sidebar_focus_shortcut, is_smb_location, is_standard_place_location, mouse_history_action,
-    parse_pinned_drag_source, parse_pinned_places, pin_status, remove_pinned_place,
-    reorder_pinned_places, reorder_places, resolve_place_order, serialize_pinned_places,
-    should_show_standard_place, sidebar_update_label, standard_place, vim_focus_direction,
+    is_sidebar_focus_shortcut, is_smb_location, is_standard_place_location, is_undo_trash_shortcut,
+    mouse_history_action, parse_pinned_drag_source, parse_pinned_places, pin_status,
+    remove_pinned_place, reorder_pinned_places, reorder_places, resolve_place_order,
+    serialize_pinned_places, should_show_standard_place, sidebar_update_label, standard_place,
+    vim_focus_direction,
 };
 
 fn release(version: &str, kind: BuildKind) -> ReleaseMetadata {
@@ -72,6 +73,22 @@ fn open_terminal_shortcut_requires_only_control() {
     ));
     assert!(!is_open_terminal_shortcut(gtk::gdk::Key::t, control | alt));
     assert!(!is_open_terminal_shortcut(gtk::gdk::Key::F4, control));
+}
+
+#[test]
+fn undo_trash_shortcut_requires_control_without_shift_or_alt() {
+    let control = gtk::gdk::ModifierType::CONTROL_MASK;
+    let shift = gtk::gdk::ModifierType::SHIFT_MASK;
+    let alt = gtk::gdk::ModifierType::ALT_MASK;
+
+    assert!(is_undo_trash_shortcut(gtk::gdk::Key::z, control));
+    assert!(is_undo_trash_shortcut(gtk::gdk::Key::Z, control));
+    assert!(!is_undo_trash_shortcut(
+        gtk::gdk::Key::z,
+        gtk::gdk::ModifierType::empty()
+    ));
+    assert!(!is_undo_trash_shortcut(gtk::gdk::Key::z, control | shift));
+    assert!(!is_undo_trash_shortcut(gtk::gdk::Key::z, control | alt));
 }
 
 #[test]


### PR DESCRIPTION
## Description

Move selected items to Trash immediately while retaining confirmation for permanent deletion. Ctrl+Z restores the latest trash operation across Strata windows, including repeated trash/restore cycles where GVfs has stale virtual-trash state. Small operations delay progress presentation to avoid flashing a dialog, while large and unbounded operations show it immediately.

## Visual evidence

N/A — the existing dialogs are visually unchanged; this changes when confirmation and progress dialogs appear.

## How to test

1. Move a small file to Trash and confirm there is no confirmation or flashing progress dialog.
2. Press Ctrl+Z, trash the restored file again, switch windows, and press Ctrl+Z again.
3. Trash at least 16 items, or run a slower operation, and confirm progress remains available.
4. Use Shift+Delete and confirm permanent deletion still asks for confirmation.

**Expected result:** Trash moves happen immediately, the latest move can be restored from any Strata window, quick operations do not flash progress, and destructive deletion remains confirmed.

## Related issue

Closes #205