### PR TITLE
feat(appearance): unify menu typography and add app-wide text sizing

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -100,6 +100,7 @@ headerbar menubutton.header-action > button:focus-visible {
 }
 
 .appearance-menu {
+  font-size: 0.88em;
   min-width: 220px;
   padding: 9px 8px;
 }
@@ -1887,6 +1888,7 @@ menubutton.column-header-action > button:active {
 }
 
 .column-menu {
+  font-size: 0.88em;
   min-width: 170px;
   padding: 8px;
 }
@@ -2221,6 +2223,7 @@ menubutton.column-header-action > button:active {
 }
 
 .folder-context-menu {
+  font-size: 0.88em;
   min-width: 230px;
   padding: 7px;
 }

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -27,7 +27,7 @@ use super::{
     browser::{BrowserView, dismiss_modal_layer, modal_layer},
     browser_modes::{BrowserMode, ClickActivation, ClickCount},
     controls::{form_entry, menu_option, modal_layout, segmented_control},
-    theme::{Theme, ThemeManager, ThemeTokens},
+    theme::{TextSize, Theme, ThemeManager, ThemeTokens},
 };
 
 type ThemeCards = Rc<RefCell<Vec<(String, gtk::Button, gtk::Image)>>>;
@@ -2235,6 +2235,41 @@ fn theme_page(manager: Rc<ThemeManager>) -> (gtk::Widget, Vec<(gtk::FlowBox, u32
         system.append(&copy);
         system.append(&follow);
         content.append(&system);
+    }
+
+    append_heading(&content, "TYPOGRAPHY");
+    let text_sizes = [TextSize::Small, TextSize::Medium, TextSize::Large];
+    let active_text_size = text_sizes
+        .iter()
+        .position(|&size| size == manager.text_size())
+        .unwrap_or(1);
+    let (text_size_control, text_size_buttons) =
+        segmented_control(&["Small", "Medium", "Large"], active_text_size);
+    let text_size_row = gtk::Box::new(gtk::Orientation::Vertical, 8);
+    text_size_row.add_css_class("settings-option");
+    let text_size_copy = gtk::Box::new(gtk::Orientation::Vertical, 2);
+    text_size_copy.set_hexpand(true);
+    let text_size_title = gtk::Label::new(Some("Text size"));
+    text_size_title.set_xalign(0.0);
+    text_size_title.add_css_class("settings-option-title");
+    let text_size_description = gtk::Label::new(Some(
+        "Scale interface text across menus, labels, and lists.",
+    ));
+    text_size_description.set_xalign(0.0);
+    text_size_description.set_wrap(true);
+    text_size_description.add_css_class("settings-option-description");
+    text_size_copy.append(&text_size_title);
+    text_size_copy.append(&text_size_description);
+    text_size_row.append(&text_size_copy);
+    text_size_row.append(&text_size_control);
+    content.append(&text_size_row);
+    for (button, size) in text_size_buttons.into_iter().zip(text_sizes) {
+        let manager = manager.clone();
+        button.connect_toggled(move |toggled| {
+            if toggled.is_active() {
+                manager.set_text_size(size);
+            }
+        });
     }
 
     append_heading(&content, "THEMES");

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -129,6 +129,8 @@ struct Preferences {
     sidebar_order: Vec<String>,
     #[serde(default)]
     show_hidden: bool,
+    #[serde(default = "default_text_size")]
+    text_size: String,
     #[serde(default = "default_enabled")]
     folders_first: bool,
     #[serde(default = "default_sort_key")]
@@ -169,6 +171,7 @@ impl Default for Preferences {
             explorer_folder_clicks: default_double_clicks(),
             sidebar_order: default_sidebar_order(),
             show_hidden: false,
+            text_size: default_text_size(),
             folders_first: true,
             sort_key: default_sort_key(),
             sort_direction: default_sort_direction(),
@@ -187,6 +190,47 @@ fn default_enabled() -> bool {
 
 fn default_release_channel() -> String {
     "stable".to_owned()
+}
+
+fn default_text_size() -> String {
+    TextSize::default().as_str().to_owned()
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum TextSize {
+    Small,
+    #[default]
+    Medium,
+    Large,
+}
+
+impl TextSize {
+    /// The persisted/config-file representation of this size.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TextSize::Small => "small",
+            TextSize::Medium => "medium",
+            TextSize::Large => "large",
+        }
+    }
+
+    /// Parses a persisted text size value, falling back to [`TextSize::Medium`]
+    /// for anything unrecognised.
+    pub fn parse(value: &str) -> TextSize {
+        match value {
+            "small" => TextSize::Small,
+            "large" => TextSize::Large,
+            _ => TextSize::Medium,
+        }
+    }
+
+    fn root_font_px(self) -> u32 {
+        match self {
+            TextSize::Small => 12,
+            TextSize::Medium => 13,
+            TextSize::Large => 15,
+        }
+    }
 }
 
 fn default_browser_mode() -> String {
@@ -473,6 +517,16 @@ impl ThemeManager {
         self.save_preferences();
     }
 
+    pub fn text_size(&self) -> TextSize {
+        TextSize::parse(&self.preferences.borrow().text_size)
+    }
+
+    pub fn set_text_size(&self, size: TextSize) {
+        self.preferences.borrow_mut().text_size = size.as_str().to_owned();
+        self.apply_selected();
+        self.save_preferences();
+    }
+
     pub fn group_by_type(&self) -> bool {
         self.preferences.borrow().group_by_type
     }
@@ -682,7 +736,8 @@ impl ThemeManager {
     }
 
     fn apply_tokens(&self, tokens: &ThemeTokens) {
-        self.provider.load_from_string(&tokens_css(tokens));
+        self.provider
+            .load_from_string(&tokens_css(tokens, self.text_size().root_font_px()));
         crate::assets::set_primary_icon_color(&tokens.accent);
         crate::assets::set_danger_icon_color(&tokens.danger);
         install_source_style_scheme(tokens);
@@ -1015,9 +1070,9 @@ fn source_style_scheme_xml(tokens: &ThemeTokens) -> String {
     )
 }
 
-fn tokens_css(tokens: &ThemeTokens) -> String {
+fn tokens_css(tokens: &ThemeTokens, root_font_px: u32) -> String {
     format!(
-        "@define-color theme_bg {};\n@define-color theme_surface {};\n@define-color theme_text {};\n@define-color theme_accent {};\n@define-color theme_danger {};\n@define-color theme_muted {};\n@define-color theme_highlight {};\n@define-color theme_border {};\n@define-color theme_dim_text {};\n",
+        "@define-color theme_bg {};\n@define-color theme_surface {};\n@define-color theme_text {};\n@define-color theme_accent {};\n@define-color theme_danger {};\n@define-color theme_muted {};\n@define-color theme_highlight {};\n@define-color theme_border {};\n@define-color theme_dim_text {};\nwindow {{ font-size: {root_font_px}px; }}\n",
         tokens.background,
         tokens.surface,
         tokens.text,

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -226,7 +226,7 @@ impl TextSize {
 
     fn root_font_px(self) -> u32 {
         match self {
-            TextSize::Small => 12,
+            TextSize::Small => 11,
             TextSize::Medium => 13,
             TextSize::Large => 15,
         }

--- a/src/ui/theme/tests.rs
+++ b/src/ui/theme/tests.rs
@@ -3,7 +3,7 @@
 use std::{cell::RefCell, collections::HashSet};
 
 use super::{
-    Preferences, Theme, azure_tokens, blend, builtins, configured_hardware_acceleration,
+    Preferences, TextSize, Theme, azure_tokens, blend, builtins, configured_hardware_acceleration,
     configured_video_preview_backend, is_omarchy_theme_event, merge_builtin_and_custom_themes,
     notify_live, slugify, sort_preferences, title_case_slug, tokens_from_quattro, validate_tokens,
 };
@@ -368,6 +368,56 @@ theme = "azure-glow"
         Channel::parse(&preferences.release_channel),
         Channel::Stable
     );
+}
+
+#[test]
+fn text_size_defaults_to_medium() {
+    let preferences = Preferences::default();
+    assert_eq!(preferences.text_size, "medium");
+    assert_eq!(TextSize::parse(&preferences.text_size), TextSize::Medium);
+}
+
+#[test]
+fn small_and_large_text_sizes_round_trip_through_toml() {
+    for size in [TextSize::Small, TextSize::Large] {
+        let preferences = Preferences {
+            text_size: size.as_str().to_owned(),
+            ..Preferences::default()
+        };
+        let serialized = toml::to_string(&preferences).expect("preferences should serialize");
+        let restored: Preferences =
+            toml::from_str(&serialized).expect("preferences should deserialize");
+        assert_eq!(TextSize::parse(&restored.text_size), size);
+    }
+}
+
+#[test]
+fn unknown_text_size_value_parses_to_medium() {
+    assert_eq!(TextSize::parse("huge"), TextSize::Medium);
+}
+
+#[test]
+fn text_sizes_map_to_a_strictly_increasing_root_font_size() {
+    let small = TextSize::Small.root_font_px();
+    let medium = TextSize::Medium.root_font_px();
+    let large = TextSize::Large.root_font_px();
+    assert!(small < medium);
+    assert!(medium < large);
+    assert_eq!(medium, 13, "medium should match the unscaled base size");
+}
+
+#[test]
+fn legacy_preferences_without_text_size_default_to_medium() {
+    let preferences: Preferences = toml::from_str(
+        r#"
+mode = "theme"
+theme = "azure-glow"
+"#,
+    )
+    .expect("legacy preferences without text_size should remain valid");
+
+    assert_eq!(preferences.text_size, "medium");
+    assert_eq!(TextSize::parse(&preferences.text_size), TextSize::Medium);
 }
 
 #[test]


### PR DESCRIPTION
## Description

Two parts, both from #155:

**Menu typography audit.** The per-item right-click menu (`.item-context-menu`) already scales its text to `0.88em`, but three sibling popovers never got the same treatment and rendered at the unscaled root size: the Sort By popover (`.column-menu`, also reused by the Settings video-backend dropdown), the top-bar Appearance popover (`.appearance-menu`), and the folder-background context menu (`.folder-context-menu`, also reused for the Trash/Network/pinned-place sidebar menus). Brought all three to the same `0.88em` already established by `.item-context-menu`, rather than inventing a new value.

**App-wide text size.** Added a Text size control (Small/Medium/Large) under Theme & appearance. It's backed by a new persisted `text_size` preference, and applies by setting the root `window` font-size through `ThemeManager`'s existing higher-priority CSS provider (the same mechanism that already injects `@define-color` theme tokens on every theme change). Since virtually everything in `style.css` is sized in `em` relative to that root, one root font-size change scales the whole app proportionally — no per-widget overrides needed, and existing size hierarchy (headings vs. labels vs. secondary text) is preserved. Applies live, no restart required.

## Visual evidence

New Text size control:

![typography settings](attach in PR comment)

Home directory at each size (Small / Medium / Large), verified via a fully isolated dev build (separate D-Bus session, so it couldn't touch the running installed app) with each size persisted to config and the app relaunched fresh — confirms the setting is read correctly at startup, not just applied live:

Screenshots attached in a follow-up comment.

## How to test

1. Open Settings → Theme & appearance. A new TYPOGRAPHY section appears between the System card and the theme grid, with a Text size row (Small/Medium/Large), Medium selected by default.
2. Switch between the three — the whole app's text (sidebar, file list, breadcrumbs, settings itself) should resize immediately, no restart needed.
3. Quit and relaunch Strata — the chosen size should still be in effect.
4. Open the top-bar Appearance menu (list icon) and the Sort By menu (column header) — their text should now read at the same smaller, denser size as the per-item right-click menu (right-click a file), instead of looking larger than the rest of the UI.
5. Right-click empty folder space, and right-click Trash/Network/a pinned place in the sidebar — those context menus should also read at the smaller size now.

**Expected result:** text size setting persists and applies live app-wide; the four affected menus (Sort By, Appearance, folder-background context menu, sidebar context menus) all read at the same size as the already-correct per-item context menu.

## Related issue

Closes #155

<img width="920" height="700" alt="image" src="https://github.com/user-attachments/assets/c3070428-9d88-46e2-9eed-c7156903ac32" />

<img width="700" height="430" alt="image" src="https://github.com/user-attachments/assets/9367210d-e91a-4a67-9bcb-0d1f5d4104cd" />

<img width="700" height="430" alt="image" src="https://github.com/user-attachments/assets/85bb4167-4e42-43ec-bc3b-b6c25df9627f" />

<img width="700" height="430" alt="image" src="https://github.com/user-attachments/assets/b66e6ee9-a017-4a52-a8ae-ed96d6d7966f" />

