### PR TITLE
feat(navigation): expand home-relative location input

### DIFF
--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -272,21 +272,6 @@ type MoveAttempt = Rc<
     ) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>>,
 >;
 
-/// Moves `source` to `target` via `attempt_move`, falling back to a safe
-/// recursive copy-then-delete when that attempt fails with
-/// [`gio::IOErrorEnum::WouldRecurse`].
-///
-/// `g_file_move` renames when it can, but for a directory it never silently
-/// recurses to cross a filesystem boundary -- it returns `WouldRecurse`
-/// instead of doing a partial, unsafe copy. [`copy_new_recursively`] already
-/// implements that recursive copy safely (staged in a sibling, then renamed
-/// into place, with the staging area cleaned up on any failure), so the
-/// fallback here reuses it rather than duplicating that staging logic; the
-/// source is only deleted once the copy has fully and durably succeeded.
-///
-/// `attempt_move` is a parameter, mirroring [`replace_local_with`], so a test
-/// can inject a `WouldRecurse` (or any other) failure without needing an
-/// actual second filesystem to reproduce it.
 async fn move_local_with(
     source: gio::File,
     target: gio::File,

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -269,11 +269,6 @@ fn staged_file_replacement_preserves_the_destination_on_disk_full() -> Result<()
     Ok(())
 }
 
-/// `WouldRecurse` is what GIO's own `move_async` returns for a directory it
-/// refuses to move across a filesystem boundary (issue #150); reproducing an
-/// actual cross-device move in a test would need a second real filesystem,
-/// so this injects the same failure `move_local_with`'s production caller
-/// would see from GIO in that situation.
 fn always_would_recurse() -> super::MoveAttempt {
     Rc::new(|_, _, _| {
         Box::pin(async {
@@ -366,10 +361,6 @@ fn a_successful_move_attempt_is_used_without_falling_back_to_copy() -> Result<()
     fs::create_dir_all(&source)?;
     fs::write(source.join("top.txt"), b"top")?;
 
-    // If a bug made `move_local_with` also run the fallback copy after a
-    // successful `attempt_move`, it would try to copy from `source` after
-    // this closure has already renamed it away -- failing with a
-    // source-not-found error instead of propagating this `Ok(())`.
     let result = glib::MainContext::default().block_on(move_local_with(
         gio::File::for_path(&source),
         gio::File::for_path(&target),

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -3,7 +3,7 @@
 use std::{
     cell::{Cell, RefCell},
     collections::HashSet,
-    path::PathBuf,
+    path::{Path, PathBuf},
     rc::{Rc, Weak},
     time::Duration,
 };
@@ -331,6 +331,7 @@ impl Browser {
     }
 
     pub fn navigate_input(self: &Rc<Self>, input: &str) -> Result<(), LocationValidationError> {
+        let input = input.trim();
         if input.is_empty() {
             return Err(LocationValidationError::Empty);
         }
@@ -1889,6 +1890,24 @@ fn deletion_parent_location(location: &Location) -> Option<Location> {
 }
 
 fn location_from_input(input: &str) -> Result<Location, LocationValidationError> {
+    location_from_input_with_home(input, &glib::home_dir())
+}
+
+fn location_from_input_with_home(
+    input: &str,
+    home: &Path,
+) -> Result<Location, LocationValidationError> {
+    if input == "~" {
+        return Ok(Location::local(home));
+    }
+    if let Some(relative) = input.strip_prefix("~/") {
+        return Ok(Location::local(home.join(relative.trim_start_matches('/'))));
+    }
+    if input.starts_with('~') {
+        return Err(LocationValidationError::UnsupportedShorthand(
+            "Only ~ and ~/ paths are supported for the current user's home directory.".to_owned(),
+        ));
+    }
     if !is_uri_like(input) {
         return Ok(Location::local(PathBuf::from(input)));
     }

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -1042,6 +1042,47 @@ fn valid_location_input_navigates_through_the_controller() {
 }
 
 #[test]
+fn location_input_expands_trimmed_home_relative_paths() {
+    let browser = Browser::new(Rc::new(FakeFileSource));
+    let home = glib::home_dir();
+
+    assert_eq!(browser.navigate_input("  ~  "), Ok(()));
+    assert_eq!(browser.active_location(), Some(Location::local(&home)));
+
+    assert_eq!(browser.navigate_input("  ~/Documents  "), Ok(()));
+    assert_eq!(
+        browser.active_location(),
+        Some(Location::local(home.join("Documents")))
+    );
+}
+
+#[test]
+fn home_relative_input_preserves_the_native_home_path() {
+    let home = Path::new("/home/fixture");
+
+    assert_eq!(
+        location_from_input_with_home("~", home),
+        Ok(Location::local("/home/fixture"))
+    );
+    assert_eq!(
+        location_from_input_with_home("~/Documents/project", home),
+        Ok(Location::local("/home/fixture/Documents/project"))
+    );
+    assert_eq!(
+        location_from_input_with_home("~//Documents", home),
+        Ok(Location::local("/home/fixture/Documents"))
+    );
+}
+
+#[test]
+fn other_users_home_shorthand_is_rejected() {
+    assert!(matches!(
+        location_from_input_with_home("~other-user/Documents", Path::new("/home/fixture")),
+        Err(LocationValidationError::UnsupportedShorthand(_))
+    ));
+}
+
+#[test]
 fn sidebar_location_navigation_validates_uris_but_navigates_native_paths_directly() {
     let remote_browser = Browser::new(Rc::new(NotMountedFileSource));
     let events = Rc::new(RefCell::new(Vec::new()));
@@ -1266,6 +1307,10 @@ fn invalid_location_text_is_rejected_before_the_provider() {
 
     assert_eq!(
         browser.navigate_input(""),
+        Err(LocationValidationError::Empty)
+    );
+    assert_eq!(
+        browser.navigate_input("   "),
         Err(LocationValidationError::Empty)
     );
     assert_eq!(


### PR DESCRIPTION
## Description

Expand `~` and `~/...` in the location bar to the current user's native home path before validation. Outer whitespace is trimmed so pasted or accidentally padded locations work as expected, while unsupported forms such as `~other-user/...` receive a clear validation error.

Also removes the redundant explanatory comments introduced by #215, leaving the transfer implementation and test names to describe the behavior.

## Visual evidence

N/A — this changes location parsing and removes comments; there is no persistent visual change to capture.

## How to test

1. Open the location bar and enter `~`, then enter `~/Documents`.
2. Repeat with leading and trailing spaces, such as `  ~/Documents  `.
3. Enter `~other-user/Documents`.

**Expected result:** `~` opens the current user's home, `~/Documents` opens the home Documents directory with or without outer spaces, and another user's shorthand is rejected with a clear message.

## Related issue

Closes #149