### PR TITLE
fix(browser): bind y/p shortcuts and shell-escape copied paths

### DIFF
--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -876,7 +876,13 @@ impl BrowserView {
         let Some(entry) = self.state.browser.focused_entry() else {
             return;
         };
-        if !entry.is_directory() {
+        let status = self
+            .state
+            .pin_status_handler
+            .borrow()
+            .as_ref()
+            .map_or(PinStatus::Unavailable, |handler| handler(&entry.location));
+        if !can_pin_entry(&entry, status) {
             return;
         }
         if let Some(handler) = self.state.pin_handler.borrow().as_ref() {
@@ -6506,6 +6512,10 @@ fn copy_locations(entries: &[FileEntry]) {
     }
 }
 
+fn can_pin_entry(entry: &FileEntry, status: PinStatus) -> bool {
+    entry.is_directory() && !is_trash_location(&entry.location) && status == PinStatus::Available
+}
+
 fn copy_path_text(location: &Location, is_directory: bool) -> String {
     match location.native_path() {
         Some(path) => {
@@ -6520,8 +6530,13 @@ fn copy_path_text(location: &Location, is_directory: bool) -> String {
 }
 
 fn shell_escape_path(path: &Path) -> String {
+    let path = path.to_string_lossy();
+    if path.contains('\n') {
+        return format!("'{}'", path.replace('\'', "'\\''"));
+    }
+
     let mut escaped = String::new();
-    for c in path.to_string_lossy().chars() {
+    for c in path.chars() {
         if needs_shell_escape(c) {
             escaped.push('\\');
             escaped.push(c);

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -857,6 +857,33 @@ impl BrowserView {
         true
     }
 
+    pub fn copy_path(&self) -> bool {
+        self.state.sync_mode_selection();
+        let entries = self.state.browser.selected_entries();
+        if entries.is_empty() {
+            let Some(entry) = self.state.browser.focused_entry() else {
+                return false;
+            };
+            copy_locations(&[entry]);
+        } else {
+            copy_locations(&entries);
+        }
+        true
+    }
+
+    pub fn pin_focused(&self) {
+        self.state.sync_mode_selection();
+        let Some(entry) = self.state.browser.focused_entry() else {
+            return;
+        };
+        if !entry.is_directory() {
+            return;
+        }
+        if let Some(handler) = self.state.pin_handler.borrow().as_ref() {
+            handler(entry.location, entry.display_name);
+        }
+    }
+
     pub fn select_all(&self) {
         if self.view_mode() == BrowserMode::Columns {
             if let Some(depth) = self.state.columns.borrow().len().checked_sub(1) {
@@ -2930,7 +2957,7 @@ impl ViewState {
             if let Some(display) = gtk::gdk::Display::default() {
                 display
                     .clipboard()
-                    .set_text(&copied_location.display_path());
+                    .set_text(&copy_path_text(&copied_location, true));
                 button.set_label("Copied");
             }
         });
@@ -3507,7 +3534,7 @@ impl ViewState {
                 copy.add_css_class("copy-path");
                 copy.set_has_frame(false);
                 copy.set_cursor_from_name(Some("pointer"));
-                let copied_path = location.display_path();
+                let copied_path = copy_path_text(location, true);
                 let feedback_generation = Rc::new(Cell::new(0_u64));
                 copy.connect_clicked(move |button| {
                     if let Some(display) = gtk::gdk::Display::default() {
@@ -6471,12 +6498,66 @@ pub(super) fn file_drag_content(entries: &[FileEntry]) -> Option<gtk::gdk::Conte
 fn copy_locations(entries: &[FileEntry]) {
     let text = entries
         .iter()
-        .map(|entry| entry.location.display_path())
+        .map(|entry| copy_path_text(&entry.location, entry.is_directory()))
         .collect::<Vec<_>>()
         .join("\n");
     if let Some(display) = gtk::gdk::Display::default() {
         display.clipboard().set_text(&text);
     }
+}
+
+fn copy_path_text(location: &Location, is_directory: bool) -> String {
+    match location.native_path() {
+        Some(path) => {
+            let mut path = shell_escape_path(path);
+            if is_directory && !path.ends_with(std::path::MAIN_SEPARATOR) {
+                path.push(std::path::MAIN_SEPARATOR);
+            }
+            path
+        }
+        None => location.display_path(),
+    }
+}
+
+fn shell_escape_path(path: &Path) -> String {
+    let mut escaped = String::new();
+    for c in path.to_string_lossy().chars() {
+        if needs_shell_escape(c) {
+            escaped.push('\\');
+            escaped.push(c);
+        } else {
+            escaped.push(c);
+        }
+    }
+    escaped
+}
+
+fn needs_shell_escape(c: char) -> bool {
+    c.is_whitespace()
+        || c.is_control()
+        || matches!(
+            c,
+            '"' | '\''
+                | '\\'
+                | '$'
+                | '`'
+                | '!'
+                | '#'
+                | '&'
+                | '*'
+                | ';'
+                | '<'
+                | '>'
+                | '?'
+                | '['
+                | ']'
+                | '{'
+                | '}'
+                | '('
+                | ')'
+                | '|'
+                | '~'
+        )
 }
 
 fn set_files_clipboard(entries: &[FileEntry]) -> bool {

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1137,3 +1137,42 @@ fn copy_path_text_keeps_uris_unescaped() {
     let remote = Location::uri("smb://server/share/folder");
     assert_eq!(copy_path_text(&remote, true), "smb://server/share/folder");
 }
+
+#[test]
+fn shell_escape_path_preserves_newlines_and_single_quotes() {
+    assert_eq!(
+        shell_escape_path(Path::new("/tmp/line\nbob's notes")),
+        "'/tmp/line\nbob'\\''s notes'"
+    );
+}
+
+#[test]
+fn pinning_requires_an_available_non_trash_directory() {
+    let entry = |location, kind| FileEntry {
+        location,
+        native_name: "item".into(),
+        display_name: "item".into(),
+        kind,
+        size: crate::model::MetadataValue::Unknown,
+        modified_unix_seconds: crate::model::MetadataValue::Unknown,
+        is_hidden: false,
+    };
+    let directory = entry(
+        Location::local("/fixture/folder"),
+        crate::model::EntryKind::Directory,
+    );
+    let file = entry(
+        Location::local("/fixture/file"),
+        crate::model::EntryKind::File,
+    );
+    let trash_directory = entry(
+        Location::uri("trash:///deleted-folder"),
+        crate::model::EntryKind::Directory,
+    );
+
+    assert!(can_pin_entry(&directory, PinStatus::Available));
+    assert!(!can_pin_entry(&directory, PinStatus::Pinned));
+    assert!(!can_pin_entry(&directory, PinStatus::Unavailable));
+    assert!(!can_pin_entry(&file, PinStatus::Available));
+    assert!(!can_pin_entry(&trash_directory, PinStatus::Available));
+}

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1102,3 +1102,38 @@ fn entry_model_value_encodes_hidden_state_and_preserves_display_name() {
     assert_eq!(model_display_name(&encoded_visible), "photo");
     assert_eq!(model_display_name(&encoded_hidden), ".config");
 }
+
+#[test]
+fn shell_escape_path_escapes_spaces_and_metacharacters_but_not_filename_unicode() {
+    assert_eq!(
+        shell_escape_path(Path::new("/mnt/Mass 1/Movies\u{2044}TV")),
+        "/mnt/Mass\\ 1/Movies\u{2044}TV"
+    );
+    assert_eq!(
+        shell_escape_path(Path::new("/tmp/archive (final) v1.2.tar.gz")),
+        "/tmp/archive\\ \\(final\\)\\ v1.2.tar.gz"
+    );
+    assert_eq!(
+        shell_escape_path(Path::new("/home/user/plain")),
+        "/home/user/plain"
+    );
+}
+
+#[test]
+fn copy_path_text_adds_trailing_slash_to_directories_only() {
+    let directory = Location::local("/mnt/Mass 1/Movies\u{2044}TV");
+    assert_eq!(
+        copy_path_text(&directory, true),
+        "/mnt/Mass\\ 1/Movies\u{2044}TV/"
+    );
+    assert_eq!(
+        copy_path_text(&directory, false),
+        "/mnt/Mass\\ 1/Movies\u{2044}TV"
+    );
+}
+
+#[test]
+fn copy_path_text_keeps_uris_unescaped() {
+    let remote = Location::uri("smb://server/share/folder");
+    assert_eq!(copy_path_text(&remote, true), "smb://server/share/folder");
+}

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -729,6 +729,14 @@ fn install_keyboard_navigation(
         if !control && !alt && !view.item_view_has_focus() && !header_left_boundary {
             return glib::Propagation::Proceed;
         }
+        if !control && !alt && matches!(key, gtk::gdk::Key::y | gtk::gdk::Key::Y) {
+            view.copy_path();
+            return glib::Propagation::Stop;
+        }
+        if !control && !alt && matches!(key, gtk::gdk::Key::p | gtk::gdk::Key::P) {
+            view.pin_focused();
+            return glib::Propagation::Stop;
+        }
         if key == gtk::gdk::Key::space && !alt && !control {
             preview.toggle(browser.focused_entry());
             return glib::Propagation::Stop;


### PR DESCRIPTION
## What changed and why

Fixes #229. Two keyboard-first issues:

1. **`y`/`p` shortcuts** — the right-click context menu advertises `Y` (Copy path) and the Pin action, but no keyboard binding existed. Added `BrowserView::copy_path()` and `BrowserView::pin_focused()`, wired to `y`/`Y` and `p`/`P` in the window key handler.
2. **Copied paths not shell-safe** — Copy path returned a raw, unescaped path with no trailing slash. Added `copy_path_text()` / `shell_escape_path()` so native directory paths get metacharacters escaped (e.g. space → `\ `) and a trailing `/`. Native files keep the escaped path without the slash; URIs are unchanged.

## How to exercise

1. Navigate to a directory with a space, select a folder such as `Movies⁄TV`, and press `y`.
2. Paste into a shell — expect `/mnt/Mass\ 1/Movies⁄TV/`.
3. Focus a folder and press `p` — expect it to pin to the sidebar.

## Expected result

- `y`/`Y` copies the focused/selected path; `p`/`P` pins the focused folder.
- Copied native directory paths are escaped with a trailing slash.

## Checklist / notes

- `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all-targets --all-features` all pass (445 tests, including 3 new regression tests).
- Screenshots: N/A (keyboard/copy-buffer behavior; verified via tests).