### PR TITLE
fix(list): create folders in the focused pane

### DIFF
--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -828,7 +828,6 @@ impl BrowserView {
         let mode = self.view_mode();
         let depth = if mode == BrowserMode::Columns {
             new_folder_destination_depth(
-                self.state.hovered_column.get(),
                 self.state.focused_column_depth(),
                 self.state.browser.active_depth(),
                 self.state.columns.borrow().len(),
@@ -924,7 +923,7 @@ impl BrowserView {
         let location = selected_terminal_location(&selected).or_else(|| {
             let mode = self.view_mode();
             let depth = if mode == BrowserMode::Columns {
-                new_folder_destination_depth(
+                terminal_destination_depth(
                     self.state.hovered_column.get(),
                     self.state.focused_column_depth(),
                     self.state.browser.active_depth(),
@@ -6715,7 +6714,20 @@ fn paste_destination_depth(hovered: Option<usize>, pane_count: usize) -> Option<
         .or_else(|| pane_count.checked_sub(1))
 }
 
+/// Keyboard-triggered folder creation must ignore the pointer so a resting mouse
+/// cannot redirect the new folder into a pane the keyboard never visited.
 fn new_folder_destination_depth(
+    focused: Option<usize>,
+    active: Option<usize>,
+    pane_count: usize,
+) -> Option<usize> {
+    focused
+        .filter(|depth| *depth < pane_count)
+        .or_else(|| active.filter(|depth| *depth < pane_count))
+        .or_else(|| pane_count.checked_sub(1))
+}
+
+fn terminal_destination_depth(
     hovered: Option<usize>,
     focused: Option<usize>,
     active: Option<usize>,
@@ -6723,9 +6735,7 @@ fn new_folder_destination_depth(
 ) -> Option<usize> {
     hovered
         .filter(|depth| *depth < pane_count)
-        .or_else(|| focused.filter(|depth| *depth < pane_count))
-        .or_else(|| active.filter(|depth| *depth < pane_count))
-        .or_else(|| pane_count.checked_sub(1))
+        .or_else(|| new_folder_destination_depth(focused, active, pane_count))
 }
 
 fn same_locations(left: &[Location], right: &[Location]) -> bool {

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -677,21 +677,30 @@ fn paste_prefers_the_hovered_pane_then_the_deepest_pane() {
 }
 
 #[test]
-fn new_folder_prefers_the_hovered_pane_then_falls_back_safely() {
+fn new_folder_prefers_the_focused_pane_then_falls_back_safely() {
+    assert_eq!(new_folder_destination_depth(Some(1), Some(2), 3), Some(1));
+    assert_eq!(new_folder_destination_depth(None, Some(2), 3), Some(2));
+    assert_eq!(new_folder_destination_depth(Some(5), Some(1), 3), Some(1));
+    assert_eq!(new_folder_destination_depth(None, None, 3), Some(2));
+    assert_eq!(new_folder_destination_depth(None, None, 0), None);
+}
+
+#[test]
+fn open_terminal_prefers_the_hovered_pane_then_falls_back_safely() {
     assert_eq!(
-        new_folder_destination_depth(Some(1), Some(0), Some(2), 3),
+        terminal_destination_depth(Some(1), Some(0), Some(2), 3),
         Some(1)
     );
     assert_eq!(
-        new_folder_destination_depth(None, Some(0), Some(2), 3),
+        terminal_destination_depth(None, Some(0), Some(2), 3),
         Some(0)
     );
     assert_eq!(
-        new_folder_destination_depth(Some(4), Some(5), Some(1), 3),
+        terminal_destination_depth(Some(4), Some(5), Some(1), 3),
         Some(1)
     );
-    assert_eq!(new_folder_destination_depth(None, None, None, 3), Some(2));
-    assert_eq!(new_folder_destination_depth(None, None, None, 0), None);
+    assert_eq!(terminal_destination_depth(None, None, None, 3), Some(2));
+    assert_eq!(terminal_destination_depth(None, None, None, 0), None);
 }
 
 #[test]


### PR DESCRIPTION
## Description

In List mode, `Ctrl+Shift+N` resolved its destination pane from the hovered pane first, then keyboard focus. Navigating entirely with the keyboard leaves the mouse pointer resting over whatever pane it was last over — usually the first one — so the new-folder field opened there instead of in the focused pane.

The shortcut now resolves the destination from the focused pane, falling back to the active pane and finally the deepest pane. Open in Terminal keeps its hover-first lookup, which now lives in its own helper.

## Visual evidence

N/A — the change only affects which existing pane the new-folder field opens in; there is no new or restyled interface element.

## How to test

1. Open Strata in List mode and navigate into a few directories so multiple panes are visible.
2. Leave the mouse pointer resting over the first pane and do not move it.
3. Use the keyboard (arrow keys) to focus a pane other than the first.
4. Press `Ctrl+Shift+N`.

**Expected result:** The new-folder field appears in the focused pane, and the created folder lands in that pane's directory.

## Related issue

Closes #236