### PR TITLE
feat(remote): complete SFTP authentication and browsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Strata combines spatial Miller-column navigation with familiar Grid and Explorer
 - **Rich previews and thumbnails:** bounded previews for text, source code, images, camera RAW, PDF, audio, and video, with native parser-backed formats isolated from the application.
 - **Responsive filesystem work:** cancellable directory loading, bounded streaming, incremental monitoring, stable selection, and virtualized large directories.
 - **Everyday file operations:** create folders, rename, cut, copy, paste, trash, permanent delete, sorting, hidden files, pins, and history.
-- **Remote locations:** browse GIO/GVfs locations such as authenticated SMB shares from the location field.
+- **Remote locations:** browse GIO/GVfs locations such as authenticated SMB shares and SFTP servers from the location field, with explicit host-key decisions.
 - **Adaptive appearance:** compact or airy density, six bundled themes, custom themes, and live Omarchy Quattro theme following.
 - **Updates in the app:** opt-in automatic checks, release notes, verified downloads, and in-place installation for release binaries.
 
@@ -232,7 +232,9 @@ omarchy menu keybindings --print | grep -i "file manager"
 
 ### Network shares
 
-Press <kbd>Ctrl</kbd>+<kbd>L</kbd>, enter an address such as `smb://server/share`, and press <kbd>Enter</kbd>. Strata uses GIO/GVfs and prompts for credentials when required. Install your distribution's SMB GVfs backend (`gvfs-smb` on Arch) to enable SMB browsing.
+Press <kbd>Ctrl</kbd>+<kbd>L</kbd>, enter an address such as `smb://server/share` or `sftp://user@host:2222/path`, and press <kbd>Enter</kbd>. Strata uses GIO/GVfs and prompts for credentials when required. Remote protocols need their GVfs backend installed; distributions split these up differently, so check yours for the SMB backend (`gvfs-smb` on Arch) and the SFTP backend (part of `gvfs` on Arch, `gvfs-backends` on Debian and Ubuntu).
+
+SFTP accepts password and SSH-key authentication, asks for an encrypted key's passphrase, and always makes you decide about an unrecognized or changed host key. See [docs/remote-sftp.md](docs/remote-sftp.md), which also documents `scripts/sftp-fixture.sh`, a disposable OpenSSH server for testing.
 
 ## Theming
 

--- a/docs/remote-sftp.md
+++ b/docs/remote-sftp.md
@@ -1,0 +1,98 @@
+# SFTP locations
+
+Strata reaches `sftp://` locations through GIO/GVfs, the same URI-native path it
+uses for every other remote scheme. This page covers what the client supports
+and how to exercise it against a disposable server.
+
+## Addresses
+
+| Address | Meaning |
+| --- | --- |
+| `sftp://host/path` | Connect as the local user on port 22 |
+| `sftp://user@host/path` | Connect as `user` |
+| `sftp://user@host:2222/path` | Connect as `user` on port 2222 |
+
+Passwords are never accepted in the address bar. A password typed there is
+stripped from the URI, used once for the connection, and never saved.
+
+## Authentication
+
+The SFTP backend decides which credentials it needs and asks Strata for them:
+
+- **Password** — the backend requests a username and password. Strata shows a
+  sign-in dialog with only the fields the backend asked for, so SMB's domain and
+  anonymous options do not appear on an SFTP prompt.
+- **SSH key** — the agent or an unencrypted key answers without any prompt.
+- **Encrypted key** — the backend asks for the key's passphrase through the same
+  request, and Strata labels the field "Passphrase" rather than "Password".
+
+Wrong credentials reopen the prompt with a message naming only the fields the
+prompt is showing. Cancelling returns to the previous location without recording
+history.
+
+## Host keys
+
+An unrecognized or changed host key reaches Strata as a `GMountOperation`
+question, and is always answered by the user:
+
+- The dialog shows the backend's own text, including the key fingerprint, and one
+  button per choice the backend offered.
+- The declining choice is focused, so pressing Enter never trusts a key.
+- Escape, the close button, and a click on the backdrop do not silently accept:
+  the backdrop is inert and the other two decline explicitly.
+- A changed host key is styled as a warning, since it can mean interception.
+
+Declining ends the attempt where a cancelled sign-in ends: back at the previous
+location, with no retry prompt.
+
+## Failures
+
+Missing backends, name-resolution failures, refused connections, timeouts,
+unreachable hosts and rejected host keys each map to their own actionable
+message. Backend text that reaches a dialog has any URI user-info stripped first.
+
+Logs never carry a host, path, username, or secret at the default level. `INFO`
+records only the backend name and outcome; the location is logged at `DEBUG`,
+already redacted of user-info, query and fragment.
+
+## Disposable test server
+
+`scripts/sftp-fixture.sh` runs an OpenSSH server on `127.0.0.1` whose host key,
+client keys, `authorized_keys`, and served files all live in one temporary
+directory that is deleted when the server stops. Nothing is written to `~/.ssh`.
+
+```console
+$ ./scripts/sftp-fixture.sh --port 2222
+Disposable SFTP fixture is listening on 127.0.0.1:2222
+
+  Open in Strata:   sftp://you@127.0.0.1:2222/tmp/strata-sftp-XXXXXX/served
+  Client key:       /tmp/strata-sftp-XXXXXX/client_ed25519
+  Encrypted key:    /tmp/strata-sftp-XXXXXX/client_ed25519_encrypted (passphrase: strata)
+```
+
+Options: `--port`, `--root DIR` to serve an existing directory, and `--keep` to
+leave the fixture in place. `STRATA_SFTP_PASSPHRASE` changes the encrypted key's
+passphrase. Password authentication stays off unless `STRATA_SFTP_PASSWORD` is
+set, because `sshd` can only check a password against a real system account.
+
+### Manual matrix
+
+Run these against the fixture. Each row is a user-visible behaviour that has no
+automated coverage, because the crate is a binary with no library target for
+integration tests and mounting through GVfs needs a live session bus.
+
+| Case | How | Expected |
+| --- | --- | --- |
+| Unknown host key | Connect for the first time | Host-key dialog, declining choice focused |
+| Declined host key | Answer Cancel | Returns to the previous location, no sign-in prompt |
+| Accepted host key | Answer the accepting choice | Connection continues |
+| Key authentication | `ssh-add` the client key, reconnect | Browses with no prompt |
+| Encrypted key | `ssh-add` the encrypted key, reconnect | Passphrase prompt, field labelled "Passphrase" |
+| Wrong passphrase | Answer with the wrong one | Prompt reopens with the retry message |
+| Cancelled sign-in | Escape the prompt | Previous location, no history entry |
+| Non-default port | Use `sftp://user@127.0.0.1:PORT/path` | Browses normally |
+| Changed host key | Restart the fixture, reconnect | Warning-styled dialog, or a `known_hosts` message |
+| Connection refused | Stop the fixture, reconnect | "The host refused the connection…" |
+| Host not found | Use a name that does not resolve | "That host couldn't be found…" |
+| Navigation | Breadcrumbs, history, Miller descent, hover peek | Behave as on local paths |
+| Export | Copy, drag out, and open a remote file | Handled by the default application |

--- a/scripts/sftp-fixture.sh
+++ b/scripts/sftp-fixture.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Runs a disposable OpenSSH server for exercising Strata's sftp:// support.
+#
+# Everything it creates — host keys, the client key pair, the authorized_keys
+# file and the served directory — lives under a single directory that is removed
+# when the server stops, so no state leaks into the developer's ~/.ssh.
+set -euo pipefail
+
+port="${STRATA_SFTP_PORT:-2222}"
+password="${STRATA_SFTP_PASSWORD:-}"
+root="${STRATA_SFTP_ROOT:-}"
+keep=""
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: scripts/sftp-fixture.sh [--port PORT] [--root DIR] [--keep]
+
+Starts sshd on 127.0.0.1 and prints the sftp:// URI to open in Strata.
+Press Ctrl-C to stop it and delete everything it created.
+
+  --port PORT  listen port (default 2222, or $STRATA_SFTP_PORT)
+  --root DIR   directory to serve (default: a generated sample tree)
+  --keep       leave the fixture directory in place on exit
+
+Password authentication is disabled unless $STRATA_SFTP_PASSWORD is set, since
+sshd can only verify a password against a real system account.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --port) port="$2"; shift 2 ;;
+    --root) root="$2"; shift 2 ;;
+    --keep) keep="yes"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage; exit 2 ;;
+  esac
+done
+
+sshd="$(command -v sshd || true)"
+for candidate in /usr/sbin/sshd /usr/lib/ssh/sshd /usr/libexec/sshd; do
+  [[ -n "$sshd" ]] && break
+  [[ -x "$candidate" ]] && sshd="$candidate"
+done
+if [[ -z "$sshd" ]]; then
+  echo "sshd not found. Install your distribution's OpenSSH server package." >&2
+  exit 1
+fi
+command -v ssh-keygen >/dev/null || { echo "ssh-keygen not found." >&2; exit 1; }
+
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/strata-sftp-XXXXXX")"
+chmod 700 "$fixture"
+
+cleanup() {
+  if [[ -f "$fixture/sshd.pid" ]]; then
+    kill "$(cat "$fixture/sshd.pid")" 2>/dev/null || true
+  fi
+  if [[ -z "$keep" ]]; then
+    rm -rf -- "$fixture"
+  else
+    echo "Fixture kept at $fixture" >&2
+  fi
+}
+trap cleanup EXIT INT TERM
+
+if [[ -z "$root" ]]; then
+  root="$fixture/served"
+  mkdir -p "$root/documents" "$root/images" "$root/nested/deeper"
+  printf 'hello from the disposable sftp fixture\n' > "$root/readme.txt"
+  printf '{"fixture": true}\n' > "$root/documents/sample.json"
+  printf 'plain text\n' > "$root/nested/deeper/leaf.txt"
+  head -c 4096 /dev/urandom > "$root/images/blob.bin"
+fi
+root="$(cd "$root" && pwd)"
+
+ssh-keygen -q -t ed25519 -N '' -f "$fixture/host_ed25519" -C 'strata-sftp-fixture-host'
+ssh-keygen -q -t ed25519 -N '' -f "$fixture/client_ed25519" -C 'strata-sftp-fixture-client'
+# An encrypted copy of the same key, for exercising the passphrase prompt.
+cp "$fixture/client_ed25519" "$fixture/client_ed25519_encrypted"
+cp "$fixture/client_ed25519.pub" "$fixture/client_ed25519_encrypted.pub"
+ssh-keygen -q -p -P '' -N "${STRATA_SFTP_PASSPHRASE:-strata}" \
+  -f "$fixture/client_ed25519_encrypted" >/dev/null
+
+cp "$fixture/client_ed25519.pub" "$fixture/authorized_keys"
+chmod 600 "$fixture/authorized_keys" "$fixture/host_ed25519" "$fixture/client_ed25519" \
+  "$fixture/client_ed25519_encrypted"
+
+sftp_server=""
+for candidate in /usr/lib/ssh/sftp-server /usr/lib/openssh/sftp-server \
+  /usr/libexec/sftp-server /usr/libexec/openssh/sftp-server; do
+  [[ -x "$candidate" ]] && { sftp_server="$candidate"; break; }
+done
+if [[ -z "$sftp_server" ]]; then
+  echo "sftp-server binary not found; install the OpenSSH server package." >&2
+  exit 1
+fi
+
+password_auth="no"
+[[ -n "$password" ]] && password_auth="yes"
+
+cat > "$fixture/sshd_config" <<CONFIG
+ListenAddress 127.0.0.1
+Port $port
+HostKey $fixture/host_ed25519
+PidFile $fixture/sshd.pid
+AuthorizedKeysFile $fixture/authorized_keys
+PasswordAuthentication $password_auth
+KbdInteractiveAuthentication no
+PubkeyAuthentication yes
+UsePAM no
+StrictModes no
+PrintMotd no
+X11Forwarding no
+Subsystem sftp $sftp_server
+LogLevel VERBOSE
+CONFIG
+
+"$sshd" -f "$fixture/sshd_config" -E "$fixture/sshd.log"
+
+user="$(id -un)"
+cat <<SUMMARY
+Disposable SFTP fixture is listening on 127.0.0.1:$port
+
+  Open in Strata:   sftp://$user@127.0.0.1:$port$root
+  Client key:       $fixture/client_ed25519
+  Encrypted key:    $fixture/client_ed25519_encrypted (passphrase: ${STRATA_SFTP_PASSPHRASE:-strata})
+  Server log:       $fixture/sshd.log
+
+The fixture host key is new, so the first connection must answer Strata's
+host-key question. To exercise the changed-host-key path, connect once, stop
+the fixture, start it again (it generates a fresh host key), and reconnect.
+
+Press Ctrl-C to stop the server and delete the fixture.
+SUMMARY
+
+while [[ -f "$fixture/sshd.pid" ]] && kill -0 "$(cat "$fixture/sshd.pid")" 2>/dev/null; do
+  sleep 1
+done

--- a/src/adapters/local_files/tests.rs
+++ b/src/adapters/local_files/tests.rs
@@ -4,62 +4,23 @@ use std::{
     error::Error,
     ffi::OsString,
     fs,
-    io::{ErrorKind, Write},
+    io::ErrorKind,
     os::unix::ffi::{OsStrExt, OsStringExt},
-    sync::{Arc, Mutex, MutexGuard},
     time::SystemTime,
 };
 
-use tracing_subscriber::fmt::MakeWriter;
-
 use super::*;
-use crate::{model::Location, test_support::ASYNC_MAIN_CONTEXT_DEFAULT};
-
-#[derive(Clone, Default)]
-struct LogWriter(Arc<Mutex<Vec<u8>>>);
-
-struct LogWriterGuard<'a>(MutexGuard<'a, Vec<u8>>);
-
-impl Write for LogWriterGuard<'_> {
-    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
-        self.0.write(buffer)
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.0.flush()
-    }
-}
-
-impl<'a> MakeWriter<'a> for LogWriter {
-    type Writer = LogWriterGuard<'a>;
-
-    fn make_writer(&'a self) -> Self::Writer {
-        LogWriterGuard(self.0.lock().unwrap_or_else(|error| error.into_inner()))
-    }
-}
-
-impl LogWriter {
-    fn output(&self) -> String {
-        let output = self.0.lock().unwrap_or_else(|error| error.into_inner());
-        String::from_utf8_lossy(&output).into_owned()
-    }
-}
+use crate::{
+    model::Location,
+    test_support::{ASYNC_MAIN_CONTEXT_DEFAULT, capture_logs},
+};
 
 fn capture_directory_start_logs(locations: &[(RequestId, &Location)]) -> String {
-    let writer = LogWriter::default();
-    let subscriber = tracing_subscriber::fmt()
-        .with_ansi(false)
-        .without_time()
-        .with_max_level(tracing::Level::DEBUG)
-        .with_writer(writer.clone())
-        .finish();
-
-    tracing::subscriber::set_global_default(subscriber)
-        .expect("the logging subscriber should only be installed once");
-    for (request_id, location) in locations {
-        log_directory_load_started(*request_id, location);
-    }
-    writer.output()
+    capture_logs(|| {
+        for (request_id, location) in locations {
+            log_directory_load_started(*request_id, location);
+        }
+    })
 }
 
 fn captured_event<'a>(output: &'a str, request_id: RequestId, message: &str) -> &'a str {

--- a/src/services/file_source.rs
+++ b/src/services/file_source.rs
@@ -67,27 +67,31 @@ impl fmt::Display for LocationValidationError {
     }
 }
 
-/// Maps a location's URI scheme to the distribution package that provides its
-/// GVfs backend, for the schemes we currently support connecting to.
+/// Names the packages a URI scheme's GVfs backend is commonly shipped in.
+/// Distributions split GVfs differently, so this lists the usual candidates
+/// rather than asserting one universal package name.
 fn backend_package_hint(scheme: &str) -> Option<&'static str> {
     match scheme.to_ascii_lowercase().as_str() {
-        "smb" => Some("gvfs-smb"),
+        "smb" => Some("gvfs-smb or gvfs-backends"),
+        "sftp" | "ftp" | "ftps" | "dav" | "davs" => Some("gvfs or gvfs-backends"),
         _ => None,
     }
 }
 
 /// Builds a "this backend isn't installed" message naming the scheme and, when
-/// known, the package that provides it, without repeating the host/share/path.
+/// known, the packages that usually provide it, without repeating the
+/// host/share/path.
 pub fn backend_unavailable_message(uri: &str) -> String {
     let scheme = uri.split("://").next().unwrap_or(uri);
     match backend_package_hint(scheme) {
-        Some(package) => format!(
-            "The {scheme}:// backend isn't installed. Install the {package} package to \
-             connect to {scheme}:// locations."
+        Some(packages) => format!(
+            "The {scheme}:// backend isn't installed. Install your distribution's GVfs \
+             {scheme} backend, commonly packaged as {packages}, then try again."
         ),
         None => format!(
             "The {scheme}:// backend isn't installed on this system, so {scheme}:// \
-             locations can't be opened."
+             locations can't be opened. Install the matching GVfs backend from your \
+             distribution, then try again."
         ),
     }
 }

--- a/src/services/file_source/tests.rs
+++ b/src/services/file_source/tests.rs
@@ -87,6 +87,26 @@ fn backend_unavailable_message_names_the_known_smb_package() {
 
 #[test]
 fn backend_unavailable_message_falls_back_for_unknown_schemes() {
-    let message = backend_unavailable_message("dav://host/path");
-    assert!(message.contains("dav://"));
+    let message = backend_unavailable_message("afp://host/path");
+    assert!(message.contains("afp://"));
+    assert!(message.contains("distribution"));
+}
+
+#[test]
+fn backend_unavailable_message_offers_candidate_packages_for_sftp() {
+    let message = backend_unavailable_message("sftp://host.example:2222/home/user");
+    assert!(message.contains("sftp://"));
+    assert!(message.contains("gvfs-backends"));
+    assert!(!message.contains("host.example"));
+}
+
+#[test]
+fn backend_unavailable_message_never_claims_one_universal_package() {
+    for uri in ["smb://host/share", "sftp://host/path", "dav://host/path"] {
+        let message = backend_unavailable_message(uri);
+        assert!(
+            message.contains("distribution"),
+            "{uri} names a package as if every distribution used it: {message}"
+        );
+    }
 }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -106,3 +106,12 @@ pub(crate) fn capture_logs(action: impl FnOnce()) -> String {
     tracing::subscriber::with_default(subscriber, action);
     writer.output()
 }
+
+/// Finds the rendered event carrying `message`, panicking with the whole
+/// capture when it is missing so a failure shows what was logged instead.
+pub(crate) fn captured_event<'a>(output: &'a str, message: &str) -> &'a str {
+    output
+        .lines()
+        .find(|line| line.contains(message))
+        .unwrap_or_else(|| panic!("missing {message:?} event in:\n{output}"))
+}

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -2,7 +2,12 @@
 
 #![cfg(test)]
 
-use std::sync::{LockResult, Mutex, MutexGuard};
+use std::{
+    io::Write,
+    sync::{Arc, LockResult, Mutex, MutexGuard, Once},
+};
+
+use tracing_subscriber::fmt::MakeWriter;
 
 pub(crate) struct TestMutex(Mutex<()>);
 
@@ -29,3 +34,75 @@ impl TestMutex {
 /// module from racing a test in another, since neither knows about the other's lock. Poisoning is
 /// cleared because the mutex protects no state and should not turn one failure into a cascade.
 pub(crate) static ASYNC_MAIN_CONTEXT_DEFAULT: TestMutex = TestMutex::new();
+
+#[derive(Clone, Default)]
+pub(crate) struct LogWriter(Arc<Mutex<Vec<u8>>>);
+
+pub(crate) struct LogWriterGuard<'a>(MutexGuard<'a, Vec<u8>>);
+
+impl Write for LogWriterGuard<'_> {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        self.0.write(buffer)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.0.flush()
+    }
+}
+
+impl<'a> MakeWriter<'a> for LogWriter {
+    type Writer = LogWriterGuard<'a>;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        LogWriterGuard(self.0.lock().unwrap_or_else(|error| error.into_inner()))
+    }
+}
+
+impl LogWriter {
+    fn output(&self) -> String {
+        let output = self.0.lock().unwrap_or_else(|error| error.into_inner());
+        String::from_utf8_lossy(&output).into_owned()
+    }
+}
+
+/// Serializes log captures, since each installs its subscriber for one thread but
+/// asserts on events the whole binary can emit.
+static LOG_CAPTURE: TestMutex = TestMutex::new();
+
+static GLOBAL_SINK: Once = Once::new();
+
+/// Installs a discarding global subscriber, once per test binary.
+///
+/// `tracing` caches a callsite's interest the first time it is reached, and a
+/// callsite first reached while the current thread has no subscriber is cached as
+/// uninteresting for every thread. Tests run in parallel, so an unrelated test
+/// logging from the same callsite can silence it inside a capture running beside
+/// it. Keeping a permissive global subscriber installed means no thread is ever
+/// without one, so callsites stay interesting and each event is resolved against
+/// whichever subscriber its own thread has.
+fn install_global_sink() {
+    GLOBAL_SINK.call_once(|| {
+        let sink = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::TRACE)
+            .with_writer(std::io::sink)
+            .finish();
+        let _installed = tracing::subscriber::set_global_default(sink);
+    });
+}
+
+/// Runs `action` against a private subscriber and returns everything it logged,
+/// so privacy assertions can read the rendered events rather than trusting the
+/// call sites.
+pub(crate) fn capture_logs(action: impl FnOnce()) -> String {
+    install_global_sink();
+    let _guard = LOG_CAPTURE.lock();
+    let writer = LogWriter::default();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_max_level(tracing::Level::DEBUG)
+        .with_writer(writer.clone())
+        .finish();
+    tracing::subscriber::with_default(subscriber, action);
+    writer.output()
+}

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -3443,6 +3443,7 @@ impl ViewState {
         if self.overlay.root().and_downcast::<gtk::Window>().is_none() {
             return;
         }
+        log_mount_started(&location, strategy);
         let activity = BrowserView {
             state: self.clone(),
         }
@@ -3544,6 +3545,7 @@ impl ViewState {
                     .await
                     .map(|_| ()),
             };
+            log_mount_finished(&location, &result);
             if let Some(prompt) = active_prompt.borrow_mut().take() {
                 dismiss_authentication_prompt(&result_overlay, &prompt);
             }
@@ -8191,6 +8193,27 @@ impl MountAttempt {
     }
 }
 
+fn log_mount_started(location: &Location, strategy: MountStrategy) {
+    tracing::info!(
+        backend = %location.backend_name(),
+        strategy = strategy.name(),
+        "mount requested"
+    );
+    tracing::debug!(location = %location.diagnostic_path(), "mount location");
+}
+
+fn log_mount_finished(location: &Location, result: &Result<(), glib::Error>) {
+    match result {
+        Ok(()) => tracing::info!(backend = %location.backend_name(), "mount finished"),
+        Err(error) => tracing::info!(
+            backend = %location.backend_name(),
+            error_domain = ?error.domain(),
+            error_code = error.code(),
+            "mount failed"
+        ),
+    }
+}
+
 #[derive(Clone, Copy)]
 enum MountStrategy {
     /// The location itself is accessible but sits on an unmounted volume.
@@ -8198,6 +8221,15 @@ enum MountStrategy {
     /// The location is itself the mountable target (an SMB share, a
     /// "Connect to Server" bookmark, ...).
     Mountable,
+}
+
+impl MountStrategy {
+    fn name(self) -> &'static str {
+        match self {
+            Self::EnclosingVolume => "enclosing-volume",
+            Self::Mountable => "mountable",
+        }
+    }
 }
 
 fn mount_error_is_authentication_failure(location: &Location, error: &glib::Error) -> bool {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -3277,26 +3277,24 @@ impl ViewState {
             location.clone(),
             strategy,
             credentials,
-            move |state, result, attempted_credentials, prompt_details| {
-                if mount_result_is_ok(&result) {
+            move |state, outcome| match outcome {
+                MountOutcome::Mounted => {
                     state.browser.navigate(location.clone());
                     state.location_stack.set_visible_child_name("breadcrumbs");
                     state.browser.focus_active();
-                } else if let Err(error) = result {
-                    if mount_error_is_authentication_failure(&location, &error) {
-                        state.prompt_to_retry_navigation(
-                            location.clone(),
-                            strategy,
-                            attempted_credentials,
-                            prompt_details,
-                        );
-                    } else {
-                        state.restore_location_text();
-                        state.location_stack.set_visible_child_name("breadcrumbs");
-                        if let Some(message) = mount_failure_message(&location, &error) {
-                            show_error_dialog(&state.overlay, "Unable to connect", &message);
-                        }
-                    }
+                }
+                MountOutcome::NeedsCredentials { attempted, details } => {
+                    state.prompt_to_retry_navigation(location.clone(), strategy, attempted, details)
+                }
+                MountOutcome::Cancelled => {
+                    state.restore_location_text();
+                    state.location_stack.set_visible_child_name("breadcrumbs");
+                    state.browser.focus_active();
+                }
+                MountOutcome::Failed(message) => {
+                    state.restore_location_text();
+                    state.location_stack.set_visible_child_name("breadcrumbs");
+                    show_error_dialog(&state.overlay, "Unable to connect", &message);
                 }
             },
         );
@@ -3322,21 +3320,19 @@ impl ViewState {
             location.clone(),
             strategy,
             credentials,
-            move |state, result, attempted_credentials, prompt_details| {
-                if mount_result_is_ok(&result) {
-                    state.browser.descend(parent_depth, location.clone());
-                } else if let Err(error) = result {
-                    if mount_error_is_authentication_failure(&location, &error) {
-                        state.prompt_to_retry_descend(
-                            parent_depth,
-                            location.clone(),
-                            strategy,
-                            attempted_credentials,
-                            prompt_details,
-                        );
-                    } else if let Some(message) = mount_failure_message(&location, &error) {
-                        show_error_dialog(&state.overlay, "Unable to connect", &message);
-                    }
+            move |state, outcome| match outcome {
+                MountOutcome::Mounted => state.browser.descend(parent_depth, location.clone()),
+                MountOutcome::NeedsCredentials { attempted, details } => state
+                    .prompt_to_retry_descend(
+                        parent_depth,
+                        location.clone(),
+                        strategy,
+                        attempted,
+                        details,
+                    ),
+                MountOutcome::Cancelled => {}
+                MountOutcome::Failed(message) => {
+                    show_error_dialog(&state.overlay, "Unable to connect", &message);
                 }
             },
         );
@@ -3442,12 +3438,7 @@ impl ViewState {
         location: Location,
         strategy: MountStrategy,
         credentials: Option<MountCredentials>,
-        on_result: impl Fn(
-            &Rc<Self>,
-            Result<(), glib::Error>,
-            Option<MountCredentials>,
-            Option<MountPromptDetails>,
-        ) + 'static,
+        on_result: impl Fn(&Rc<Self>, MountOutcome) + 'static,
     ) {
         if self.overlay.root().and_downcast::<gtk::Window>().is_none() {
             return;
@@ -3458,33 +3449,37 @@ impl ViewState {
         .begin_global_activity("Connecting…");
         let file = gio_file_for_location(&location);
         let operation = gio::MountOperation::new();
-        let prompt_overlay = self.overlay.clone();
+        let attempt = Rc::new(RefCell::new(MountAttempt::new(credentials)));
         let active_prompt = Rc::new(RefCell::new(None::<gtk::Box>));
+
+        let prompt_overlay = self.overlay.clone();
         let prompt_for_signal = active_prompt.clone();
-        let prompt_details = Rc::new(RefCell::new(None::<MountPromptDetails>));
-        let details_for_signal = prompt_details.clone();
-        let attempted_credentials = Rc::new(RefCell::new(credentials.clone()));
-        let attempts_for_signal = attempted_credentials.clone();
-        let supplied_credentials = Rc::new(RefCell::new(credentials));
-        let credentials_for_signal = supplied_credentials.clone();
-        let already_prompted = Cell::new(credentials_for_signal.borrow().is_some());
+        let attempt_for_password = attempt.clone();
         operation.connect_ask_password(
             move |operation, message, default_user, default_domain, flags| {
-                details_for_signal.replace(Some(MountPromptDetails {
-                    message: message.to_owned(),
-                    default_user: default_user.to_owned(),
-                    default_domain: default_domain.to_owned(),
-                    flags,
-                }));
-                if let Some(credentials) = credentials_for_signal.borrow_mut().take() {
-                    apply_mount_credentials(operation, &credentials);
-                    operation.reply(gio::MountOperationResult::Handled);
-                    return;
-                }
+                let request = attempt_for_password
+                    .borrow_mut()
+                    .ask_password(MountPromptDetails {
+                        message: message.to_owned(),
+                        default_user: default_user.to_owned(),
+                        default_domain: default_domain.to_owned(),
+                        flags,
+                    });
+                let retry = match request {
+                    PasswordRequest::Reply => {
+                        if let Some(credentials) =
+                            attempt_for_password.borrow().attempted.as_ref().cloned()
+                        {
+                            apply_mount_credentials(operation, &credentials);
+                        }
+                        operation.reply(gio::MountOperationResult::Handled);
+                        return;
+                    }
+                    PasswordRequest::Ask { retry } => retry,
+                };
                 if let Some(previous) = prompt_for_signal.borrow_mut().take() {
                     dismiss_authentication_prompt(&prompt_overlay, &previous);
                 }
-                let retry = already_prompted.replace(true);
                 let prompt = show_authentication_dialog(
                     &prompt_overlay,
                     Some(operation),
@@ -3494,10 +3489,8 @@ impl ViewState {
                     retry,
                     MountDialogHandlers {
                         submitted: Some(Rc::new({
-                            let attempts_for_signal = attempts_for_signal.clone();
-                            move |credentials| {
-                                attempts_for_signal.replace(Some(credentials));
-                            }
+                            let attempt = attempt_for_password.clone();
+                            move |credentials| attempt.borrow_mut().submitted(credentials)
                         })),
                         cancelled: None,
                     },
@@ -3523,12 +3516,8 @@ impl ViewState {
                 dismiss_authentication_prompt(&result_overlay, &prompt);
             }
             if let Some(state) = weak.upgrade() {
-                on_result(
-                    &state,
-                    result,
-                    attempted_credentials.borrow().clone(),
-                    prompt_details.borrow().clone(),
-                );
+                let outcome = attempt.borrow().outcome(&location, result);
+                on_result(&state, outcome);
             }
         });
     }
@@ -7860,6 +7849,84 @@ fn apply_mount_credentials(operation: &gio::MountOperation, credentials: &MountC
     operation.set_password_save(credentials.save);
 }
 
+/// How a finished mount attempt should be reported to the caller.
+enum MountOutcome {
+    Mounted,
+    /// The user backed out, so the browser returns to where it already was.
+    Cancelled,
+    NeedsCredentials {
+        attempted: Option<MountCredentials>,
+        details: Option<MountPromptDetails>,
+    },
+    Failed(String),
+}
+
+/// What a backend password request should do, given what the attempt has
+/// already asked the user.
+#[derive(Debug, Eq, PartialEq)]
+enum PasswordRequest {
+    /// Credentials the user already supplied are replayed without a prompt.
+    Reply,
+    /// The user must be asked; `retry` marks a second or later request, which
+    /// only happens after the backend rejected the previous answer.
+    Ask { retry: bool },
+}
+
+/// Tracks what a single mount attempt has already asked the user, so the
+/// credential prompt is shown once per backend request rather than looping.
+#[derive(Default)]
+struct MountAttempt {
+    supplied: Option<MountCredentials>,
+    attempted: Option<MountCredentials>,
+    prompted: bool,
+    details: Option<MountPromptDetails>,
+}
+
+impl MountAttempt {
+    fn new(credentials: Option<MountCredentials>) -> Self {
+        Self {
+            prompted: credentials.is_some(),
+            supplied: credentials.clone(),
+            attempted: credentials,
+            ..Self::default()
+        }
+    }
+
+    fn ask_password(&mut self, details: MountPromptDetails) -> PasswordRequest {
+        self.details = Some(details);
+        if self.supplied.take().is_some() {
+            return PasswordRequest::Reply;
+        }
+        PasswordRequest::Ask {
+            retry: std::mem::replace(&mut self.prompted, true),
+        }
+    }
+
+    fn submitted(&mut self, credentials: MountCredentials) {
+        self.attempted = Some(credentials);
+    }
+
+    fn outcome(&self, location: &Location, result: Result<(), glib::Error>) -> MountOutcome {
+        let error = match result {
+            Ok(()) => return MountOutcome::Mounted,
+            Err(error) if error.matches(gio::IOErrorEnum::AlreadyMounted) => {
+                return MountOutcome::Mounted;
+            }
+            Err(error) => error,
+        };
+        if mount_error_is_authentication_failure(location, &error) {
+            return MountOutcome::NeedsCredentials {
+                attempted: self.attempted.clone(),
+                details: self.details.clone(),
+            };
+        }
+        match mount_failure_message(location, &error) {
+            Some(message) => MountOutcome::Failed(message),
+            None => MountOutcome::Cancelled,
+        }
+    }
+}
+
 #[derive(Clone, Copy)]
 enum MountStrategy {
     /// The location itself is accessible but sits on an unmounted volume.
@@ -7867,13 +7934,6 @@ enum MountStrategy {
     /// The location is itself the mountable target (an SMB share, a
     /// "Connect to Server" bookmark, ...).
     Mountable,
-}
-
-fn mount_result_is_ok(result: &Result<(), glib::Error>) -> bool {
-    match result {
-        Ok(()) => true,
-        Err(error) => error.matches(gio::IOErrorEnum::AlreadyMounted),
-    }
 }
 
 fn mount_error_is_authentication_failure(location: &Location, error: &glib::Error) -> bool {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -31,8 +31,8 @@ use super::{
     browser_modes::{BrowserDensity, BrowserMode, ClickActivation, ClickCount, ModeViews},
     controls::{
         ModalTone, form_check_button, form_entry, form_label, form_password_entry, menu_option,
-        message_dialog_description, message_dialog_layout, modal_layout, segmented_control,
-        wrap_dialog_text,
+        message_dialog_description, message_dialog_layout, modal_layout, modal_layout_with_tone,
+        segmented_control, wrap_dialog_text,
     },
     motion::{animations_enabled, emphasized_deceleration},
 };
@@ -3498,6 +3498,38 @@ impl ViewState {
                 prompt_for_signal.replace(prompt);
             },
         );
+        let question_overlay = self.overlay.clone();
+        let question_prompt = active_prompt.clone();
+        let attempt_for_question = attempt.clone();
+        // `ask-question` carries a GStrv, which gir cannot wrap, so the backend's
+        // trust decisions are taken from the raw signal rather than dropped.
+        operation.connect_local("ask-question", false, move |values| {
+            let operation = values
+                .first()
+                .and_then(|value| value.get::<gio::MountOperation>().ok())?;
+            let message = values
+                .get(1)
+                .and_then(|value| value.get::<String>().ok())
+                .unwrap_or_default();
+            let choices = values
+                .get(2)
+                .and_then(|value| value.get::<Vec<String>>().ok())
+                .unwrap_or_default();
+            let details = MountQuestionDetails { message, choices };
+            attempt_for_question
+                .borrow_mut()
+                .ask_question(details.clone());
+            if let Some(previous) = question_prompt.borrow_mut().take() {
+                dismiss_authentication_prompt(&question_overlay, &previous);
+            }
+            let prompt = show_mount_question_dialog(&question_overlay, &operation, &details, {
+                let attempt = attempt_for_question.clone();
+                move |decision| attempt.borrow_mut().decide(decision)
+            });
+            question_prompt.replace(prompt);
+            None
+        });
+
         let weak = Rc::downgrade(self);
         let result_overlay = self.overlay.clone();
         glib::MainContext::default().spawn_local(async move {
@@ -7849,6 +7881,225 @@ fn apply_mount_credentials(operation: &gio::MountOperation, credentials: &MountC
     operation.set_password_save(credentials.save);
 }
 
+/// A `GMountOperation::ask-question` request: a trust decision the backend
+/// refuses to make on its own, such as an unrecognized or changed SSH host key.
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct MountQuestionDetails {
+    message: String,
+    choices: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MountQuestionKind {
+    UnknownHostKey,
+    ChangedHostKey,
+    Other,
+}
+
+impl MountQuestionKind {
+    fn classify(message: &str) -> Self {
+        let message = message.to_ascii_lowercase();
+        let about_host_key = ["host key", "identity of the remote computer", "fingerprint"]
+            .iter()
+            .any(|marker| message.contains(marker));
+        if !about_host_key {
+            return Self::Other;
+        }
+        if ["changed", "man-in-the-middle", "nasty", "eavesdropping"]
+            .iter()
+            .any(|marker| message.contains(marker))
+        {
+            Self::ChangedHostKey
+        } else {
+            Self::UnknownHostKey
+        }
+    }
+
+    fn heading(self) -> (&'static str, &'static str) {
+        match self {
+            Self::UnknownHostKey => (
+                "Unrecognized host key",
+                "This computer has not been verified before",
+            ),
+            Self::ChangedHostKey => (
+                "Host key changed",
+                "This computer is not presenting the key it used before",
+            ),
+            Self::Other => (
+                "Confirmation required",
+                "The connection needs a decision before it can continue",
+            ),
+        }
+    }
+
+    fn tone(self) -> ModalTone {
+        match self {
+            Self::ChangedHostKey => ModalTone::Danger,
+            Self::UnknownHostKey | Self::Other => ModalTone::Accent,
+        }
+    }
+
+    fn icon(self) -> &'static str {
+        match self {
+            Self::ChangedHostKey => crate::assets::icons::TRIANGLE_ALERT,
+            Self::UnknownHostKey | Self::Other => crate::assets::icons::KEY,
+        }
+    }
+}
+
+/// Recognizes the choice that declines, so it can be the focused default. A
+/// trust decision is never pre-selected in the accepting direction.
+fn choice_declines(label: &str) -> bool {
+    let label = label.to_ascii_lowercase();
+    ["cancel", "abort", "no", "don't", "do not", "reject", "deny"]
+        .iter()
+        .any(|marker| label.contains(marker))
+}
+
+fn safest_choice(choices: &[String]) -> usize {
+    choices
+        .iter()
+        .position(|choice| choice_declines(choice))
+        .unwrap_or_else(|| choices.len().saturating_sub(1))
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MountQuestionDecision {
+    Chose(usize),
+    Declined,
+}
+
+fn show_mount_question_dialog(
+    browser_overlay: &gtk::Overlay,
+    operation: &gio::MountOperation,
+    details: &MountQuestionDetails,
+    decided: impl Fn(MountQuestionDecision) + 'static,
+) -> Option<gtk::Box> {
+    if details.choices.is_empty() {
+        operation.reply(gio::MountOperationResult::Aborted);
+        decided(MountQuestionDecision::Declined);
+        return None;
+    }
+    let Some(window_overlay) = browser_overlay
+        .root()
+        .and_downcast::<gtk::Window>()
+        .and_then(|window| window.child())
+        .and_downcast::<gtk::Overlay>()
+    else {
+        operation.reply(gio::MountOperationResult::Aborted);
+        decided(MountQuestionDecision::Declined);
+        return None;
+    };
+    let blurred_root = window_overlay.child().and_downcast::<BlurBin>();
+    if let Some(root) = blurred_root.as_ref() {
+        root.set_blurred(true);
+    }
+
+    let kind = MountQuestionKind::classify(&details.message);
+    let (heading, subheading) = kind.heading();
+    let layout = modal_layout_with_tone(kind.icon(), heading, subheading, "Continue", kind.tone());
+    layout.content.add_css_class("wide");
+    layout.body.add_css_class("authentication-body");
+    let explanation = gtk::Label::new(Some(&wrap_dialog_text(
+        details.message.trim(),
+        AUTHENTICATION_TEXT_WIDTH_CHARS as usize,
+    )));
+    explanation.add_css_class("authentication-explanation");
+    explanation.set_max_width_chars(AUTHENTICATION_TEXT_WIDTH_CHARS);
+    explanation.set_selectable(true);
+    explanation.set_wrap(true);
+    explanation.set_xalign(0.0);
+    layout.body.append(&explanation);
+
+    // The backend owns the wording of every option, so the stock Cancel and
+    // Continue buttons are replaced by one button per offered choice.
+    while let Some(child) = layout.actions.first_child() {
+        layout.actions.remove(&child);
+    }
+    let spacer = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    spacer.set_hexpand(true);
+    layout.actions.append(&spacer);
+
+    let content = layout.content;
+    let layer = modal_layer(
+        &content,
+        &window_overlay,
+        blurred_root.clone(),
+        Some(Rc::new(|| true)),
+    );
+    window_overlay.add_overlay(&layer);
+    let decided = Rc::new(decided);
+    let answered = Rc::new(Cell::new(false));
+
+    let default_choice = safest_choice(&details.choices);
+    let mut default_button = None;
+    for (index, choice) in details.choices.iter().enumerate() {
+        let button = gtk::Button::with_label(choice);
+        if choice_declines(choice) {
+            button.add_css_class("action-dialog-cancel");
+        } else {
+            button.add_css_class("action-dialog-confirm");
+            if kind.tone() == ModalTone::Danger {
+                button.add_css_class("danger");
+            }
+        }
+        let operation = operation.clone();
+        let decided = decided.clone();
+        let answered = answered.clone();
+        let layer = layer.clone();
+        let overlay = window_overlay.clone();
+        let root = blurred_root.clone();
+        button.connect_clicked(move |_| {
+            if answered.replace(true) {
+                return;
+            }
+            dismiss_modal_layer(&layer, &overlay, root.as_ref());
+            operation.set_choice(index as i32);
+            operation.reply(gio::MountOperationResult::Handled);
+            decided(MountQuestionDecision::Chose(index));
+        });
+        layout.actions.append(&button);
+        if index == default_choice {
+            default_button = Some(button);
+        }
+    }
+
+    let decline = {
+        let operation = operation.clone();
+        let decided = decided.clone();
+        let answered = answered.clone();
+        let layer = layer.clone();
+        let overlay = window_overlay.clone();
+        let root = blurred_root.clone();
+        Rc::new(move || {
+            if answered.replace(true) {
+                return;
+            }
+            dismiss_modal_layer(&layer, &overlay, root.as_ref());
+            operation.reply(gio::MountOperationResult::Aborted);
+            decided(MountQuestionDecision::Declined);
+        })
+    };
+
+    let close_decline = decline.clone();
+    layout.close.connect_clicked(move |_| close_decline());
+
+    let escape = gtk::EventControllerKey::new();
+    escape.connect_key_pressed(move |_, key, _, _| {
+        if key != gtk::gdk::Key::Escape {
+            return glib::Propagation::Proceed;
+        }
+        decline();
+        glib::Propagation::Stop
+    });
+    layer.add_controller(escape);
+
+    if let Some(button) = default_button {
+        button.grab_focus();
+    }
+    Some(layer)
+}
+
 /// How a finished mount attempt should be reported to the caller.
 enum MountOutcome {
     Mounted,
@@ -7880,6 +8131,8 @@ struct MountAttempt {
     attempted: Option<MountCredentials>,
     prompted: bool,
     details: Option<MountPromptDetails>,
+    question: Option<MountQuestionDetails>,
+    declined: bool,
 }
 
 impl MountAttempt {
@@ -7906,6 +8159,14 @@ impl MountAttempt {
         self.attempted = Some(credentials);
     }
 
+    fn ask_question(&mut self, details: MountQuestionDetails) {
+        self.question = Some(details);
+    }
+
+    fn decide(&mut self, decision: MountQuestionDecision) {
+        self.declined = decision == MountQuestionDecision::Declined;
+    }
+
     fn outcome(&self, location: &Location, result: Result<(), glib::Error>) -> MountOutcome {
         let error = match result {
             Ok(()) => return MountOutcome::Mounted,
@@ -7914,6 +8175,9 @@ impl MountAttempt {
             }
             Err(error) => error,
         };
+        if self.declined {
+            return MountOutcome::Cancelled;
+        }
         if mount_error_is_authentication_failure(location, &error) {
             return MountOutcome::NeedsCredentials {
                 attempted: self.attempted.clone(),

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -3414,7 +3414,7 @@ impl ViewState {
         let authentication_failed = previous_credentials.is_some();
         let details = prompt_details.unwrap_or_else(|| MountPromptDetails::fallback(location));
         let defaults = previous_credentials.unwrap_or_else(|| {
-            let mut defaults = MountCredentials::default_for_prompt();
+            let mut defaults = MountCredentials::default_for_prompt(details.flags);
             if !details.default_user.is_empty() {
                 defaults.username.clone_from(&details.default_user);
             }
@@ -7465,16 +7465,86 @@ struct MountPromptDetails {
 impl MountPromptDetails {
     fn fallback(location: &Location) -> Self {
         Self {
-            message: format!("Enter user and password for “{}”.", location.display_path()),
+            message: format!("Enter your credentials for “{}”.", location.display_path()),
             default_user: String::new(),
             default_domain: String::new(),
-            flags: gio::AskPasswordFlags::NEED_USERNAME
-                | gio::AskPasswordFlags::NEED_DOMAIN
-                | gio::AskPasswordFlags::NEED_PASSWORD
-                | gio::AskPasswordFlags::SAVING_SUPPORTED
-                | gio::AskPasswordFlags::ANONYMOUS_SUPPORTED,
+            flags: fallback_ask_password_flags(location),
         }
     }
+}
+
+/// Chooses which credential fields to offer when a mount fails before the
+/// backend ever asked for any, so an SFTP retry does not present SMB's domain
+/// and anonymous options.
+fn fallback_ask_password_flags(location: &Location) -> gio::AskPasswordFlags {
+    let mut flags = gio::AskPasswordFlags::NEED_USERNAME
+        | gio::AskPasswordFlags::NEED_PASSWORD
+        | gio::AskPasswordFlags::SAVING_SUPPORTED;
+    match location_scheme(location).as_str() {
+        "smb" => {
+            flags |=
+                gio::AskPasswordFlags::NEED_DOMAIN | gio::AskPasswordFlags::ANONYMOUS_SUPPORTED;
+        }
+        "ftp" | "ftps" => flags |= gio::AskPasswordFlags::ANONYMOUS_SUPPORTED,
+        _ => {}
+    }
+    flags
+}
+
+fn location_scheme(location: &Location) -> String {
+    location
+        .uri_value()
+        .and_then(|uri| uri.split("://").next())
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+}
+
+/// SFTP asks for an encrypted key's passphrase through the same password
+/// prompt, so the secret field is labelled from the backend's own wording.
+fn password_field_label(message: &str) -> &'static str {
+    if message.to_ascii_lowercase().contains("passphrase") {
+        "Passphrase"
+    } else {
+        "Password"
+    }
+}
+
+fn authentication_dialog_heading(message: &str) -> (&'static str, &'static str) {
+    if password_field_label(message) == "Passphrase" {
+        (
+            "Passphrase required",
+            "Unlock the key this connection needs",
+        )
+    } else {
+        (
+            "Authentication required",
+            "Sign in to access this network location",
+        )
+    }
+}
+
+/// Names only the fields the prompt is actually showing, so an SFTP retry does
+/// not tell the user to check a domain it never asked for.
+fn authentication_failure_hint(flags: gio::AskPasswordFlags, secret_label: &str) -> String {
+    let mut fields: Vec<String> = Vec::new();
+    if flags.contains(gio::AskPasswordFlags::NEED_USERNAME) {
+        fields.push("username".to_owned());
+    }
+    if flags.contains(gio::AskPasswordFlags::NEED_DOMAIN) {
+        fields.push("domain".to_owned());
+    }
+    if flags.contains(gio::AskPasswordFlags::NEED_PASSWORD) {
+        fields.push(secret_label.to_ascii_lowercase());
+    }
+    let Some(last) = fields.pop() else {
+        return "That attempt wasn’t accepted. Try again.".to_owned();
+    };
+    let listed = if fields.is_empty() {
+        last
+    } else {
+        format!("{} and {last}", fields.join(", "))
+    };
+    format!("That attempt wasn’t accepted. Check the {listed}, then try again.")
 }
 
 const AUTHENTICATION_TEXT_WIDTH_CHARS: i32 = 64;
@@ -7508,12 +7578,9 @@ fn show_authentication_dialog(
         root.set_blurred(true);
     }
 
-    let layout = modal_layout(
-        crate::assets::icons::KEY,
-        "Authentication required",
-        "Sign in to access this network location",
-        "Connect",
-    );
+    let secret_label = password_field_label(message);
+    let (heading, subheading) = authentication_dialog_heading(message);
+    let layout = modal_layout(crate::assets::icons::KEY, heading, subheading, "Connect");
     layout.content.add_css_class("wide");
     layout.body.add_css_class("authentication-body");
     let explanation_text =
@@ -7526,7 +7593,7 @@ fn show_authentication_dialog(
     layout.body.append(&explanation);
     if authentication_failed {
         let error_text = wrap_dialog_text(
-            "Those credentials weren’t accepted. Check the username, domain, and password, then try again.",
+            &authentication_failure_hint(flags, secret_label),
             AUTHENTICATION_TEXT_WIDTH_CHARS as usize,
         );
         let error = gtk::Label::new(Some(&error_text));
@@ -7555,7 +7622,7 @@ fn show_authentication_dialog(
     let password = form_password_entry();
     password.set_show_peek_icon(true);
     if flags.contains(gio::AskPasswordFlags::NEED_PASSWORD) {
-        append_authentication_field(&credentials, "Password", &password);
+        append_authentication_field(&credentials, secret_label, &password);
     }
 
     let (connect_as_control, connect_as_buttons) =
@@ -7765,11 +7832,15 @@ struct MountCredentials {
 }
 
 impl MountCredentials {
-    fn default_for_prompt() -> Self {
+    fn default_for_prompt(flags: gio::AskPasswordFlags) -> Self {
         Self {
             anonymous: false,
             username: glib::user_name().to_string_lossy().into_owned(),
-            domain: "WORKGROUP".to_owned(),
+            domain: if flags.contains(gio::AskPasswordFlags::NEED_DOMAIN) {
+                "WORKGROUP".to_owned()
+            } else {
+                String::new()
+            },
             password: String::new(),
             save: gio::PasswordSave::Never,
         }

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -7809,6 +7809,9 @@ fn mount_error_is_authentication_failure(location: &Location, error: &glib::Erro
     if location.uri_value().is_none() {
         return false;
     }
+    if mount_error_is_host_key_rejection(error) {
+        return false;
+    }
     if error.matches(gio::IOErrorEnum::PermissionDenied) {
         return true;
     }
@@ -7819,8 +7822,26 @@ fn mount_error_is_authentication_failure(location: &Location, error: &glib::Erro
     [
         "permission denied",
         "authentication failed",
+        "authentication required",
+        "auth fail",
         "logon failure",
         "invalid credentials",
+        "too many authentication failures",
+    ]
+    .iter()
+    .any(|reason| message.contains(reason))
+}
+
+/// Host-key problems reach us as generic failures whose message is the only
+/// signal. They must not be replayed as rejected credentials, or declining a
+/// key would immediately reopen the sign-in prompt.
+fn mount_error_is_host_key_rejection(error: &glib::Error) -> bool {
+    let message = error.message().to_ascii_lowercase();
+    [
+        "host key",
+        "host identification",
+        "fingerprint",
+        "known_hosts",
     ]
     .iter()
     .any(|reason| message.contains(reason))
@@ -7842,7 +7863,80 @@ fn mount_failure_message(location: &Location, error: &glib::Error) -> Option<Str
             location.uri_value().unwrap_or_default(),
         ));
     }
-    Some(error.to_string())
+    if mount_error_is_host_key_rejection(error) {
+        return Some(
+            "The remote computer’s host key could not be verified, so the connection was \
+             refused. Confirm the new key with whoever runs the server and remove the stale \
+             entry from your known_hosts file before trying again."
+                .to_owned(),
+        );
+    }
+    if let Some(message) = transport_failure_message(error) {
+        return Some(message);
+    }
+    Some(sanitize_failure_message(&error.to_string()))
+}
+
+/// Turns the transport failures a remote mount can hit into guidance the user
+/// can act on, instead of the backend's own terse wording.
+fn transport_failure_message(error: &glib::Error) -> Option<String> {
+    if error.matches(gio::IOErrorEnum::HostNotFound) {
+        return Some(
+            "That host couldn’t be found. Check the address for typos and confirm the name \
+             resolves on this network."
+                .to_owned(),
+        );
+    }
+    if error.matches(gio::IOErrorEnum::ConnectionRefused) {
+        return Some(
+            "The host refused the connection. Check that the service is running and that you \
+             used the right port."
+                .to_owned(),
+        );
+    }
+    if error.matches(gio::IOErrorEnum::TimedOut) {
+        return Some(
+            "The connection timed out. Check that the host is reachable and that a firewall \
+             isn’t blocking the port."
+                .to_owned(),
+        );
+    }
+    if error.matches(gio::IOErrorEnum::HostUnreachable)
+        || error.matches(gio::IOErrorEnum::NetworkUnreachable)
+    {
+        return Some(
+            "That host is unreachable from this network. Check your connection, then try again."
+                .to_owned(),
+        );
+    }
+    None
+}
+
+/// Strips URI user-info secrets from a backend message, so a password typed
+/// into the address bar cannot resurface in an error dialog.
+fn sanitize_failure_message(message: &str) -> String {
+    message
+        .split_inclusive(char::is_whitespace)
+        .map(|token| {
+            let Some((scheme, rest)) = token.split_once("://") else {
+                return token.to_owned();
+            };
+            let authority_end = rest.find('/').unwrap_or(rest.len());
+            let Some(userinfo_end) = rest[..authority_end].rfind('@') else {
+                return token.to_owned();
+            };
+            let user = rest[..userinfo_end]
+                .split([':', ';'])
+                .next()
+                .unwrap_or_default();
+            let remainder = &rest[userinfo_end + 1..];
+            if user.is_empty() {
+                format!("{scheme}://{remainder}")
+            } else {
+                format!("{scheme}://{user}@{remainder}")
+            }
+        })
+        .collect()
 }
 
 pub(super) fn is_trash_root(location: &Location) -> bool {

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1503,3 +1503,35 @@ fn accepting_a_host_key_lets_the_attempt_report_its_real_result() {
         MountOutcome::NeedsCredentials { .. }
     ));
 }
+
+#[test]
+fn mount_logging_respects_default_and_diagnostic_privacy() {
+    let location = Location::uri("sftp://alice:hunter2@host.example:2222/home/alice");
+    let output = crate::test_support::capture_logs(|| {
+        log_mount_started(&location, MountStrategy::EnclosingVolume);
+        log_mount_finished(
+            &location,
+            &Err(glib::Error::new(
+                gio::IOErrorEnum::Failed,
+                "Permission denied for alice@host.example",
+            )),
+        );
+    });
+
+    for message in ["mount requested", "mount failed"] {
+        let event = crate::test_support::captured_event(&output, message);
+        assert_eq!(event.split_whitespace().next(), Some("INFO"));
+        assert!(event.contains("backend=sftp"));
+        for secret in ["alice", "hunter2", "host.example", "/home/alice"] {
+            assert!(
+                !event.contains(secret),
+                "{message:?} leaked {secret:?}: {event}"
+            );
+        }
+    }
+
+    let diagnostic = crate::test_support::captured_event(&output, "mount location");
+    assert_eq!(diagnostic.split_whitespace().next(), Some("DEBUG"));
+    assert!(diagnostic.contains("sftp://host.example:2222/home/alice"));
+    assert!(!diagnostic.contains("hunter2"));
+}

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -152,9 +152,9 @@ fn a_missing_backend_reports_which_package_to_install() {
 #[test]
 fn a_genuine_mount_failure_still_reports_an_error() {
     let location = Location::uri("smb://host/share");
-    let error = glib::Error::new(gio::IOErrorEnum::HostNotFound, "no route to host");
+    let error = glib::Error::new(gio::IOErrorEnum::Failed, "the server gave up");
     let message = mount_failure_message(&location, &error).expect("should report a message");
-    assert!(message.contains("no route to host"));
+    assert!(message.contains("the server gave up"));
 }
 
 #[test]
@@ -1187,4 +1187,77 @@ fn pinning_requires_an_available_non_trash_directory() {
     assert!(!can_pin_entry(&directory, PinStatus::Unavailable));
     assert!(!can_pin_entry(&file, PinStatus::Available));
     assert!(!can_pin_entry(&trash_directory, PinStatus::Available));
+}
+
+#[test]
+fn a_missing_sftp_backend_names_candidate_packages_without_claiming_one_is_universal() {
+    let location = Location::uri("sftp://host.example/home/user");
+    let error = glib::Error::new(gio::IOErrorEnum::NotSupported, "no handler for sftp");
+    let message = mount_failure_message(&location, &error).expect("should report a message");
+    assert!(message.contains("sftp://"));
+    assert!(message.contains("gvfs-backends"));
+    assert!(message.contains("distribution"));
+}
+
+#[test]
+fn transport_failures_map_to_guidance_the_user_can_act_on() {
+    let location = Location::uri("sftp://host.example:2222/home/user");
+    for (kind, expected) in [
+        (gio::IOErrorEnum::HostNotFound, "couldn’t be found"),
+        (gio::IOErrorEnum::ConnectionRefused, "right port"),
+        (gio::IOErrorEnum::TimedOut, "timed out"),
+        (gio::IOErrorEnum::HostUnreachable, "unreachable"),
+        (gio::IOErrorEnum::NetworkUnreachable, "unreachable"),
+    ] {
+        let error = glib::Error::new(kind, "sftp backend said so");
+        let message =
+            mount_failure_message(&location, &error).expect("transport failures are reportable");
+        assert!(
+            message.contains(expected),
+            "{kind:?} produced {message:?}, expected it to mention {expected:?}"
+        );
+        assert!(!message.contains("sftp backend said so"));
+    }
+}
+
+#[test]
+fn a_rejected_host_key_is_reported_rather_than_replayed_as_bad_credentials() {
+    let location = Location::uri("sftp://host.example/home/user");
+    let error = glib::Error::new(
+        gio::IOErrorEnum::Failed,
+        "Host key verification failed. Permission denied",
+    );
+
+    assert!(mount_error_is_host_key_rejection(&error));
+    assert!(!mount_error_is_authentication_failure(&location, &error));
+    let message = mount_failure_message(&location, &error).expect("should report a message");
+    assert!(message.contains("known_hosts"));
+}
+
+#[test]
+fn sftp_authentication_failures_are_still_recognized() {
+    let location = Location::uri("sftp://host.example/home/user");
+    for message in [
+        "Permission denied (publickey,password)",
+        "Authentication failed",
+        "Too many authentication failures",
+    ] {
+        let error = glib::Error::new(gio::IOErrorEnum::Failed, message);
+        assert!(
+            mount_error_is_authentication_failure(&location, &error),
+            "{message:?} should ask for credentials again"
+        );
+    }
+}
+
+#[test]
+fn failure_messages_never_echo_a_password_typed_into_the_address_bar() {
+    let sanitized = sanitize_failure_message(
+        "Unable to mount sftp://alice:hunter2@host.example/home/alice now",
+    );
+
+    assert!(!sanitized.contains("hunter2"));
+    assert!(sanitized.contains("sftp://alice@host.example/home/alice"));
+    assert!(sanitized.contains("Unable to mount"));
+    assert!(sanitized.ends_with(" now"));
 }

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1315,3 +1315,100 @@ fn an_encrypted_key_prompt_asks_for_a_passphrase_not_a_password() {
         "Authentication required"
     );
 }
+
+#[test]
+fn supplied_credentials_answer_the_backend_once_and_are_never_re_prompted() {
+    let credentials = MountCredentials {
+        anonymous: false,
+        username: "alice".to_owned(),
+        domain: String::new(),
+        password: "secret".to_owned(),
+        save: gio::PasswordSave::Never,
+    };
+    let mut attempt = MountAttempt::new(Some(credentials));
+    let details = MountPromptDetails::fallback(&Location::uri("sftp://host.example/home/alice"));
+
+    assert_eq!(
+        attempt.ask_password(details.clone()),
+        PasswordRequest::Reply,
+        "credentials from the address bar answer the first request without a dialog"
+    );
+    assert_eq!(
+        attempt.ask_password(details),
+        PasswordRequest::Ask { retry: true },
+        "a second request means they were rejected, so the prompt opens in retry mode"
+    );
+}
+
+#[test]
+fn an_unprompted_attempt_asks_before_it_retries() {
+    let mut attempt = MountAttempt::new(None);
+    let details = MountPromptDetails::fallback(&Location::uri("sftp://host.example/home/alice"));
+
+    assert_eq!(
+        attempt.ask_password(details.clone()),
+        PasswordRequest::Ask { retry: false }
+    );
+    assert_eq!(
+        attempt.ask_password(details),
+        PasswordRequest::Ask { retry: true }
+    );
+}
+
+#[test]
+fn a_rejected_password_carries_the_last_attempt_into_the_retry_prompt() {
+    let location = Location::uri("sftp://host.example/home/alice");
+    let mut attempt = MountAttempt::new(None);
+    attempt.ask_password(MountPromptDetails::fallback(&location));
+    attempt.submitted(MountCredentials {
+        anonymous: false,
+        username: "alice".to_owned(),
+        domain: String::new(),
+        password: "wrong".to_owned(),
+        save: gio::PasswordSave::Never,
+    });
+
+    let outcome = attempt.outcome(
+        &location,
+        Err(glib::Error::new(
+            gio::IOErrorEnum::Failed,
+            "Permission denied (publickey,password)",
+        )),
+    );
+    let MountOutcome::NeedsCredentials { attempted, details } = outcome else {
+        panic!("a rejected password should reopen the prompt");
+    };
+    assert_eq!(attempted.expect("last attempt is kept").username, "alice");
+    assert!(details.is_some());
+}
+
+#[test]
+fn an_already_mounted_location_counts_as_mounted() {
+    let attempt = MountAttempt::new(None);
+    let location = Location::uri("sftp://host.example/home/alice");
+    assert!(matches!(
+        attempt.outcome(
+            &location,
+            Err(glib::Error::new(
+                gio::IOErrorEnum::AlreadyMounted,
+                "already mounted",
+            )),
+        ),
+        MountOutcome::Mounted
+    ));
+}
+
+#[test]
+fn a_cancelled_prompt_ends_the_attempt_without_an_error_dialog() {
+    let attempt = MountAttempt::new(None);
+    let location = Location::uri("sftp://host.example/home/alice");
+    for kind in [gio::IOErrorEnum::Cancelled, gio::IOErrorEnum::FailedHandled] {
+        assert!(
+            matches!(
+                attempt.outcome(&location, Err(glib::Error::new(kind, "cancelled"))),
+                MountOutcome::Cancelled
+            ),
+            "{kind:?} is the user backing out, not a failure"
+        );
+    }
+}

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1261,3 +1261,57 @@ fn failure_messages_never_echo_a_password_typed_into_the_address_bar() {
     assert!(sanitized.contains("Unable to mount"));
     assert!(sanitized.ends_with(" now"));
 }
+
+#[test]
+fn an_sftp_fallback_prompt_drops_the_smb_only_fields() {
+    let flags =
+        MountPromptDetails::fallback(&Location::uri("sftp://host.example:2222/home/user")).flags;
+
+    assert!(flags.contains(gio::AskPasswordFlags::NEED_USERNAME));
+    assert!(flags.contains(gio::AskPasswordFlags::NEED_PASSWORD));
+    assert!(!flags.contains(gio::AskPasswordFlags::NEED_DOMAIN));
+    assert!(!flags.contains(gio::AskPasswordFlags::ANONYMOUS_SUPPORTED));
+    assert!(
+        MountCredentials::default_for_prompt(flags)
+            .domain
+            .is_empty()
+    );
+}
+
+#[test]
+fn retry_copy_names_only_the_fields_the_prompt_is_showing() {
+    let smb = gio::AskPasswordFlags::NEED_USERNAME
+        | gio::AskPasswordFlags::NEED_DOMAIN
+        | gio::AskPasswordFlags::NEED_PASSWORD;
+    assert_eq!(
+        authentication_failure_hint(smb, "Password"),
+        "That attempt wasn’t accepted. Check the username, domain and password, then try again."
+    );
+
+    let passphrase = gio::AskPasswordFlags::NEED_PASSWORD;
+    assert_eq!(
+        authentication_failure_hint(passphrase, "Passphrase"),
+        "That attempt wasn’t accepted. Check the passphrase, then try again."
+    );
+    assert_eq!(
+        authentication_failure_hint(gio::AskPasswordFlags::empty(), "Password"),
+        "That attempt wasn’t accepted. Try again."
+    );
+}
+
+#[test]
+fn an_encrypted_key_prompt_asks_for_a_passphrase_not_a_password() {
+    let passphrase = "Enter passphrase for key '/home/user/.ssh/id_ed25519':";
+    assert_eq!(password_field_label(passphrase), "Passphrase");
+    assert_eq!(
+        authentication_dialog_heading(passphrase).0,
+        "Passphrase required"
+    );
+
+    let password = "Password required for share on host";
+    assert_eq!(password_field_label(password), "Password");
+    assert_eq!(
+        authentication_dialog_heading(password).0,
+        "Authentication required"
+    );
+}

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1412,3 +1412,94 @@ fn a_cancelled_prompt_ends_the_attempt_without_an_error_dialog() {
         );
     }
 }
+
+#[test]
+fn host_key_questions_are_classified_from_the_backend_wording() {
+    assert_eq!(
+        MountQuestionKind::classify(
+            "The identity of the remote computer is not known. Its host key fingerprint is \
+             SHA256:abc. Are you sure you want to continue connecting?"
+        ),
+        MountQuestionKind::UnknownHostKey
+    );
+    assert_eq!(
+        MountQuestionKind::classify(
+            "WARNING: The host key for host.example has changed. Someone could be eavesdropping \
+             on you right now (man-in-the-middle attack)."
+        ),
+        MountQuestionKind::ChangedHostKey
+    );
+    assert_eq!(
+        MountQuestionKind::classify("Replace the existing file?"),
+        MountQuestionKind::Other
+    );
+    assert_eq!(
+        MountQuestionKind::ChangedHostKey.tone(),
+        crate::ui::controls::ModalTone::Danger
+    );
+}
+
+#[test]
+fn a_trust_decision_never_defaults_to_accepting() {
+    let choices = ["Log In Anyway".to_owned(), "Cancel".to_owned()];
+    assert_eq!(safest_choice(&choices), 1);
+    assert!(choice_declines("Cancel"));
+    assert!(!choice_declines("Log In Anyway"));
+
+    let unlabelled = ["Continue".to_owned(), "Accept and remember".to_owned()];
+    assert_eq!(
+        safest_choice(&unlabelled),
+        1,
+        "with nothing recognizable to decline, the last choice is focused, never the first"
+    );
+    assert_eq!(safest_choice(&[]), 0);
+}
+
+#[test]
+fn declining_a_host_key_ends_the_attempt_instead_of_asking_to_sign_in_again() {
+    let location = Location::uri("sftp://host.example/home/alice");
+    let mut attempt = MountAttempt::new(None);
+    attempt.ask_question(MountQuestionDetails {
+        message: "The identity of the remote computer is not known.".to_owned(),
+        choices: vec!["Log In Anyway".to_owned(), "Cancel".to_owned()],
+    });
+    attempt.decide(MountQuestionDecision::Declined);
+
+    let outcome = attempt.outcome(
+        &location,
+        Err(glib::Error::new(
+            gio::IOErrorEnum::PermissionDenied,
+            "Permission denied",
+        )),
+    );
+    assert!(
+        matches!(outcome, MountOutcome::Cancelled),
+        "the user already answered, so the browser returns to where it was"
+    );
+}
+
+#[test]
+fn accepting_a_host_key_lets_the_attempt_report_its_real_result() {
+    let location = Location::uri("sftp://host.example/home/alice");
+    let mut attempt = MountAttempt::new(None);
+    attempt.ask_question(MountQuestionDetails {
+        message: "The identity of the remote computer is not known.".to_owned(),
+        choices: vec!["Log In Anyway".to_owned(), "Cancel".to_owned()],
+    });
+    attempt.decide(MountQuestionDecision::Chose(0));
+
+    assert!(matches!(
+        attempt.outcome(&location, Ok(())),
+        MountOutcome::Mounted
+    ));
+    assert!(matches!(
+        attempt.outcome(
+            &location,
+            Err(glib::Error::new(
+                gio::IOErrorEnum::PermissionDenied,
+                "Permission denied",
+            )),
+        ),
+        MountOutcome::NeedsCredentials { .. }
+    ));
+}


### PR DESCRIPTION
## Description

Completes first-class SFTP support on the URI-native GIO/GVfs foundation. SMB was the only remote protocol exercised end to end, and the custom `gio::MountOperation` handled password prompts only — so a backend trust decision such as an unrecognized or changed SSH host key was silently dropped, and SFTP inherited SMB's prompt shape and error text.

- **Host keys are now an explicit decision.** `ask-question` is answered through a modal that renders the backend's own text (fingerprint included) and one button per offered choice. The declining choice is focused, so Enter never trusts a key; the backdrop is inert; Escape and the close button decline explicitly. A changed key is styled as a warning. gir cannot wrap the signal's `GStrv`, so it is connected from the raw signal.
- **Per-attempt state moved into `MountAttempt`.** It decides whether a password request is replayed from already-supplied credentials or prompted, tracks the last attempt for the retry prompt, and turns a finished attempt into a single outcome. A declined host key now ends the attempt where a cancelled sign-in does, instead of reopening the credential prompt.
- **Prompts fit the scheme.** SFTP loses SMB's domain and anonymous options, an encrypted key's request is labelled "Passphrase" rather than "Password", and the retry message names only the fields on screen.
- **Failures map to guidance.** Missing backend, host not found, connection refused, timeout, unreachable host, permission denied, authentication failure and host-key rejection each get their own actionable message. Backend text reaching a dialog has URI user-info stripped first.
- **Backend hints stop naming one package as universal.** Each scheme lists the usual candidates and points at the distribution.
- **Logging stays private.** `INFO` records the backend and outcome only; the location goes to `DEBUG` already redacted of user-info, query and fragment.
- **Disposable OpenSSH fixture.** `scripts/sftp-fixture.sh` runs sshd on `127.0.0.1` with host keys, client keys (plain and encrypted), `authorized_keys` and served files all inside one temporary directory that is deleted on exit. Nothing is written to `~/.ssh`.

The log-capture helper in `test_support` also had to grow a second caller. `main` installs that capture with `set_global_default`, which can only happen once, so it moves back to a per-thread subscriber; a permissive discarding global subscriber keeps the callsite-interest flake that `set_global_default` was working around from returning.

Split into eight commits, each of which passes `cargo fmt --check`, `cargo clippy -D warnings` and the full test suite on its own.

## Visual evidence

The SFTP credential prompt, reached by opening the fixture's address — username and password only, with no domain field and no anonymous option, unlike the SMB prompt:

<img width="620" alt="Strata's SFTP sign-in dialog: Authentication required, with Username, Password and Password storage fields" src="https://raw.githubusercontent.com/spandan11106/strata/pr-assets/sftp-auth-dialog.png" />

Note what is *not* there: no Domain field and no "Connect as: Registered user / Anonymous" control. The SMB prompt still shows both, and before this change SFTP inherited them too.

## How to test

1. Start the disposable server: `./scripts/sftp-fixture.sh --port 2222`. It prints the `sftp://` address to open, the client key paths, and the encrypted key's passphrase.
2. In Strata, press <kbd>Ctrl</kbd>+<kbd>L</kbd> and enter the printed address.
3. Answer the host-key question if your GVfs backend raises one, then work through the manual matrix in [docs/remote-sftp.md](docs/remote-sftp.md): key and passphrase authentication, a wrong secret, a cancelled prompt, a non-default port, breadcrumbs, history, Miller descent, hover peek, and opening a remote file.
4. Stop the fixture and reconnect to see the refused-connection message; use a name that does not resolve to see the host-not-found message.

**Expected result:** the address browses once authentication succeeds; every trust decision is made by you and never assumed; wrong credentials reopen the prompt without flicker; cancelling returns to the previous location without adding history; and each failure explains what to do next.

The manual matrix is manual because the crate is a binary with no library target for integration tests, and mounting through GVfs needs a live session bus and would write to the developer's `known_hosts`. The decision logic it covers is unit-tested: prompt and question state transitions, cancellation, error mapping, message sanitization, and log privacy.

## Related issue

Closes #63
