### PR TITLE
feat(transfer): allow copy and paste in same folder with duplicate renaming

### DIFF
--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -71,34 +71,45 @@ fn transfer_is_noop(source: &gio::File, destination: &gio::File, target: &gio::F
     source.equal(target) || source.equal(destination) || destination.has_prefix(source)
 }
 
-fn parse_copy_suffix(stem: &str) -> (&str, Option<u64>) {
-    if let Some(base) = stem.strip_suffix(" copy") {
-        return (base, Some(1));
+fn parse_copy_suffix(stem: &OsStr) -> (&OsStr, Option<u64>) {
+    let bytes = stem.as_bytes();
+    if let Some(base) = bytes.strip_suffix(b" copy") {
+        return (OsStr::from_bytes(base), Some(1));
     }
-    if let Some((prefix, suffix)) = stem.rsplit_once(" copy ")
-        && !suffix.is_empty()
-        && !suffix.starts_with('0')
-        && suffix.chars().all(|c| c.is_ascii_digit())
-        && let Ok(n) = suffix.parse::<u64>()
-        && n >= 1
+    if let Some(separator) = bytes
+        .windows(b" copy ".len())
+        .rposition(|window| window == b" copy ")
     {
-        return (prefix, Some(n));
+        let suffix = &bytes[separator + b" copy ".len()..];
+        if !suffix.is_empty()
+            && suffix[0] != b'0'
+            && suffix.iter().all(u8::is_ascii_digit)
+            && let Ok(suffix) = std::str::from_utf8(suffix)
+            && let Ok(number) = suffix.parse::<u64>()
+            && number < u64::MAX
+        {
+            return (OsStr::from_bytes(&bytes[..separator]), Some(number));
+        }
     }
     (stem, None)
 }
 
-fn duplicate_candidate_name(base_stem: &str, extension: Option<&str>, copy_number: u64) -> String {
-    if copy_number <= 1 {
-        match extension {
-            Some(ext) => format!("{base_stem} copy.{ext}"),
-            None => format!("{base_stem} copy"),
-        }
-    } else {
-        match extension {
-            Some(ext) => format!("{base_stem} copy {copy_number}.{ext}"),
-            None => format!("{base_stem} copy {copy_number}"),
-        }
+fn duplicate_candidate_name(
+    base_stem: &OsStr,
+    extension: Option<&OsStr>,
+    copy_number: u64,
+) -> OsString {
+    let mut candidate = base_stem.as_bytes().to_vec();
+    candidate.extend_from_slice(b" copy");
+    if copy_number > 1 {
+        candidate.push(b' ');
+        candidate.extend_from_slice(copy_number.to_string().as_bytes());
     }
+    if let Some(extension) = extension {
+        candidate.push(b'.');
+        candidate.extend_from_slice(extension.as_bytes());
+    }
+    OsString::from_vec(candidate)
 }
 
 fn duplicate_target(
@@ -108,26 +119,17 @@ fn duplicate_target(
     cancellable: &gio::Cancellable,
 ) -> Result<gio::File, glib::Error> {
     cancellable.set_error_if_cancelled()?;
-    let name_str = name.to_string_lossy();
+    let name = name.as_os_str();
     let (stem, extension) = if is_directory {
-        (name_str.as_ref(), None)
+        (name, None)
     } else {
-        let ext = name
-            .extension()
-            .and_then(|e| e.to_str())
-            .filter(|e| !e.is_empty());
-        let stem = name
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or(name_str.as_ref());
-        (stem, ext)
+        let path = Path::new(name);
+        let extension = path.extension().filter(|extension| !extension.is_empty());
+        (path.file_stem().unwrap_or(name), extension)
     };
     let (base_stem, copy_num) = parse_copy_suffix(stem);
-    let start_index = match copy_num {
-        Some(n) => n + 1,
-        None => 1,
-    };
-    for index in start_index..u64::MAX {
+    let start_index = copy_num.map_or(1, |number| number + 1);
+    for index in start_index..=u64::MAX {
         cancellable.set_error_if_cancelled()?;
         let candidate_name = duplicate_candidate_name(base_stem, extension, index);
         let candidate = destination.child(&candidate_name);

--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -71,6 +71,73 @@ fn transfer_is_noop(source: &gio::File, destination: &gio::File, target: &gio::F
     source.equal(target) || source.equal(destination) || destination.has_prefix(source)
 }
 
+fn parse_copy_suffix(stem: &str) -> (&str, Option<u64>) {
+    if let Some(base) = stem.strip_suffix(" copy") {
+        return (base, Some(1));
+    }
+    if let Some((prefix, suffix)) = stem.rsplit_once(" copy ")
+        && !suffix.is_empty()
+        && !suffix.starts_with('0')
+        && suffix.chars().all(|c| c.is_ascii_digit())
+        && let Ok(n) = suffix.parse::<u64>()
+        && n >= 1
+    {
+        return (prefix, Some(n));
+    }
+    (stem, None)
+}
+
+fn duplicate_candidate_name(base_stem: &str, extension: Option<&str>, copy_number: u64) -> String {
+    if copy_number <= 1 {
+        match extension {
+            Some(ext) => format!("{base_stem} copy.{ext}"),
+            None => format!("{base_stem} copy"),
+        }
+    } else {
+        match extension {
+            Some(ext) => format!("{base_stem} copy {copy_number}.{ext}"),
+            None => format!("{base_stem} copy {copy_number}"),
+        }
+    }
+}
+
+fn duplicate_target(
+    destination: &gio::File,
+    name: &Path,
+    is_directory: bool,
+    cancellable: &gio::Cancellable,
+) -> Result<gio::File, glib::Error> {
+    cancellable.set_error_if_cancelled()?;
+    let name_str = name.to_string_lossy();
+    let (stem, extension) = if is_directory {
+        (name_str.as_ref(), None)
+    } else {
+        let ext = name
+            .extension()
+            .and_then(|e| e.to_str())
+            .filter(|e| !e.is_empty());
+        let stem = name
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or(name_str.as_ref());
+        (stem, ext)
+    };
+    let (base_stem, copy_num) = parse_copy_suffix(stem);
+    let start_index = match copy_num {
+        Some(n) => n + 1,
+        None => 1,
+    };
+    for index in start_index..u64::MAX {
+        cancellable.set_error_if_cancelled()?;
+        let candidate_name = duplicate_candidate_name(base_stem, extension, index);
+        let candidate = destination.child(&candidate_name);
+        if !candidate.query_exists(Some(cancellable)) {
+            return Ok(candidate);
+        }
+    }
+    Err(io_error("Could not find an unused duplicate name"))
+}
+
 fn was_cancelled(error: &glib::Error) -> bool {
     error.matches(gio::IOErrorEnum::Cancelled)
 }
@@ -1074,8 +1141,9 @@ impl OperationProvider for LocalOperationProvider {
                     });
                     return;
                 };
-                let target = destination.child(name);
-                if transfer_is_noop(&source, &destination, &target) {
+                let default_target = destination.child(&name);
+                let is_duplicate = !request.move_sources && source.equal(&default_target);
+                if !is_duplicate && transfer_is_noop(&source, &destination, &default_target) {
                     completed.push(item.source.clone());
                     emit(OperationEvent::TransferProgress {
                         request_id: request.id,
@@ -1084,11 +1152,84 @@ impl OperationProvider for LocalOperationProvider {
                     });
                     continue;
                 }
+                let target = if is_duplicate {
+                    let is_directory = match await_cancellable(
+                        &source,
+                        &operation_cancellable,
+                        |source, cancellable, result| {
+                            source.query_info_async(
+                                "standard::type",
+                                gio::FileQueryInfoFlags::NOFOLLOW_SYMLINKS,
+                                glib::Priority::DEFAULT,
+                                Some(cancellable),
+                                move |output| result.resolve(output),
+                            );
+                        },
+                    )
+                    .await
+                    {
+                        Ok(info) => info.file_type() == gio::FileType::Directory,
+                        Err(error) => {
+                            if was_cancelled(&error) {
+                                emit(cancelled_event(
+                                    request.id,
+                                    completed,
+                                    vec![item.source.clone()],
+                                    request.items[index + 1..]
+                                        .iter()
+                                        .map(|item| item.source.clone())
+                                        .collect(),
+                                    affected_locations,
+                                ));
+                                return;
+                            }
+                            emit(OperationEvent::TransferFailed {
+                                request_id: request.id,
+                                completed_locations: completed,
+                                message: error.to_string(),
+                            });
+                            return;
+                        }
+                    };
+                    match duplicate_target(
+                        &destination,
+                        &name,
+                        is_directory,
+                        &operation_cancellable,
+                    ) {
+                        Ok(target) => target,
+                        Err(error) => {
+                            if was_cancelled(&error) {
+                                emit(cancelled_event(
+                                    request.id,
+                                    completed,
+                                    vec![item.source.clone()],
+                                    request.items[index + 1..]
+                                        .iter()
+                                        .map(|item| item.source.clone())
+                                        .collect(),
+                                    affected_locations,
+                                ));
+                                return;
+                            }
+                            emit(OperationEvent::TransferFailed {
+                                request_id: request.id,
+                                completed_locations: completed,
+                                message: error.to_string(),
+                            });
+                            return;
+                        }
+                    }
+                } else {
+                    default_target
+                };
                 affected_locations.insert(item.source.clone());
                 if let Some(target) = location_for_file(&target) {
                     affected_locations.insert(target);
                 }
-                let result = if item.conflict == TransferConflict::ReplaceExisting {
+                let result = if is_duplicate {
+                    copy_new_recursively(source, target, operation_cancellable.clone()).await
+                } else if item.conflict == TransferConflict::ReplaceExisting {
                     replace_local(
                         source,
                         target,

--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -73,14 +73,12 @@ fn transfer_is_noop(source: &gio::File, destination: &gio::File, target: &gio::F
 
 fn parse_copy_suffix(stem: &OsStr) -> (&OsStr, Option<u64>) {
     let bytes = stem.as_bytes();
-    if let Some(base) = bytes.strip_suffix(b" copy") {
-        return (OsStr::from_bytes(base), Some(1));
-    }
-    if let Some(separator) = bytes
-        .windows(b" copy ".len())
-        .rposition(|window| window == b" copy ")
+    if let Some(without_closing_parenthesis) = bytes.strip_suffix(b")")
+        && let Some(separator) = without_closing_parenthesis
+            .windows(b" (".len())
+            .rposition(|window| window == b" (")
     {
-        let suffix = &bytes[separator + b" copy ".len()..];
+        let suffix = &without_closing_parenthesis[separator + b" (".len()..];
         if !suffix.is_empty()
             && suffix[0] != b'0'
             && suffix.iter().all(u8::is_ascii_digit)
@@ -100,11 +98,9 @@ fn duplicate_candidate_name(
     copy_number: u64,
 ) -> OsString {
     let mut candidate = base_stem.as_bytes().to_vec();
-    candidate.extend_from_slice(b" copy");
-    if copy_number > 1 {
-        candidate.push(b' ');
-        candidate.extend_from_slice(copy_number.to_string().as_bytes());
-    }
+    candidate.extend_from_slice(b" (");
+    candidate.extend_from_slice(copy_number.to_string().as_bytes());
+    candidate.push(b')');
     if let Some(extension) = extension {
         candidate.push(b'.');
         candidate.extend_from_slice(extension.as_bytes());

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -1407,58 +1407,54 @@ fn copy_suffix_parsing_and_candidate_naming() {
         (OsStr::new("name"), None)
     );
     assert_eq!(
-        parse_copy_suffix(OsStr::new("name copy")),
+        parse_copy_suffix(OsStr::new("name (1)")),
         (OsStr::new("name"), Some(1))
     );
     assert_eq!(
-        parse_copy_suffix(OsStr::new("name copy 2")),
+        parse_copy_suffix(OsStr::new("name (2)")),
         (OsStr::new("name"), Some(2))
     );
     assert_eq!(
-        parse_copy_suffix(OsStr::new("name copy 42")),
+        parse_copy_suffix(OsStr::new("name (42)")),
         (OsStr::new("name"), Some(42))
     );
     assert_eq!(
-        parse_copy_suffix(OsStr::new("name copy foo")),
-        (OsStr::new("name copy foo"), None)
+        parse_copy_suffix(OsStr::new("name (foo)")),
+        (OsStr::new("name (foo)"), None)
     );
     assert_eq!(
-        parse_copy_suffix(OsStr::new("name copy 0")),
-        (OsStr::new("name copy 0"), None)
+        parse_copy_suffix(OsStr::new("name (0)")),
+        (OsStr::new("name (0)"), None)
     );
     assert_eq!(
-        parse_copy_suffix(OsStr::new("copy")),
-        (OsStr::new("copy"), None)
+        parse_copy_suffix(OsStr::new("name (2")),
+        (OsStr::new("name (2"), None)
     );
     assert_eq!(
-        parse_copy_suffix(OsStr::new("copy 2")),
-        (OsStr::new("copy 2"), None)
-    );
-    assert_eq!(
-        parse_copy_suffix(OsStr::new("name copy 18446744073709551615")),
-        (OsStr::new("name copy 18446744073709551615"), None)
+        parse_copy_suffix(OsStr::new("name (18446744073709551615)")),
+        (OsStr::new("name (18446744073709551615)"), None)
     );
 
     assert_eq!(
         duplicate_candidate_name(OsStr::new("name"), Some(OsStr::new("ext")), 1),
-        OsString::from("name copy.ext")
+        OsString::from("name (1).ext")
     );
     assert_eq!(
         duplicate_candidate_name(OsStr::new("name"), Some(OsStr::new("ext")), 2),
-        OsString::from("name copy 2.ext")
+        OsString::from("name (2).ext")
     );
     assert_eq!(
         duplicate_candidate_name(OsStr::new("name"), None, 1),
-        OsString::from("name copy")
+        OsString::from("name (1)")
     );
     assert_eq!(
         duplicate_candidate_name(OsStr::new("name"), None, 2),
-        OsString::from("name copy 2")
+        OsString::from("name (2)")
     );
 }
 
 #[test]
-fn duplicating_a_file_generates_name_copy_ext() -> Result<(), Box<dyn Error>> {
+fn duplicating_a_file_generates_numbered_name() -> Result<(), Box<dyn Error>> {
     let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
         .lock()
         .map_err(|error| error.to_string())?;
@@ -1497,7 +1493,7 @@ fn duplicating_a_file_generates_name_copy_ext() -> Result<(), Box<dyn Error>> {
     ));
     assert!(source.exists());
     assert_eq!(fs::read(&source)?, b"original-content");
-    let duplicate = destination.join("photo copy.jpg");
+    let duplicate = destination.join("photo (1).jpg");
     assert!(duplicate.exists());
     assert_eq!(fs::read(&duplicate)?, b"original-content");
     Ok(())
@@ -1542,20 +1538,20 @@ fn duplicating_a_file_preserves_non_utf8_name_bytes() -> Result<(), Box<dyn Erro
         events.borrow().last(),
         Some(OperationEvent::Pasted { .. })
     ));
-    let duplicate_name = OsString::from_vec(b"photo-\xff copy.jpg".to_vec());
+    let duplicate_name = OsString::from_vec(b"photo-\xff (1).jpg".to_vec());
     let duplicate = destination.join(duplicate_name);
     assert_eq!(fs::read(duplicate)?, b"original-content");
     Ok(())
 }
 
 #[test]
-fn duplicating_an_existing_name_copy_ext_generates_name_copy_2_ext() -> Result<(), Box<dyn Error>> {
+fn duplicating_an_existing_numbered_name_advances_its_index() -> Result<(), Box<dyn Error>> {
     let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
         .lock()
         .map_err(|error| error.to_string())?;
     let root = tempfile::tempdir()?;
     let destination = root.path().to_path_buf();
-    let source = destination.join("photo copy.jpg");
+    let source = destination.join("photo (1).jpg");
     fs::write(&source, b"copy-content")?;
 
     let events = Rc::new(RefCell::new(Vec::new()));
@@ -1588,14 +1584,15 @@ fn duplicating_an_existing_name_copy_ext_generates_name_copy_2_ext() -> Result<(
     ));
     assert!(source.exists());
     assert_eq!(fs::read(&source)?, b"copy-content");
-    let duplicate = destination.join("photo copy 2.jpg");
+    let duplicate = destination.join("photo (2).jpg");
     assert!(duplicate.exists());
     assert_eq!(fs::read(&duplicate)?, b"copy-content");
     Ok(())
 }
 
 #[test]
-fn duplicating_file_with_existing_copy_advances_to_next_copy_index() -> Result<(), Box<dyn Error>> {
+fn duplicating_file_with_existing_numbered_name_advances_to_next_index()
+-> Result<(), Box<dyn Error>> {
     let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
         .lock()
         .map_err(|error| error.to_string())?;
@@ -1603,7 +1600,7 @@ fn duplicating_file_with_existing_copy_advances_to_next_copy_index() -> Result<(
     let destination = root.path().to_path_buf();
     let source = destination.join("photo.jpg");
     fs::write(&source, b"original")?;
-    fs::write(destination.join("photo copy.jpg"), b"first copy")?;
+    fs::write(destination.join("photo (1).jpg"), b"first copy")?;
 
     let events = Rc::new(RefCell::new(Vec::new()));
     let emitted = events.clone();
@@ -1633,13 +1630,13 @@ fn duplicating_file_with_existing_copy_advances_to_next_copy_index() -> Result<(
         events.borrow().last(),
         Some(OperationEvent::Pasted { .. })
     ));
-    assert_eq!(fs::read(destination.join("photo copy 2.jpg"))?, b"original");
-    assert_eq!(fs::read(destination.join("photo copy.jpg"))?, b"first copy");
+    assert_eq!(fs::read(destination.join("photo (2).jpg"))?, b"original");
+    assert_eq!(fs::read(destination.join("photo (1).jpg"))?, b"first copy");
     Ok(())
 }
 
 #[test]
-fn duplicating_a_directory_generates_name_copy() -> Result<(), Box<dyn Error>> {
+fn duplicating_a_directory_generates_numbered_name() -> Result<(), Box<dyn Error>> {
     let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
         .lock()
         .map_err(|error| error.to_string())?;
@@ -1678,7 +1675,7 @@ fn duplicating_a_directory_generates_name_copy() -> Result<(), Box<dyn Error>> {
         Some(OperationEvent::Pasted { .. })
     ));
     assert!(source.is_dir());
-    let duplicate = destination.join("documents copy");
+    let duplicate = destination.join("documents (1)");
     assert!(duplicate.is_dir());
     assert_eq!(fs::read(duplicate.join("notes.txt"))?, b"nested-file");
     Ok(())
@@ -1732,7 +1729,7 @@ fn cutting_in_the_same_folder_remains_a_noop() -> Result<(), Box<dyn Error>> {
     ));
     assert!(file.exists());
     assert!(directory.is_dir());
-    assert!(!destination.join("document copy.txt").exists());
-    assert!(!destination.join("folder copy").exists());
+    assert!(!destination.join("document (1).txt").exists());
+    assert!(!destination.join("folder (1)").exists());
     Ok(())
 }

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -4,10 +4,10 @@ use std::{
     cell::{Cell, RefCell},
     collections::HashSet,
     error::Error,
-    ffi::OsString,
+    ffi::{OsStr, OsString},
     fs,
     io::{Cursor, Write},
-    os::unix::fs::PermissionsExt,
+    os::unix::{ffi::OsStringExt, fs::PermissionsExt},
     path::Path,
     rc::Rc,
     sync::{
@@ -1402,25 +1402,59 @@ fn cancelling_restore_before_io_reports_every_item_as_unattempted() -> Result<()
 
 #[test]
 fn copy_suffix_parsing_and_candidate_naming() {
-    assert_eq!(parse_copy_suffix("name"), ("name", None));
-    assert_eq!(parse_copy_suffix("name copy"), ("name", Some(1)));
-    assert_eq!(parse_copy_suffix("name copy 2"), ("name", Some(2)));
-    assert_eq!(parse_copy_suffix("name copy 42"), ("name", Some(42)));
-    assert_eq!(parse_copy_suffix("name copy foo"), ("name copy foo", None));
-    assert_eq!(parse_copy_suffix("name copy 0"), ("name copy 0", None));
-    assert_eq!(parse_copy_suffix("copy"), ("copy", None));
-    assert_eq!(parse_copy_suffix("copy 2"), ("copy 2", None));
+    assert_eq!(
+        parse_copy_suffix(OsStr::new("name")),
+        (OsStr::new("name"), None)
+    );
+    assert_eq!(
+        parse_copy_suffix(OsStr::new("name copy")),
+        (OsStr::new("name"), Some(1))
+    );
+    assert_eq!(
+        parse_copy_suffix(OsStr::new("name copy 2")),
+        (OsStr::new("name"), Some(2))
+    );
+    assert_eq!(
+        parse_copy_suffix(OsStr::new("name copy 42")),
+        (OsStr::new("name"), Some(42))
+    );
+    assert_eq!(
+        parse_copy_suffix(OsStr::new("name copy foo")),
+        (OsStr::new("name copy foo"), None)
+    );
+    assert_eq!(
+        parse_copy_suffix(OsStr::new("name copy 0")),
+        (OsStr::new("name copy 0"), None)
+    );
+    assert_eq!(
+        parse_copy_suffix(OsStr::new("copy")),
+        (OsStr::new("copy"), None)
+    );
+    assert_eq!(
+        parse_copy_suffix(OsStr::new("copy 2")),
+        (OsStr::new("copy 2"), None)
+    );
+    assert_eq!(
+        parse_copy_suffix(OsStr::new("name copy 18446744073709551615")),
+        (OsStr::new("name copy 18446744073709551615"), None)
+    );
 
     assert_eq!(
-        duplicate_candidate_name("name", Some("ext"), 1),
-        "name copy.ext"
+        duplicate_candidate_name(OsStr::new("name"), Some(OsStr::new("ext")), 1),
+        OsString::from("name copy.ext")
     );
     assert_eq!(
-        duplicate_candidate_name("name", Some("ext"), 2),
-        "name copy 2.ext"
+        duplicate_candidate_name(OsStr::new("name"), Some(OsStr::new("ext")), 2),
+        OsString::from("name copy 2.ext")
     );
-    assert_eq!(duplicate_candidate_name("name", None, 1), "name copy");
-    assert_eq!(duplicate_candidate_name("name", None, 2), "name copy 2");
+    assert_eq!(
+        duplicate_candidate_name(OsStr::new("name"), None, 1),
+        OsString::from("name copy")
+    );
+    assert_eq!(
+        duplicate_candidate_name(OsStr::new("name"), None, 2),
+        OsString::from("name copy 2")
+    );
 }
 
 #[test]
@@ -1466,6 +1500,51 @@ fn duplicating_a_file_generates_name_copy_ext() -> Result<(), Box<dyn Error>> {
     let duplicate = destination.join("photo copy.jpg");
     assert!(duplicate.exists());
     assert_eq!(fs::read(&duplicate)?, b"original-content");
+    Ok(())
+}
+
+#[test]
+fn duplicating_a_file_preserves_non_utf8_name_bytes() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let root = tempfile::tempdir()?;
+    let destination = root.path().to_path_buf();
+    let source_name = OsString::from_vec(b"photo-\xff.jpg".to_vec());
+    let source = destination.join(&source_name);
+    fs::write(&source, b"original-content")?;
+
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let emitted = events.clone();
+    let _operation = LocalOperationProvider.paste(
+        PasteRequest {
+            id: OperationRequestId(15),
+            destination: Location::local(&destination),
+            items: vec![PasteItem {
+                source: Location::local(&source),
+                conflict: TransferConflict::FailIfExists,
+            }],
+            move_sources: false,
+        },
+        Rc::new(move |event| emitted.borrow_mut().push(event)),
+    );
+
+    while !events.borrow().iter().any(|event| {
+        matches!(
+            event,
+            OperationEvent::Pasted { .. } | OperationEvent::TransferFailed { .. }
+        )
+    }) {
+        glib::MainContext::default().iteration(true);
+    }
+
+    assert!(matches!(
+        events.borrow().last(),
+        Some(OperationEvent::Pasted { .. })
+    ));
+    let duplicate_name = OsString::from_vec(b"photo-\xff copy.jpg".to_vec());
+    let duplicate = destination.join(duplicate_name);
+    assert_eq!(fs::read(duplicate)?, b"original-content");
     Ok(())
 }
 

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -23,10 +23,11 @@ use crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT;
 
 use super::{
     LocalOperationProvider, await_cancellable, copy_new_recursively, copy_recursively,
-    deletion_error_message, deletion_error_summary, extract_7z_from_reader, extract_tar,
-    extract_zip_from_archive, home_trash_entries_at, is_trash_unsupported_failure, move_local_with,
-    operation_error_summary, replace_local, replace_local_with, transfer_is_noop,
-    validated_archive_path, validated_child, write_staged_archive,
+    deletion_error_message, deletion_error_summary, duplicate_candidate_name,
+    extract_7z_from_reader, extract_tar, extract_zip_from_archive, home_trash_entries_at,
+    is_trash_unsupported_failure, move_local_with, operation_error_summary, parse_copy_suffix,
+    replace_local, replace_local_with, transfer_is_noop, validated_archive_path, validated_child,
+    write_staged_archive,
 };
 use crate::{
     model::{EntryKind, FileEntry, Location, MetadataValue},
@@ -1396,5 +1397,263 @@ fn cancelling_restore_before_io_reports_every_item_as_unattempted() -> Result<()
                 && result.failed.is_empty()
                 && result.not_attempted == [entries[0].location.clone()]
     ));
+    Ok(())
+}
+
+#[test]
+fn copy_suffix_parsing_and_candidate_naming() {
+    assert_eq!(parse_copy_suffix("name"), ("name", None));
+    assert_eq!(parse_copy_suffix("name copy"), ("name", Some(1)));
+    assert_eq!(parse_copy_suffix("name copy 2"), ("name", Some(2)));
+    assert_eq!(parse_copy_suffix("name copy 42"), ("name", Some(42)));
+    assert_eq!(parse_copy_suffix("name copy foo"), ("name copy foo", None));
+    assert_eq!(parse_copy_suffix("name copy 0"), ("name copy 0", None));
+    assert_eq!(parse_copy_suffix("copy"), ("copy", None));
+    assert_eq!(parse_copy_suffix("copy 2"), ("copy 2", None));
+
+    assert_eq!(
+        duplicate_candidate_name("name", Some("ext"), 1),
+        "name copy.ext"
+    );
+    assert_eq!(
+        duplicate_candidate_name("name", Some("ext"), 2),
+        "name copy 2.ext"
+    );
+    assert_eq!(duplicate_candidate_name("name", None, 1), "name copy");
+    assert_eq!(duplicate_candidate_name("name", None, 2), "name copy 2");
+}
+
+#[test]
+fn duplicating_a_file_generates_name_copy_ext() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let root = tempfile::tempdir()?;
+    let destination = root.path().to_path_buf();
+    let source = destination.join("photo.jpg");
+    fs::write(&source, b"original-content")?;
+
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let emitted = events.clone();
+    let _operation = LocalOperationProvider.paste(
+        PasteRequest {
+            id: OperationRequestId(10),
+            destination: Location::local(&destination),
+            items: vec![PasteItem {
+                source: Location::local(&source),
+                conflict: TransferConflict::FailIfExists,
+            }],
+            move_sources: false,
+        },
+        Rc::new(move |event| emitted.borrow_mut().push(event)),
+    );
+
+    while !events.borrow().iter().any(|event| {
+        matches!(
+            event,
+            OperationEvent::Pasted { .. } | OperationEvent::TransferFailed { .. }
+        )
+    }) {
+        glib::MainContext::default().iteration(true);
+    }
+
+    assert!(matches!(
+        events.borrow().last(),
+        Some(OperationEvent::Pasted { .. })
+    ));
+    assert!(source.exists());
+    assert_eq!(fs::read(&source)?, b"original-content");
+    let duplicate = destination.join("photo copy.jpg");
+    assert!(duplicate.exists());
+    assert_eq!(fs::read(&duplicate)?, b"original-content");
+    Ok(())
+}
+
+#[test]
+fn duplicating_an_existing_name_copy_ext_generates_name_copy_2_ext() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let root = tempfile::tempdir()?;
+    let destination = root.path().to_path_buf();
+    let source = destination.join("photo copy.jpg");
+    fs::write(&source, b"copy-content")?;
+
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let emitted = events.clone();
+    let _operation = LocalOperationProvider.paste(
+        PasteRequest {
+            id: OperationRequestId(11),
+            destination: Location::local(&destination),
+            items: vec![PasteItem {
+                source: Location::local(&source),
+                conflict: TransferConflict::FailIfExists,
+            }],
+            move_sources: false,
+        },
+        Rc::new(move |event| emitted.borrow_mut().push(event)),
+    );
+
+    while !events.borrow().iter().any(|event| {
+        matches!(
+            event,
+            OperationEvent::Pasted { .. } | OperationEvent::TransferFailed { .. }
+        )
+    }) {
+        glib::MainContext::default().iteration(true);
+    }
+
+    assert!(matches!(
+        events.borrow().last(),
+        Some(OperationEvent::Pasted { .. })
+    ));
+    assert!(source.exists());
+    assert_eq!(fs::read(&source)?, b"copy-content");
+    let duplicate = destination.join("photo copy 2.jpg");
+    assert!(duplicate.exists());
+    assert_eq!(fs::read(&duplicate)?, b"copy-content");
+    Ok(())
+}
+
+#[test]
+fn duplicating_file_with_existing_copy_advances_to_next_copy_index() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let root = tempfile::tempdir()?;
+    let destination = root.path().to_path_buf();
+    let source = destination.join("photo.jpg");
+    fs::write(&source, b"original")?;
+    fs::write(destination.join("photo copy.jpg"), b"first copy")?;
+
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let emitted = events.clone();
+    let _operation = LocalOperationProvider.paste(
+        PasteRequest {
+            id: OperationRequestId(12),
+            destination: Location::local(&destination),
+            items: vec![PasteItem {
+                source: Location::local(&source),
+                conflict: TransferConflict::FailIfExists,
+            }],
+            move_sources: false,
+        },
+        Rc::new(move |event| emitted.borrow_mut().push(event)),
+    );
+
+    while !events.borrow().iter().any(|event| {
+        matches!(
+            event,
+            OperationEvent::Pasted { .. } | OperationEvent::TransferFailed { .. }
+        )
+    }) {
+        glib::MainContext::default().iteration(true);
+    }
+
+    assert!(matches!(
+        events.borrow().last(),
+        Some(OperationEvent::Pasted { .. })
+    ));
+    assert_eq!(fs::read(destination.join("photo copy 2.jpg"))?, b"original");
+    assert_eq!(fs::read(destination.join("photo copy.jpg"))?, b"first copy");
+    Ok(())
+}
+
+#[test]
+fn duplicating_a_directory_generates_name_copy() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let root = tempfile::tempdir()?;
+    let destination = root.path().to_path_buf();
+    let source = destination.join("documents");
+    fs::create_dir_all(&source)?;
+    fs::write(source.join("notes.txt"), b"nested-file")?;
+
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let emitted = events.clone();
+    let _operation = LocalOperationProvider.paste(
+        PasteRequest {
+            id: OperationRequestId(13),
+            destination: Location::local(&destination),
+            items: vec![PasteItem {
+                source: Location::local(&source),
+                conflict: TransferConflict::FailIfExists,
+            }],
+            move_sources: false,
+        },
+        Rc::new(move |event| emitted.borrow_mut().push(event)),
+    );
+
+    while !events.borrow().iter().any(|event| {
+        matches!(
+            event,
+            OperationEvent::Pasted { .. } | OperationEvent::TransferFailed { .. }
+        )
+    }) {
+        glib::MainContext::default().iteration(true);
+    }
+
+    assert!(matches!(
+        events.borrow().last(),
+        Some(OperationEvent::Pasted { .. })
+    ));
+    assert!(source.is_dir());
+    let duplicate = destination.join("documents copy");
+    assert!(duplicate.is_dir());
+    assert_eq!(fs::read(duplicate.join("notes.txt"))?, b"nested-file");
+    Ok(())
+}
+
+#[test]
+fn cutting_in_the_same_folder_remains_a_noop() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let root = tempfile::tempdir()?;
+    let destination = root.path().to_path_buf();
+    let file = destination.join("document.txt");
+    let directory = destination.join("folder");
+    fs::write(&file, b"content")?;
+    fs::create_dir_all(&directory)?;
+
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let emitted = events.clone();
+    let _operation = LocalOperationProvider.paste(
+        PasteRequest {
+            id: OperationRequestId(14),
+            destination: Location::local(&destination),
+            items: vec![
+                PasteItem {
+                    source: Location::local(&file),
+                    conflict: TransferConflict::FailIfExists,
+                },
+                PasteItem {
+                    source: Location::local(&directory),
+                    conflict: TransferConflict::FailIfExists,
+                },
+            ],
+            move_sources: true,
+        },
+        Rc::new(move |event| emitted.borrow_mut().push(event)),
+    );
+
+    while !events.borrow().iter().any(|event| {
+        matches!(
+            event,
+            OperationEvent::Pasted { .. } | OperationEvent::TransferFailed { .. }
+        )
+    }) {
+        glib::MainContext::default().iteration(true);
+    }
+
+    assert!(matches!(
+        events.borrow().last(),
+        Some(OperationEvent::Pasted { .. })
+    ));
+    assert!(file.exists());
+    assert!(directory.is_dir());
+    assert!(!destination.join("document copy.txt").exists());
+    assert!(!destination.join("folder copy").exists());
     Ok(())
 }

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -885,18 +885,12 @@ impl BrowserView {
     }
 
     pub fn duplicate_selection(&self) -> bool {
-        if !self.copy_selection() {
+        self.state.sync_mode_selection();
+        let entries = self.state.browser.selected_entries();
+        let Some((destination, sources)) = duplicate_transfer(&entries) else {
             return false;
-        }
-        let depth = paste_destination_depth(
-            self.view_mode(),
-            self.state.hovered_column.get(),
-            self.state.browser.active_depth(),
-            self.state.columns.borrow().len(),
-        );
-        if let Some(location) = depth.and_then(|depth| self.state.browser.location_at(depth)) {
-            self.state.paste_into(location);
-        }
+        };
+        self.state.start_transfer(destination, sources, false);
         true
     }
 
@@ -6957,6 +6951,18 @@ fn terminal_destination_depth(
     hovered
         .filter(|depth| *depth < pane_count)
         .or_else(|| new_folder_destination_depth(focused, active, pane_count))
+}
+
+fn duplicate_transfer(entries: &[FileEntry]) -> Option<(Location, Vec<Location>)> {
+    let destination = entries.first()?.location.parent()?;
+    if !entries
+        .iter()
+        .all(|entry| entry.location.parent().as_ref() == Some(&destination))
+    {
+        return None;
+    }
+    let sources = entries.iter().map(|entry| entry.location.clone()).collect();
+    Some((destination, sources))
 }
 
 fn same_locations(left: &[Location], right: &[Location]) -> bool {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -884,6 +884,22 @@ impl BrowserView {
         true
     }
 
+    pub fn duplicate_selection(&self) -> bool {
+        if !self.copy_selection() {
+            return false;
+        }
+        let depth = paste_destination_depth(
+            self.view_mode(),
+            self.state.hovered_column.get(),
+            self.state.browser.active_depth(),
+            self.state.columns.borrow().len(),
+        );
+        if let Some(location) = depth.and_then(|depth| self.state.browser.location_at(depth)) {
+            self.state.paste_into(location);
+        }
+        true
+    }
+
     pub fn cut_selection(&self) -> bool {
         self.state.sync_mode_selection();
         let entries = self.state.browser.selected_entries();

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -508,6 +508,10 @@ fn transfer_collisions_detect_existing_destination_items() -> Result<(), Box<dyn
         &Location::local(&source),
         &Location::local(&destination)
     ));
+    assert!(!transfer_has_collision(
+        &Location::local(&source),
+        &Location::local(&source_dir)
+    ));
     std::fs::write(destination.join("photo.jpg"), b"old")?;
     assert!(transfer_has_collision(
         &Location::local(&source),

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -25,6 +25,34 @@ fn terminal_shortcut_prefers_one_selected_directory() {
     assert_eq!(selected_terminal_location(&[]), None);
 }
 
+#[test]
+fn duplicate_transfer_uses_the_selected_entries_parent() {
+    let entry = |path: &str| FileEntry {
+        location: Location::local(path),
+        native_name: Path::new(path).file_name().unwrap_or_default().to_owned(),
+        display_name: path.to_owned(),
+        kind: crate::model::EntryKind::File,
+        size: crate::model::MetadataValue::Unknown,
+        modified_unix_seconds: crate::model::MetadataValue::Unknown,
+        is_hidden: false,
+    };
+    let first = entry("/fixture/selected/first.txt");
+    let second = entry("/fixture/selected/second.txt");
+
+    assert_eq!(
+        duplicate_transfer(&[first.clone(), second.clone()]),
+        Some((
+            Location::local("/fixture/selected"),
+            vec![first.location, second.location]
+        ))
+    );
+    assert_eq!(
+        duplicate_transfer(&[entry("/fixture/one.txt"), entry("/other/two.txt")]),
+        None
+    );
+    assert_eq!(duplicate_transfer(&[]), None);
+}
+
 #[cfg(unix)]
 #[test]
 fn terminal_directory_argument_preserves_native_path_bytes() {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -655,6 +655,14 @@ fn install_keyboard_navigation(
                 return glib::Propagation::Stop;
             }
         }
+        if control && !shift && matches!(key, gtk::gdk::Key::d | gtk::gdk::Key::D) {
+            if view.filter_has_focus() {
+                return glib::Propagation::Proceed;
+            }
+            if view.duplicate_selection() {
+                return glib::Propagation::Stop;
+            }
+        }
         if control && !shift && key == gtk::gdk::Key::x {
             if view.filter_has_focus() {
                 return glib::Propagation::Proceed;


### PR DESCRIPTION
## Description

Enable same-folder copy and paste transfers by automatically generating numbered duplicate names (`<stem> (1).<ext>`, `<stem> (2).<ext>`, or `<folder> (1)`). This compact, language-neutral convention is widely recognizable across file managers, browsers, office applications, and cloud storage. Cut transfers within the same directory remain a no-op. Adds Ctrl+D to duplicate the current selection in its actual parent folder without changing the clipboard.

## Visual evidence

The original recording below demonstrates the duplicate workflow. It predates the final naming decision; generated names now use `(n)` rather than `copy n`.

<img width="960" height="518" alt="Same-folder duplicate workflow" src="https://github.com/user-attachments/assets/bfbbcd95-e8f8-46fc-b91e-1014f3f8327a" />

## How to test

1. Copy `document.txt` and paste it into the same folder.
2. Copy `document (1).txt` and paste it into the same folder.
3. Copy a folder and paste it into its parent folder.
4. Cut a file or folder and paste it into the same parent folder.
5. In Columns mode, select a file, hover a different pane, and press Ctrl+D.

**Expected result:**
- Pasting `document.txt` creates `document (1).txt`.
- Pasting `document (1).txt` creates `document (2).txt`.
- Pasting a folder creates `<folder> (1)`.
- Same-folder cut/paste is a no-op.
- Ctrl+D duplicates into the selection's parent, not the hovered pane, and preserves the clipboard.
- Native non-UTF-8 filename bytes are preserved.

## Related issue

Closes #270
