### PR TITLE
fix(browser): hide peeks that overlap source columns

### DIFF
--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -527,6 +527,9 @@ impl Browser {
 
     pub fn begin_peek(self: &Rc<Self>, origin_depth: usize, location: Location) {
         self.close_peek();
+        if self.is_open_child(origin_depth, &location) {
+            return;
+        }
         let request_id = self.new_request_id();
         if !self
             .state
@@ -1403,7 +1406,7 @@ impl Browser {
         self.activate_focused();
     }
 
-    fn is_open_child(&self, parent_depth: usize, location: &Location) -> bool {
+    pub(crate) fn is_open_child(&self, parent_depth: usize, location: &Location) -> bool {
         parent_depth
             .checked_add(1)
             .and_then(|depth| self.location_at(depth))

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -1299,6 +1299,27 @@ fn peeking_streams_results_without_committing_navigation_history() {
 }
 
 #[test]
+fn an_already_open_child_is_not_peeked() {
+    let browser = Browser::new(Rc::new(FakeFileSource));
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let observed = events.clone();
+    browser.observe(move |event| observed.borrow_mut().push(event));
+    let child = Location::local("/fixture/child");
+    browser.navigate(Location::local("/fixture"));
+    browser.descend(0, child.clone());
+    events.borrow_mut().clear();
+
+    browser.begin_peek(0, child);
+
+    assert!(
+        !events
+            .borrow()
+            .iter()
+            .any(|event| matches!(event, BrowserEvent::PeekStarted { .. }))
+    );
+}
+
+#[test]
 fn committing_a_peek_descends_and_creates_history() {
     let browser = Browser::new(Rc::new(FakeFileSource));
     let events = Rc::new(RefCell::new(Vec::new()));

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -4916,6 +4916,11 @@ impl ViewState {
         }
         cancel_source(&self.pending_peek);
         cancel_source(&self.pending_close);
+        if self.browser.is_open_child(origin_depth, &location) {
+            self.peek_anchor.take();
+            self.browser.close_peek();
+            return;
+        }
         if self
             .peek
             .borrow()

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -40,6 +40,8 @@ use super::{
 const COLUMN_WIDTH: i32 = 300;
 const COLUMN_OFFSET: i32 = 24;
 const COLUMN_TRANSITION: Duration = Duration::from_millis(220);
+const PEEK_WIDTH: i32 = 256;
+const PEEK_GAP: f32 = 8.0;
 
 #[derive(Clone)]
 struct LoadPresentation {
@@ -114,6 +116,11 @@ struct TrashLoadingView {
     layer: gtk::Box,
     overlay: gtk::Overlay,
     blurred_root: Option<BlurBin>,
+}
+
+struct PeekAnchor {
+    widget: gtk::Widget,
+    origin_depth: usize,
 }
 
 struct PeekView {
@@ -291,7 +298,7 @@ pub(super) struct ViewState {
     peek: RefCell<Option<PeekView>>,
     pending_peek: RefCell<Option<glib::SourceId>>,
     pending_close: RefCell<Option<glib::SourceId>>,
-    peek_anchor: RefCell<Option<gtk::Widget>>,
+    peek_anchor: RefCell<Option<PeekAnchor>>,
     peek_behavior: PeekBehavior,
     peek_enabled: Cell<bool>,
     single_click_previews: Cell<bool>,
@@ -4917,7 +4924,10 @@ impl ViewState {
         {
             return;
         }
-        self.peek_anchor.replace(Some(anchor));
+        self.peek_anchor.replace(Some(PeekAnchor {
+            widget: anchor,
+            origin_depth,
+        }));
 
         let weak_state = Rc::downgrade(self);
         let source = glib::timeout_add_local_once(self.peek_behavior.open_delay, move || {
@@ -4950,9 +4960,30 @@ impl ViewState {
             self.browser.close_peek();
             return;
         };
+        let Some(row_bounds) = anchor.widget.compute_bounds(&self.overlay) else {
+            self.browser.close_peek();
+            return;
+        };
+        let Some(column_bounds) = self
+            .columns
+            .borrow()
+            .get(anchor.origin_depth)
+            .and_then(|column| column.shell.compute_bounds(&self.overlay))
+        else {
+            self.browser.close_peek();
+            return;
+        };
+        let Some(placement) = peek_horizontal_placement(
+            column_bounds.x(),
+            column_bounds.width(),
+            self.overlay.width() as f32,
+        ) else {
+            self.browser.close_peek();
+            return;
+        };
 
         let content = gtk::Box::new(gtk::Orientation::Vertical, 0);
-        content.set_size_request(256, -1);
+        content.set_size_request(PEEK_WIDTH, -1);
         content.set_overflow(gtk::Overflow::Hidden);
 
         let header = gtk::Box::new(gtk::Orientation::Horizontal, 8);
@@ -5014,26 +5045,13 @@ impl ViewState {
         });
         content.add_controller(click);
 
-        let Some(bounds) = anchor.compute_bounds(&self.overlay) else {
-            self.browser.close_peek();
-            return;
-        };
         content.add_css_class("peek-popover");
-        let gap = 8.0;
-        let right = bounds.x() + bounds.width() + gap;
-        let left = (bounds.x() - 260.0).max(0.0);
-        let positioned_right = right + 256.0 <= self.overlay.width() as f32;
-        let x = if positioned_right { right } else { left };
         let transition_duration = self
             .peek_behavior
             .fade_duration
             .as_millis()
             .min(u128::from(u32::MAX)) as u32;
-        let transition_type = if positioned_right {
-            gtk::RevealerTransitionType::SlideRight
-        } else {
-            gtk::RevealerTransitionType::SlideLeft
-        };
+        let transition_type = peek_transition(placement.side);
         let revealer = gtk::Revealer::builder()
             .child(&content)
             .transition_type(transition_type)
@@ -5041,8 +5059,8 @@ impl ViewState {
             .reveal_child(false)
             .halign(gtk::Align::Start)
             .valign(gtk::Align::Start)
-            .margin_start(x.round() as i32)
-            .margin_top(bounds.y().round().max(0.0) as i32)
+            .margin_start(placement.x.round() as i32)
+            .margin_top(row_bounds.y().round().max(0.0) as i32)
             .build();
         self.overlay.add_overlay(&revealer);
         self.peek.replace(Some(PeekView {
@@ -7144,6 +7162,45 @@ fn icon_for_name(name: &str) -> &'static str {
         ) => crate::assets::icons::FILE_CODE,
         _ => crate::assets::icons::DOCUMENTS,
     }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PeekSide {
+    Left,
+    Right,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct PeekPlacement {
+    x: f32,
+    side: PeekSide,
+}
+
+fn peek_transition(side: PeekSide) -> gtk::RevealerTransitionType {
+    match side {
+        PeekSide::Left => gtk::RevealerTransitionType::SlideLeft,
+        PeekSide::Right => gtk::RevealerTransitionType::SlideRight,
+    }
+}
+
+fn peek_horizontal_placement(
+    source_x: f32,
+    source_width: f32,
+    viewport_width: f32,
+) -> Option<PeekPlacement> {
+    let right = source_x + source_width + PEEK_GAP;
+    if right + PEEK_WIDTH as f32 <= viewport_width {
+        return Some(PeekPlacement {
+            x: right,
+            side: PeekSide::Right,
+        });
+    }
+
+    let left = source_x - PEEK_GAP - PEEK_WIDTH as f32;
+    (left >= 0.0).then_some(PeekPlacement {
+        x: left,
+        side: PeekSide::Left,
+    })
 }
 
 fn append_peek_entries(peek: &PeekView, entries: Vec<FileEntry>, limit: usize) {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -5052,14 +5052,17 @@ impl ViewState {
             .as_millis()
             .min(u128::from(u32::MAX)) as u32;
         let transition_type = peek_transition(placement.side);
+        let (halign, margin_start, margin_end) =
+            peek_horizontal_layout(placement, self.overlay.width() as f32);
         let revealer = gtk::Revealer::builder()
             .child(&content)
             .transition_type(transition_type)
             .transition_duration(transition_duration)
             .reveal_child(false)
-            .halign(gtk::Align::Start)
+            .halign(halign)
             .valign(gtk::Align::Start)
-            .margin_start(placement.x.round() as i32)
+            .margin_start(margin_start)
+            .margin_end(margin_end)
             .margin_top(row_bounds.y().round().max(0.0) as i32)
             .build();
         self.overlay.add_overlay(&revealer);
@@ -7180,6 +7183,19 @@ fn peek_transition(side: PeekSide) -> gtk::RevealerTransitionType {
     match side {
         PeekSide::Left => gtk::RevealerTransitionType::SlideLeft,
         PeekSide::Right => gtk::RevealerTransitionType::SlideRight,
+    }
+}
+
+fn peek_horizontal_layout(placement: PeekPlacement, viewport_width: f32) -> (gtk::Align, i32, i32) {
+    match placement.side {
+        PeekSide::Right => (gtk::Align::Start, placement.x.round() as i32, 0),
+        PeekSide::Left => (
+            gtk::Align::End,
+            0,
+            (viewport_width - placement.x - PEEK_WIDTH as f32)
+                .max(0.0)
+                .round() as i32,
+        ),
     }
 }
 

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -4969,18 +4969,24 @@ impl ViewState {
             self.browser.close_peek();
             return;
         };
-        let Some(column_bounds) = self
-            .columns
-            .borrow()
-            .get(anchor.origin_depth)
-            .and_then(|column| column.shell.compute_bounds(&self.overlay))
-        else {
-            self.browser.close_peek();
-            return;
+        let source_bounds = match peek_origin_bounds(self.mode_views.borrow().mode()) {
+            PeekOriginBounds::Anchor => row_bounds,
+            PeekOriginBounds::Column => {
+                let Some(bounds) = self
+                    .columns
+                    .borrow()
+                    .get(anchor.origin_depth)
+                    .and_then(|column| column.shell.compute_bounds(&self.overlay))
+                else {
+                    self.browser.close_peek();
+                    return;
+                };
+                bounds
+            }
         };
         let Some(placement) = peek_horizontal_placement(
-            column_bounds.x(),
-            column_bounds.width(),
+            source_bounds.x(),
+            source_bounds.width(),
             self.overlay.width() as f32,
         ) else {
             self.browser.close_peek();
@@ -7169,6 +7175,19 @@ fn icon_for_name(name: &str) -> &'static str {
             | "lua" | "php" | "html" | "css" | "scss" | "json",
         ) => crate::assets::icons::FILE_CODE,
         _ => crate::assets::icons::DOCUMENTS,
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PeekOriginBounds {
+    Anchor,
+    Column,
+}
+
+fn peek_origin_bounds(mode: BrowserMode) -> PeekOriginBounds {
+    match mode {
+        BrowserMode::Columns => PeekOriginBounds::Column,
+        BrowserMode::Grid | BrowserMode::Explorer => PeekOriginBounds::Anchor,
     }
 }
 

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -233,6 +233,30 @@ fn folder_peek_animation_moves_toward_its_placement_side() {
 }
 
 #[test]
+fn folder_peek_animation_is_anchored_to_the_source_side() {
+    assert_eq!(
+        peek_horizontal_layout(
+            PeekPlacement {
+                x: 408.0,
+                side: PeekSide::Right,
+            },
+            800.0,
+        ),
+        (gtk::Align::Start, 408, 0)
+    );
+    assert_eq!(
+        peek_horizontal_layout(
+            PeekPlacement {
+                x: 36.0,
+                side: PeekSide::Left,
+            },
+            700.0,
+        ),
+        (gtk::Align::End, 0, 408)
+    );
+}
+
+#[test]
 fn folder_peek_accepts_an_exact_viewport_fit() {
     assert_eq!(
         peek_horizontal_placement(0.0, 300.0, 564.0),

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -198,6 +198,52 @@ fn delete_confirmation_labels_distinguish_files_and_folders() {
 }
 
 #[test]
+fn folder_peek_prefers_space_to_the_right_of_its_source_column() {
+    assert_eq!(
+        peek_horizontal_placement(100.0, 300.0, 800.0),
+        Some(PeekPlacement {
+            x: 408.0,
+            side: PeekSide::Right,
+        })
+    );
+}
+
+#[test]
+fn folder_peek_uses_the_left_only_when_it_fits_outside_the_source_column() {
+    assert_eq!(
+        peek_horizontal_placement(300.0, 300.0, 700.0),
+        Some(PeekPlacement {
+            x: 36.0,
+            side: PeekSide::Left,
+        })
+    );
+    assert_eq!(peek_horizontal_placement(200.0, 300.0, 700.0), None);
+}
+
+#[test]
+fn folder_peek_animation_moves_toward_its_placement_side() {
+    assert_eq!(
+        peek_transition(PeekSide::Left),
+        gtk::RevealerTransitionType::SlideLeft
+    );
+    assert_eq!(
+        peek_transition(PeekSide::Right),
+        gtk::RevealerTransitionType::SlideRight
+    );
+}
+
+#[test]
+fn folder_peek_accepts_an_exact_viewport_fit() {
+    assert_eq!(
+        peek_horizontal_placement(0.0, 300.0, 564.0),
+        Some(PeekPlacement {
+            x: 308.0,
+            side: PeekSide::Right,
+        })
+    );
+}
+
+#[test]
 fn small_operations_delay_progress_while_large_or_unbounded_operations_show_it_immediately() {
     assert!(!should_show_progress_immediately(1));
     assert!(!should_show_progress_immediately(

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -198,6 +198,22 @@ fn delete_confirmation_labels_distinguish_files_and_folders() {
 }
 
 #[test]
+fn folder_peek_uses_visible_mode_bounds() {
+    assert_eq!(
+        peek_origin_bounds(BrowserMode::Columns),
+        PeekOriginBounds::Column
+    );
+    assert_eq!(
+        peek_origin_bounds(BrowserMode::Grid),
+        PeekOriginBounds::Anchor
+    );
+    assert_eq!(
+        peek_origin_bounds(BrowserMode::Explorer),
+        PeekOriginBounds::Anchor
+    );
+}
+
+#[test]
 fn folder_peek_prefers_space_to_the_right_of_its_source_column() {
     assert_eq!(
         peek_horizontal_placement(100.0, 300.0, 800.0),


### PR DESCRIPTION
## Description

Position folder peeks from the full source-column bounds and suppress them when neither side has enough viewport space. Left-side peeks now explicitly animate left, while right-side peeks animate right. Folders already open as the next Miller column are not peeked.

## Visual evidence

**Before — peek overlaps its source column:**

![Before: folder peek overlapping its source column](https://gist.githubusercontent.com/l0gicgate/5f81660c0e752471563f679d7a4b0b5f/raw/3ceaff9c2c957db0104b9259f94de1774808a15d/strata-folder-peek-small-viewport.svg)

**After — left-side fallback remains fully outside its source column:**

![After: folder peek positioned left of its source column](https://gist.githubusercontent.com/l0gicgate/eeb5524d9f276f7d3bc34219634bc6bc/raw/e72edfec8fbe88e3285d8b699e4707b874c72a42/strata-231-after.svg)

## How to test

1. Open nested folders, then hover a folder where the peek fits only to the left; verify it appears outside the source column and slides left.
2. Narrow the viewport until the peek cannot fit fully on either side, then hover a folder.
3. Widen the viewport and hover the folder again.
4. Open a child folder as the next Miller column, then hover that same folder in its parent column.

**Expected result:** Peeks choose a fitting side and animate toward it, remain hidden when neither side fits or the folder is already open, and become available again after the viewport is widened.

## Related issue

Closes #231

