### PR TITLE
fix(operations): stop trusting stale types for replace/move cleanup

### DIFF
--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -565,6 +565,149 @@ fn permanently_delete(
     })
 }
 
+/// The outcome of resolving one delete target relative to its parent
+/// directory's file descriptor.
+enum LocalDeleteStep {
+    /// A non-directory entry (file, symlink, or other special file) that has
+    /// already been unlinked.
+    Removed,
+    /// A directory that was opened (not yet removed) along with its
+    /// immediate children, still to be deleted before the directory itself.
+    Directory {
+        handle: OwnedFd,
+        children: Vec<OsString>,
+    },
+}
+
+/// Inspects and, for non-directories, immediately deletes the entry named
+/// `name` inside `parent`. The type is re-read from disk here rather than
+/// trusted from any earlier listing, so a symlink swapped in for a
+/// directory is deleted as the symlink it now is instead of being opened as
+/// a directory.
+fn open_local_delete_target<Fd: AsFd>(
+    parent: &Fd,
+    name: &OsStr,
+) -> Result<LocalDeleteStep, String> {
+    let stat = rustix::fs::statat(parent, name, rustix::fs::AtFlags::SYMLINK_NOFOLLOW)
+        .map_err(|error| format!("Could not inspect {}: {error}", name.to_string_lossy()))?;
+    if !matches!(
+        rustix::fs::FileType::from_raw_mode(stat.st_mode),
+        rustix::fs::FileType::Directory
+    ) {
+        rustix::fs::unlinkat(parent, name, rustix::fs::AtFlags::empty())
+            .map_err(|error| format!("Could not delete {}: {error}", name.to_string_lossy()))?;
+        return Ok(LocalDeleteStep::Removed);
+    }
+    // RESOLVE_NO_SYMLINKS (stronger than O_NOFOLLOW) plus RESOLVE_BENEATH and
+    // RESOLVE_NO_MAGICLINKS: if `name` changed to a symlink (or a magic link)
+    // in the moment since the statat above, this fails closed instead of
+    // opening whatever it now points to.
+    let handle = rustix::fs::openat2(
+        parent,
+        name,
+        rustix::fs::OFlags::RDONLY | rustix::fs::OFlags::DIRECTORY | rustix::fs::OFlags::CLOEXEC,
+        rustix::fs::Mode::empty(),
+        rustix::fs::ResolveFlags::BENEATH
+            | rustix::fs::ResolveFlags::NO_SYMLINKS
+            | rustix::fs::ResolveFlags::NO_MAGICLINKS,
+    )
+    .map_err(|error| {
+        format!(
+            "{} changed while it was being deleted: {error}",
+            name.to_string_lossy()
+        )
+    })?;
+    let mut children = Vec::new();
+    for entry in rustix::fs::Dir::read_from(&handle).map_err(|error| error.to_string())? {
+        let entry = entry.map_err(|error| error.to_string())?;
+        let entry_name = entry.file_name();
+        if entry_name == c"." || entry_name == c".." {
+            continue;
+        }
+        children.push(OsString::from_vec(entry_name.to_bytes().to_vec()));
+    }
+    Ok(LocalDeleteStep::Directory { handle, children })
+}
+
+fn cancelled_local_delete() -> glib::Error {
+    glib::Error::new(gio::IOErrorEnum::Cancelled, "Delete cancelled")
+}
+
+async fn run_local_delete_step<T: Send + 'static>(
+    work: impl FnOnce() -> Result<T, String> + Send + 'static,
+) -> Result<T, glib::Error> {
+    gio::spawn_blocking(work)
+        .await
+        .map_err(|_| io_error("Delete task panicked"))?
+        .map_err(io_error)
+}
+
+/// Recursively and permanently deletes the entry named `name` inside
+/// `parent`, walking descriptor-relative to each already-open directory
+/// rather than re-resolving paths, so a component swapped out from under an
+/// in-progress delete cannot redirect it outside the tree it started in.
+fn permanently_delete_local(
+    parent: OwnedFd,
+    name: OsString,
+    cancellable: gio::Cancellable,
+) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>> {
+    Box::pin(async move {
+        if cancellable.is_cancelled() {
+            return Err(cancelled_local_delete());
+        }
+        let step_parent = parent.try_clone().map_err(io_error)?;
+        let step_name = name.clone();
+        let step =
+            run_local_delete_step(move || open_local_delete_target(&step_parent, &step_name))
+                .await?;
+        let LocalDeleteStep::Directory { handle, children } = step else {
+            return Ok(());
+        };
+        for child in children {
+            if cancellable.is_cancelled() {
+                return Err(cancelled_local_delete());
+            }
+            let child_parent = handle.try_clone().map_err(io_error)?;
+            permanently_delete_local(child_parent, child, cancellable.clone()).await?;
+        }
+        run_local_delete_step(move || {
+            rustix::fs::unlinkat(&parent, &name, rustix::fs::AtFlags::REMOVEDIR)
+                .map_err(|error| format!("Could not delete {}: {error}", name.to_string_lossy()))
+        })
+        .await
+    })
+}
+
+/// Entry point for permanently deleting a local path: opens the target's
+/// parent directory once, then hands off to the descriptor-relative walk in
+/// [`permanently_delete_local`] for everything below it.
+fn permanently_delete_local_path(
+    path: PathBuf,
+    cancellable: gio::Cancellable,
+) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>> {
+    Box::pin(async move {
+        let Some(parent_path) = path.parent().map(Path::to_path_buf) else {
+            return Err(io_error("Cannot permanently delete the filesystem root"));
+        };
+        let Some(name) = path.file_name().map(OsStr::to_os_string) else {
+            return Err(io_error("Invalid delete target"));
+        };
+        let parent = run_local_delete_step(move || {
+            rustix::fs::open(
+                &parent_path,
+                rustix::fs::OFlags::RDONLY
+                    | rustix::fs::OFlags::DIRECTORY
+                    | rustix::fs::OFlags::NOFOLLOW
+                    | rustix::fs::OFlags::CLOEXEC,
+                rustix::fs::Mode::empty(),
+            )
+            .map_err(|error| format!("Could not open {}: {error}", parent_path.display()))
+        })
+        .await?;
+        permanently_delete_local(parent, name, cancellable).await
+    })
+}
+
 fn operation_error_summary(errors: &[String], action: &str) -> String {
     let mut summary = format!(
         "{} could not be {action}. The remaining items were processed.",
@@ -1192,7 +1335,16 @@ impl OperationProvider for LocalOperationProvider {
                             },
                         )
                         .await
+                    } else if let Some(native_path) = entry.location.native_path() {
+                        permanently_delete_local_path(
+                            native_path.to_path_buf(),
+                            operation_cancellable.clone(),
+                        )
+                        .await
                     } else {
+                        // Remote (GVfs) locations have no local file descriptor to
+                        // walk against, so this falls back to the path-based
+                        // GIO delete rather than claiming an equivalent guarantee.
                         permanently_delete(
                             file,
                             entry.is_directory(),

--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -259,7 +259,7 @@ async fn copy_new_recursively(
     .await;
     if result.as_ref().is_err_and(was_cancelled) && created_root.get() {
         let cleanup = gio::Cancellable::new();
-        let _cleanup_result = permanently_delete(target, true, cleanup).await;
+        let _cleanup_result = permanently_delete_maybe_local(target, true, cleanup).await;
     }
     result
 }
@@ -282,7 +282,7 @@ async fn move_local_with(
     match result {
         Err(error) if error.matches(gio::IOErrorEnum::WouldRecurse) => {
             copy_new_recursively(source.clone(), target, cancellable.clone()).await?;
-            permanently_delete(source, true, cancellable).await
+            permanently_delete_maybe_local(source, true, cancellable).await
         }
         other => other,
     }
@@ -462,13 +462,14 @@ async fn replace_local_with(
     }
 
     if let Err(error) =
-        permanently_delete(staged_file, target_is_directory, gio::Cancellable::new()).await
+        permanently_delete_maybe_local(staged_file, target_is_directory, gio::Cancellable::new())
+            .await
     {
         discard_staged(staged).await;
         return Err(error);
     }
     if move_source {
-        permanently_delete(source, source_is_directory, cancellable).await?;
+        permanently_delete_maybe_local(source, source_is_directory, cancellable).await?;
     }
     Ok(())
 }
@@ -706,6 +707,26 @@ fn permanently_delete_local_path(
         .await?;
         permanently_delete_local(parent, name, cancellable).await
     })
+}
+
+/// Deletes `file` through the descriptor-relative local walk when it names a
+/// local path, or through the path-based GIO delete otherwise. Used for
+/// every permanent delete this module performs on the caller's behalf --
+/// not just the user-requested ones -- so that cleaning up a staged
+/// replacement's old target, or a move's now-copied source, gets the same
+/// race safety and doesn't act on whatever type that entry was earlier in
+/// the operation rather than what it actually is right before deletion.
+fn permanently_delete_maybe_local(
+    file: gio::File,
+    directory: bool,
+    cancellable: gio::Cancellable,
+) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>> {
+    if file.is_native()
+        && let Some(path) = file.path()
+    {
+        return permanently_delete_local_path(path, cancellable);
+    }
+    permanently_delete(file, directory, cancellable)
 }
 
 fn operation_error_summary(errors: &[String], action: &str) -> String {
@@ -1335,17 +1356,8 @@ impl OperationProvider for LocalOperationProvider {
                             },
                         )
                         .await
-                    } else if let Some(native_path) = entry.location.native_path() {
-                        permanently_delete_local_path(
-                            native_path.to_path_buf(),
-                            operation_cancellable.clone(),
-                        )
-                        .await
                     } else {
-                        // Remote (GVfs) locations have no local file descriptor to
-                        // walk against, so this falls back to the path-based
-                        // GIO delete rather than claiming an equivalent guarantee.
-                        permanently_delete(
+                        permanently_delete_maybe_local(
                             file,
                             entry.is_directory(),
                             operation_cancellable.clone(),

--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -254,6 +254,33 @@ fn open_local_copy_source<Fd: AsFd>(parent: &Fd, name: &OsStr) -> Result<LocalCo
     }
 }
 
+struct CreatedCopyRoot {
+    was_created: Cell<bool>,
+    identity: Cell<Option<LocalFileIdentity>>,
+}
+
+impl CreatedCopyRoot {
+    fn new() -> Self {
+        Self {
+            was_created: Cell::new(false),
+            identity: Cell::new(None),
+        }
+    }
+}
+
+async fn record_created_copy_root(
+    created_root: &Option<Rc<CreatedCopyRoot>>,
+    target: &gio::File,
+) -> Result<(), glib::Error> {
+    if let Some(created_root) = created_root {
+        created_root.was_created.set(true);
+        created_root
+            .identity
+            .set(local_file_identity(target).await?);
+    }
+    Ok(())
+}
+
 /// Recursively copies the entry named `name` inside `parent` to `target`,
 /// walking descriptor-relative to each already-open source directory
 /// instead of re-resolving paths, so a component swapped out from under an
@@ -267,7 +294,7 @@ fn copy_recursively_local(
     target: gio::File,
     overwrite_existing: bool,
     cancellable: gio::Cancellable,
-    created_root: Option<Rc<Cell<bool>>>,
+    created_root: Option<Rc<CreatedCopyRoot>>,
 ) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>> {
     Box::pin(async move {
         if cancellable.is_cancelled() {
@@ -332,9 +359,7 @@ fn copy_recursively_local(
                         );
                     })
                     .await?;
-                    if let Some(created_root) = &created_root {
-                        created_root.set(true);
-                    }
+                    record_created_copy_root(&created_root, &target).await?;
                 }
                 for child_name in children {
                     if cancellable.is_cancelled() {
@@ -366,7 +391,7 @@ fn copy_recursively_local_path(
     target: gio::File,
     overwrite_existing: bool,
     cancellable: gio::Cancellable,
-    created_root: Option<Rc<Cell<bool>>>,
+    created_root: Option<Rc<CreatedCopyRoot>>,
 ) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>> {
     Box::pin(async move {
         let Some(parent_path) = source_path.parent().map(Path::to_path_buf) else {
@@ -404,7 +429,7 @@ fn copy_recursively(
     target: gio::File,
     overwrite_existing: bool,
     cancellable: gio::Cancellable,
-    created_root: Option<Rc<Cell<bool>>>,
+    created_root: Option<Rc<CreatedCopyRoot>>,
 ) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>> {
     if source.is_native()
         && target.is_native()
@@ -442,9 +467,7 @@ fn copy_recursively(
                     );
                 })
                 .await?;
-                if let Some(created_root) = &created_root {
-                    created_root.set(true);
-                }
+                record_created_copy_root(&created_root, &target).await?;
             }
             let enumerator =
                 await_cancellable(&source, &cancellable, |source, cancellable, result| {
@@ -579,7 +602,7 @@ async fn copy_new_recursively(
         }
     }
 
-    let created_root = Rc::new(Cell::new(false));
+    let created_root = Rc::new(CreatedCopyRoot::new());
     let result = copy_recursively(
         source,
         target.clone(),
@@ -588,9 +611,15 @@ async fn copy_new_recursively(
         Some(created_root.clone()),
     )
     .await;
-    if result.as_ref().is_err_and(was_cancelled) && created_root.get() {
+    if result.as_ref().is_err_and(was_cancelled) && created_root.was_created.get() {
         let cleanup = gio::Cancellable::new();
-        let _cleanup_result = permanently_delete_maybe_local(target, true, cleanup).await;
+        let _cleanup_result = permanently_delete_maybe_local_if_unchanged(
+            target,
+            true,
+            created_root.identity.get(),
+            cleanup,
+        )
+        .await;
     }
     result
 }
@@ -609,11 +638,13 @@ async fn move_local_with(
     cancellable: gio::Cancellable,
     attempt_move: MoveAttempt,
 ) -> Result<(), glib::Error> {
+    let source_identity = local_file_identity(&source).await?;
     let result = attempt_move(source.clone(), target.clone(), cancellable.clone()).await;
     match result {
         Err(error) if error.matches(gio::IOErrorEnum::WouldRecurse) => {
             copy_new_recursively(source.clone(), target, cancellable.clone()).await?;
-            permanently_delete_maybe_local(source, true, cancellable).await
+            permanently_delete_maybe_local_if_unchanged(source, true, source_identity, cancellable)
+                .await
         }
         other => other,
     }
@@ -672,6 +703,13 @@ impl StagedSibling {
         match self {
             Self::File(path) => path,
             Self::Directory(directory) => directory.path(),
+        }
+    }
+
+    fn keep(self) -> io::Result<PathBuf> {
+        match self {
+            Self::File(path) => path.keep().map_err(|error| error.error),
+            Self::Directory(directory) => Ok(directory.keep()),
         }
     }
 }
@@ -750,6 +788,8 @@ async fn replace_local_with(
         ));
     }
 
+    let source_identity = local_file_identity(&source).await?;
+    let target_identity = local_file_identity(&target).await?;
     let staged = StagedSibling::create(parent, source_is_directory).map_err(io_error)?;
     let staged_file = gio::File::for_path(staged.path());
     if let Err(error) = copy_to_stage(
@@ -764,6 +804,10 @@ async fn replace_local_with(
         return Err(error);
     }
     if let Err(error) = cancellable.set_error_if_cancelled() {
+        discard_staged(staged).await;
+        return Err(error);
+    }
+    if let Err(error) = ensure_local_file_identity(&target, target_identity).await {
         discard_staged(staged).await;
         return Err(error);
     }
@@ -792,15 +836,22 @@ async fn replace_local_with(
         return Err(error);
     }
 
-    if let Err(error) =
-        permanently_delete_maybe_local(staged_file, target_is_directory, gio::Cancellable::new())
-            .await
-    {
-        discard_staged(staged).await;
-        return Err(error);
-    }
+    let staged_file = gio::File::for_path(staged.keep().map_err(io_error)?);
+    permanently_delete_maybe_local_if_unchanged(
+        staged_file,
+        target_is_directory,
+        target_identity,
+        gio::Cancellable::new(),
+    )
+    .await?;
     if move_source {
-        permanently_delete_maybe_local(source, source_is_directory, cancellable).await?;
+        permanently_delete_maybe_local_if_unchanged(
+            source,
+            source_is_directory,
+            source_identity,
+            cancellable,
+        )
+        .await?;
     }
     Ok(())
 }
@@ -911,6 +962,35 @@ enum LocalDeleteStep {
     },
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct LocalFileIdentity {
+    device: u64,
+    inode: u64,
+}
+
+impl LocalFileIdentity {
+    fn from_stat(stat: &rustix::fs::Stat) -> Self {
+        Self {
+            device: stat.st_dev,
+            inode: stat.st_ino,
+        }
+    }
+}
+
+fn ensure_expected_local_identity(
+    name: &OsStr,
+    stat: &rustix::fs::Stat,
+    expected: Option<LocalFileIdentity>,
+) -> Result<(), String> {
+    if expected.is_some_and(|expected| expected != LocalFileIdentity::from_stat(stat)) {
+        return Err(format!(
+            "{} changed while the operation was in progress",
+            name.to_string_lossy()
+        ));
+    }
+    Ok(())
+}
+
 /// Fails closed if an opened directory is no longer at its original name.
 fn ensure_local_delete_target_unchanged<ParentFd: AsFd, TargetFd: AsFd>(
     parent: &ParentFd,
@@ -942,9 +1022,11 @@ fn ensure_local_delete_target_unchanged<ParentFd: AsFd, TargetFd: AsFd>(
 fn open_local_delete_target<Fd: AsFd>(
     parent: &Fd,
     name: &OsStr,
+    expected: Option<LocalFileIdentity>,
 ) -> Result<LocalDeleteStep, String> {
     let stat = rustix::fs::statat(parent, name, rustix::fs::AtFlags::SYMLINK_NOFOLLOW)
         .map_err(|error| format!("Could not inspect {}: {error}", name.to_string_lossy()))?;
+    ensure_expected_local_identity(name, &stat, expected)?;
     if !matches!(
         rustix::fs::FileType::from_raw_mode(stat.st_mode),
         rustix::fs::FileType::Directory
@@ -972,6 +1054,9 @@ fn open_local_delete_target<Fd: AsFd>(
             name.to_string_lossy()
         )
     })?;
+    let opened = rustix::fs::fstat(&handle)
+        .map_err(|error| format!("Could not recheck {}: {error}", name.to_string_lossy()))?;
+    ensure_expected_local_identity(name, &opened, expected)?;
     let mut children = Vec::new();
     for entry in rustix::fs::Dir::read_from(&handle).map_err(|error| error.to_string())? {
         let entry = entry.map_err(|error| error.to_string())?;
@@ -1004,6 +1089,7 @@ async fn run_local_delete_step<T: Send + 'static>(
 fn permanently_delete_local(
     parent: OwnedFd,
     name: OsString,
+    expected: Option<LocalFileIdentity>,
     cancellable: gio::Cancellable,
 ) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>> {
     Box::pin(async move {
@@ -1012,9 +1098,10 @@ fn permanently_delete_local(
         }
         let step_parent = parent.try_clone().map_err(io_error)?;
         let step_name = name.clone();
-        let step =
-            run_local_delete_step(move || open_local_delete_target(&step_parent, &step_name))
-                .await?;
+        let step = run_local_delete_step(move || {
+            open_local_delete_target(&step_parent, &step_name, expected)
+        })
+        .await?;
         let LocalDeleteStep::Directory { handle, children } = step else {
             return Ok(());
         };
@@ -1034,7 +1121,7 @@ fn permanently_delete_local(
             })
             .await?;
             let child_parent = handle.try_clone().map_err(io_error)?;
-            permanently_delete_local(child_parent, child, cancellable.clone()).await?;
+            permanently_delete_local(child_parent, child, None, cancellable.clone()).await?;
         }
         run_local_delete_step(move || {
             ensure_local_delete_target_unchanged(&parent, &name, &handle)?;
@@ -1076,8 +1163,9 @@ fn open_local_delete_parent(parent_path: &Path) -> Result<OwnedFd, String> {
 /// Entry point for permanently deleting a local path: opens the target's
 /// parent directory once, then hands off to the descriptor-relative walk in
 /// [`permanently_delete_local`] for everything below it.
-fn permanently_delete_local_path(
+fn permanently_delete_local_path_if_unchanged(
     path: PathBuf,
+    expected: Option<LocalFileIdentity>,
     cancellable: gio::Cancellable,
 ) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>> {
     Box::pin(async move {
@@ -1088,8 +1176,44 @@ fn permanently_delete_local_path(
             return Err(io_error("Invalid delete target"));
         };
         let parent = run_local_delete_step(move || open_local_delete_parent(&parent_path)).await?;
-        permanently_delete_local(parent, name, cancellable).await
+        permanently_delete_local(parent, name, expected, cancellable).await
     })
+}
+
+async fn local_file_identity(file: &gio::File) -> Result<Option<LocalFileIdentity>, glib::Error> {
+    if !file.is_native() {
+        return Ok(None);
+    }
+    let Some(path) = file.path() else {
+        return Ok(None);
+    };
+    run_local_delete_step(move || {
+        let parent_path = path
+            .parent()
+            .ok_or_else(|| "Cannot inspect the filesystem root".to_owned())?;
+        let name = path
+            .file_name()
+            .ok_or_else(|| "Invalid local filesystem target".to_owned())?;
+        let parent = open_local_delete_parent(parent_path)?;
+        let stat = rustix::fs::statat(&parent, name, rustix::fs::AtFlags::SYMLINK_NOFOLLOW)
+            .map_err(|error| format!("Could not inspect {}: {error}", path.display()))?;
+        Ok(LocalFileIdentity::from_stat(&stat))
+    })
+    .await
+    .map(Some)
+}
+
+async fn ensure_local_file_identity(
+    file: &gio::File,
+    expected: Option<LocalFileIdentity>,
+) -> Result<(), glib::Error> {
+    let current = local_file_identity(file).await?;
+    if current != expected {
+        return Err(io_error(
+            "The target changed while the operation was in progress",
+        ));
+    }
+    Ok(())
 }
 
 /// Deletes `file` through the descriptor-relative local walk when it names a
@@ -1104,10 +1228,19 @@ fn permanently_delete_maybe_local(
     directory: bool,
     cancellable: gio::Cancellable,
 ) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>> {
+    permanently_delete_maybe_local_if_unchanged(file, directory, None, cancellable)
+}
+
+fn permanently_delete_maybe_local_if_unchanged(
+    file: gio::File,
+    directory: bool,
+    expected: Option<LocalFileIdentity>,
+    cancellable: gio::Cancellable,
+) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>> {
     if file.is_native()
         && let Some(path) = file.path()
     {
-        return permanently_delete_local_path(path, cancellable);
+        return permanently_delete_local_path_if_unchanged(path, expected, cancellable);
     }
     permanently_delete(file, directory, cancellable)
 }

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -24,7 +24,7 @@ use crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT;
 use super::{
     LocalOperationProvider, await_cancellable, copy_new_recursively, copy_recursively,
     deletion_error_message, deletion_error_summary, duplicate_candidate_name,
-    extract_7z_from_reader, extract_tar, extract_zip_from_archive, home_trash_entries_at,
+    extract_7z_from_reader, extract_tar, extract_zip_from_archive, home_trash_entries_at, io_error,
     is_trash_unsupported_failure, move_local_with, operation_error_summary, parse_copy_suffix,
     replace_local, replace_local_with, transfer_is_noop, validated_archive_path, validated_child,
     write_staged_archive,
@@ -556,6 +556,96 @@ fn staged_file_replacement_commits_then_removes_a_moved_source() -> Result<(), B
     assert!(!source.exists());
     assert_eq!(fs::read_dir(&root)?.count(), 1);
     fs::remove_dir_all(root)?;
+    Ok(())
+}
+
+#[test]
+fn replacement_move_does_not_delete_a_substituted_source() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let root = tempfile::tempdir()?;
+    let source = root.path().join("source.txt");
+    let original_source = root.path().join("original-source.txt");
+    let target = root.path().join("target.txt");
+    fs::write(&source, b"replacement")?;
+    fs::write(&target, b"original target")?;
+
+    let replaced_source = source.clone();
+    let new_source = source.clone();
+    let preserved_source = original_source.clone();
+    let result = glib::MainContext::default().block_on(replace_local_with(
+        gio::File::for_path(&source),
+        gio::File::for_path(&target),
+        true,
+        gio::Cancellable::new(),
+        None,
+        Rc::new(move |_, staged, _, _| {
+            let replaced_source = replaced_source.clone();
+            let new_source = new_source.clone();
+            let preserved_source = preserved_source.clone();
+            Box::pin(async move {
+                fs::write(staged.path().unwrap_or_default(), b"replacement").map_err(io_error)?;
+                fs::rename(replaced_source, preserved_source).map_err(io_error)?;
+                fs::write(new_source, b"new arrival").map_err(io_error)
+            })
+        }),
+    ));
+
+    let error = result.expect_err("a substituted source must fail identity validation");
+    assert!(error.to_string().contains("changed"), "{error}");
+    assert_eq!(fs::read(target)?, b"replacement");
+    assert_eq!(fs::read(source)?, b"new arrival");
+    assert_eq!(fs::read(original_source)?, b"replacement");
+    Ok(())
+}
+
+#[test]
+fn replacement_stops_before_exchanging_a_substituted_target() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let root = tempfile::tempdir()?;
+    let source = root.path().join("source.txt");
+    let target = root.path().join("target.txt");
+    let original_target = root.path().join("original-target.txt");
+    fs::write(&source, b"replacement")?;
+    fs::write(&target, b"original target")?;
+    let staged_path = Rc::new(RefCell::new(None));
+    let recorded_staged_path = staged_path.clone();
+    let replaced_target = target.clone();
+    let new_target = target.clone();
+    let preserved_target = original_target.clone();
+
+    let result = glib::MainContext::default().block_on(replace_local_with(
+        gio::File::for_path(&source),
+        gio::File::for_path(&target),
+        false,
+        gio::Cancellable::new(),
+        None,
+        Rc::new(move |_, staged, _, _| {
+            let staged = staged.path().unwrap_or_default();
+            *recorded_staged_path.borrow_mut() = Some(staged.clone());
+            let replaced_target = replaced_target.clone();
+            let new_target = new_target.clone();
+            let preserved_target = preserved_target.clone();
+            Box::pin(async move {
+                fs::write(&staged, b"replacement").map_err(io_error)?;
+                fs::rename(replaced_target, preserved_target).map_err(io_error)?;
+                fs::write(new_target, b"new arrival").map_err(io_error)
+            })
+        }),
+    ));
+
+    let error = result.expect_err("a substituted target must fail identity validation");
+    assert!(error.to_string().contains("changed"), "{error}");
+    assert_eq!(fs::read(target)?, b"new arrival");
+    assert_eq!(fs::read(original_target)?, b"original target");
+    let staged_path = staged_path
+        .borrow()
+        .clone()
+        .ok_or("the staging path was not recorded")?;
+    assert!(!staged_path.exists());
     Ok(())
 }
 

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -624,6 +624,55 @@ fn staged_directory_replacement_does_not_merge_old_contents() -> Result<(), Box<
     Ok(())
 }
 
+#[test]
+fn replacing_a_directory_cleans_up_a_symlink_in_the_old_contents_without_following_it()
+-> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("strata-replace-symlink-cleanup-test-{unique}"));
+    let source = root.join("source");
+    let target = root.join("target");
+    let outside = root.join("outside");
+    fs::create_dir_all(&source)?;
+    fs::write(source.join("item.txt"), b"new")?;
+    fs::create_dir_all(&target)?;
+    fs::write(target.join("keep.txt"), b"old")?;
+    fs::create_dir_all(&outside)?;
+    fs::write(outside.join("secret.txt"), b"do not delete me")?;
+    std::os::unix::fs::symlink(&outside, target.join("decoy"))?;
+
+    let result = glib::MainContext::default().block_on(replace_local(
+        gio::File::for_path(&source),
+        gio::File::for_path(&target),
+        false,
+        gio::Cancellable::new(),
+        None,
+    ));
+
+    assert!(result.is_ok(), "{result:?}");
+    assert_eq!(fs::read(target.join("item.txt"))?, b"new");
+    assert!(
+        !target.join("keep.txt").exists(),
+        "the replaced directory's old contents must be gone"
+    );
+    assert!(
+        !target.join("decoy").exists() && !target.join("decoy").is_symlink(),
+        "the old decoy symlink itself must be gone from the replaced directory"
+    );
+    assert_eq!(
+        fs::read(outside.join("secret.txt"))?,
+        b"do not delete me",
+        "cleaning up the old target must never follow a symlink it contained"
+    );
+
+    fs::remove_dir_all(root)?;
+    Ok(())
+}
+
 fn test_file_entry(path: &Path) -> FileEntry {
     let name = path.file_name().unwrap_or_default().to_os_string();
     FileEntry {

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -1144,6 +1144,104 @@ fn cancelling_recursive_copy_removes_only_its_staging_output() -> Result<(), Box
 }
 
 #[test]
+fn permanent_delete_removes_a_symlink_standing_in_for_a_directory_without_following_it()
+-> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_nanos();
+    let outside = std::env::temp_dir().join(format!("strata-delete-symlink-outside-{unique}"));
+    let decoy = std::env::temp_dir().join(format!("strata-delete-symlink-decoy-{unique}"));
+    fs::create_dir_all(&outside)?;
+    let sentinel = outside.join("sentinel.txt");
+    fs::write(&sentinel, b"do not delete me")?;
+    // `directory_entry` reports `kind: Directory` even though the entry is
+    // actually a symlink on disk, standing in for a `FileEntry` whose type
+    // went stale because the real directory was swapped for a symlink.
+    std::os::unix::fs::symlink(&outside, &decoy)?;
+
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let emitted = events.clone();
+    let _operation = LocalOperationProvider.delete(
+        DeleteRequest {
+            id: OperationRequestId(20),
+            entries: vec![directory_entry(&decoy)],
+            permanent: true,
+        },
+        Rc::new(move |event| emitted.borrow_mut().push(event)),
+    );
+    let context = glib::MainContext::default();
+    while !events
+        .borrow()
+        .iter()
+        .any(|event| matches!(event, OperationEvent::Deleted { .. }))
+    {
+        context.iteration(true);
+    }
+
+    assert!(
+        sentinel.exists(),
+        "deleting the symlink must never touch what it points to"
+    );
+    assert_eq!(fs::read_dir(&outside)?.count(), 1);
+    assert!(!decoy.exists() && !decoy.is_symlink());
+
+    fs::remove_dir_all(outside)?;
+    Ok(())
+}
+
+#[test]
+fn permanent_delete_does_not_follow_a_symlink_nested_inside_the_tree() -> Result<(), Box<dyn Error>>
+{
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("strata-delete-nested-symlink-test-{unique}"));
+    let outside = std::env::temp_dir().join(format!("strata-delete-nested-outside-{unique}"));
+    let nested = root.join("nested");
+    fs::create_dir_all(&nested)?;
+    fs::create_dir_all(&outside)?;
+    let sentinel = outside.join("sentinel.txt");
+    fs::write(&sentinel, b"do not delete me")?;
+    fs::write(nested.join("visible.txt"), b"contents")?;
+    std::os::unix::fs::symlink(&outside, nested.join("decoy"))?;
+
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let emitted = events.clone();
+    let _operation = LocalOperationProvider.delete(
+        DeleteRequest {
+            id: OperationRequestId(21),
+            entries: vec![directory_entry(&root)],
+            permanent: true,
+        },
+        Rc::new(move |event| emitted.borrow_mut().push(event)),
+    );
+    let context = glib::MainContext::default();
+    while !events
+        .borrow()
+        .iter()
+        .any(|event| matches!(event, OperationEvent::Deleted { .. }))
+    {
+        context.iteration(true);
+    }
+
+    assert!(
+        sentinel.exists(),
+        "a symlink nested inside the deleted tree must never lead outside it"
+    );
+    assert_eq!(fs::read_dir(&outside)?.count(), 1);
+    assert!(!root.exists());
+
+    fs::remove_dir_all(outside)?;
+    Ok(())
+}
+
+#[test]
 fn cancelling_recursive_delete_leaves_the_unfinished_root_in_place() -> Result<(), Box<dyn Error>> {
     let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
         .lock()


### PR DESCRIPTION
## Description

**Depends on #253** (not yet merged) — built directly on that branch since this needs `permanently_delete_local_path` from it. GitHub is showing #253's commits as part of this diff for now; once #253 merges into `main`, this PR's diff will automatically narrow to just the commits below. The actual new content of this PR is the last commit only.

Four internal cleanup deletes still called the old GIO-based `permanently_delete`, each deciding directory-vs-file from a type determined once, well before the (potentially slow) operation it was cleaning up after:

- `replace_local_with`, after the atomic exchange: deleting whatever the old target turns out to be, using `target_is_directory` computed before the copy-to-stage step.
- `replace_local_with`, `move_source` cleanup: deleting the original source after a successful replace-as-move, using `source_is_directory` from the same early check.
- `move_local_with`'s `WouldRecurse` fallback: deleting the source after a cross-filesystem copy finishes.
- `copy_new_recursively`'s cancellation cleanup.

All five `permanently_delete` call sites (these four, plus the user-facing delete request handler from #253) now go through a new shared `permanently_delete_maybe_local` helper — local paths get the descriptor-relative walk, which re-reads each entry's real type itself and never accepts a caller-supplied hint at all; remote (GVfs) locations keep the existing GIO delete. This also de-duplicates the local-vs-remote dispatch that was written inline in #253's delete handler.

**Worth being direct about what this does and doesn't demonstrate**, since I want to flag this for review rather than let the commit message undersell or oversell it: GIO's `NOFOLLOW_SYMLINKS` already made a symlink standing in for a tracked directory at these specific call sites fail safe — I added a test for exactly that (`replacing_a_directory_cleans_up_a_symlink_in_the_old_contents_without_following_it`) and confirmed by temporarily reverting one call site that it **passes against the pre-existing code too**. So this isn't closing a bug that test demonstrates.

What it actually buys is protection the old path-based approach structurally cannot offer, and that a static symlink-substitution test can't exercise: once a directory is opened as a descriptor, nothing that happens to its *name* afterward — unlink-and-recreate, rename, anything short of touching the open file itself — can redirect an already-open fd to something else. That's a property of what a file descriptor is, not something provable by a single-shot unit test. This change closes that gap at every internal cleanup site instead of only the one path a user's delete click reaches directly, and stops trusting a type hint (`target_is_directory`/`source_is_directory`) that may be stale by the time it's acted on — matching the issue's "avoid trusting stale type metadata for recursion decisions" criterion, even though these aren't literally `FileEntry` values.

## Visual evidence

N/A — internal cleanup path, no UI change. Manually verified the replace-with-conflict flow still works correctly end-to-end in the app: pasted a folder onto an existing same-named folder, chose Replace, confirmed the new content landed and the old content was fully cleaned up (`old-item.txt` gone, `item.txt` has the new content).

## How to test

1. `cargo test` — the new `replacing_a_directory_cleans_up_a_symlink_in_the_old_contents_without_following_it`, plus the existing `staged_directory_replacement_does_not_merge_old_contents` / `staged_file_replacement_*` tests, which continue to pass unchanged against the new dispatch.
2. In the app: paste a folder onto an existing same-named folder and choose Replace. Confirm the new content lands and old content is fully gone.

**Expected result:** no behavior change visible to the user; internal cleanup after replace/move now shares the same race-safe, type-revalidating delete as the user-facing one.

## Related issue

Related to #8 (closes the remaining "stale type" gap across delete/copy/replace cleanup paths)