### PR TITLE
perf(thumbnails): smart viewport lookahead for near-instant rendering

### DIFF
--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -3725,10 +3725,12 @@ impl ViewState {
         self.mode_views.borrow_mut().handle(&event);
         match event {
             BrowserEvent::Reset => {
+                super::thumbnail::clear_lookahead();
                 self.pending_location_credentials.take();
                 self.truncate(0);
             }
             BrowserEvent::ColumnsTruncated { len } => {
+                super::thumbnail::clear_lookahead();
                 self.truncate(len);
                 self.sync_active_location();
             }
@@ -3762,6 +3764,7 @@ impl ViewState {
                 }
             }
             BrowserEvent::EntriesReplaced { depth, entries } => {
+                super::thumbnail::clear_lookahead();
                 if self.mode_views.borrow().mode() == BrowserMode::Columns
                     && let Some(column) = self.columns.borrow().get(depth).cloned()
                 {
@@ -4681,6 +4684,7 @@ impl ViewState {
         let source_for_bind = model.clone();
         let filtered_for_bind = filtered_model.clone();
         let weak_state_for_bind = Rc::downgrade(self);
+        let lookahead = ColumnLookaheadTracker::default();
         factory.connect_bind(move |_, item| {
             let Some(item) = item.downcast_ref::<gtk::ListItem>() else {
                 return;
@@ -4743,6 +4747,15 @@ impl ViewState {
                 super::thumbnail::set_thumbnail_or_icon(&icon, entry, entry_icon(entry), 17, 17);
                 icon.set_opacity(if entry.is_directory() { 1.0 } else { 0.72 });
                 chevron.set_visible(entry.is_directory());
+                schedule_column_viewport_lookahead(
+                    &weak_state_for_bind,
+                    depth,
+                    &source_for_bind,
+                    &filtered_for_bind,
+                    item.position(),
+                    &lookahead,
+                    17,
+                );
             } else {
                 super::thumbnail::show_fallback_icon(&icon, crate::assets::icons::DOCUMENTS, 17);
                 icon.set_opacity(0.72);
@@ -5401,6 +5414,80 @@ fn source_positions_for_filtered(
             None
         })
         .collect()
+}
+
+#[derive(Clone, Default)]
+struct ColumnLookaheadTracker {
+    last_position: Rc<Cell<Option<u32>>>,
+    pending_idle: Rc<Cell<bool>>,
+}
+
+const COLUMN_LOOKAHEAD_COUNT: usize = 16;
+
+fn schedule_column_viewport_lookahead(
+    state: &std::rc::Weak<ViewState>,
+    depth: usize,
+    source: &gtk::StringList,
+    filtered: &gtk::FilterListModel,
+    bound_position: u32,
+    tracker: &ColumnLookaheadTracker,
+    thumbnail_size: i32,
+) {
+    let previous = tracker.last_position.get();
+    let scrolling_down = previous.is_none_or(|prev| bound_position >= prev);
+    tracker.last_position.set(Some(bound_position));
+
+    if tracker.pending_idle.get() {
+        return;
+    }
+    tracker.pending_idle.set(true);
+
+    let state = state.clone();
+    let source = source.clone();
+    let filtered = filtered.clone();
+    let last_pos = tracker.last_position.clone();
+    let pending = tracker.pending_idle.clone();
+
+    glib::idle_add_local_once(move || {
+        pending.set(false);
+        let Some(current_position) = last_pos.get() else {
+            return;
+        };
+        let Some(state) = state.upgrade() else {
+            return;
+        };
+
+        let total_items = filtered.n_items();
+        let mut entries = Vec::with_capacity(COLUMN_LOOKAHEAD_COUNT);
+        if scrolling_down {
+            let start = current_position.saturating_add(1);
+            let end = (current_position
+                .saturating_add(1)
+                .saturating_add(COLUMN_LOOKAHEAD_COUNT as u32))
+            .min(total_items);
+            for pos in start..end {
+                if let Some(src_pos) = source_position_for_filtered(&source, &filtered, pos)
+                    && let Some(entry) = state.browser.entry_at(depth, src_pos)
+                {
+                    entries.push(entry);
+                }
+            }
+        } else {
+            let start = current_position.saturating_sub(COLUMN_LOOKAHEAD_COUNT as u32);
+            let end = current_position;
+            for pos in (start..end).rev() {
+                if let Some(src_pos) = source_position_for_filtered(&source, &filtered, pos)
+                    && let Some(entry) = state.browser.entry_at(depth, src_pos)
+                {
+                    entries.push(entry);
+                }
+            }
+        }
+
+        if !entries.is_empty() {
+            super::thumbnail::update_lookahead(&entries, thumbnail_size);
+        }
+    });
 }
 
 fn set_column_selection(column: &ColumnView, position: u32) {

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -551,6 +551,7 @@ impl ModeViews {
     }
 
     pub fn set_mode(&mut self, mode: BrowserMode) {
+        super::thumbnail::clear_lookahead();
         self.cancel_new_entry();
         self.cancel_rename();
         self.mode = mode;
@@ -1522,6 +1523,7 @@ fn build_grid_view(
     let cuts_for_bind = context.cuts.clone();
     let thumbnail_size_for_bind = context.thumbnail_size.clone();
     let entry_kind_for_bind = context.new_entry_is_directory.clone();
+    let lookahead = ViewportLookaheadTracker::default();
     factory.connect_bind(move |_, item| {
         let Some(item) = item.downcast_ref::<gtk::ListItem>() else {
             return;
@@ -1563,6 +1565,15 @@ fn build_grid_view(
                 thumbnail_size_for_bind.get(),
             );
             icon.set_opacity(if entry.is_directory() { 1.0 } else { 0.72 });
+            schedule_viewport_lookahead(
+                &browser_for_bind,
+                depth,
+                &source_for_bind,
+                &filtered_for_bind,
+                item.position(),
+                &lookahead,
+                thumbnail_size_for_bind.get(),
+            );
         } else {
             card.remove_css_class("cut-item");
             let icon_name = if entry_kind_for_bind.get() {
@@ -2234,6 +2245,7 @@ fn build_explorer_pane(
     let view_model_for_bind = view_model_object.clone();
     let cuts_for_bind = cut_locations.clone();
     let entry_kind_for_bind = new_entry_is_directory.clone();
+    let lookahead = ViewportLookaheadTracker::default();
     factory.connect_bind(move |_, item| {
         let Some(item) = item.downcast_ref::<gtk::ListItem>() else {
             return;
@@ -2285,6 +2297,15 @@ fn build_explorer_pane(
             size.set_label(&entry_size(&entry));
             kind.set_label(entry_type(&entry));
             crate::util::set_modified_date(&modified, Some(&entry), "—");
+            schedule_viewport_lookahead(
+                &browser_for_bind,
+                depth,
+                &source_for_bind,
+                &view_model_for_bind,
+                item.position(),
+                &lookahead,
+                18,
+            );
         } else {
             row.remove_css_class("cut-item");
             let icon_name = if entry_kind_for_bind.get() {
@@ -2799,6 +2820,80 @@ fn view_position_for_source(
     let item = source.item(position as u32)?;
     (0..filtered.n_items())
         .find(|candidate| filtered.item(*candidate).is_some_and(|value| value == item))
+}
+
+#[derive(Clone, Default)]
+struct ViewportLookaheadTracker {
+    last_position: Rc<Cell<Option<u32>>>,
+    pending_idle: Rc<Cell<bool>>,
+}
+
+const LOOKAHEAD_COUNT: usize = 16;
+
+fn schedule_viewport_lookahead(
+    browser: &Weak<Browser>,
+    depth: usize,
+    source: &gtk::StringList,
+    filtered: &gio::ListModel,
+    bound_position: u32,
+    tracker: &ViewportLookaheadTracker,
+    thumbnail_size: i32,
+) {
+    let previous = tracker.last_position.get();
+    let scrolling_down = previous.is_none_or(|prev| bound_position >= prev);
+    tracker.last_position.set(Some(bound_position));
+
+    if tracker.pending_idle.get() {
+        return;
+    }
+    tracker.pending_idle.set(true);
+
+    let browser = browser.clone();
+    let source = source.clone();
+    let filtered = filtered.clone();
+    let last_pos = tracker.last_position.clone();
+    let pending = tracker.pending_idle.clone();
+
+    glib::idle_add_local_once(move || {
+        pending.set(false);
+        let Some(current_position) = last_pos.get() else {
+            return;
+        };
+        let Some(browser) = browser.upgrade() else {
+            return;
+        };
+
+        let total_items = filtered.n_items();
+        let mut entries = Vec::with_capacity(LOOKAHEAD_COUNT);
+        if scrolling_down {
+            let start = current_position.saturating_add(1);
+            let end = (current_position
+                .saturating_add(1)
+                .saturating_add(LOOKAHEAD_COUNT as u32))
+            .min(total_items);
+            for pos in start..end {
+                if let Some(src_pos) = source_position_for_view(&source, Some(&filtered), pos)
+                    && let Some(entry) = browser.entry_at(depth, src_pos)
+                {
+                    entries.push(entry);
+                }
+            }
+        } else {
+            let start = current_position.saturating_sub(LOOKAHEAD_COUNT as u32);
+            let end = current_position;
+            for pos in (start..end).rev() {
+                if let Some(src_pos) = source_position_for_view(&source, Some(&filtered), pos)
+                    && let Some(entry) = browser.entry_at(depth, src_pos)
+                {
+                    entries.push(entry);
+                }
+            }
+        }
+
+        if !entries.is_empty() {
+            super::thumbnail::update_lookahead(&entries, thumbnail_size);
+        }
+    });
 }
 
 fn install_preview_click(

--- a/src/ui/thumbnail.rs
+++ b/src/ui/thumbnail.rs
@@ -20,6 +20,7 @@ const MAX_CACHE_ENTRIES: usize = 256;
 const MAX_CACHE_BYTES: usize = 64 * 1024 * 1024;
 const MAX_THUMBNAIL_WORKERS: usize = 1;
 const MAX_QUEUED_THUMBNAILS: usize = 64;
+const MAX_LOOKAHEAD_ITEMS: usize = 16;
 const FAILED_THUMBNAIL_TTL: Duration = Duration::from_secs(30);
 
 thread_local! {
@@ -147,28 +148,87 @@ impl CachedThumbnail {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ThumbnailPriority {
+    High,
+    Low,
+}
+
 #[derive(Default)]
 struct ThumbnailQueue {
     running: usize,
     queued: VecDeque<ThumbnailKey>,
+    low_priority: VecDeque<ThumbnailKey>,
 }
 
 impl ThumbnailQueue {
+    #[cfg(test)]
     fn enqueue(&mut self, key: ThumbnailKey) -> bool {
-        if self.queued.len() >= MAX_QUEUED_THUMBNAILS {
-            return false;
+        self.enqueue_with_priority(key, ThumbnailPriority::High)
+    }
+
+    fn enqueue_with_priority(&mut self, key: ThumbnailKey, priority: ThumbnailPriority) -> bool {
+        match priority {
+            ThumbnailPriority::High => {
+                if self.queued.contains(&key) {
+                    return true;
+                }
+                if let Some(pos) = self
+                    .low_priority
+                    .iter()
+                    .position(|candidate| candidate == &key)
+                {
+                    if let Some(key) = self.low_priority.remove(pos) {
+                        self.queued.push_back(key);
+                    }
+                    return true;
+                }
+                if self.queued.len() >= MAX_QUEUED_THUMBNAILS {
+                    return false;
+                }
+                self.queued.push_back(key);
+                true
+            }
+            ThumbnailPriority::Low => {
+                if self.queued.contains(&key) || self.low_priority.contains(&key) {
+                    return true;
+                }
+                if self.low_priority.len() >= MAX_LOOKAHEAD_ITEMS {
+                    return false;
+                }
+                if self.queued.len() + self.low_priority.len() >= MAX_QUEUED_THUMBNAILS {
+                    return false;
+                }
+                self.low_priority.push_back(key);
+                true
+            }
         }
-        self.queued.push_back(key);
-        true
+    }
+
+    fn promote(&mut self, key: &ThumbnailKey) {
+        if let Some(pos) = self
+            .low_priority
+            .iter()
+            .position(|candidate| candidate == key)
+            && let Some(key) = self.low_priority.remove(pos)
+        {
+            self.queued.push_back(key);
+        }
     }
 
     fn begin_next(&mut self) -> Option<ThumbnailKey> {
         if self.running >= MAX_THUMBNAIL_WORKERS {
             return None;
         }
-        let key = self.queued.pop_front()?;
-        self.running += 1;
-        Some(key)
+        if let Some(key) = self.queued.pop_front() {
+            self.running += 1;
+            return Some(key);
+        }
+        if let Some(key) = self.low_priority.pop_front() {
+            self.running += 1;
+            return Some(key);
+        }
+        None
     }
 
     fn finish(&mut self) {
@@ -177,6 +237,11 @@ impl ThumbnailQueue {
 
     fn cancel(&mut self, key: &ThumbnailKey) {
         self.queued.retain(|queued| queued != key);
+        self.low_priority.retain(|queued| queued != key);
+    }
+
+    fn clear_low_priority(&mut self) -> Vec<ThumbnailKey> {
+        self.low_priority.drain(..).collect()
     }
 }
 
@@ -226,6 +291,90 @@ pub(super) fn set_thumbnail_or_icon_for_path(
         icon_size,
         thumbnail_size,
     );
+}
+
+pub(super) fn update_lookahead(entries: &[FileEntry], thumbnail_size: i32) {
+    let thumbnail_size = thumbnail_size.clamp(16, 256);
+    let pruned = THUMBNAIL_QUEUE.with(|queue| queue.borrow_mut().clear_low_priority());
+    PENDING_THUMBNAILS.with(|pending| {
+        let mut pending = pending.borrow_mut();
+        for key in pruned {
+            if pending
+                .get(&key)
+                .is_some_and(|item| item.targets.is_empty())
+            {
+                pending.remove(&key);
+            }
+        }
+    });
+
+    for entry in entries.iter().take(MAX_LOOKAHEAD_ITEMS) {
+        let Some(path) = entry.location.native_path() else {
+            continue;
+        };
+        let Some(kind) = thumbnail_kind(path) else {
+            continue;
+        };
+        let key = ThumbnailKey {
+            path: path.to_path_buf(),
+            modified: known_metadata(&entry.modified_unix_seconds),
+            file_size: known_metadata(&entry.size),
+            thumbnail_size,
+        };
+
+        let is_cached = THUMBNAIL_CACHE.with(|cache| cache.borrow_mut().get(&key).is_some());
+        if is_cached {
+            continue;
+        }
+
+        PENDING_THUMBNAILS.with(|pending| {
+            let mut pending = pending.borrow_mut();
+            if pending.contains_key(&key) {
+                return;
+            }
+            let queued = THUMBNAIL_QUEUE.with(|queue| {
+                queue
+                    .borrow_mut()
+                    .enqueue_with_priority(key.clone(), ThumbnailPriority::Low)
+            });
+            if queued {
+                pending.insert(
+                    key.clone(),
+                    PendingThumbnail {
+                        id: NEXT_REQUEST.fetch_add(1, Ordering::Relaxed),
+                        kind,
+                        cancellation: Cancellation::default(),
+                        targets: Vec::new(),
+                    },
+                );
+            }
+        });
+    }
+
+    start_thumbnail_jobs();
+}
+
+pub(super) fn clear_lookahead() {
+    let pruned = THUMBNAIL_QUEUE.with(|queue| queue.borrow_mut().clear_low_priority());
+    PENDING_THUMBNAILS.with(|pending| {
+        let mut pending = pending.borrow_mut();
+        for key in pruned {
+            if pending
+                .get(&key)
+                .is_some_and(|item| item.targets.is_empty())
+            {
+                pending.remove(&key);
+            }
+        }
+        pending.retain(|_, item| {
+            if item.targets.is_empty() {
+                item.cancellation.cancel();
+                false
+            } else {
+                true
+            }
+        });
+    });
 }
 
 fn set_thumbnail_for_path(
@@ -301,9 +450,14 @@ fn schedule_thumbnail(key: ThumbnailKey, kind: ThumbnailKind, target: PendingTar
         let mut pending = pending.borrow_mut();
         if let Some(pending) = pending.get_mut(&key) {
             pending.targets.push(target);
+            THUMBNAIL_QUEUE.with(|queue| queue.borrow_mut().promote(&key));
             true
         } else {
-            let queued = THUMBNAIL_QUEUE.with(|queue| queue.borrow_mut().enqueue(key.clone()));
+            let queued = THUMBNAIL_QUEUE.with(|queue| {
+                queue
+                    .borrow_mut()
+                    .enqueue_with_priority(key.clone(), ThumbnailPriority::High)
+            });
             if queued {
                 pending.insert(
                     key.clone(),
@@ -531,10 +685,11 @@ fn cancel_thumbnail(image_id: usize) {
         let mut pending = pending.borrow_mut();
         let mut cancelled = Vec::new();
         pending.retain(|key, thumbnail| {
+            let had_targets = !thumbnail.targets.is_empty();
             thumbnail
                 .targets
                 .retain(|target| target.image_id != image_id);
-            if thumbnail.targets.is_empty() {
+            if had_targets && thumbnail.targets.is_empty() {
                 thumbnail.cancellation.cancel();
                 cancelled.push(key.clone());
                 false

--- a/src/ui/thumbnail/tests.rs
+++ b/src/ui/thumbnail/tests.rs
@@ -9,10 +9,11 @@ use gtk::glib;
 
 use super::{
     ACTIVE_REQUESTS, ActiveRequest, CacheHit, CachedThumbnail, MAX_CACHE_ENTRIES,
-    MAX_QUEUED_THUMBNAILS, MAX_THUMBNAIL_WORKERS, PENDING_THUMBNAILS, PendingTarget,
-    PendingThumbnail, THUMBNAIL_QUEUE, ThumbnailCache, ThumbnailKey, ThumbnailKind, ThumbnailQueue,
-    cancel_thumbnail, finish_thumbnail_targets, retry_deferred_thumbnail, schedule_or_defer,
-    take_pending_targets, thumbnail_kind,
+    MAX_LOOKAHEAD_ITEMS, MAX_QUEUED_THUMBNAILS, MAX_THUMBNAIL_WORKERS, PENDING_THUMBNAILS,
+    PendingTarget, PendingThumbnail, THUMBNAIL_QUEUE, ThumbnailCache, ThumbnailKey, ThumbnailKind,
+    ThumbnailPriority, ThumbnailQueue, cancel_thumbnail, clear_lookahead, finish_thumbnail_targets,
+    retry_deferred_thumbnail, schedule_or_defer, take_pending_targets, thumbnail_kind,
+    update_lookahead,
 };
 
 fn key(index: usize) -> ThumbnailKey {
@@ -259,4 +260,154 @@ fn failed_thumbnails_expire_and_share_the_cache_bound() {
 fn rejects_files_without_a_thumbnail_provider() {
     assert_eq!(thumbnail_kind(Path::new("README.md")), None);
     assert_eq!(thumbnail_kind(Path::new("no-extension")), None);
+}
+
+fn test_entry(index: usize) -> crate::model::FileEntry {
+    let name = format!("photo-{index}.png");
+    crate::model::FileEntry {
+        location: crate::model::Location::local(PathBuf::from(&name)),
+        native_name: std::ffi::OsString::from(&name),
+        display_name: name,
+        kind: crate::model::EntryKind::File,
+        size: crate::model::MetadataValue::Known(100),
+        modified_unix_seconds: crate::model::MetadataValue::Known(1),
+        is_hidden: false,
+    }
+}
+
+#[test]
+fn high_priority_thumbnails_run_before_low_priority_lookahead() {
+    let mut queue = ThumbnailQueue::default();
+    assert!(queue.enqueue_with_priority(key(1), ThumbnailPriority::Low));
+    assert!(queue.enqueue_with_priority(key(2), ThumbnailPriority::Low));
+    assert!(queue.enqueue_with_priority(key(99), ThumbnailPriority::High));
+
+    let first = queue.begin_next();
+    assert_eq!(first, Some(key(99)));
+    queue.finish();
+
+    let second = queue.begin_next();
+    assert_eq!(second, Some(key(1)));
+    queue.finish();
+
+    let third = queue.begin_next();
+    assert_eq!(third, Some(key(2)));
+    queue.finish();
+
+    assert!(queue.begin_next().is_none());
+}
+
+#[test]
+fn lookahead_item_promoted_when_live_target_is_scheduled() {
+    let mut queue = ThumbnailQueue::default();
+    assert!(queue.enqueue_with_priority(key(5), ThumbnailPriority::Low));
+    assert!(queue.low_priority.contains(&key(5)));
+    assert!(!queue.queued.contains(&key(5)));
+
+    queue.promote(&key(5));
+    assert!(!queue.low_priority.contains(&key(5)));
+    assert!(queue.queued.contains(&key(5)));
+}
+
+#[test]
+fn lookahead_queue_bounds_speculative_items() {
+    let mut queue = ThumbnailQueue::default();
+    for index in 0..MAX_LOOKAHEAD_ITEMS {
+        assert!(queue.enqueue_with_priority(key(index), ThumbnailPriority::Low));
+    }
+    assert!(!queue.enqueue_with_priority(key(MAX_LOOKAHEAD_ITEMS), ThumbnailPriority::Low));
+}
+
+#[test]
+fn update_lookahead_clears_unstarted_speculative_items() {
+    PENDING_THUMBNAILS.with(|pending| pending.borrow_mut().clear());
+    THUMBNAIL_QUEUE.with(|queue| {
+        queue.borrow_mut().queued.clear();
+        queue.borrow_mut().low_priority.clear();
+    });
+
+    let first_batch = vec![test_entry(1), test_entry(2)];
+    update_lookahead(&first_batch, 64);
+
+    let key1 = ThumbnailKey {
+        path: PathBuf::from("photo-1.png"),
+        modified: Some(1),
+        file_size: Some(100),
+        thumbnail_size: 64,
+    };
+    let key2 = ThumbnailKey {
+        path: PathBuf::from("photo-2.png"),
+        modified: Some(1),
+        file_size: Some(100),
+        thumbnail_size: 64,
+    };
+    let key3 = ThumbnailKey {
+        path: PathBuf::from("photo-3.png"),
+        modified: Some(1),
+        file_size: Some(100),
+        thumbnail_size: 64,
+    };
+
+    PENDING_THUMBNAILS.with(|pending| {
+        let pending = pending.borrow();
+        assert!(pending.contains_key(&key1));
+        assert!(pending.contains_key(&key2));
+    });
+
+    let second_batch = vec![test_entry(3)];
+    update_lookahead(&second_batch, 64);
+
+    PENDING_THUMBNAILS.with(|pending| {
+        let pending = pending.borrow();
+        assert!(!pending.contains_key(&key2));
+        assert!(pending.contains_key(&key3));
+    });
+
+    clear_lookahead();
+    PENDING_THUMBNAILS.with(|pending| {
+        assert!(pending.borrow().is_empty());
+    });
+    THUMBNAIL_QUEUE.with(|queue| {
+        assert!(queue.borrow().low_priority.is_empty());
+    });
+}
+
+#[test]
+fn cancel_thumbnail_does_not_cancel_unrelated_lookahead_jobs() {
+    PENDING_THUMBNAILS.with(|pending| pending.borrow_mut().clear());
+    THUMBNAIL_QUEUE.with(|queue| {
+        queue.borrow_mut().queued.clear();
+        queue.borrow_mut().low_priority.clear();
+    });
+
+    let lookahead_key = key(42);
+    PENDING_THUMBNAILS.with(|pending| {
+        pending.borrow_mut().insert(
+            lookahead_key.clone(),
+            PendingThumbnail {
+                id: 100,
+                kind: ThumbnailKind::Image,
+                cancellation: crate::sandbox::Cancellation::default(),
+                targets: Vec::new(),
+            },
+        );
+    });
+    THUMBNAIL_QUEUE.with(|queue| {
+        assert!(
+            queue
+                .borrow_mut()
+                .enqueue_with_priority(lookahead_key.clone(), ThumbnailPriority::Low)
+        );
+    });
+
+    cancel_thumbnail(999);
+
+    PENDING_THUMBNAILS.with(|pending| {
+        assert!(pending.borrow().contains_key(&lookahead_key));
+        pending.borrow_mut().clear();
+    });
+    THUMBNAIL_QUEUE.with(|queue| {
+        assert!(queue.borrow().low_priority.contains(&lookahead_key));
+        queue.borrow_mut().low_priority.clear();
+    });
 }


### PR DESCRIPTION
## Description

Implement smart viewport lookahead for thumbnails to make scrolling feel near-instant while keeping the queue strictly bounded and responsive.

- Extended the thumbnail worker queue with a two-tier priority system (`High` for visible items, `Low` for speculative lookahead).
- Visible items always run first; lookahead items are processed only when the high-priority queue is idle.
- If a low-priority lookahead item scrolls into the visible viewport, it is immediately promoted to high priority and attached to the live widget target.
- Enqueue up to 16 items immediately following the scroll boundary in Grid, List, and Miller column views via debounced GLib idle scheduling.
- Prune unstarted low-priority jobs whenever the lookahead window shifts or the directory/view mode changes, avoiding backlog build-up.

## Visual evidence

N/A (Performance and scheduling optimization with no new UI elements)

## How to test

1. Open a directory containing many image and video files in Grid or List view.
2. Scroll down smoothly through the list.
3. Observe that thumbnails in the upcoming scroll boundary render ahead of time and display immediately when scrolled into view, without lagging or blocking visible item renders.
4. Fast-scroll or switch view modes / directories to verify lookahead queue clears and does not perform stale background work.

**Expected result:**
Thumbnails ahead of the scroll position render proactively without stalling visible items, and stale lookahead tasks are cleared on viewport changes.

## Related issue

Closes #267
