### PR TITLE
fix(operations): harden local copy against symlink races

### DIFF
--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -10,7 +10,7 @@ use std::{
     future::Future,
     io,
     os::{
-        fd::{AsFd, OwnedFd},
+        fd::{AsFd, AsRawFd, OwnedFd},
         unix::{
             ffi::{OsStrExt, OsStringExt},
             fs::PermissionsExt,
@@ -83,6 +83,257 @@ fn is_trash_unsupported_failure(permanent: bool, error: &glib::Error) -> bool {
     !permanent && error.matches(gio::IOErrorEnum::NotSupported)
 }
 
+fn cancelled_local_operation() -> glib::Error {
+    glib::Error::new(gio::IOErrorEnum::Cancelled, "Operation cancelled")
+}
+
+async fn run_local_fs_step<T: Send + 'static>(
+    work: impl FnOnce() -> Result<T, String> + Send + 'static,
+) -> Result<T, glib::Error> {
+    gio::spawn_blocking(work)
+        .await
+        .map_err(|_| io_error("Local filesystem task panicked"))?
+        .map_err(io_error)
+}
+
+fn open_local_child_directory<Fd: AsFd>(parent: &Fd, name: &OsStr) -> Result<OwnedFd, String> {
+    // RESOLVE_NO_SYMLINKS (stronger than O_NOFOLLOW) plus RESOLVE_BENEATH and
+    // RESOLVE_NO_MAGICLINKS: if `name` changed to a symlink (or a magic
+    // link) since it was last inspected, this fails closed instead of
+    // opening whatever it now points to.
+    rustix::fs::openat2(
+        parent,
+        name,
+        rustix::fs::OFlags::RDONLY | rustix::fs::OFlags::DIRECTORY | rustix::fs::OFlags::CLOEXEC,
+        rustix::fs::Mode::empty(),
+        rustix::fs::ResolveFlags::BENEATH
+            | rustix::fs::ResolveFlags::NO_SYMLINKS
+            | rustix::fs::ResolveFlags::NO_MAGICLINKS,
+    )
+    .map_err(|error| {
+        format!(
+            "{} changed while it was being read: {error}",
+            name.to_string_lossy()
+        )
+    })
+}
+
+fn local_directory_children<Fd: AsFd>(handle: &Fd) -> Result<Vec<OsString>, String> {
+    let mut children = Vec::new();
+    for entry in rustix::fs::Dir::read_from(handle).map_err(|error| error.to_string())? {
+        let entry = entry.map_err(|error| error.to_string())?;
+        let entry_name = entry.file_name();
+        if entry_name == c"." || entry_name == c".." {
+            continue;
+        }
+        children.push(OsString::from_vec(entry_name.to_bytes().to_vec()));
+    }
+    Ok(children)
+}
+
+/// The outcome of resolving one copy source entry relative to its parent
+/// directory's file descriptor. The type is re-read from disk here rather
+/// than trusted from any earlier listing, so a symlink swapped in for a
+/// directory is copied as the symlink it now is instead of being opened as
+/// a directory.
+enum LocalCopySource {
+    /// An open file description for a regular file. Kept alive until the
+    /// GIO copy that reads through it has finished, so `/proc/self/fd/<n>`
+    /// always resolves to this exact file no matter what happens to its
+    /// name afterward.
+    File(std::fs::File),
+    /// A symlink and the path it points to, copied as a new symlink rather
+    /// than by following it.
+    Symlink(OsString),
+    Directory {
+        handle: OwnedFd,
+        children: Vec<OsString>,
+    },
+}
+
+fn open_local_copy_source<Fd: AsFd>(parent: &Fd, name: &OsStr) -> Result<LocalCopySource, String> {
+    let stat = rustix::fs::statat(parent, name, rustix::fs::AtFlags::SYMLINK_NOFOLLOW)
+        .map_err(|error| format!("Could not inspect {}: {error}", name.to_string_lossy()))?;
+    match rustix::fs::FileType::from_raw_mode(stat.st_mode) {
+        rustix::fs::FileType::Symlink => {
+            let link = rustix::fs::readlinkat(parent, name, Vec::new()).map_err(|error| {
+                format!("Could not read link {}: {error}", name.to_string_lossy())
+            })?;
+            Ok(LocalCopySource::Symlink(OsString::from_vec(
+                link.into_bytes(),
+            )))
+        }
+        rustix::fs::FileType::Directory => {
+            let handle = open_local_child_directory(parent, name)?;
+            let children = local_directory_children(&handle)?;
+            Ok(LocalCopySource::Directory { handle, children })
+        }
+        _ => {
+            let file = rustix::fs::openat2(
+                parent,
+                name,
+                rustix::fs::OFlags::RDONLY | rustix::fs::OFlags::CLOEXEC,
+                rustix::fs::Mode::empty(),
+                rustix::fs::ResolveFlags::BENEATH
+                    | rustix::fs::ResolveFlags::NO_SYMLINKS
+                    | rustix::fs::ResolveFlags::NO_MAGICLINKS,
+            )
+            .map_err(|error| {
+                format!(
+                    "{} changed while it was being copied: {error}",
+                    name.to_string_lossy()
+                )
+            })?;
+            Ok(LocalCopySource::File(std::fs::File::from(file)))
+        }
+    }
+}
+
+/// Recursively copies the entry named `name` inside `parent` to `target`,
+/// walking descriptor-relative to each already-open source directory
+/// instead of re-resolving paths, so a component swapped out from under an
+/// in-progress copy cannot redirect what gets read. Regular files are
+/// hand-ed to GIO's own copy (preserving its metadata handling and any
+/// reflink optimisation) through a `/proc/self/fd` reference pinned to the
+/// exact file just verified, rather than the original, re-resolvable path.
+fn copy_recursively_local(
+    parent: OwnedFd,
+    name: OsString,
+    target: gio::File,
+    overwrite_existing: bool,
+    cancellable: gio::Cancellable,
+    created_root: Option<Rc<Cell<bool>>>,
+) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>> {
+    Box::pin(async move {
+        if cancellable.is_cancelled() {
+            return Err(cancelled_local_operation());
+        }
+        let step_parent = parent.try_clone().map_err(io_error)?;
+        let step_name = name.clone();
+        let step =
+            run_local_fs_step(move || open_local_copy_source(&step_parent, &step_name)).await?;
+        match step {
+            LocalCopySource::Symlink(link_target) => {
+                let target_path = target
+                    .path()
+                    .ok_or_else(|| io_error("Copy destination must be a local path"))?;
+                run_local_fs_step(move || {
+                    rustix::fs::symlink(&link_target, &target_path).map_err(|error| {
+                        format!("Could not recreate {}: {error}", target_path.display())
+                    })
+                })
+                .await
+            }
+            LocalCopySource::File(file) => {
+                // Deliberately no NOFOLLOW_SYMLINKS here: `/proc/self/fd/<n>`
+                // is itself reported as a symlink by lstat, even though the
+                // fd it names was already verified to be a plain file. GIO
+                // must follow it to reach that file's actual content rather
+                // than copying the magic-link's target text as a new symlink.
+                let source_ref = gio::File::for_path(format!("/proc/self/fd/{}", file.as_raw_fd()));
+                let flags = gio::FileCopyFlags::ALL_METADATA
+                    | if overwrite_existing {
+                        gio::FileCopyFlags::OVERWRITE
+                    } else {
+                        gio::FileCopyFlags::NONE
+                    };
+                let result = await_cancellable(
+                    &source_ref,
+                    &cancellable,
+                    move |source, cancellable, result| {
+                        source.copy_async(
+                            &target,
+                            flags,
+                            glib::Priority::DEFAULT,
+                            Some(cancellable),
+                            None,
+                            move |output| result.resolve(output),
+                        );
+                    },
+                )
+                .await;
+                // Keeps `file` open (and its fd number stable) for the
+                // duration of the copy above; only drop it once resolved.
+                drop(file);
+                result
+            }
+            LocalCopySource::Directory { handle, children } => {
+                if !overwrite_existing || !target.query_exists(Some(&cancellable)) {
+                    await_cancellable(&target, &cancellable, |target, cancellable, result| {
+                        target.make_directory_async(
+                            glib::Priority::DEFAULT,
+                            Some(cancellable),
+                            move |output| result.resolve(output),
+                        );
+                    })
+                    .await?;
+                    if let Some(created_root) = &created_root {
+                        created_root.set(true);
+                    }
+                }
+                for child_name in children {
+                    if cancellable.is_cancelled() {
+                        return Err(cancelled_local_operation());
+                    }
+                    let child_parent = handle.try_clone().map_err(io_error)?;
+                    let child_target = target.child(&child_name);
+                    copy_recursively_local(
+                        child_parent,
+                        child_name,
+                        child_target,
+                        overwrite_existing,
+                        cancellable.clone(),
+                        None,
+                    )
+                    .await?;
+                }
+                Ok(())
+            }
+        }
+    })
+}
+
+/// Entry point for locally copying a source path: opens its parent
+/// directory once, then hands off to the descriptor-relative walk in
+/// [`copy_recursively_local`] for everything below it.
+fn copy_recursively_local_path(
+    source_path: PathBuf,
+    target: gio::File,
+    overwrite_existing: bool,
+    cancellable: gio::Cancellable,
+    created_root: Option<Rc<Cell<bool>>>,
+) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>> {
+    Box::pin(async move {
+        let Some(parent_path) = source_path.parent().map(Path::to_path_buf) else {
+            return Err(io_error("Cannot copy the filesystem root"));
+        };
+        let Some(name) = source_path.file_name().map(OsStr::to_os_string) else {
+            return Err(io_error("Invalid copy source"));
+        };
+        let parent = run_local_fs_step(move || {
+            rustix::fs::open(
+                &parent_path,
+                rustix::fs::OFlags::RDONLY
+                    | rustix::fs::OFlags::DIRECTORY
+                    | rustix::fs::OFlags::NOFOLLOW
+                    | rustix::fs::OFlags::CLOEXEC,
+                rustix::fs::Mode::empty(),
+            )
+            .map_err(|error| format!("Could not open {}: {error}", parent_path.display()))
+        })
+        .await?;
+        copy_recursively_local(
+            parent,
+            name,
+            target,
+            overwrite_existing,
+            cancellable,
+            created_root,
+        )
+        .await
+    })
+}
+
 fn copy_recursively(
     source: gio::File,
     target: gio::File,
@@ -90,6 +341,21 @@ fn copy_recursively(
     cancellable: gio::Cancellable,
     created_root: Option<Rc<Cell<bool>>>,
 ) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>> {
+    if source.is_native()
+        && target.is_native()
+        && let Some(source_path) = source.path()
+    {
+        // Remote (GVfs) locations have no local descriptor to walk against,
+        // so anything not fully local keeps the GIO path-based copy below
+        // rather than claiming an equivalent guarantee.
+        return copy_recursively_local_path(
+            source_path,
+            target,
+            overwrite_existing,
+            cancellable,
+            created_root,
+        );
+    }
     Box::pin(async move {
         let info = await_cancellable(&source, &cancellable, |source, cancellable, result| {
             source.query_info_async(

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -225,6 +225,90 @@ fn recursive_copy_preserves_nested_directory_contents() -> Result<(), Box<dyn Er
 }
 
 #[test]
+fn copy_recursively_does_not_follow_a_symlink_nested_inside_the_tree() -> Result<(), Box<dyn Error>>
+{
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("strata-copy-symlink-test-{unique}"));
+    let source = root.join("source");
+    let outside = root.join("outside");
+    let target = root.join("target");
+    fs::create_dir_all(source.join("nested"))?;
+    fs::create_dir_all(&outside)?;
+    fs::write(outside.join("secret.txt"), b"do not copy me")?;
+    fs::write(source.join("nested/visible.txt"), b"contents")?;
+    std::os::unix::fs::symlink(&outside, source.join("nested/decoy"))?;
+
+    let result = glib::MainContext::default().block_on(copy_recursively(
+        gio::File::for_path(&source),
+        gio::File::for_path(&target),
+        false,
+        gio::Cancellable::new(),
+        None,
+    ));
+
+    assert!(result.is_ok());
+    assert_eq!(fs::read(target.join("nested/visible.txt"))?, b"contents");
+    let decoy_dest = target.join("nested/decoy");
+    let decoy_metadata = fs::symlink_metadata(&decoy_dest)?;
+    assert!(
+        decoy_metadata.file_type().is_symlink(),
+        "the decoy must be copied as a symlink, not followed into a real directory"
+    );
+    assert_eq!(fs::read_link(&decoy_dest)?, outside);
+    // `is_symlink` above already rules out a real directory of copied
+    // content existing under this name; confirm the thing it still points
+    // at (unavoidably reachable by following the recreated symlink, same as
+    // the original) was left untouched rather than overwritten.
+    assert_eq!(fs::read(outside.join("secret.txt"))?, b"do not copy me");
+
+    fs::remove_dir_all(root)?;
+    Ok(())
+}
+
+#[test]
+fn copy_recursively_of_a_symlink_creates_a_symlink_not_a_recursive_copy()
+-> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("strata-copy-symlink-top-test-{unique}"));
+    let outside = root.join("outside");
+    let decoy = root.join("decoy");
+    let target = root.join("target-link");
+    fs::create_dir_all(&outside)?;
+    fs::write(outside.join("secret.txt"), b"do not copy me")?;
+    std::os::unix::fs::symlink(&outside, &decoy)?;
+
+    let result = glib::MainContext::default().block_on(copy_recursively(
+        gio::File::for_path(&decoy),
+        gio::File::for_path(&target),
+        false,
+        gio::Cancellable::new(),
+        None,
+    ));
+
+    assert!(result.is_ok());
+    let target_metadata = fs::symlink_metadata(&target)?;
+    assert!(
+        target_metadata.file_type().is_symlink(),
+        "copying a symlink must produce a symlink, not a recursive copy of its target"
+    );
+    assert_eq!(fs::read_link(&target)?, outside);
+    assert_eq!(fs::read(outside.join("secret.txt"))?, b"do not copy me");
+
+    fs::remove_dir_all(root)?;
+    Ok(())
+}
+
+#[test]
 fn staged_file_replacement_preserves_the_destination_on_disk_full() -> Result<(), Box<dyn Error>> {
     let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
         .lock()


### PR DESCRIPTION
## Description

Follow-up to #253 (permanent-delete hardening), covering the other half of #8: copying. `copy_recursively` is the single function behind paste-copy, the cross-filesystem move fallback, and staged replace's copy-to-stage step — walking its source the same path-based way delete used to (enumerate, then re-resolve each child's own path next call), trusting whatever type GIO reported at listing time.

For fully local source/target pairs, `copy_recursively` now dispatches to a descriptor-relative walk, mirroring #253's approach:

- Each source directory is opened once via `openat2` with `RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS | RESOLVE_NO_MAGICLINKS`, and every entry's real type is re-read immediately before deciding what to do with it — never trusted from an earlier listing.
- Symlinks are recreated directly (`readlinkat` + `symlink`), never followed.
- Regular files still go through GIO's own `copy_async` unchanged, except for one thing: instead of the original (re-resolvable) path, it's handed a `/proc/self/fd/<n>` reference to the fd already opened and verified via `openat2`, kept alive for the call's duration. That keeps GIO's metadata handling, progress reporting, and any reflink optimization completely untouched, while pinning what actually gets read to the exact object already checked — immune to the name being swapped afterward.
- The **destination** side stays on GIO throughout and needed no change: every call site here already writes to a private, freshly created staging name first and only becomes visible via the existing atomic `renameat2` commit, so it isn't exposed to the same class of race.
- Remote (GVfs) locations keep the existing path-based copy — explicit, not claiming an equivalent guarantee.
- Move's primary path is already a single atomic rename and needed no change; only its cross-filesystem fallback (when rename returns `WouldRecurse`) goes through this same hardened `copy_recursively`.

**One non-obvious wrinkle worth flagging for review:** `/proc/self/fd` entries are themselves reported as symlinks by `lstat`, so `NOFOLLOW_SYMLINKS` has to be dropped from the GIO copy call for the regular-file case specifically. Keeping it caused GIO to copy the magic-link's *target path text* as a new symlink instead of the file's actual bytes — caught immediately by the existing `moving_a_directory_falls_back_to_a_safe_copy_when_the_move_would_recurse` test, which started failing until this was found and fixed. Left a comment on that line explaining why.

## Visual evidence

N/A — this changes how local copies read the source tree internally; nothing in the UI changes. Two rounds of manual verification instead of screenshots (folder-listing screenshots of a copy operation don't show anything a picture can capture — the interesting part is on disk):

1. **Metadata preservation**: copied a folder where one file had unusual permissions (`754`) through the real app (Ctrl+C / Ctrl+V). The copy landed with `-rwxr-xr--` — exact match — confirming the `/proc/self/fd` handoff didn't regress GIO's metadata copying.
2. **Symlink safety**: copied a folder containing a symlink pointing outside the tree to a sentinel file, through the real app. Destination:
   ```
   to/source/nested/decoy -> .../outside-sentinel   (a real symlink, not a directory)
   ```
   `outside-sentinel/secret.txt` was never touched or duplicated into the destination.

New adversarial unit tests cover the same two scenarios (nested symlink, top-level symlink) deterministically.

## How to test

1. Create a folder containing a real subdirectory with a file, plus a symlink pointing somewhere outside that folder.
2. Copy it in Strata (Ctrl+C / Ctrl+V, or drag to another pane) into a new location.
3. Confirm the copy succeeds, the symlink is recreated as a symlink (not expanded into a real directory), and whatever it points to is untouched.
4. `cargo test` — `copy_recursively_does_not_follow_a_symlink_nested_inside_the_tree` and `copy_recursively_of_a_symlink_creates_a_symlink_not_a_recursive_copy`.

**Expected result:** a symlink anywhere in a copied tree is recreated as a symlink pointing at the same target, never followed into a real copy of its contents.

## Related issue

Related to #8 (copy half; delete covered by #253)