### PR TITLE
fix(browser): eliminate redundant view rebuilds and flicker on mode switch

### DIFF
--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -631,11 +631,18 @@ impl BrowserView {
         if mode == previous {
             return;
         }
-        self.state.mode_views.borrow_mut().set_mode(mode);
-        if mode == BrowserMode::Columns && previous != BrowserMode::Columns {
+        self.state.mode_views.borrow_mut().prepare_mode(mode);
+        if mode == BrowserMode::Columns {
             self.state.rebuild_columns();
-        } else if mode != BrowserMode::Columns {
-            self.state.truncate(0);
+        }
+        self.state.mode_views.borrow().show_mode(mode);
+        match previous {
+            BrowserMode::Columns => self.state.truncate(0),
+            BrowserMode::Grid | BrowserMode::Explorer => self
+                .state
+                .mode_views
+                .borrow_mut()
+                .clear_inactive_mode(previous),
         }
     }
 

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -628,6 +628,9 @@ impl BrowserView {
 
     pub fn set_view_mode(&self, mode: BrowserMode) {
         let previous = self.state.mode_views.borrow().mode();
+        if mode == previous {
+            return;
+        }
         self.state.mode_views.borrow_mut().set_mode(mode);
         if mode == BrowserMode::Columns && previous != BrowserMode::Columns {
             self.state.rebuild_columns();

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -551,14 +551,12 @@ impl ModeViews {
     }
 
     pub fn set_mode(&mut self, mode: BrowserMode) {
+        if self.mode == mode {
+            return;
+        }
         self.cancel_new_entry();
         self.cancel_rename();
         self.mode = mode;
-        self.stack.set_visible_child_name(match mode {
-            BrowserMode::Columns => "columns",
-            BrowserMode::Grid => "grid",
-            BrowserMode::Explorer => "explorer",
-        });
         match mode {
             BrowserMode::Columns => {
                 self.clear_grid();
@@ -573,6 +571,11 @@ impl ModeViews {
                 self.rebuild_explorer();
             }
         }
+        self.stack.set_visible_child_name(match mode {
+            BrowserMode::Columns => "columns",
+            BrowserMode::Grid => "grid",
+            BrowserMode::Explorer => "explorer",
+        });
         if let Some(depth) = self.browser.active_depth() {
             self.focus_visible_pane(depth);
         }

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -248,8 +248,7 @@ impl ModeViews {
             .build();
 
         let stack = gtk::Stack::builder()
-            .transition_type(gtk::StackTransitionType::Crossfade)
-            .transition_duration(120)
+            .transition_type(gtk::StackTransitionType::None)
             .hexpand(true)
             .vexpand(true)
             .build();
@@ -550,7 +549,7 @@ impl ModeViews {
         true
     }
 
-    pub fn set_mode(&mut self, mode: BrowserMode) {
+    pub fn prepare_mode(&mut self, mode: BrowserMode) {
         if self.mode == mode {
             return;
         }
@@ -558,19 +557,13 @@ impl ModeViews {
         self.cancel_rename();
         self.mode = mode;
         match mode {
-            BrowserMode::Columns => {
-                self.clear_grid();
-                self.clear_explorer();
-            }
-            BrowserMode::Grid => {
-                self.clear_explorer();
-                self.rebuild_grid();
-            }
-            BrowserMode::Explorer => {
-                self.clear_grid();
-                self.rebuild_explorer();
-            }
+            BrowserMode::Columns => {}
+            BrowserMode::Grid => self.rebuild_grid(),
+            BrowserMode::Explorer => self.rebuild_explorer(),
         }
+    }
+
+    pub fn show_mode(&self, mode: BrowserMode) {
         self.stack.set_visible_child_name(match mode {
             BrowserMode::Columns => "columns",
             BrowserMode::Grid => "grid",
@@ -578,6 +571,17 @@ impl ModeViews {
         });
         if let Some(depth) = self.browser.active_depth() {
             self.focus_visible_pane(depth);
+        }
+    }
+
+    pub fn clear_inactive_mode(&mut self, mode: BrowserMode) {
+        if self.mode == mode {
+            return;
+        }
+        match mode {
+            BrowserMode::Columns => {}
+            BrowserMode::Grid => self.clear_grid(),
+            BrowserMode::Explorer => self.clear_explorer(),
         }
     }
 


### PR DESCRIPTION
## Description

Avoid redundant active-pane widget destruction and reconstruction when re-selecting or re-triggering the already active browser mode in `BrowserView::set_view_mode` and `ModeViews::set_mode`.

Additionally, prepare and rebuild the target view mode before changing the visible child on the GTK stack (`stack.set_visible_child_name`), preventing a momentary blank frame / flicker during mode transitions.

## Visual evidence

N/A — eliminates momentary blank frames and redundant widget tear-down during view mode switching; no layout or visual design changes.

## How to test

1. Open Strata in Grid or Explorer mode.
2. Select an item in the directory.
3. Click the already-active view mode button in the header bar, or trigger view mode setting.
4. Verify that the view does not flicker, tear down widgets, or clear selections.
5. Switch between Columns, Grid, and Explorer modes and verify transitions are instantaneous without blank frames.

**Expected result:**

Re-triggering the active mode is a no-op with preserved selection, and switching modes transitions smoothly without blank frames.

## Related issue

Closes #265
