### PR TITLE
feat(navigation): sort names case-insensitively

### DIFF
--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -919,7 +919,7 @@ fn compare_entries(left: &FileEntry, right: &FileEntry, preferences: ViewPrefere
     }
 
     let ordering = match preferences.sort_key {
-        SortKey::Name => left.display_name.cmp(&right.display_name),
+        SortKey::Name => compare_display_names(&left.display_name, &right.display_name),
         SortKey::Type => left.kind.cmp(&right.kind),
         SortKey::Size => compare_metadata(&left.size, &right.size),
         SortKey::Modified => {
@@ -931,8 +931,14 @@ fn compare_entries(left: &FileEntry, right: &FileEntry, preferences: ViewPrefere
         SortDirection::Descending => ordering.reverse(),
     };
     ordering
-        .then_with(|| left.display_name.cmp(&right.display_name))
+        .then_with(|| compare_display_names(&left.display_name, &right.display_name))
         .then_with(|| left.location.compare(&right.location))
+}
+
+fn compare_display_names(left: &str, right: &str) -> Ordering {
+    glib::casefold(left)
+        .cmp(&glib::casefold(right))
+        .then_with(|| left.cmp(right))
 }
 
 fn compare_metadata<T: Ord>(left: &MetadataValue<T>, right: &MetadataValue<T>) -> Ordering {

--- a/src/app/navigation/tests.rs
+++ b/src/app/navigation/tests.rs
@@ -515,6 +515,39 @@ fn batches_are_merged_into_one_global_sort_order() {
 }
 
 #[test]
+fn names_are_sorted_case_insensitively() {
+    let mut state = NavigationState::default();
+    state.navigate(location("/fixture"), RequestId(1));
+    state.apply_batch(
+        RequestId(1),
+        vec![
+            named_entry("/fixture/apple", "apple"),
+            named_entry("/fixture/Banana", "Banana"),
+            named_entry("/fixture/cherry", "cherry"),
+            named_entry("/fixture/Date", "Date"),
+        ],
+    );
+
+    assert_eq!(
+        state.columns[0]
+            .entries
+            .iter()
+            .map(|entry| entry.display_name.as_str())
+            .collect::<Vec<_>>(),
+        ["apple", "Banana", "cherry", "Date"]
+    );
+}
+
+#[test]
+fn names_that_differ_only_by_case_have_a_deterministic_order() {
+    assert_eq!(compare_display_names("file", "FILE"), Ordering::Greater);
+    assert_eq!(
+        compare_display_names("Straße", "STRASSE"),
+        Ordering::Greater
+    );
+}
+
+#[test]
 fn changing_sort_preferences_preserves_the_selected_entry() {
     let mut state = NavigationState::default();
     state.navigate(location("/fixture"), RequestId(1));


### PR DESCRIPTION
## Description

Use Unicode case folding when comparing display names so uppercase and lowercase entries are interleaved conventionally. Names that fold to the same value use their original spelling as a deterministic tie-breaker, and secondary name ordering uses the same comparison.

## Visual evidence

N/A — this changes item ordering only and does not alter the interface layout or styling.

## How to test

1. Create a folder containing `apple`, `Banana`, `cherry`, and `Date`.
2. Open it in Strata and sort by Name ascending.

**Expected result:**

The entries appear as `apple`, `Banana`, `cherry`, `Date`.

## Related issue

Closes #216
