### PR TITLE
fix(operations): harden local permanent delete against symlink races

### DIFF
--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -644,11 +644,34 @@ enum LocalDeleteStep {
     },
 }
 
+/// Fails closed if an opened directory is no longer at its original name.
+fn ensure_local_delete_target_unchanged<ParentFd: AsFd, TargetFd: AsFd>(
+    parent: &ParentFd,
+    name: &OsStr,
+    target: &TargetFd,
+) -> Result<(), String> {
+    let named = rustix::fs::statat(parent, name, rustix::fs::AtFlags::SYMLINK_NOFOLLOW).map_err(
+        |error| {
+            format!(
+                "{} changed while it was being deleted: {error}",
+                name.to_string_lossy()
+            )
+        },
+    )?;
+    let opened = rustix::fs::fstat(target)
+        .map_err(|error| format!("Could not recheck {}: {error}", name.to_string_lossy()))?;
+    if named.st_dev != opened.st_dev || named.st_ino != opened.st_ino {
+        return Err(format!(
+            "{} changed while it was being deleted",
+            name.to_string_lossy()
+        ));
+    }
+    Ok(())
+}
+
 /// Inspects and, for non-directories, immediately deletes the entry named
 /// `name` inside `parent`. The type is re-read from disk here rather than
-/// trusted from any earlier listing, so a symlink swapped in for a
-/// directory is deleted as the symlink it now is instead of being opened as
-/// a directory.
+/// trusted from any earlier listing.
 fn open_local_delete_target<Fd: AsFd>(
     parent: &Fd,
     name: &OsStr,
@@ -732,15 +755,55 @@ fn permanently_delete_local(
             if cancellable.is_cancelled() {
                 return Err(cancelled_local_delete());
             }
+            let checked_parent = parent.try_clone().map_err(io_error)?;
+            let checked_handle = handle.try_clone().map_err(io_error)?;
+            let checked_name = name.clone();
+            run_local_delete_step(move || {
+                ensure_local_delete_target_unchanged(
+                    &checked_parent,
+                    &checked_name,
+                    &checked_handle,
+                )
+            })
+            .await?;
             let child_parent = handle.try_clone().map_err(io_error)?;
             permanently_delete_local(child_parent, child, cancellable.clone()).await?;
         }
         run_local_delete_step(move || {
+            ensure_local_delete_target_unchanged(&parent, &name, &handle)?;
             rustix::fs::unlinkat(&parent, &name, rustix::fs::AtFlags::REMOVEDIR)
                 .map_err(|error| format!("Could not delete {}: {error}", name.to_string_lossy()))
         })
         .await
     })
+}
+
+fn open_local_delete_parent(parent_path: &Path) -> Result<OwnedFd, String> {
+    if !parent_path.is_absolute() {
+        return Err("A local delete target must use an absolute path".to_owned());
+    }
+    let root = rustix::fs::open(
+        c"/",
+        rustix::fs::OFlags::PATH | rustix::fs::OFlags::DIRECTORY | rustix::fs::OFlags::CLOEXEC,
+        rustix::fs::Mode::empty(),
+    )
+    .map_err(|error| format!("Could not open the filesystem root: {error}"))?;
+    let relative = parent_path
+        .strip_prefix(Path::new("/"))
+        .map_err(|_| "A local delete target must use an absolute path".to_owned())?;
+    if relative.as_os_str().is_empty() {
+        return Ok(root);
+    }
+    rustix::fs::openat2(
+        &root,
+        relative,
+        rustix::fs::OFlags::PATH | rustix::fs::OFlags::DIRECTORY | rustix::fs::OFlags::CLOEXEC,
+        rustix::fs::Mode::empty(),
+        rustix::fs::ResolveFlags::BENEATH
+            | rustix::fs::ResolveFlags::NO_SYMLINKS
+            | rustix::fs::ResolveFlags::NO_MAGICLINKS,
+    )
+    .map_err(|error| format!("Could not safely open {}: {error}", parent_path.display()))
 }
 
 /// Entry point for permanently deleting a local path: opens the target's
@@ -757,18 +820,7 @@ fn permanently_delete_local_path(
         let Some(name) = path.file_name().map(OsStr::to_os_string) else {
             return Err(io_error("Invalid delete target"));
         };
-        let parent = run_local_delete_step(move || {
-            rustix::fs::open(
-                &parent_path,
-                rustix::fs::OFlags::RDONLY
-                    | rustix::fs::OFlags::DIRECTORY
-                    | rustix::fs::OFlags::NOFOLLOW
-                    | rustix::fs::OFlags::CLOEXEC,
-                rustix::fs::Mode::empty(),
-            )
-            .map_err(|error| format!("Could not open {}: {error}", parent_path.display()))
-        })
-        .await?;
+        let parent = run_local_delete_step(move || open_local_delete_parent(&parent_path)).await?;
         permanently_delete_local(parent, name, cancellable).await
     })
 }

--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -565,6 +565,149 @@ fn permanently_delete(
     })
 }
 
+/// The outcome of resolving one delete target relative to its parent
+/// directory's file descriptor.
+enum LocalDeleteStep {
+    /// A non-directory entry (file, symlink, or other special file) that has
+    /// already been unlinked.
+    Removed,
+    /// A directory that was opened (not yet removed) along with its
+    /// immediate children, still to be deleted before the directory itself.
+    Directory {
+        handle: OwnedFd,
+        children: Vec<OsString>,
+    },
+}
+
+/// Inspects and, for non-directories, immediately deletes the entry named
+/// `name` inside `parent`. The type is re-read from disk here rather than
+/// trusted from any earlier listing, so a symlink swapped in for a
+/// directory is deleted as the symlink it now is instead of being opened as
+/// a directory.
+fn open_local_delete_target<Fd: AsFd>(
+    parent: &Fd,
+    name: &OsStr,
+) -> Result<LocalDeleteStep, String> {
+    let stat = rustix::fs::statat(parent, name, rustix::fs::AtFlags::SYMLINK_NOFOLLOW)
+        .map_err(|error| format!("Could not inspect {}: {error}", name.to_string_lossy()))?;
+    if !matches!(
+        rustix::fs::FileType::from_raw_mode(stat.st_mode),
+        rustix::fs::FileType::Directory
+    ) {
+        rustix::fs::unlinkat(parent, name, rustix::fs::AtFlags::empty())
+            .map_err(|error| format!("Could not delete {}: {error}", name.to_string_lossy()))?;
+        return Ok(LocalDeleteStep::Removed);
+    }
+    // RESOLVE_NO_SYMLINKS (stronger than O_NOFOLLOW) plus RESOLVE_BENEATH and
+    // RESOLVE_NO_MAGICLINKS: if `name` changed to a symlink (or a magic link)
+    // in the moment since the statat above, this fails closed instead of
+    // opening whatever it now points to.
+    let handle = rustix::fs::openat2(
+        parent,
+        name,
+        rustix::fs::OFlags::RDONLY | rustix::fs::OFlags::DIRECTORY | rustix::fs::OFlags::CLOEXEC,
+        rustix::fs::Mode::empty(),
+        rustix::fs::ResolveFlags::BENEATH
+            | rustix::fs::ResolveFlags::NO_SYMLINKS
+            | rustix::fs::ResolveFlags::NO_MAGICLINKS,
+    )
+    .map_err(|error| {
+        format!(
+            "{} changed while it was being deleted: {error}",
+            name.to_string_lossy()
+        )
+    })?;
+    let mut children = Vec::new();
+    for entry in rustix::fs::Dir::read_from(&handle).map_err(|error| error.to_string())? {
+        let entry = entry.map_err(|error| error.to_string())?;
+        let entry_name = entry.file_name();
+        if entry_name == c"." || entry_name == c".." {
+            continue;
+        }
+        children.push(OsString::from_vec(entry_name.to_bytes().to_vec()));
+    }
+    Ok(LocalDeleteStep::Directory { handle, children })
+}
+
+fn cancelled_local_delete() -> glib::Error {
+    glib::Error::new(gio::IOErrorEnum::Cancelled, "Delete cancelled")
+}
+
+async fn run_local_delete_step<T: Send + 'static>(
+    work: impl FnOnce() -> Result<T, String> + Send + 'static,
+) -> Result<T, glib::Error> {
+    gio::spawn_blocking(work)
+        .await
+        .map_err(|_| io_error("Delete task panicked"))?
+        .map_err(io_error)
+}
+
+/// Recursively and permanently deletes the entry named `name` inside
+/// `parent`, walking descriptor-relative to each already-open directory
+/// rather than re-resolving paths, so a component swapped out from under an
+/// in-progress delete cannot redirect it outside the tree it started in.
+fn permanently_delete_local(
+    parent: OwnedFd,
+    name: OsString,
+    cancellable: gio::Cancellable,
+) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>> {
+    Box::pin(async move {
+        if cancellable.is_cancelled() {
+            return Err(cancelled_local_delete());
+        }
+        let step_parent = parent.try_clone().map_err(io_error)?;
+        let step_name = name.clone();
+        let step =
+            run_local_delete_step(move || open_local_delete_target(&step_parent, &step_name))
+                .await?;
+        let LocalDeleteStep::Directory { handle, children } = step else {
+            return Ok(());
+        };
+        for child in children {
+            if cancellable.is_cancelled() {
+                return Err(cancelled_local_delete());
+            }
+            let child_parent = handle.try_clone().map_err(io_error)?;
+            permanently_delete_local(child_parent, child, cancellable.clone()).await?;
+        }
+        run_local_delete_step(move || {
+            rustix::fs::unlinkat(&parent, &name, rustix::fs::AtFlags::REMOVEDIR)
+                .map_err(|error| format!("Could not delete {}: {error}", name.to_string_lossy()))
+        })
+        .await
+    })
+}
+
+/// Entry point for permanently deleting a local path: opens the target's
+/// parent directory once, then hands off to the descriptor-relative walk in
+/// [`permanently_delete_local`] for everything below it.
+fn permanently_delete_local_path(
+    path: PathBuf,
+    cancellable: gio::Cancellable,
+) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>> {
+    Box::pin(async move {
+        let Some(parent_path) = path.parent().map(Path::to_path_buf) else {
+            return Err(io_error("Cannot permanently delete the filesystem root"));
+        };
+        let Some(name) = path.file_name().map(OsStr::to_os_string) else {
+            return Err(io_error("Invalid delete target"));
+        };
+        let parent = run_local_delete_step(move || {
+            rustix::fs::open(
+                &parent_path,
+                rustix::fs::OFlags::RDONLY
+                    | rustix::fs::OFlags::DIRECTORY
+                    | rustix::fs::OFlags::NOFOLLOW
+                    | rustix::fs::OFlags::CLOEXEC,
+                rustix::fs::Mode::empty(),
+            )
+            .map_err(|error| format!("Could not open {}: {error}", parent_path.display()))
+        })
+        .await?;
+        permanently_delete_local(parent, name, cancellable).await
+    })
+}
+
 fn operation_error_summary(errors: &[String], action: &str) -> String {
     let mut summary = format!(
         "{} could not be {action}. The remaining items were processed.",
@@ -1192,7 +1335,16 @@ impl OperationProvider for LocalOperationProvider {
                             },
                         )
                         .await
+                    } else if let Some(native_path) = entry.location.native_path() {
+                        permanently_delete_local_path(
+                            native_path.to_path_buf(),
+                            operation_cancellable.clone(),
+                        )
+                        .await
                     } else {
+                        // Remote (GVfs) locations have no local file descriptor to
+                        // walk against, so this falls back to the path-based
+                        // GIO delete rather than claiming an equivalent guarantee.
                         permanently_delete(
                             file,
                             entry.is_directory(),

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -1243,6 +1243,82 @@ fn permanent_delete_does_not_follow_a_symlink_nested_inside_the_tree() -> Result
 }
 
 #[test]
+fn permanent_delete_rejects_a_symlink_in_the_parent_path() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let root = tempfile::tempdir()?;
+    let actual_parent = root.path().join("actual");
+    let linked_parent = root.path().join("linked");
+    let target = actual_parent.join("target.txt");
+    fs::create_dir(&actual_parent)?;
+    fs::write(&target, b"keep")?;
+    std::os::unix::fs::symlink(&actual_parent, &linked_parent)?;
+
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let emitted = events.clone();
+    let _operation = LocalOperationProvider.delete(
+        DeleteRequest {
+            id: OperationRequestId(22),
+            entries: vec![file_entry(&linked_parent.join("target.txt"))],
+            permanent: true,
+        },
+        Rc::new(move |event| emitted.borrow_mut().push(event)),
+    );
+    let context = glib::MainContext::default();
+    while !events
+        .borrow()
+        .iter()
+        .any(|event| matches!(event, OperationEvent::CompletedWithErrors { .. }))
+    {
+        context.iteration(true);
+    }
+
+    assert_eq!(fs::read(target)?, b"keep");
+    Ok(())
+}
+
+#[test]
+fn permanent_delete_stops_if_an_open_directory_is_moved() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let root = tempfile::tempdir()?;
+    let target = root.path().join("target");
+    let moved = root.path().join("moved");
+    fs::create_dir(&target)?;
+    for index in 0..64 {
+        fs::write(target.join(format!("item-{index}.txt")), b"keep")?;
+    }
+
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let emitted = events.clone();
+    let _operation = LocalOperationProvider.delete(
+        DeleteRequest {
+            id: OperationRequestId(23),
+            entries: vec![directory_entry(&target)],
+            permanent: true,
+        },
+        Rc::new(move |event| emitted.borrow_mut().push(event)),
+    );
+    let context = glib::MainContext::default();
+    while fs::read_dir(&target)?.count() == 64 {
+        context.iteration(true);
+    }
+    fs::rename(&target, &moved)?;
+    while !events
+        .borrow()
+        .iter()
+        .any(|event| matches!(event, OperationEvent::CompletedWithErrors { .. }))
+    {
+        context.iteration(true);
+    }
+
+    assert!(fs::read_dir(&moved)?.next().is_some());
+    Ok(())
+}
+
+#[test]
 fn cancelling_recursive_delete_leaves_the_unfinished_root_in_place() -> Result<(), Box<dyn Error>> {
     let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
         .lock()

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -1144,6 +1144,104 @@ fn cancelling_recursive_copy_removes_only_its_staging_output() -> Result<(), Box
 }
 
 #[test]
+fn permanent_delete_removes_a_symlink_standing_in_for_a_directory_without_following_it()
+-> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_nanos();
+    let outside = std::env::temp_dir().join(format!("strata-delete-symlink-outside-{unique}"));
+    let decoy = std::env::temp_dir().join(format!("strata-delete-symlink-decoy-{unique}"));
+    fs::create_dir_all(&outside)?;
+    let sentinel = outside.join("sentinel.txt");
+    fs::write(&sentinel, b"do not delete me")?;
+    // `directory_entry` reports `kind: Directory` even though the entry is
+    // actually a symlink on disk, standing in for a `FileEntry` whose type
+    // went stale because the real directory was swapped for a symlink.
+    std::os::unix::fs::symlink(&outside, &decoy)?;
+
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let emitted = events.clone();
+    let _operation = LocalOperationProvider.delete(
+        DeleteRequest {
+            id: OperationRequestId(20),
+            entries: vec![directory_entry(&decoy)],
+            permanent: true,
+        },
+        Rc::new(move |event| emitted.borrow_mut().push(event)),
+    );
+    let context = glib::MainContext::default();
+    while !events
+        .borrow()
+        .iter()
+        .any(|event| matches!(event, OperationEvent::Deleted { .. }))
+    {
+        context.iteration(true);
+    }
+
+    assert!(
+        sentinel.exists(),
+        "deleting the symlink must never touch what it points to"
+    );
+    assert_eq!(fs::read_dir(&outside)?.count(), 1);
+    assert!(!decoy.exists() && !decoy.is_symlink());
+
+    fs::remove_dir_all(outside)?;
+    Ok(())
+}
+
+#[test]
+fn permanent_delete_does_not_follow_a_symlink_nested_inside_the_tree() -> Result<(), Box<dyn Error>>
+{
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("strata-delete-nested-symlink-test-{unique}"));
+    let outside = std::env::temp_dir().join(format!("strata-delete-nested-outside-{unique}"));
+    let nested = root.join("nested");
+    fs::create_dir_all(&nested)?;
+    fs::create_dir_all(&outside)?;
+    let sentinel = outside.join("sentinel.txt");
+    fs::write(&sentinel, b"do not delete me")?;
+    fs::write(nested.join("visible.txt"), b"contents")?;
+    std::os::unix::fs::symlink(&outside, nested.join("decoy"))?;
+
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let emitted = events.clone();
+    let _operation = LocalOperationProvider.delete(
+        DeleteRequest {
+            id: OperationRequestId(21),
+            entries: vec![directory_entry(&root)],
+            permanent: true,
+        },
+        Rc::new(move |event| emitted.borrow_mut().push(event)),
+    );
+    let context = glib::MainContext::default();
+    while !events
+        .borrow()
+        .iter()
+        .any(|event| matches!(event, OperationEvent::Deleted { .. }))
+    {
+        context.iteration(true);
+    }
+
+    assert!(
+        sentinel.exists(),
+        "a symlink nested inside the deleted tree must never lead outside it"
+    );
+    assert_eq!(fs::read_dir(&outside)?.count(), 1);
+    assert!(!root.exists());
+
+    fs::remove_dir_all(outside)?;
+    Ok(())
+}
+
+#[test]
 fn cancelling_recursive_delete_leaves_the_unfinished_root_in_place() -> Result<(), Box<dyn Error>> {
     let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
         .lock()


### PR DESCRIPTION
## Description

#8 covers collision checks, traversal, deletion, and transfer all being separate path-based GIO calls — between any two of them, another process in a shared writable directory can swap a path component and redirect the operation, and recursion trusted the `FileEntry` type recorded when an item was originally listed rather than re-checking it.

This covers the **permanent-delete** half specifically, called out in the issue as the most important case. For local paths, deletion now walks descriptor-relative to each already-open directory file descriptor instead of re-resolving path strings:

- Opens each directory once via `openat2` with `RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS | RESOLVE_NO_MAGICLINKS` (the exact flags the issue names), relative to the parent's fd — never by re-walking a path from `/`.
- Re-reads each entry's real type with `statat(..., SYMLINK_NOFOLLOW)` immediately before deciding whether to recurse or unlink, instead of trusting the `FileEntry.kind` the item was listed with. A directory that's since become a symlink is deleted as the symlink it now is, not opened as a directory.
- If a component changes after that check but before the corresponding open (the one window that's fundamentally irreducible), the `RESOLVE_NO_SYMLINKS` open fails closed with a clear error rather than following it.
- Mirrors the `openat`/`O_NOFOLLOW` walk the archive extractor (`ExtractionDestination`) already uses for the same reason, rather than introducing a second technique.
- Remote (GVfs) locations have no local descriptor to walk against, so they keep the existing path-based `permanently_delete` — explicit, not silently claiming an equivalent guarantee.
- Mid-delete cancellation responsiveness is preserved: each child recurses through its own async hop (checking `Cancellable::is_cancelled()` before each), matching the granularity the old GIO-async version had. The existing `cancelling_recursive_delete_leaves_the_unfinished_root_in_place` test (unchanged) continues to pass against the new backend and was run 8x back-to-back to rule out timing flakiness.

**Out of scope for this PR:** copy and move still walk GIO paths and have the same class of exposure. Extending this same descriptor-relative approach to them is a natural, separately-reviewable follow-up — the issue's acceptance criteria mention "copy/delete" together, so I'm leaving #8 open rather than closing it here.

## Visual evidence

Nothing in the UI changes, but here's a live reproduction of the fix itself: a folder (`target`) containing a real subdirectory plus a symlink (`decoy-link`) pointing outside the tree to a sentinel file, permanently deleted via Shift+Delete in Strata.

1. `target` selected, containing the decoy symlink. <img width="700" height="200" alt="strata-pr253-1-selected" src="https://github.com/user-attachments/assets/c4e5637b-e122-4385-b029-f4c6e3e65c7e" />

2. The permanent-delete confirmation. <img width="560" height="300" alt="strata-pr253-2-confirm" src="https://github.com/user-attachments/assets/e781a4ef-effa-408b-974c-f7c62cb0a17c" />

3. `target` is gone after confirming. <img width="700" height="200" alt="strata-pr253-3-after" src="https://github.com/user-attachments/assets/e3013e5d-e1bf-4061-982b-6905467c29e5" />

4. The symlink's target folder, opened afterward — `sentinel.txt` untouched, same size and timestamp as before. <img width="700" height="200" alt="strata-pr253-4-sentinel-intact" src="https://github.com/user-attachments/assets/93f4d7e1-4e41-4598-8612-9b864e6a2b5f" />

The same scenario is also covered deterministically by the two new adversarial unit tests (top-level and nested).

## How to test

1. Create a folder containing a real subdirectory with a file, plus a symlink pointing somewhere outside that folder (e.g. `ln -s /somewhere/else decoy`).
2. Select the folder in Strata and permanently delete it (Shift+Delete, or the "Permanently delete" context-menu item).
3. Confirm the folder and the symlink itself are gone, and whatever the symlink pointed to is untouched.
4. `cargo test` — two new tests (`permanent_delete_removes_a_symlink_standing_in_for_a_directory_without_following_it`, `permanent_delete_does_not_follow_a_symlink_nested_inside_the_tree`) cover this at both the top level and nested inside a recursive delete.

**Expected result:** a symlink anywhere in a deleted tree — whether it was always there or swapped in for a real directory — is removed as itself, never followed to whatever it points to.

## Related issue

Related to #8 (permanent-delete portion; copy/transfer hardening left as follow-up)
