### PR TITLE
feat(view): improve hidden-files toggle discovery

### DIFF
--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -5325,6 +5325,20 @@ pub(super) fn install_folder_context_menu(
     let paste = context_menu_option(crate::assets::icons::CLIPBOARD_PASTE, "Paste", "Ctrl+V");
     let select_all = context_menu_option(crate::assets::icons::LIST_CHECKS, "Select All", "Ctrl+A");
     let refresh = context_menu_option(crate::assets::icons::REFRESH, "Refresh", "F5");
+    let hidden_files_shown = state.browser.preferences().show_hidden;
+    let (toggle_hidden, toggle_hidden_icon, toggle_hidden_label) = context_menu_toggle_option(
+        if hidden_files_shown {
+            crate::assets::icons::EYE
+        } else {
+            crate::assets::icons::EYE_OFF
+        },
+        if hidden_files_shown {
+            "Hide Hidden Files"
+        } else {
+            "Show Hidden Files"
+        },
+        "Ctrl+H",
+    );
     let properties = context_menu_option(crate::assets::icons::INFO, "Properties", "");
     content.append(&new_folder);
     content.append(&new_file);
@@ -5333,6 +5347,7 @@ pub(super) fn install_folder_context_menu(
     content.append(&paste);
     content.append(&select_all);
     content.append(&refresh);
+    content.append(&toggle_hidden);
     content.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
     content.append(&properties);
 
@@ -5400,6 +5415,16 @@ pub(super) fn install_folder_context_menu(
         }
     });
     let weak = Rc::downgrade(state);
+    let toggle_hidden_popover = popover.downgrade();
+    toggle_hidden.connect_clicked(move |_| {
+        if let Some(popover) = toggle_hidden_popover.upgrade() {
+            popover.popdown();
+        }
+        if let Some(state) = weak.upgrade() {
+            state.browser.toggle_hidden();
+        }
+    });
+    let weak = Rc::downgrade(state);
     let properties_popover = popover.downgrade();
     let properties_location = location.clone();
     properties.connect_clicked(move |_| {
@@ -5425,6 +5450,7 @@ pub(super) fn install_folder_context_menu(
     let menu_click = gtk::GestureClick::new();
     menu_click.set_button(3);
     let popover_for_click = popover.clone();
+    let browser_for_click = state.browser.clone();
     menu_click.connect_pressed(move |gesture, _, x, y| {
         let over_item = gesture
             .widget()
@@ -5442,6 +5468,20 @@ pub(super) fn install_folder_context_menu(
         }));
         select_all.set_sensitive(has_entries());
         open_terminal.set_sensitive(can_open_terminal(&location));
+        let hidden_files_shown = browser_for_click.preferences().show_hidden;
+        toggle_hidden_label.set_text(if hidden_files_shown {
+            "Hide Hidden Files"
+        } else {
+            "Show Hidden Files"
+        });
+        crate::assets::set_primary_icon(
+            &toggle_hidden_icon,
+            if hidden_files_shown {
+                crate::assets::icons::EYE
+            } else {
+                crate::assets::icons::EYE_OFF
+            },
+        );
         if popover_for_click.parent().is_none()
             && let Some(parent) = gesture.widget()
         {
@@ -6795,9 +6835,11 @@ fn item_context_option_with_icon(icon: gtk::Image, label: &str, accelerator: &st
     button
 }
 
-fn context_menu_option(icon: &str, label: &str, accelerator: &str) -> gtk::Button {
-    let button = gtk::Button::new();
-    button.add_css_class("folder-context-option");
+fn context_menu_row(
+    icon: &str,
+    label: &str,
+    accelerator: &str,
+) -> (gtk::Box, gtk::Image, gtk::Label) {
     let row = gtk::Box::new(gtk::Orientation::Horizontal, 8);
     let icon = crate::assets::primary_icon(icon, 15);
     icon.add_css_class("folder-context-icon");
@@ -6811,8 +6853,27 @@ fn context_menu_option(icon: &str, label: &str, accelerator: &str) -> gtk::Butto
         shortcut.add_css_class("folder-context-shortcut");
         row.append(&shortcut);
     }
+    (row, icon, title)
+}
+
+fn context_menu_option(icon: &str, label: &str, accelerator: &str) -> gtk::Button {
+    let (row, _, _) = context_menu_row(icon, label, accelerator);
+    let button = gtk::Button::new();
+    button.add_css_class("folder-context-option");
     button.set_child(Some(&row));
     button
+}
+
+fn context_menu_toggle_option(
+    icon: &str,
+    label: &str,
+    accelerator: &str,
+) -> (gtk::Button, gtk::Image, gtk::Label) {
+    let (row, icon, title) = context_menu_row(icon, label, accelerator);
+    let button = gtk::Button::new();
+    button.add_css_class("folder-context-option");
+    button.set_child(Some(&row));
+    (button, icon, title)
 }
 
 pub(super) fn pane_refresh_button(browser: &Rc<Browser>, depth: usize) -> gtk::Button {

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -2093,6 +2093,9 @@ fn keybindings_page() -> gtk::Widget {
         append_keybinding(&content, label, keys);
     }
 
+    append_heading(&content, "VIEW");
+    append_keybinding(&content, "Toggle hidden files", "Ctrl + H  or  Ctrl + .");
+
     append_heading(&content, "FILE OPERATIONS");
     for (label, keys) in [
         ("Create new folder", "Ctrl + Shift + N"),

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -670,7 +670,7 @@ fn install_keyboard_navigation(
             view.select_all();
             return glib::Propagation::Stop;
         }
-        if control && key == gtk::gdk::Key::h {
+        if is_toggle_hidden_shortcut(key, modifiers) {
             browser.toggle_hidden();
             return glib::Propagation::Stop;
         }
@@ -819,6 +819,16 @@ fn is_open_terminal_shortcut(key: gtk::gdk::Key, modifiers: gtk::gdk::ModifierTy
         && !modifiers
             .intersects(gtk::gdk::ModifierType::SHIFT_MASK | gtk::gdk::ModifierType::ALT_MASK)
         && matches!(key, gtk::gdk::Key::t | gtk::gdk::Key::T)
+}
+
+fn is_toggle_hidden_shortcut(key: gtk::gdk::Key, modifiers: gtk::gdk::ModifierType) -> bool {
+    modifiers.contains(gtk::gdk::ModifierType::CONTROL_MASK)
+        && !modifiers
+            .intersects(gtk::gdk::ModifierType::SHIFT_MASK | gtk::gdk::ModifierType::ALT_MASK)
+        && matches!(
+            key,
+            gtk::gdk::Key::h | gtk::gdk::Key::H | gtk::gdk::Key::period
+        )
 }
 
 fn is_refresh_shortcut(key: gtk::gdk::Key, modifiers: gtk::gdk::ModifierType) -> bool {
@@ -1011,13 +1021,14 @@ fn build_appearance_menu(
 
     content.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
     content.append(&group_by_type);
-    let (hidden, hidden_check, hidden_icon) = appearance_option(
+    let (hidden, hidden_check, hidden_icon) = appearance_option_with_shortcut(
         if hidden_files_shown {
             crate::assets::icons::EYE
         } else {
             crate::assets::icons::EYE_OFF
         },
         "Hidden files",
+        "Ctrl + H",
         hidden_files_shown,
         true,
     );
@@ -1069,6 +1080,16 @@ fn appearance_option(
     checked: bool,
     sensitive: bool,
 ) -> (gtk::Button, gtk::Image, gtk::Image) {
+    appearance_option_with_shortcut(icon, label, "", checked, sensitive)
+}
+
+fn appearance_option_with_shortcut(
+    icon: &str,
+    label: &str,
+    shortcut: &str,
+    checked: bool,
+    sensitive: bool,
+) -> (gtk::Button, gtk::Image, gtk::Image) {
     let row = gtk::Box::new(gtk::Orientation::Horizontal, 10);
     let check = crate::assets::primary_icon(crate::assets::icons::CHECK, 16);
     check.set_visible(checked);
@@ -1078,6 +1099,11 @@ fn appearance_option(
     label.set_hexpand(true);
     row.append(&option);
     row.append(&label);
+    if !shortcut.is_empty() {
+        let shortcut = gtk::Label::new(Some(shortcut));
+        shortcut.add_css_class("folder-context-shortcut");
+        row.append(&shortcut);
+    }
     row.append(&check);
     let button = gtk::Button::builder()
         .child(&row)

--- a/src/ui/window/tests.rs
+++ b/src/ui/window/tests.rs
@@ -6,11 +6,11 @@ use crate::services::{BuildKind, ReleaseMetadata};
 
 use super::{
     MouseHistoryAction, PinStatus, STANDARD_PLACE_IDS, is_open_terminal_shortcut,
-    is_sidebar_focus_shortcut, is_smb_location, is_standard_place_location, is_undo_trash_shortcut,
-    mouse_history_action, parse_pinned_drag_source, parse_pinned_places, pin_status,
-    remove_pinned_place, reorder_pinned_places, reorder_places, resolve_place_order,
-    serialize_pinned_places, should_show_standard_place, sidebar_update_label, standard_place,
-    vim_focus_direction,
+    is_sidebar_focus_shortcut, is_smb_location, is_standard_place_location,
+    is_toggle_hidden_shortcut, is_undo_trash_shortcut, mouse_history_action,
+    parse_pinned_drag_source, parse_pinned_places, pin_status, remove_pinned_place,
+    reorder_pinned_places, reorder_places, resolve_place_order, serialize_pinned_places,
+    should_show_standard_place, sidebar_update_label, standard_place, vim_focus_direction,
 };
 
 fn release(version: &str, kind: BuildKind) -> ReleaseMetadata {
@@ -89,6 +89,30 @@ fn undo_trash_shortcut_requires_control_without_shift_or_alt() {
     ));
     assert!(!is_undo_trash_shortcut(gtk::gdk::Key::z, control | shift));
     assert!(!is_undo_trash_shortcut(gtk::gdk::Key::z, control | alt));
+}
+
+#[test]
+fn toggle_hidden_shortcut_accepts_h_or_period_with_only_control() {
+    let control = gtk::gdk::ModifierType::CONTROL_MASK;
+    let shift = gtk::gdk::ModifierType::SHIFT_MASK;
+    let alt = gtk::gdk::ModifierType::ALT_MASK;
+
+    assert!(is_toggle_hidden_shortcut(gtk::gdk::Key::h, control));
+    assert!(is_toggle_hidden_shortcut(gtk::gdk::Key::H, control));
+    assert!(is_toggle_hidden_shortcut(gtk::gdk::Key::period, control));
+    assert!(!is_toggle_hidden_shortcut(
+        gtk::gdk::Key::h,
+        gtk::gdk::ModifierType::empty()
+    ));
+    assert!(!is_toggle_hidden_shortcut(
+        gtk::gdk::Key::h,
+        control | shift
+    ));
+    assert!(!is_toggle_hidden_shortcut(gtk::gdk::Key::h, control | alt));
+    assert!(!is_toggle_hidden_shortcut(
+        gtk::gdk::Key::period,
+        control | shift
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Description

The hidden-files toggle existed (Appearance menu, Ctrl+H) but was hard to discover: the Appearance menu item didn't show its shortcut, there was no entry point in the folder-background context menu, and the Keybindings settings page didn't list it at all. This closes the gaps from #121:

- The Appearance menu's "Hidden files" row now shows `Ctrl + H` alongside it.
- Right-clicking empty space in a folder now offers "Show Hidden Files" / "Hide Hidden Files" (updates live to reflect current state).
- The Keybindings settings page lists a new VIEW section with the toggle and both shortcuts.
- Added `Ctrl + .` as an alias for `Ctrl + H` (both keep working; existing muscle memory isn't disrupted).
- All three entry points (menu, context menu, shortcut) drive the same `Browser::toggle_hidden` state, so they always agree.
- Confirmed the show/hide preference persists across a full app restart (per the implementation note on the issue) — it was already wired through `ThemeManager`, verified end-to-end rather than re-implemented.

## Visual evidence

Toggling with Ctrl+H then Ctrl+. in a folder with a dotfile:

| Hidden files off | Ctrl+H (on) | Ctrl+. (off again) |
|---|---|---|
| only `visible-file.txt` | `.hidden-dotfile.txt` appears | back to just `visible-file.txt` |

New Keybindings settings page entry (VIEW section, "Toggle hidden files — Ctrl + H or Ctrl + ."):

Screenshots attached in a follow-up comment (before/after toggle states, restart-persistence check, and the Keybindings page).

## How to test

1. Open a folder containing a dotfile (e.g. `.bashrc` in your home directory).
2. Press `Ctrl + H` — hidden files appear. Press `Ctrl + .` — they disappear again. Both shortcuts should behave identically.
3. Open the Appearance menu (top-bar list icon) — the "Hidden files" row now shows `Ctrl + H` next to it.
4. Right-click empty space in the folder view — a "Show Hidden Files" / "Hide Hidden Files" item appears near Refresh, and toggles the same state.
5. Open Settings → Keybindings — a new VIEW section lists "Toggle hidden files" with both shortcuts.
6. Toggle hidden files on, fully quit and relaunch Strata — hidden files should still be shown (preference persists).

**Expected result:** all four entry points (menu, context menu, both shortcuts, and the settings page listing) stay in sync, and the preference survives a restart.

## Related issue

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)