### PR TITLE
perf(browser): reduce large-directory and thumbnail latency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ gtk = { package = "gtk4", version = "0.11.4", features = ["v4_12"] }
 ignore = "0.4.23"
 poppler = { package = "poppler-rs", version = "0.26.0" }
 pulldown-cmark = { version = "0.13", default-features = false }
-rustix = { version = "1.1.4", features = ["fs", "process"] }
+rustix = { version = "1.1.4", features = ["fs", "process", "event"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sevenz-rust2 = "0.22.2"
@@ -36,6 +36,13 @@ zip = "8.6.0"
 
 [build-dependencies]
 glib-build-tools = "0.22.8"
+
+[profile.release]
+# Whole-program optimization for the hot listing/sort/insert paths. Build
+# time only: no runtime behavior change. (Stripping stays in the packaging
+# flow, not here, so crash reports keep symbols.)
+lto = true
+codegen-units = 1
 
 [lints.rust]
 unsafe_code = "deny"

--- a/src/adapters/local_files.rs
+++ b/src/adapters/local_files.rs
@@ -2,11 +2,14 @@
 
 use std::{
     cell::{Cell, RefCell},
-    collections::HashMap,
-    io::ErrorKind,
+    collections::{HashMap, HashSet},
+    ffi::OsString,
+    fs,
+    io::{ErrorKind, Read},
+    os::unix::ffi::OsStringExt,
     path::{Path, PathBuf},
     rc::Rc,
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use gtk::{gio, glib, prelude::*};
@@ -15,12 +18,25 @@ use crate::{
     model::{EntryKind, FileEntry, Location, MetadataValue},
     services::{
         DirectoryChange, DirectoryEvent, DirectoryRequest, FileSource, LoadHandle,
-        LocationValidationError, RequestId, backend_unavailable_message, sanitize_uri_credentials,
+        LocationValidationError, MetadataOutcome, MetadataRequest, MetadataUpdate, RequestId,
+        backend_unavailable_message, sanitize_uri_credentials,
     },
 };
 
-const ATTRIBUTES: &str = "standard::display-name,standard::name,standard::type,standard::is-hidden,standard::is-symlink,standard::size,time::modified";
+/// Attributes for streaming enumeration: identity and kind only, no size or
+/// modification time, so large directories list without statting every entry.
+/// Size and modification time arrive later through `fill_metadata` for the
+/// rows the views actually bind.
+const LIST_ATTRIBUTES: &str =
+    "standard::display-name,standard::name,standard::type,standard::is-hidden,standard::is-symlink";
+/// Full attributes for single-entry reads (monitor upserts), where one stat
+/// is the whole cost.
+const FULL_ATTRIBUTES: &str = "standard::display-name,standard::name,standard::type,standard::is-hidden,standard::is-symlink,standard::size,time::modified";
+/// Per-entry metadata fill: size and modification time only. Type rides along
+/// free from the dirent, so directory rows can keep their unknown size.
+const METADATA_ATTRIBUTES: &str = "standard::type,standard::size,time::modified";
 const MAX_PENDING_MONITOR_CHANGES: usize = 256;
+const MAX_HIDDEN_FILE_BYTES: u64 = 1024 * 1024;
 
 #[derive(Default)]
 pub struct LocalFileSource;
@@ -31,6 +47,15 @@ enum PendingMonitorChange {
     Remove(PathBuf),
     Move { from: PathBuf, to: PathBuf },
     Rescan,
+}
+
+enum NativeEnumeration {
+    Complete {
+        entries: Vec<FileEntry>,
+        truncated: bool,
+    },
+    Failed(String),
+    Cancelled,
 }
 
 fn map_validation_error(error: std::io::Error) -> LocationValidationError {
@@ -103,27 +128,271 @@ fn entry_from_info(location: Location, info: gio::FileInfo) -> FileEntry {
         (gio::FileType::SymbolicLink, _) => EntryKind::SymbolicLink,
         _ => EntryKind::Other,
     };
+    // Size and modification time are only present when the query asked for
+    // them: streaming enumeration skips both so it never stats, while the
+    // window fill and single-entry monitor reads bring them afterwards.
+    let size = if matches!(
+        kind,
+        EntryKind::Directory | EntryKind::DirectorySymbolicLink
+    ) {
+        MetadataValue::Unknown
+    } else if info.has_attribute(gio::FILE_ATTRIBUTE_STANDARD_SIZE) {
+        u64::try_from(info.size())
+            .map(MetadataValue::Known)
+            .unwrap_or(MetadataValue::Unavailable)
+    } else {
+        MetadataValue::Unknown
+    };
+    let modified_unix_seconds = if info.has_attribute(gio::FILE_ATTRIBUTE_TIME_MODIFIED) {
+        info.modification_date_time()
+            .map(|modified| MetadataValue::Known(modified.to_unix()))
+            .unwrap_or(MetadataValue::Unavailable)
+    } else {
+        MetadataValue::Unknown
+    };
     FileEntry {
         location,
         native_name,
         display_name: info.display_name().to_string(),
         kind,
-        size: if matches!(
-            kind,
-            EntryKind::Directory | EntryKind::DirectorySymbolicLink
-        ) {
-            MetadataValue::Unknown
-        } else {
-            u64::try_from(info.size())
-                .map(MetadataValue::Known)
-                .unwrap_or(MetadataValue::Unavailable)
-        },
-        modified_unix_seconds: info
-            .modification_date_time()
-            .map(|modified| MetadataValue::Known(modified.to_unix()))
-            .unwrap_or(MetadataValue::Unavailable),
+        size,
+        modified_unix_seconds,
         is_hidden: info_is_hidden(&info),
     }
+}
+
+fn native_kind(file_type: fs::FileType, path: &Path) -> EntryKind {
+    if file_type.is_dir() {
+        return EntryKind::Directory;
+    }
+    if file_type.is_file() {
+        return EntryKind::File;
+    }
+    if !file_type.is_symlink() {
+        return EntryKind::Other;
+    }
+    match fs::metadata(path) {
+        Ok(metadata) if metadata.is_dir() => EntryKind::DirectorySymbolicLink,
+        Ok(metadata) if metadata.is_file() => EntryKind::FileSymbolicLink,
+        Ok(_) => EntryKind::Other,
+        Err(_) => EntryKind::SymbolicLink,
+    }
+}
+
+fn unix_seconds(time: SystemTime) -> Option<i64> {
+    match time.duration_since(UNIX_EPOCH) {
+        Ok(duration) => i64::try_from(duration.as_secs()).ok(),
+        Err(error) => {
+            let duration = error.duration();
+            let seconds = i64::try_from(duration.as_secs()).ok()?;
+            seconds
+                .checked_neg()?
+                .checked_sub(i64::from(duration.subsec_nanos() != 0))
+        }
+    }
+}
+
+fn fill_native_entry_metadata(entry: &mut FileEntry) {
+    let Some(path) = entry.location.native_path() else {
+        return;
+    };
+    let Ok(metadata) = fs::metadata(path) else {
+        entry.size = MetadataValue::Unknown;
+        entry.modified_unix_seconds = MetadataValue::Unknown;
+        return;
+    };
+    entry.size = if metadata.is_dir() {
+        MetadataValue::Unknown
+    } else {
+        MetadataValue::Known(metadata.len())
+    };
+    entry.modified_unix_seconds = metadata
+        .modified()
+        .ok()
+        .and_then(unix_seconds)
+        .map(MetadataValue::Known)
+        .unwrap_or(MetadataValue::Unavailable);
+}
+
+fn native_hidden_names(path: &Path) -> HashSet<OsString> {
+    let Ok(file) = fs::File::open(path.join(".hidden")) else {
+        return HashSet::new();
+    };
+    let mut bytes = Vec::new();
+    if file
+        .take(MAX_HIDDEN_FILE_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .is_err()
+        || bytes.len() as u64 > MAX_HIDDEN_FILE_BYTES
+    {
+        return HashSet::new();
+    }
+    bytes
+        .split(|byte| *byte == b'\n')
+        .filter(|name| !name.is_empty())
+        .map(|name| OsString::from_vec(name.strip_suffix(b"\r").unwrap_or(name).to_vec()))
+        .collect()
+}
+
+fn scan_native_directory(
+    path: &Path,
+    request: &DirectoryRequest,
+    cancellable: &gio::Cancellable,
+    deadline: Instant,
+) -> NativeEnumeration {
+    let children = match fs::read_dir(path) {
+        Ok(children) => children,
+        Err(error) => return NativeEnumeration::Failed(error.to_string()),
+    };
+    let hidden_names = native_hidden_names(path);
+    let mut entries = Vec::new();
+    for child in children {
+        if cancellable.is_cancelled() {
+            return NativeEnumeration::Cancelled;
+        }
+        if Instant::now() >= deadline {
+            return NativeEnumeration::Complete {
+                entries,
+                truncated: true,
+            };
+        }
+        let child = match child {
+            Ok(child) => child,
+            Err(error) => return NativeEnumeration::Failed(error.to_string()),
+        };
+        let native_name = child.file_name();
+        let is_hidden = native_name.as_encoded_bytes().first().copied() == Some(b'.')
+            || hidden_names.contains(&native_name);
+        if entries.len() == request.max_entries {
+            return NativeEnumeration::Complete {
+                entries,
+                truncated: true,
+            };
+        }
+        let file_type = match child.file_type() {
+            Ok(file_type) => file_type,
+            Err(error) if error.kind() == ErrorKind::NotFound => continue,
+            Err(error) => return NativeEnumeration::Failed(error.to_string()),
+        };
+        let path = child.path();
+        let kind = native_kind(file_type, &path);
+        entries.push(FileEntry {
+            location: Location::local(path),
+            display_name: native_name.to_string_lossy().into_owned(),
+            native_name,
+            kind,
+            size: MetadataValue::Unknown,
+            modified_unix_seconds: MetadataValue::Unknown,
+            is_hidden,
+        });
+    }
+
+    if request.include_metadata && !entries.is_empty() {
+        let width = sort_fill_width().min(entries.len());
+        let chunk = entries.len().div_ceil(width);
+        std::thread::scope(|scope| {
+            for piece in entries.chunks_mut(chunk) {
+                let cancellable = cancellable.clone();
+                scope.spawn(move || {
+                    for entry in piece {
+                        if cancellable.is_cancelled() || Instant::now() >= deadline {
+                            break;
+                        }
+                        fill_native_entry_metadata(entry);
+                    }
+                });
+            }
+        });
+        if cancellable.is_cancelled() {
+            return NativeEnumeration::Cancelled;
+        }
+        if Instant::now() >= deadline {
+            return NativeEnumeration::Complete {
+                entries,
+                truncated: true,
+            };
+        }
+    }
+
+    NativeEnumeration::Complete {
+        entries,
+        truncated: false,
+    }
+}
+
+fn enumerate_native(
+    request: DirectoryRequest,
+    emit: Rc<dyn Fn(DirectoryEvent)>,
+    started: Instant,
+    path: PathBuf,
+) -> LoadHandle {
+    let request_id = request.id;
+    let cancellable = gio::Cancellable::new();
+    let cancel = cancellable.clone();
+    let task = glib::MainContext::default().spawn_local(async move {
+        let deadline = started + request.time_budget;
+        let outcome = gio::spawn_blocking(move || {
+            scan_native_directory(&path, &request, &cancellable, deadline)
+        })
+        .await;
+        let Ok(outcome) = outcome else {
+            emit(DirectoryEvent::Failed {
+                request_id,
+                message: "Native directory worker failed".to_owned(),
+            });
+            return;
+        };
+        match outcome {
+            NativeEnumeration::Complete { entries, truncated } => {
+                let total_entries = entries.len();
+                if !entries.is_empty() {
+                    tracing::info!(
+                        request_id = request_id.0,
+                        entries = total_entries,
+                        elapsed_ms = started.elapsed().as_millis() as u64,
+                        "first directory batch ready"
+                    );
+                    emit(DirectoryEvent::Batch {
+                        request_id,
+                        entries,
+                    });
+                }
+                if truncated {
+                    tracing::warn!(
+                        request_id = request_id.0,
+                        entries = total_entries,
+                        elapsed_ms = started.elapsed().as_millis() as u64,
+                        reason = "budget",
+                        "directory load truncated"
+                    );
+                } else {
+                    tracing::info!(
+                        request_id = request_id.0,
+                        entries = total_entries,
+                        elapsed_ms = started.elapsed().as_millis() as u64,
+                        "directory load finished"
+                    );
+                }
+                emit(DirectoryEvent::Finished {
+                    request_id,
+                    truncated,
+                });
+            }
+            NativeEnumeration::Failed(message) => {
+                tracing::warn!(request_id = request_id.0, "directory load failed");
+                emit(DirectoryEvent::Failed {
+                    request_id,
+                    message,
+                });
+            }
+            NativeEnumeration::Cancelled => {}
+        }
+    });
+    LoadHandle::new(move || {
+        tracing::debug!(request_id = request_id.0, "directory load cancelled");
+        cancel.cancel();
+        task.abort();
+    })
 }
 
 impl FileSource for LocalFileSource {
@@ -182,6 +451,10 @@ impl FileSource for LocalFileSource {
         let started = Instant::now();
         log_directory_load_started(request_id, &location);
 
+        if let Some(path) = location.native_path() {
+            return enumerate_native(request, emit, started, path.to_path_buf());
+        }
+
         let task = glib::MainContext::default().spawn_local(async move {
             let deadline = started + request.time_budget;
             let finish_truncated = |entries: usize, reason: &'static str| {
@@ -206,10 +479,17 @@ impl FileSource for LocalFileSource {
                 finish_truncated(0, "time budget");
                 return;
             }
+            // Size/date sorts arrive with metadata inline: statting once per
+            // file up front beats listing placeholders and re-sorting after.
+            let attributes = if request.include_metadata {
+                FULL_ATTRIBUTES
+            } else {
+                LIST_ATTRIBUTES
+            };
             let enumerator = match glib::future_with_timeout(
                 remaining,
                 directory.enumerate_children_future(
-                    ATTRIBUTES,
+                    attributes,
                     gio::FileQueryInfoFlags::NONE,
                     glib::Priority::DEFAULT,
                 ),
@@ -321,6 +601,94 @@ impl FileSource for LocalFileSource {
         })
     }
 
+    fn supports_metadata_fill(&self, _location: &Location) -> bool {
+        // Native paths and remote URIs alike go through cancellable async
+        // GIO queries; unstatable entries degrade to placeholders per the
+        // fill protocol instead of being rejected up front.
+        true
+    }
+
+    fn fill_metadata(
+        &self,
+        request: MetadataRequest,
+        emit: Rc<dyn Fn(DirectoryEvent)>,
+    ) -> LoadHandle {
+        // Defensive cap: the UI only ever asks for its visible window, but a
+        // bug upstream must not turn one fill into a full-directory stat.
+        // Sorts set `full` to stat the whole column behind their spinner.
+        const MAX_FILL_ENTRIES: usize = 1024;
+        let request_id = request.id;
+        let mut locations = request.entries;
+        if !request.full {
+            locations.truncate(MAX_FILL_ENTRIES);
+        }
+        // Viewport fills stay on one sequential async pass over the visible
+        // window; only full native sorts fan out, and remote entries never
+        // do (bounded cancellable GIO, no server-request fan-out).
+        let all_native = locations
+            .iter()
+            .all(|location| location.native_path().is_some());
+        if request.full && all_native && !locations.is_empty() {
+            return fill_parallel(request_id, locations, request.time_budget, emit);
+        }
+        let task = glib::MainContext::default().spawn_local(async move {
+            let deadline = Instant::now() + request.time_budget;
+            let mut updates = Vec::with_capacity(locations.len());
+            let mut truncated = false;
+            let mut attempted = 0usize;
+            let mut failed = 0usize;
+            for location in &locations {
+                if Instant::now() >= deadline {
+                    truncated = true;
+                    break;
+                }
+                // Remote and GVfs entries stat through the same cancellable
+                // async GIO query; only locations with no usable form at all
+                // are skipped.
+                let Some(file) = location
+                    .native_path()
+                    .map(gio::File::for_path)
+                    .or_else(|| location.uri_value().map(gio::File::for_uri))
+                else {
+                    continue;
+                };
+                attempted += 1;
+                // A row that vanished between listing and fill keeps its
+                // placeholder: Unknown re-arms the next bind's request.
+                let (update, ok) = match file
+                    .query_info_future(
+                        METADATA_ATTRIBUTES,
+                        gio::FileQueryInfoFlags::NONE,
+                        glib::Priority::DEFAULT,
+                    )
+                    .await
+                {
+                    Ok(info) => update_from_info(&info, location),
+                    Err(_) => (
+                        MetadataUpdate {
+                            location: location.clone(),
+                            size: MetadataValue::Unknown,
+                            modified_unix_seconds: MetadataValue::Unknown,
+                        },
+                        false,
+                    ),
+                };
+                failed += usize::from(!ok);
+                updates.push(update);
+            }
+            emit_fill_outcome(
+                &emit,
+                request_id,
+                updates,
+                truncated,
+                attempted,
+                failed,
+                locations.len(),
+            );
+        });
+        LoadHandle::new(move || task.abort())
+    }
+
     fn watch(
         &self,
         location: Location,
@@ -421,6 +789,200 @@ impl FileSource for LocalFileSource {
         }))
     }
 }
+/// Worker width for full native sort fills: the machine's parallelism
+/// capped at the measured optimum. Sweep on this machine's 8-core host over
+/// 3,000 warm-cache files: 1→11.6 ms, 2→5.4 ms, 4→3.4 ms, 8→2.7 ms. Eight
+/// is the fastest without sustained pressure (sorts run rarely, behind a
+/// spinner, in millisecond bursts); fewer cores scale the width down.
+fn sort_fill_width() -> usize {
+    std::thread::available_parallelism()
+        .map(|parallelism| parallelism.get().min(8))
+        .unwrap_or(4)
+        .max(1)
+}
+/// Stats a full native column with bounded scoped workers over synchronous
+/// GIO queries. Cancellation and the deadline are checked between entries;
+/// a cancelled fill reports `Cancelled` with no chunks, never a partial
+/// pass masquerading as complete.
+fn fill_parallel(
+    request_id: RequestId,
+    locations: Vec<Location>,
+    time_budget: Duration,
+    emit: Rc<dyn Fn(DirectoryEvent)>,
+) -> LoadHandle {
+    fill_parallel_with(sort_fill_width(), request_id, locations, time_budget, emit)
+}
+
+/// Width-parameterized core, so the worker sweep measures the real path.
+fn fill_parallel_with(
+    width: usize,
+    request_id: RequestId,
+    locations: Vec<Location>,
+    time_budget: Duration,
+    emit: Rc<dyn Fn(DirectoryEvent)>,
+) -> LoadHandle {
+    let cancellable = gio::Cancellable::new();
+    let cancel = cancellable.clone();
+    let cancelled = cancellable.clone();
+    let task = glib::MainContext::default().spawn_local(async move {
+        let deadline = Instant::now() + time_budget;
+        let outcome = gio::spawn_blocking(move || {
+            let width = width.max(1);
+            let chunk = locations.len().div_ceil(width);
+            let mut updates = Vec::with_capacity(locations.len());
+            let mut attempted = 0usize;
+            let mut failed = 0usize;
+            let mut truncated = false;
+            std::thread::scope(|scope| {
+                let mut handles = Vec::new();
+                for piece in locations.chunks(chunk.max(1)) {
+                    let cancellable = cancellable.clone();
+                    handles.push(scope.spawn(move || {
+                        let mut updates = Vec::with_capacity(piece.len());
+                        let mut attempted = 0usize;
+                        let mut failed = 0usize;
+                        let mut truncated = false;
+                        for location in piece {
+                            if cancellable.is_cancelled() || Instant::now() >= deadline {
+                                truncated = true;
+                                break;
+                            }
+                            let Some(path) = location.native_path() else {
+                                continue;
+                            };
+                            attempted += 1;
+                            let (update, ok) = match gio::File::for_path(path).query_info(
+                                METADATA_ATTRIBUTES,
+                                gio::FileQueryInfoFlags::NONE,
+                                Some(&cancellable),
+                            ) {
+                                Ok(info) => update_from_info(&info, location),
+                                Err(_) => (
+                                    MetadataUpdate {
+                                        location: location.clone(),
+                                        size: MetadataValue::Unknown,
+                                        modified_unix_seconds: MetadataValue::Unknown,
+                                    },
+                                    false,
+                                ),
+                            };
+                            failed += usize::from(!ok);
+                            updates.push(update);
+                        }
+                        (updates, attempted, failed, truncated)
+                    }));
+                }
+                for handle in handles {
+                    let Ok((piece, attempted_piece, failed_piece, truncated_piece)) = handle.join()
+                    else {
+                        truncated = true;
+                        continue;
+                    };
+                    updates.extend(piece);
+                    attempted += attempted_piece;
+                    failed += failed_piece;
+                    truncated = truncated || truncated_piece;
+                }
+            });
+            (updates, attempted, failed, truncated, locations.len())
+        })
+        .await;
+        let Ok((updates, attempted, failed, truncated, total)) = outcome else {
+            return;
+        };
+        if cancelled.is_cancelled() {
+            emit(DirectoryEvent::MetadataFinished {
+                request_id,
+                outcome: MetadataOutcome::Cancelled,
+            });
+            return;
+        }
+        if !updates.is_empty() {
+            emit(DirectoryEvent::MetadataFilled {
+                request_id,
+                updates,
+            });
+        }
+        let outcome = if truncated {
+            MetadataOutcome::Truncated
+        } else if attempted == 0 && total > 0 {
+            MetadataOutcome::Unsupported
+        } else if attempted > 0 && failed == attempted {
+            MetadataOutcome::Failed
+        } else {
+            MetadataOutcome::Complete
+        };
+        emit(DirectoryEvent::MetadataFinished {
+            request_id,
+            outcome,
+        });
+    });
+    LoadHandle::new(move || {
+        cancel.cancel();
+        task.abort();
+    })
+}
+
+/// Maps one stat result to its update. Symlink semantics are explicit:
+/// queries follow links (the same flags as enumeration), so a symlink
+/// reports its target's size and mtime, while a link to a directory keeps
+/// the explicitly unavailable directory size. Returns whether the stat
+/// succeeded as more than a placeholder.
+fn update_from_info(info: &gio::FileInfo, location: &Location) -> (MetadataUpdate, bool) {
+    let size = if info.file_type() == gio::FileType::Directory {
+        MetadataValue::Unknown
+    } else {
+        u64::try_from(info.size())
+            .map(MetadataValue::Known)
+            .unwrap_or(MetadataValue::Unavailable)
+    };
+    let modified_unix_seconds = info
+        .modification_date_time()
+        .map(|modified| MetadataValue::Known(modified.to_unix()))
+        .unwrap_or(MetadataValue::Unavailable);
+    let ok = size != MetadataValue::Unknown || modified_unix_seconds != MetadataValue::Unknown;
+    (
+        MetadataUpdate {
+            location: location.clone(),
+            size,
+            modified_unix_seconds,
+        },
+        ok,
+    )
+}
+
+/// Emits one chunk plus the total-protocol terminal for a fill. A pass that
+/// statted nothing successfully is a failure, not a complete pass over
+/// placeholders; a pass with no usable entries at all is unsupported.
+fn emit_fill_outcome(
+    emit: &Rc<dyn Fn(DirectoryEvent)>,
+    request_id: RequestId,
+    updates: Vec<MetadataUpdate>,
+    truncated: bool,
+    attempted: usize,
+    failed: usize,
+    total: usize,
+) {
+    if !updates.is_empty() {
+        emit(DirectoryEvent::MetadataFilled {
+            request_id,
+            updates,
+        });
+    }
+    let outcome = if truncated {
+        MetadataOutcome::Truncated
+    } else if attempted == 0 && total > 0 {
+        MetadataOutcome::Unsupported
+    } else if attempted > 0 && failed == attempted {
+        MetadataOutcome::Failed
+    } else {
+        MetadataOutcome::Complete
+    };
+    emit(DirectoryEvent::MetadataFinished {
+        request_id,
+        outcome,
+    });
+}
 
 fn log_directory_load_started(request_id: RequestId, location: &Location) {
     tracing::info!(
@@ -517,7 +1079,7 @@ fn query_monitored_entry(
         let file = gio::File::for_path(&path);
         let result = file
             .query_info_future(
-                ATTRIBUTES,
+                FULL_ATTRIBUTES,
                 gio::FileQueryInfoFlags::NONE,
                 glib::Priority::DEFAULT,
             )

--- a/src/adapters/local_files.rs
+++ b/src/adapters/local_files.rs
@@ -23,17 +23,9 @@ use crate::{
     },
 };
 
-/// Attributes for streaming enumeration: identity and kind only, no size or
-/// modification time, so large directories list without statting every entry.
-/// Size and modification time arrive later through `fill_metadata` for the
-/// rows the views actually bind.
 const LIST_ATTRIBUTES: &str =
     "standard::display-name,standard::name,standard::type,standard::is-hidden,standard::is-symlink";
-/// Full attributes for single-entry reads (monitor upserts), where one stat
-/// is the whole cost.
 const FULL_ATTRIBUTES: &str = "standard::display-name,standard::name,standard::type,standard::is-hidden,standard::is-symlink,standard::size,time::modified";
-/// Per-entry metadata fill: size and modification time only. Type rides along
-/// free from the dirent, so directory rows can keep their unknown size.
 const METADATA_ATTRIBUTES: &str = "standard::type,standard::size,time::modified";
 const MAX_PENDING_MONITOR_CHANGES: usize = 256;
 const MAX_HIDDEN_FILE_BYTES: u64 = 1024 * 1024;
@@ -53,6 +45,7 @@ enum NativeEnumeration {
     Complete {
         entries: Vec<FileEntry>,
         truncated: bool,
+        metadata_complete: bool,
     },
     Failed(String),
     Cancelled,
@@ -128,9 +121,6 @@ fn entry_from_info(location: Location, info: gio::FileInfo) -> FileEntry {
         (gio::FileType::SymbolicLink, _) => EntryKind::SymbolicLink,
         _ => EntryKind::Other,
     };
-    // Size and modification time are only present when the query asked for
-    // them: streaming enumeration skips both so it never stats, while the
-    // window fill and single-entry monitor reads bring them afterwards.
     let size = if matches!(
         kind,
         EntryKind::Directory | EntryKind::DirectorySymbolicLink
@@ -215,23 +205,40 @@ fn fill_native_entry_metadata(entry: &mut FileEntry) {
 }
 
 fn native_hidden_names(path: &Path) -> HashSet<OsString> {
-    let Ok(file) = fs::File::open(path.join(".hidden")) else {
+    let Some(bytes) = read_hidden_bounded(&path.join(".hidden")) else {
         return HashSet::new();
     };
-    let mut bytes = Vec::new();
-    if file
-        .take(MAX_HIDDEN_FILE_BYTES + 1)
-        .read_to_end(&mut bytes)
-        .is_err()
-        || bytes.len() as u64 > MAX_HIDDEN_FILE_BYTES
-    {
-        return HashSet::new();
-    }
     bytes
         .split(|byte| *byte == b'\n')
         .filter(|name| !name.is_empty())
         .map(|name| OsString::from_vec(name.strip_suffix(b"\r").unwrap_or(name).to_vec()))
         .collect()
+}
+
+fn read_hidden_bounded(path: &Path) -> Option<Vec<u8>> {
+    // Opening a FIFO without `NONBLOCK` would block waiting for a writer.
+    let fd = rustix::fs::open(
+        path,
+        rustix::fs::OFlags::RDONLY
+            | rustix::fs::OFlags::NOFOLLOW
+            | rustix::fs::OFlags::CLOEXEC
+            | rustix::fs::OFlags::NONBLOCK,
+        rustix::fs::Mode::empty(),
+    )
+    .ok()?;
+    let stat = rustix::fs::fstat(&fd).ok()?;
+    if rustix::fs::FileType::from_raw_mode(stat.st_mode) != rustix::fs::FileType::RegularFile {
+        return None;
+    }
+    let file = std::fs::File::from(fd);
+    let mut bytes = Vec::new();
+    file.take(MAX_HIDDEN_FILE_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .ok()?;
+    if bytes.len() as u64 > MAX_HIDDEN_FILE_BYTES {
+        return None;
+    }
+    Some(bytes)
 }
 
 fn scan_native_directory(
@@ -246,15 +253,14 @@ fn scan_native_directory(
     };
     let hidden_names = native_hidden_names(path);
     let mut entries = Vec::new();
+    let mut truncated = false;
     for child in children {
         if cancellable.is_cancelled() {
             return NativeEnumeration::Cancelled;
         }
         if Instant::now() >= deadline {
-            return NativeEnumeration::Complete {
-                entries,
-                truncated: true,
-            };
+            truncated = true;
+            break;
         }
         let child = match child {
             Ok(child) => child,
@@ -264,10 +270,8 @@ fn scan_native_directory(
         let is_hidden = native_name.as_encoded_bytes().first().copied() == Some(b'.')
             || hidden_names.contains(&native_name);
         if entries.len() == request.max_entries {
-            return NativeEnumeration::Complete {
-                entries,
-                truncated: true,
-            };
+            truncated = true;
+            break;
         }
         let file_type = match child.file_type() {
             Ok(file_type) => file_type,
@@ -287,7 +291,8 @@ fn scan_native_directory(
         });
     }
 
-    if request.include_metadata && !entries.is_empty() {
+    let mut metadata_complete = true;
+    if request.include_metadata && !entries.is_empty() && Instant::now() < deadline {
         let width = sort_fill_width().min(entries.len());
         let chunk = entries.len().div_ceil(width);
         std::thread::scope(|scope| {
@@ -306,17 +311,15 @@ fn scan_native_directory(
         if cancellable.is_cancelled() {
             return NativeEnumeration::Cancelled;
         }
-        if Instant::now() >= deadline {
-            return NativeEnumeration::Complete {
-                entries,
-                truncated: true,
-            };
-        }
+        metadata_complete = Instant::now() < deadline;
+    } else if request.include_metadata && !entries.is_empty() {
+        metadata_complete = false;
     }
 
     NativeEnumeration::Complete {
         entries,
-        truncated: false,
+        truncated,
+        metadata_complete,
     }
 }
 
@@ -343,7 +346,11 @@ fn enumerate_native(
             return;
         };
         match outcome {
-            NativeEnumeration::Complete { entries, truncated } => {
+            NativeEnumeration::Complete {
+                entries,
+                truncated,
+                metadata_complete,
+            } => {
                 let total_entries = entries.len();
                 if !entries.is_empty() {
                     tracing::info!(
@@ -356,6 +363,16 @@ fn enumerate_native(
                         request_id,
                         entries,
                     });
+                }
+                if !metadata_complete {
+                    tracing::warn!(
+                        request_id = request_id.0,
+                        entries = total_entries,
+                        elapsed_ms = started.elapsed().as_millis() as u64,
+                        reason = "metadata budget",
+                        "initial metadata pass incomplete"
+                    );
+                    emit(DirectoryEvent::MetadataIncomplete { request_id });
                 }
                 if truncated {
                     tracing::warn!(
@@ -479,8 +496,6 @@ impl FileSource for LocalFileSource {
                 finish_truncated(0, "time budget");
                 return;
             }
-            // Size/date sorts arrive with metadata inline: statting once per
-            // file up front beats listing placeholders and re-sorting after.
             let attributes = if request.include_metadata {
                 FULL_ATTRIBUTES
             } else {
@@ -602,9 +617,6 @@ impl FileSource for LocalFileSource {
     }
 
     fn supports_metadata_fill(&self, _location: &Location) -> bool {
-        // Native paths and remote URIs alike go through cancellable async
-        // GIO queries; unstatable entries degrade to placeholders per the
-        // fill protocol instead of being rejected up front.
         true
     }
 
@@ -613,18 +625,13 @@ impl FileSource for LocalFileSource {
         request: MetadataRequest,
         emit: Rc<dyn Fn(DirectoryEvent)>,
     ) -> LoadHandle {
-        // Defensive cap: the UI only ever asks for its visible window, but a
-        // bug upstream must not turn one fill into a full-directory stat.
-        // Sorts set `full` to stat the whole column behind their spinner.
+        // Cap viewport fills so a buggy caller cannot stat a full directory.
         const MAX_FILL_ENTRIES: usize = 1024;
         let request_id = request.id;
         let mut locations = request.entries;
         if !request.full {
             locations.truncate(MAX_FILL_ENTRIES);
         }
-        // Viewport fills stay on one sequential async pass over the visible
-        // window; only full native sorts fan out, and remote entries never
-        // do (bounded cancellable GIO, no server-request fan-out).
         let all_native = locations
             .iter()
             .all(|location| location.native_path().is_some());
@@ -642,9 +649,6 @@ impl FileSource for LocalFileSource {
                     truncated = true;
                     break;
                 }
-                // Remote and GVfs entries stat through the same cancellable
-                // async GIO query; only locations with no usable form at all
-                // are skipped.
                 let Some(file) = location
                     .native_path()
                     .map(gio::File::for_path)
@@ -653,18 +657,24 @@ impl FileSource for LocalFileSource {
                     continue;
                 };
                 attempted += 1;
-                // A row that vanished between listing and fill keeps its
-                // placeholder: Unknown re-arms the next bind's request.
-                let (update, ok) = match file
-                    .query_info_future(
+                // Bound each stat by the remaining budget so one hung mount cannot stall the fill.
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    truncated = true;
+                    break;
+                }
+                let (update, ok) = match glib::future_with_timeout(
+                    remaining,
+                    file.query_info_future(
                         METADATA_ATTRIBUTES,
                         gio::FileQueryInfoFlags::NONE,
                         glib::Priority::DEFAULT,
-                    )
-                    .await
+                    ),
+                )
+                .await
                 {
-                    Ok(info) => update_from_info(&info, location),
-                    Err(_) => (
+                    Ok(Ok(info)) => update_from_info(&info, location),
+                    Ok(Err(_)) => (
                         MetadataUpdate {
                             location: location.clone(),
                             size: MetadataValue::Unknown,
@@ -672,6 +682,10 @@ impl FileSource for LocalFileSource {
                         },
                         false,
                     ),
+                    Err(_) => {
+                        truncated = true;
+                        break;
+                    }
                 };
                 failed += usize::from(!ok);
                 updates.push(update);
@@ -789,21 +803,13 @@ impl FileSource for LocalFileSource {
         }))
     }
 }
-/// Worker width for full native sort fills: the machine's parallelism
-/// capped at the measured optimum. Sweep on this machine's 8-core host over
-/// 3,000 warm-cache files: 1→11.6 ms, 2→5.4 ms, 4→3.4 ms, 8→2.7 ms. Eight
-/// is the fastest without sustained pressure (sorts run rarely, behind a
-/// spinner, in millisecond bursts); fewer cores scale the width down.
+
 fn sort_fill_width() -> usize {
     std::thread::available_parallelism()
         .map(|parallelism| parallelism.get().min(8))
         .unwrap_or(4)
         .max(1)
 }
-/// Stats a full native column with bounded scoped workers over synchronous
-/// GIO queries. Cancellation and the deadline are checked between entries;
-/// a cancelled fill reports `Cancelled` with no chunks, never a partial
-/// pass masquerading as complete.
 fn fill_parallel(
     request_id: RequestId,
     locations: Vec<Location>,
@@ -813,7 +819,6 @@ fn fill_parallel(
     fill_parallel_with(sort_fill_width(), request_id, locations, time_budget, emit)
 }
 
-/// Width-parameterized core, so the worker sweep measures the real path.
 fn fill_parallel_with(
     width: usize,
     request_id: RequestId,
@@ -923,11 +928,6 @@ fn fill_parallel_with(
     })
 }
 
-/// Maps one stat result to its update. Symlink semantics are explicit:
-/// queries follow links (the same flags as enumeration), so a symlink
-/// reports its target's size and mtime, while a link to a directory keeps
-/// the explicitly unavailable directory size. Returns whether the stat
-/// succeeded as more than a placeholder.
 fn update_from_info(info: &gio::FileInfo, location: &Location) -> (MetadataUpdate, bool) {
     let size = if info.file_type() == gio::FileType::Directory {
         MetadataValue::Unknown
@@ -951,9 +951,6 @@ fn update_from_info(info: &gio::FileInfo, location: &Location) -> (MetadataUpdat
     )
 }
 
-/// Emits one chunk plus the total-protocol terminal for a fill. A pass that
-/// statted nothing successfully is a failure, not a complete pass over
-/// placeholders; a pass with no usable entries at all is unsupported.
 fn emit_fill_outcome(
     emit: &Rc<dyn Fn(DirectoryEvent)>,
     request_id: RequestId,

--- a/src/adapters/local_files/tests.rs
+++ b/src/adapters/local_files/tests.rs
@@ -448,6 +448,40 @@ fn enumerate_reports_truncated_once_the_entry_budget_is_exceeded() {
 }
 
 #[test]
+fn entry_limited_metadata_load_fills_every_retained_entry() {
+    let root = unique_fixture_root("entry-budget-metadata");
+    fs::create_dir_all(&root).expect("the fixture directory should be created");
+    for index in 0..5 {
+        fs::write(root.join(format!("file-{index}.txt")), b"content")
+            .expect("the fixture file should be written");
+    }
+
+    let events = run_enumerate(DirectoryRequest {
+        id: RequestId(1),
+        location: Location::local(&root),
+        batch_size: 2,
+        include_metadata: true,
+        max_entries: 3,
+        time_budget: Duration::from_secs(10),
+    });
+    fs::remove_dir_all(&root).expect("the fixture directory should be removed");
+
+    assert_eq!(finished_truncated(&events), Some(true));
+    let entries = batched_entries(&events);
+    assert_eq!(entries.len(), 3);
+    assert!(
+        entries
+            .iter()
+            .all(|entry| matches!(entry.size, MetadataValue::Known(7)))
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, DirectoryEvent::MetadataIncomplete { .. }))
+    );
+}
+
+#[test]
 fn enumerate_completes_untruncated_at_the_exact_entry_budget() {
     let root = unique_fixture_root("exact-entry-budget");
     fs::create_dir_all(&root).expect("the fixture directory should be created");
@@ -660,9 +694,6 @@ fn enumerate_with_metadata_fills_sizes_up_front() -> Result<(), Box<dyn Error>> 
     Ok(())
 }
 
-/// `fill_metadata()` spawns on the shared default context like `enumerate()`
-/// does, so it needs the same serialized `block_on` bridge. The terminal is
-/// `MetadataFinished` instead of `Finished`.
 fn run_fill(request: MetadataRequest) -> Vec<DirectoryEvent> {
     let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
         .lock()
@@ -725,6 +756,41 @@ fn fill_empty_entries_completes_without_chunks() {
 }
 
 #[test]
+fn sequential_fill_with_no_time_remaining_is_truncated() {
+    let events = run_fill(MetadataRequest {
+        id: RequestId(1),
+        entries: vec![Location::local("/fixture/file.txt")],
+        full: false,
+        time_budget: Duration::ZERO,
+    });
+    assert_eq!(fill_outcome(&events), Some(MetadataOutcome::Truncated));
+    assert_eq!(fill_chunk_count(&events), 0);
+}
+
+#[test]
+fn hostile_hidden_files_are_ignored_without_blocking_or_following() {
+    use std::os::unix::fs::symlink;
+
+    let root = unique_fixture_root("hidden-hostile");
+    fs::create_dir_all(&root).expect("the fixture directory should be created");
+    let hidden = root.join(".hidden");
+    rustix::fs::mkfifoat(
+        rustix::fs::CWD,
+        &hidden,
+        rustix::fs::Mode::from_bits_truncate(0o600),
+    )
+    .expect("the fifo should be created");
+    assert!(native_hidden_names(&root).is_empty());
+
+    fs::remove_file(&hidden).expect("the fifo should be removed");
+    let target = root.join("target");
+    fs::write(&target, b"secret\n").expect("the target should be written");
+    symlink(&target, &hidden).expect("the symlink should be created");
+    assert!(native_hidden_names(&root).is_empty());
+    fs::remove_dir_all(&root).expect("the fixture should be removed");
+}
+
+#[test]
 fn fill_all_vanished_entries_reports_failed() {
     let root = unique_fixture_root("fill-vanished");
     let events = run_fill(MetadataRequest {
@@ -736,7 +802,6 @@ fn fill_all_vanished_entries_reports_failed() {
         full: true,
         time_budget: Duration::from_secs(10),
     });
-    // Every stat failed: a failure, not a complete pass over placeholders.
     assert_eq!(fill_outcome(&events), Some(MetadataOutcome::Failed));
 }
 
@@ -748,9 +813,6 @@ fn fill_unreachable_remote_reports_failed() {
         full: false,
         time_budget: Duration::from_secs(10),
     });
-    // The remote form is statable in principle, so the provider attempts it
-    // through GIO and reports the failure instead of claiming no support.
-    // The failed row still rides along as a placeholder chunk.
     assert_eq!(fill_outcome(&events), Some(MetadataOutcome::Failed));
     assert_eq!(fill_chunk_count(&events), 1);
 }
@@ -769,8 +831,6 @@ fn fill_file_uri_stats_through_the_uri_form() -> Result<(), Box<dyn Error>> {
         full: false,
         time_budget: Duration::from_secs(10),
     });
-    // URI-form entries stat through `gio::File::for_uri`, the same path
-    // remote and GVfs fills take.
     assert_eq!(fill_outcome(&events), Some(MetadataOutcome::Complete));
     assert_eq!(fill_chunk_count(&events), 1);
     Ok(())
@@ -835,8 +895,6 @@ fn parallel_fill_follows_symlinks_like_enumeration() -> Result<(), Box<dyn Error
             _ => None,
         })
     };
-    // A file symlink reports its target's size and mtime (follows, like the
-    // enumeration queries do), never the link's own bytes.
     let link_update = by_location(&Location::local(&link)).expect("the link should fill");
     let target_update = by_location(&Location::local(&target)).expect("the target should fill");
     assert_eq!(link_update.size, MetadataValue::Known(10));
@@ -845,7 +903,6 @@ fn parallel_fill_follows_symlinks_like_enumeration() -> Result<(), Box<dyn Error
         link_update.modified_unix_seconds,
         target_update.modified_unix_seconds
     );
-    // A directory symlink keeps the explicitly unavailable directory size.
     let dir_update = by_location(&Location::local(&dir_link)).expect("the dir link should fill");
     assert_eq!(dir_update.size, MetadataValue::Unknown);
     assert!(matches!(
@@ -862,9 +919,6 @@ fn parallel_fill_cancellation_reports_cancelled_without_chunks() {
         .expect("the async test lock should not be poisoned");
     let root = unique_fixture_root("fill-cancel");
     let count = 20_000;
-    // Entries need not exist: cancellation must win before any stat runs.
-    // (Nonexistent paths would fail fast, so create a handful to keep
-    // workers busy and the rest virtual.)
     fs::create_dir_all(&root).expect("the fixture directory should be created");
     for index in 0..100 {
         fs::write(root.join(format!("file-{index:04}.txt")), b"content")
@@ -881,11 +935,6 @@ fn parallel_fill_cancellation_reports_cancelled_without_chunks() {
     glib::MainContext::default().block_on(async {
         let handle =
             super::fill_parallel_with(8, RequestId(1), entries, Duration::from_secs(60), emit);
-        // Yield once so the driver task starts its workers, then cancel
-        // mid-flight: the abort silences the driver while the shared
-        // cancellable stops the workers, so neither chunks nor Complete
-        // ever arrive. No `iteration()` inside `block_on` (reentering the
-        // executor panics); a one-shot timeout wakes the grace poll.
         let mut yielded = false;
         std::future::poll_fn(|cx| {
             if yielded {
@@ -900,8 +949,6 @@ fn parallel_fill_cancellation_reports_cancelled_without_chunks() {
         drop(handle);
         let waker: Rc<RefCell<Option<std::task::Waker>>> = Rc::new(RefCell::new(None));
         let wake = waker.clone();
-        // Recurring wake-ups: a one-shot wake parks forever once spent,
-        // since the aborted driver emits nothing more.
         let ticker = glib::timeout_add_local(Duration::from_millis(20), move || {
             if let Some(waker) = wake.borrow_mut().take() {
                 waker.wake();

--- a/src/adapters/local_files/tests.rs
+++ b/src/adapters/local_files/tests.rs
@@ -7,13 +7,16 @@ use std::{
     io::{ErrorKind, Write},
     os::unix::ffi::{OsStrExt, OsStringExt},
     sync::{Arc, Mutex, MutexGuard},
-    time::SystemTime,
+    time::{Instant, SystemTime},
 };
 
 use tracing_subscriber::fmt::MakeWriter;
 
 use super::*;
-use crate::{model::Location, test_support::ASYNC_MAIN_CONTEXT_DEFAULT};
+use crate::{
+    model::{Location, MetadataValue},
+    test_support::ASYNC_MAIN_CONTEXT_DEFAULT,
+};
 
 #[derive(Clone, Default)]
 struct LogWriter(Arc<Mutex<Vec<u8>>>);
@@ -149,12 +152,18 @@ fn invalid_utf8_names_keep_their_native_bytes() -> Result<(), Box<dyn Error>> {
     let path = directory.join(&native_name);
     fs::write(&path, b"fixture")?;
 
-    let info = gio::File::for_path(&path).query_info(
-        ATTRIBUTES,
-        gio::FileQueryInfoFlags::NONE,
-        None::<&gio::Cancellable>,
-    )?;
-    let entry = entry_from_info(Location::local(path.clone()), info);
+    let events = run_enumerate(DirectoryRequest {
+        id: RequestId(1),
+        location: Location::local(&directory),
+        batch_size: 64,
+        include_metadata: false,
+        max_entries: 100,
+        time_budget: Duration::from_secs(10),
+    });
+    let entry = batched_entries(&events)
+        .into_iter()
+        .next()
+        .expect("the invalid UTF-8 entry should be listed");
 
     assert_eq!(entry.native_name.as_bytes(), native_name.as_bytes());
     assert_eq!(entry.location.native_path(), Some(path.as_path()));
@@ -240,19 +249,26 @@ fn symlink_targets_and_broken_links_are_distinguished() -> Result<(), Box<dyn Er
     symlink("file", directory.join("file-link"))?;
     symlink("missing", directory.join("broken-link"))?;
 
-    let kind = |name: &str| -> Result<EntryKind, glib::Error> {
-        let path = directory.join(name);
-        let info = gio::File::for_path(&path).query_info(
-            ATTRIBUTES,
-            gio::FileQueryInfoFlags::NONE,
-            None::<&gio::Cancellable>,
-        )?;
-        Ok(entry_from_info(Location::local(path), info).kind)
+    let events = run_enumerate(DirectoryRequest {
+        id: RequestId(1),
+        location: Location::local(&directory),
+        batch_size: 64,
+        include_metadata: true,
+        max_entries: 100,
+        time_budget: Duration::from_secs(10),
+    });
+    let entries = batched_entries(&events);
+    let kind = |name: &str| {
+        entries
+            .iter()
+            .find(|entry| entry.native_name == name)
+            .map(|entry| entry.kind)
+            .expect("the symlink should be listed")
     };
 
-    assert_eq!(kind("directory-link")?, EntryKind::DirectorySymbolicLink);
-    assert_eq!(kind("file-link")?, EntryKind::FileSymbolicLink);
-    assert_eq!(kind("broken-link")?, EntryKind::SymbolicLink);
+    assert_eq!(kind("directory-link"), EntryKind::DirectorySymbolicLink);
+    assert_eq!(kind("file-link"), EntryKind::FileSymbolicLink);
+    assert_eq!(kind("broken-link"), EntryKind::SymbolicLink);
 
     fs::remove_dir_all(directory)?;
     Ok(())
@@ -382,6 +398,17 @@ fn batched_entry_count(events: &[DirectoryEvent]) -> usize {
         .sum()
 }
 
+fn batched_entries(events: &[DirectoryEvent]) -> Vec<FileEntry> {
+    events
+        .iter()
+        .filter_map(|event| match event {
+            DirectoryEvent::Batch { entries, .. } => Some(entries.iter().cloned()),
+            _ => None,
+        })
+        .flatten()
+        .collect()
+}
+
 fn finished_truncated(events: &[DirectoryEvent]) -> Option<bool> {
     events.iter().find_map(|event| match event {
         DirectoryEvent::Finished { truncated, .. } => Some(*truncated),
@@ -402,6 +429,7 @@ fn enumerate_reports_truncated_once_the_entry_budget_is_exceeded() {
         id: RequestId(1),
         location: Location::local(&root),
         batch_size: 2,
+        include_metadata: false,
         max_entries: 3,
         time_budget: Duration::from_secs(10),
     });
@@ -432,6 +460,7 @@ fn enumerate_completes_untruncated_at_the_exact_entry_budget() {
         id: RequestId(1),
         location: Location::local(&root),
         batch_size: 2,
+        include_metadata: false,
         max_entries: 4,
         time_budget: Duration::from_secs(10),
     });
@@ -456,6 +485,7 @@ fn enumerate_reports_truncated_once_the_time_budget_is_exceeded() {
         id: RequestId(1),
         location: Location::local(&root),
         batch_size: 1,
+        include_metadata: false,
         max_entries: usize::MAX,
         time_budget: Duration::from_nanos(1),
     });
@@ -481,6 +511,7 @@ fn enumerate_completes_untruncated_within_budget() {
         id: RequestId(1),
         location: Location::local(&root),
         batch_size: 64,
+        include_metadata: false,
         max_entries: 100,
         time_budget: Duration::from_secs(10),
     });
@@ -492,4 +523,405 @@ fn enumerate_completes_untruncated_within_budget() {
         "a directory well within budget should not be reported as truncated"
     );
     assert_eq!(batched_entry_count(&events), 5);
+}
+
+#[test]
+fn native_enumeration_marks_hidden_files() {
+    let root = unique_fixture_root("hidden");
+    fs::create_dir_all(&root).expect("the fixture directory should be created");
+    fs::write(root.join("visible.txt"), b"content").expect("the visible file should be written");
+    fs::write(root.join(".hidden.txt"), b"content").expect("the hidden file should be written");
+    fs::write(root.join("listed-hidden.txt"), b"content")
+        .expect("the listed hidden file should be written");
+    fs::write(root.join(".hidden"), b"listed-hidden.txt\n")
+        .expect("the hidden-name list should be written");
+
+    let entries = batched_entries(&run_enumerate(DirectoryRequest {
+        id: RequestId(1),
+        location: Location::local(&root),
+        batch_size: 64,
+        include_metadata: false,
+        max_entries: 100,
+        time_budget: Duration::from_secs(10),
+    }));
+    assert_eq!(entries.len(), 4);
+    assert!(
+        entries
+            .iter()
+            .find(|entry| entry.native_name == "visible.txt")
+            .is_some_and(|entry| !entry.is_hidden)
+    );
+    for name in [".hidden.txt", "listed-hidden.txt", ".hidden"] {
+        assert!(
+            entries
+                .iter()
+                .find(|entry| entry.native_name == name)
+                .is_some_and(|entry| entry.is_hidden),
+            "{name} should be marked hidden"
+        );
+    }
+
+    fs::remove_dir_all(&root).expect("the fixture directory should be removed");
+}
+
+#[test]
+fn native_enumeration_reports_an_unreadable_root() {
+    let root = unique_fixture_root("missing-root");
+    let events = run_enumerate(DirectoryRequest {
+        id: RequestId(1),
+        location: Location::local(root),
+        batch_size: 64,
+        include_metadata: false,
+        max_entries: 100,
+        time_budget: Duration::from_secs(10),
+    });
+
+    assert!(matches!(events.as_slice(), [DirectoryEvent::Failed { .. }]));
+}
+
+#[test]
+fn cancelled_native_scan_returns_no_partial_result() {
+    let root = unique_fixture_root("cancelled");
+    fs::create_dir_all(&root).expect("the fixture directory should be created");
+    fs::write(root.join("file.txt"), b"content").expect("the fixture file should be written");
+    let request = DirectoryRequest {
+        id: RequestId(1),
+        location: Location::local(&root),
+        batch_size: 64,
+        include_metadata: false,
+        max_entries: 100,
+        time_budget: Duration::from_secs(10),
+    };
+    let cancellable = gio::Cancellable::new();
+    cancellable.cancel();
+
+    assert!(matches!(
+        scan_native_directory(
+            &root,
+            &request,
+            &cancellable,
+            Instant::now() + Duration::from_secs(10)
+        ),
+        NativeEnumeration::Cancelled
+    ));
+
+    fs::remove_dir_all(&root).expect("the fixture directory should be removed");
+}
+
+#[test]
+fn enumerate_with_metadata_fills_sizes_up_front() -> Result<(), Box<dyn Error>> {
+    let root = unique_fixture_root("with-metadata");
+    fs::create_dir_all(&root).expect("the fixture directory should be created");
+    fs::write(root.join("file-0.txt"), b"content").expect("the fixture file should be written");
+
+    let with_metadata = run_enumerate(DirectoryRequest {
+        id: RequestId(1),
+        location: Location::local(&root),
+        batch_size: 64,
+        include_metadata: true,
+        max_entries: 100,
+        time_budget: Duration::from_secs(10),
+    });
+    let streaming = run_enumerate(DirectoryRequest {
+        id: RequestId(2),
+        location: Location::local(&root),
+        batch_size: 64,
+        include_metadata: false,
+        max_entries: 100,
+        time_budget: Duration::from_secs(10),
+    });
+    fs::remove_dir_all(&root).expect("the fixture directory should be removed");
+
+    let sizes = |events: &[DirectoryEvent]| {
+        events
+            .iter()
+            .filter_map(|event| match event {
+                DirectoryEvent::Batch { entries, .. } => Some(
+                    entries
+                        .iter()
+                        .map(|entry| entry.size.clone())
+                        .collect::<Vec<_>>(),
+                ),
+                _ => None,
+            })
+            .flatten()
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(
+        sizes(&with_metadata),
+        vec![MetadataValue::Known(7)],
+        "a metadata load should stat every entry up front"
+    );
+    assert_eq!(
+        sizes(&streaming),
+        vec![MetadataValue::Unknown],
+        "a streaming load should leave sizes for the window fill"
+    );
+    Ok(())
+}
+
+/// `fill_metadata()` spawns on the shared default context like `enumerate()`
+/// does, so it needs the same serialized `block_on` bridge. The terminal is
+/// `MetadataFinished` instead of `Finished`.
+fn run_fill(request: MetadataRequest) -> Vec<DirectoryEvent> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
+    glib::MainContext::default().block_on(async move {
+        let events: Rc<RefCell<Vec<DirectoryEvent>>> = Rc::new(RefCell::new(Vec::new()));
+        let waker: Rc<RefCell<Option<std::task::Waker>>> = Rc::new(RefCell::new(None));
+        let collected = events.clone();
+        let collected_waker = waker.clone();
+        let emit: Rc<dyn Fn(DirectoryEvent)> = Rc::new(move |event| {
+            let is_terminal = matches!(event, DirectoryEvent::MetadataFinished { .. });
+            collected.borrow_mut().push(event);
+            if is_terminal && let Some(waker) = collected_waker.borrow_mut().take() {
+                waker.wake();
+            }
+        });
+        let handle = LocalFileSource.fill_metadata(request, emit);
+        std::future::poll_fn(|cx| {
+            let has_terminal_event = events
+                .borrow()
+                .iter()
+                .any(|event| matches!(event, DirectoryEvent::MetadataFinished { .. }));
+            if has_terminal_event {
+                std::task::Poll::Ready(())
+            } else {
+                *waker.borrow_mut() = Some(cx.waker().clone());
+                std::task::Poll::Pending
+            }
+        })
+        .await;
+        drop(handle);
+        events.borrow().clone()
+    })
+}
+
+fn fill_outcome(events: &[DirectoryEvent]) -> Option<MetadataOutcome> {
+    events.iter().find_map(|event| match event {
+        DirectoryEvent::MetadataFinished { outcome, .. } => Some(*outcome),
+        _ => None,
+    })
+}
+
+fn fill_chunk_count(events: &[DirectoryEvent]) -> usize {
+    events
+        .iter()
+        .filter(|event| matches!(event, DirectoryEvent::MetadataFilled { .. }))
+        .count()
+}
+
+#[test]
+fn fill_empty_entries_completes_without_chunks() {
+    let events = run_fill(MetadataRequest {
+        id: RequestId(1),
+        entries: Vec::new(),
+        full: true,
+        time_budget: Duration::from_secs(10),
+    });
+    assert_eq!(fill_outcome(&events), Some(MetadataOutcome::Complete));
+    assert_eq!(fill_chunk_count(&events), 0);
+}
+
+#[test]
+fn fill_all_vanished_entries_reports_failed() {
+    let root = unique_fixture_root("fill-vanished");
+    let events = run_fill(MetadataRequest {
+        id: RequestId(1),
+        entries: vec![
+            Location::local(root.join("gone-0.txt")),
+            Location::local(root.join("gone-1.txt")),
+        ],
+        full: true,
+        time_budget: Duration::from_secs(10),
+    });
+    // Every stat failed: a failure, not a complete pass over placeholders.
+    assert_eq!(fill_outcome(&events), Some(MetadataOutcome::Failed));
+}
+
+#[test]
+fn fill_unreachable_remote_reports_failed() {
+    let events = run_fill(MetadataRequest {
+        id: RequestId(1),
+        entries: vec![Location::uri("sftp://host/share/photo.jpg")],
+        full: false,
+        time_budget: Duration::from_secs(10),
+    });
+    // The remote form is statable in principle, so the provider attempts it
+    // through GIO and reports the failure instead of claiming no support.
+    // The failed row still rides along as a placeholder chunk.
+    assert_eq!(fill_outcome(&events), Some(MetadataOutcome::Failed));
+    assert_eq!(fill_chunk_count(&events), 1);
+}
+
+#[test]
+fn fill_file_uri_stats_through_the_uri_form() -> Result<(), Box<dyn Error>> {
+    let root = unique_fixture_root("fill-uri");
+    fs::create_dir_all(&root).expect("the fixture directory should be created");
+    let path = root.join("photo.jpg");
+    fs::write(&path, b"content").expect("the fixture file should be written");
+
+    let uri = format!("file://{}", path.display());
+    let events = run_fill(MetadataRequest {
+        id: RequestId(1),
+        entries: vec![Location::uri(uri)],
+        full: false,
+        time_budget: Duration::from_secs(10),
+    });
+    // URI-form entries stat through `gio::File::for_uri`, the same path
+    // remote and GVfs fills take.
+    assert_eq!(fill_outcome(&events), Some(MetadataOutcome::Complete));
+    assert_eq!(fill_chunk_count(&events), 1);
+    Ok(())
+}
+
+#[test]
+fn fill_live_file_completes_with_a_chunk() -> Result<(), Box<dyn Error>> {
+    let root = unique_fixture_root("fill-live");
+    fs::create_dir_all(&root).expect("the fixture directory should be created");
+    fs::write(root.join("photo.jpg"), b"content").expect("the fixture file should be written");
+
+    let events = run_fill(MetadataRequest {
+        id: RequestId(1),
+        entries: vec![Location::local(root.join("photo.jpg"))],
+        full: false,
+        time_budget: Duration::from_secs(10),
+    });
+    assert_eq!(fill_outcome(&events), Some(MetadataOutcome::Complete));
+    assert_eq!(fill_chunk_count(&events), 1);
+    let size = events.iter().find_map(|event| match event {
+        DirectoryEvent::MetadataFilled { updates, .. } => {
+            updates.first().map(|update| update.size.clone())
+        }
+        _ => None,
+    });
+    assert_eq!(size, Some(MetadataValue::Known(7)));
+    Ok(())
+}
+
+#[test]
+fn parallel_fill_follows_symlinks_like_enumeration() -> Result<(), Box<dyn Error>> {
+    use std::os::unix::fs::symlink;
+
+    let root = unique_fixture_root("fill-symlink");
+    fs::create_dir_all(&root).expect("the fixture directory should be created");
+    let target = root.join("target.txt");
+    fs::write(&target, b"0123456789").expect("the target should be written");
+    let link = root.join("link.txt");
+    symlink(&target, &link).expect("the symlink should be created");
+    let subdir = root.join("sub");
+    fs::create_dir_all(&subdir).expect("the subdir should be created");
+    let dir_link = root.join("dir-link");
+    symlink(&subdir, &dir_link).expect("the dir symlink should be created");
+
+    let events = run_fill(MetadataRequest {
+        id: RequestId(1),
+        entries: vec![
+            Location::local(&link),
+            Location::local(&dir_link),
+            Location::local(&target),
+        ],
+        full: true,
+        time_budget: Duration::from_secs(10),
+    });
+    assert_eq!(fill_outcome(&events), Some(MetadataOutcome::Complete));
+    let by_location = |wanted: &Location| {
+        events.iter().find_map(|event| match event {
+            DirectoryEvent::MetadataFilled { updates, .. } => updates
+                .iter()
+                .find(|update| &update.location == wanted)
+                .cloned(),
+            _ => None,
+        })
+    };
+    // A file symlink reports its target's size and mtime (follows, like the
+    // enumeration queries do), never the link's own bytes.
+    let link_update = by_location(&Location::local(&link)).expect("the link should fill");
+    let target_update = by_location(&Location::local(&target)).expect("the target should fill");
+    assert_eq!(link_update.size, MetadataValue::Known(10));
+    assert_eq!(link_update.size, target_update.size);
+    assert_eq!(
+        link_update.modified_unix_seconds,
+        target_update.modified_unix_seconds
+    );
+    // A directory symlink keeps the explicitly unavailable directory size.
+    let dir_update = by_location(&Location::local(&dir_link)).expect("the dir link should fill");
+    assert_eq!(dir_update.size, MetadataValue::Unknown);
+    assert!(matches!(
+        dir_update.modified_unix_seconds,
+        MetadataValue::Known(_)
+    ));
+    Ok(())
+}
+
+#[test]
+fn parallel_fill_cancellation_reports_cancelled_without_chunks() {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
+    let root = unique_fixture_root("fill-cancel");
+    let count = 20_000;
+    // Entries need not exist: cancellation must win before any stat runs.
+    // (Nonexistent paths would fail fast, so create a handful to keep
+    // workers busy and the rest virtual.)
+    fs::create_dir_all(&root).expect("the fixture directory should be created");
+    for index in 0..100 {
+        fs::write(root.join(format!("file-{index:04}.txt")), b"content")
+            .expect("the fixture file should be written");
+    }
+    let entries: Vec<Location> = (0..count)
+        .map(|index| Location::local(root.join(format!("file-{index:05}.txt"))))
+        .collect();
+    let events: Rc<RefCell<Vec<DirectoryEvent>>> = Rc::new(RefCell::new(Vec::new()));
+    let collected = events.clone();
+    let emit: Rc<dyn Fn(DirectoryEvent)> = Rc::new(move |event| {
+        collected.borrow_mut().push(event);
+    });
+    glib::MainContext::default().block_on(async {
+        let handle =
+            super::fill_parallel_with(8, RequestId(1), entries, Duration::from_secs(60), emit);
+        // Yield once so the driver task starts its workers, then cancel
+        // mid-flight: the abort silences the driver while the shared
+        // cancellable stops the workers, so neither chunks nor Complete
+        // ever arrive. No `iteration()` inside `block_on` (reentering the
+        // executor panics); a one-shot timeout wakes the grace poll.
+        let mut yielded = false;
+        std::future::poll_fn(|cx| {
+            if yielded {
+                std::task::Poll::Ready(())
+            } else {
+                yielded = true;
+                cx.waker().wake_by_ref();
+                std::task::Poll::Pending
+            }
+        })
+        .await;
+        drop(handle);
+        let waker: Rc<RefCell<Option<std::task::Waker>>> = Rc::new(RefCell::new(None));
+        let wake = waker.clone();
+        // Recurring wake-ups: a one-shot wake parks forever once spent,
+        // since the aborted driver emits nothing more.
+        let ticker = glib::timeout_add_local(Duration::from_millis(20), move || {
+            if let Some(waker) = wake.borrow_mut().take() {
+                waker.wake();
+            }
+            glib::ControlFlow::Continue
+        });
+        let deadline = Instant::now() + Duration::from_secs(1);
+        std::future::poll_fn(|cx| {
+            let done = events
+                .borrow()
+                .iter()
+                .any(|event| matches!(event, DirectoryEvent::MetadataFinished { .. }));
+            if done || Instant::now() >= deadline {
+                std::task::Poll::Ready(())
+            } else {
+                *waker.borrow_mut() = Some(cx.waker().clone());
+                std::task::Poll::Pending
+            }
+        })
+        .await;
+        ticker.remove();
+    });
 }

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -2,21 +2,22 @@
 
 use std::{
     cell::{Cell, RefCell},
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     rc::{Rc, Weak},
     time::Duration,
 };
 
 use crate::{
-    app::navigation::{EntryInsertion, EntrySplice, NavigationPath, NavigationState},
+    app::navigation::{EntryInsertion, EntrySplice, NavigationPath, NavigationState, sort_entries},
     model::{FileEntry, Location, SortDirection, SortKey, ViewPreferences},
     services::{
         ArchiveFormat, CompressRequest, CreateDirectoryRequest, CreateFileRequest, DeleteRequest,
         DirectoryChange, DirectoryEvent, DirectoryRequest, ExtractRequest, FileSource, LoadHandle,
-        LocationValidationError, OperationEvent, OperationProvider, OperationRequestId, PasteItem,
-        PasteRequest, RenameRequest, RequestId, RestoreRequest, RestoreSource, TransferConflict,
-        validate_basename, validate_uri_credentials,
+        LocationValidationError, MetadataOutcome, MetadataRequest, OperationEvent,
+        OperationProvider, OperationRequestId, PasteItem, PasteRequest, RenameRequest, RequestId,
+        RestoreRequest, RestoreSource, TransferConflict, validate_basename,
+        validate_uri_credentials,
     },
 };
 
@@ -25,6 +26,13 @@ use crate::{
 /// merge cost grows enough that browsing stops feeling responsive.
 const MAX_DIRECTORY_ENTRIES: usize = 100_000;
 const DIRECTORY_LOAD_TIME_BUDGET: Duration = Duration::from_secs(10);
+
+/// GIO batch size for local directories. Fewer, larger batches cut the
+/// per-batch merge, selection scan, and GTK splice count ~4x on large
+/// listings. Remote (GVfs) locations keep small batches so first paint
+/// doesn't wait out high per-file latency on slow links.
+const NATIVE_DIRECTORY_BATCH_SIZE: usize = 512;
+const REMOTE_DIRECTORY_BATCH_SIZE: usize = 128;
 
 /// A hover peek only ever displays a handful of entries (`PeekBehavior::item_limit`), so it
 /// needs far less headroom than a full directory load -- just enough to survive hidden-file
@@ -36,7 +44,6 @@ const PEEK_TIME_BUDGET: Duration = Duration::from_secs(3);
 #[derive(Clone, Debug)]
 pub struct BrowserColumnSnapshot {
     pub location: Location,
-    pub entries: Vec<FileEntry>,
     pub selected_positions: Vec<usize>,
     pub loading: bool,
     pub error: Option<String>,
@@ -59,7 +66,15 @@ pub enum BrowserEvent {
     },
     EntriesReplaced {
         depth: usize,
-        entries: Vec<FileEntry>,
+        count: usize,
+    },
+    /// A contiguous range already installed in authoritative state. Views
+    /// borrow that range during synchronous dispatch instead of receiving a
+    /// deep clone of every entry.
+    EntriesPublished {
+        depth: usize,
+        position: usize,
+        count: usize,
     },
     SortingStarted {
         depth: usize,
@@ -71,6 +86,13 @@ pub enum BrowserEvent {
         depth: usize,
         splices: Vec<EntrySplice>,
         selected: Option<usize>,
+    },
+    /// Size/mtime arrivals for already-rendered rows: positions with their
+    /// refreshed entries, for an in-place same-count model refresh. The order
+    /// never changes here; sorting by size or date runs its own full pass.
+    MetadataFilled {
+        depth: usize,
+        updates: Vec<(usize, FileEntry)>,
     },
     ColumnReloaded {
         depth: usize,
@@ -182,7 +204,14 @@ pub enum BrowserEvent {
     TransferCompleted,
 }
 
-type Observer = Rc<dyn Fn(BrowserEvent)>;
+/// Observers receive the event by reference during synchronous dispatch:
+/// listing payloads (`Vec<FileEntry>`) move exactly once from the provider
+/// into authoritative state and the single emitted event, and fan-out to
+/// every observer borrows instead of deep-cloning per observer. Consumers
+/// that retain data clone only the small field they store. The observer
+/// list itself is cloned before dispatch so add/remove/reentrant emission
+/// stays safe.
+type Observer = Rc<dyn Fn(&BrowserEvent)>;
 type PreferencesObserver = Rc<dyn Fn(ViewPreferences)>;
 
 const MAX_INCREMENTAL_OPERATION_UPDATES: usize = 64;
@@ -247,11 +276,116 @@ fn pending_trash_undo() -> Vec<Location> {
     PENDING_TRASH_UNDO.with(|pending| pending.borrow().locations.clone())
 }
 
+/// Settles scrolling before asking for viewport metadata, so a fling never
+/// stats hundreds of rows it never shows.
+const METADATA_FILL_DEBOUNCE: Duration = Duration::from_millis(100);
+/// Bounds one metadata fill; partial results still apply, the rest retries on
+/// its next bind.
+const METADATA_FILL_TIME_BUDGET: Duration = Duration::from_secs(5);
+/// Defensive cap per depth: the UI only ever asks for its visible window.
+const MAX_PENDING_FILL_LOCATIONS: usize = 1024;
+
+/// Accumulates this many entries before flushing early: first paint applies
+/// at once, later batches merge, scan, and splice in groups of four.
+/// Remote loads only; native loads stage instead (see `StagingLoad`).
+const COALESCE_ENTRIES: usize = 2048;
+/// Bounds one remote progressive flush: a slow link must not turn one timer
+/// fire into a multi-frame GTK mutation.
+const REMOTE_FLUSH_CAP: usize = 512;
+/// Maximum latency for remote progressive rows: later batches flush on the
+/// next idle/frame instead of waiting solely for the count threshold.
+const REMOTE_FLUSH_DELAY: Duration = Duration::from_millis(50);
+/// Rows published synchronously with a staged load or sort; the rest stream
+/// from idle callbacks inside an 8 ms work budget.
+const FIRST_PUBLISH_COUNT: usize = 128;
+/// Loads at or below this size publish in one synchronous replace.
+const STAGE_INLINE_LIMIT: usize = 512;
+/// Snapshots at or below this size sort synchronously on the calling
+/// thread: sub-millisecond work that needs no off-thread hop and no main
+/// context. Larger snapshots sort in a blocking worker.
+const SORT_INLINE_LIMIT: usize = 2048;
+/// Rows per publication tail callback.
+const PUBLISH_TAIL_CHUNK: usize = 2048;
+/// Main-thread work budget per publication tail callback.
+const PUBLISH_SLICE_BUDGET: Duration = Duration::from_millis(8);
+
+/// Last selection event emitted per depth on the batch path, keyed by request
+/// so a new load re-emits even when it selects the same rows. Lets background
+/// batches skip the redundant per-pane selection refresh (and its scroll)
+/// when nothing moved.
+type BatchSelectionState = HashMap<usize, (RequestId, Vec<usize>, usize)>;
+
+/// One bound row's viewport fill request: the stable location plus the source
+/// position it occupied when bound, so fills apply in O(requested rows)
+/// after validating the row has not moved.
+struct ViewportTarget {
+    position: usize,
+    location: Location,
+}
+
+/// A native initial load in flight. Identity batches accumulate here with no
+/// merge walk and no UI events; monitor deltas arriving mid-stage queue for
+/// one reconcile instead of racing the snapshot. Removed locations filter
+/// later batches, so a removed entry is never resurrected by a stale batch
+/// while an upserted one still lands.
+struct StagingLoad {
+    request_id: RequestId,
+    entries: Vec<FileEntry>,
+    removed: HashSet<Location>,
+    deltas: Vec<(Location, DirectoryChange)>,
+}
+
+/// A native load sorting off-thread after enumeration finished. Deltas
+/// arriving here queue for the completion's silent reconcile.
+struct SortingLoad {
+    request_id: RequestId,
+    deltas: Vec<(Location, DirectoryChange)>,
+}
+
+/// Terminal event owed after a staged publication's final tail.
+enum PublishTerminal {
+    LoadFinished { truncated: bool },
+    SortingFinished,
+}
+
+/// A staged publication streaming to the UI: the prefix is already in the
+/// model, and idle callbacks append contiguous tails inside a work budget.
+/// Chunks clone from authoritative state at fire time, so no full-vector
+/// copy ever crosses the publish path. Selection and the terminal event
+/// wait for the final tail, so no out-of-range selection and no premature
+/// completion is ever published.
+struct StagedPublish {
+    request_id: RequestId,
+    published: usize,
+    total: usize,
+    focused: Option<usize>,
+    positions: Vec<usize>,
+    terminal: PublishTerminal,
+}
+
 pub struct Browser {
     source: Rc<dyn FileSource>,
     state: RefCell<NavigationState>,
     loads: RefCell<Vec<LoadHandle>>,
     monitors: RefCell<Vec<Option<LoadHandle>>>,
+    metadata_pending: RefCell<HashMap<usize, Vec<ViewportTarget>>>,
+    metadata_timer: RefCell<Option<gio::glib::SourceId>>,
+    staging: RefCell<HashMap<usize, StagingLoad>>,
+    /// Native loads whose snapshot is sorting off-thread. Monitor deltas
+    /// arriving mid-sort queue here for the same silent reconcile.
+    sorting: RefCell<HashMap<usize, SortingLoad>>,
+    staged_publishes: RefCell<HashMap<usize, StagedPublish>>,
+    publish_timer: RefCell<Option<gio::glib::SourceId>>,
+    remote_flush_timer: RefCell<Option<gio::glib::SourceId>>,
+    metadata_loads: RefCell<HashMap<usize, LoadHandle>>,
+    /// Stable `(position, Location)` tokens per in-flight viewport fill, so
+    fill_tokens: RefCell<HashMap<RequestId, Vec<(usize, Location)>>>,
+    /// Full-column sort fills, kept apart from viewport fills so a viewport
+    /// settle timer can never overwrite or cancel an active full sort.
+    sort_loads: RefCell<HashMap<usize, LoadHandle>>,
+    coalesce_pending: RefCell<HashMap<usize, (RequestId, Vec<FileEntry>)>>,
+    sort_awaiting_fill: RefCell<Option<(u64, usize, RequestId, ViewPreferences)>>,
+    last_batch_selection: RefCell<BatchSelectionState>,
     peek_load: RefCell<Option<LoadHandle>>,
     validation_load: RefCell<Option<LoadHandle>>,
     validation_generation: Cell<u64>,
@@ -282,6 +416,19 @@ impl Browser {
             state: RefCell::new(NavigationState::with_preferences(preferences)),
             loads: RefCell::new(Vec::new()),
             monitors: RefCell::new(Vec::new()),
+            metadata_pending: RefCell::new(HashMap::new()),
+            metadata_timer: RefCell::new(None),
+            staging: RefCell::new(HashMap::new()),
+            sorting: RefCell::new(HashMap::new()),
+            staged_publishes: RefCell::new(HashMap::new()),
+            publish_timer: RefCell::new(None),
+            remote_flush_timer: RefCell::new(None),
+            metadata_loads: RefCell::new(HashMap::new()),
+            fill_tokens: RefCell::new(HashMap::new()),
+            sort_loads: RefCell::new(HashMap::new()),
+            coalesce_pending: RefCell::new(HashMap::new()),
+            sort_awaiting_fill: RefCell::new(None),
+            last_batch_selection: RefCell::new(HashMap::new()),
             peek_load: RefCell::new(None),
             validation_load: RefCell::new(None),
             validation_generation: Cell::new(0),
@@ -301,7 +448,7 @@ impl Browser {
         })
     }
 
-    pub fn observe(&self, observer: impl Fn(BrowserEvent) + 'static) {
+    pub fn observe(&self, observer: impl Fn(&BrowserEvent) + 'static) {
         self.observers.borrow_mut().push(Rc::new(observer));
     }
 
@@ -422,6 +569,7 @@ impl Browser {
         self.close_peek();
         self.loads.borrow_mut().clear();
         self.monitors.borrow_mut().clear();
+        self.cancel_deferred_work();
         let request_id = self.new_request_id();
         self.state
             .borrow_mut()
@@ -521,6 +669,7 @@ impl Browser {
         let retained = parent_depth + 1;
         self.loads.borrow_mut().truncate(retained);
         self.monitors.borrow_mut().truncate(retained);
+        self.truncate_deferred_from(retained);
         self.emit(BrowserEvent::ColumnsTruncated { len: retained });
         self.emit(BrowserEvent::ColumnAdded {
             depth: retained,
@@ -556,11 +705,14 @@ impl Browser {
                 browser.handle_directory_event(event);
             }
         });
+        // Peeks stay small and show metadata immediately, so they keep the
+        // old always-stat behavior instead of the streaming split.
         let handle = self.source.enumerate(
             DirectoryRequest {
                 id: request_id,
                 location,
                 batch_size: 128,
+                include_metadata: true,
                 max_entries: PEEK_MAX_ENTRIES,
                 time_budget: PEEK_TIME_BUDGET,
             },
@@ -578,7 +730,7 @@ impl Browser {
         closed
     }
 
-    pub fn escape(&self) {
+    pub fn escape(self: &Rc<Self>) {
         if self.close_peek() {
             return;
         }
@@ -588,17 +740,19 @@ impl Browser {
             let len = depth + 1;
             self.loads.borrow_mut().truncate(len);
             self.monitors.borrow_mut().truncate(len);
+            self.truncate_deferred_from(len);
             self.emit(BrowserEvent::ColumnsTruncated { len });
             self.emit(BrowserEvent::FocusChanged { depth, position });
         }
     }
 
-    pub fn close_column(&self, depth: usize) {
+    pub fn close_column(self: &Rc<Self>, depth: usize) {
         self.close_peek();
         let closed = self.state.borrow_mut().close_from(depth);
         if let Some((parent_depth, position)) = closed {
             self.loads.borrow_mut().truncate(depth);
             self.monitors.borrow_mut().truncate(depth);
+            self.truncate_deferred_from(depth);
             self.emit(BrowserEvent::ColumnsTruncated { len: depth });
             self.emit(BrowserEvent::FocusChanged {
                 depth: parent_depth,
@@ -678,40 +832,68 @@ impl Browser {
         self.emit(BrowserEvent::SortingStarted { depth });
         let weak = Rc::downgrade(self);
         gio::glib::timeout_add_local_once(Duration::from_millis(16), move || {
-            let Some(browser) = weak.upgrade() else {
-                return;
-            };
-            if browser.pending_sort.get() != Some((generation, depth)) {
-                return;
+            if let Some(browser) = weak.upgrade() {
+                browser.apply_debounced_sort(depth, generation, update);
             }
-            let result = {
-                let mut state = browser.state.borrow_mut();
-                let Some(mut preferences) = state.column_preferences(depth) else {
-                    drop(state);
-                    browser.pending_sort.set(None);
-                    browser.emit(BrowserEvent::SortingFinished { depth });
-                    return;
-                };
-                update(&mut preferences);
-                let result = state.set_column_preferences(depth, preferences);
-                browser.preferences.set(preferences);
-                result
-            };
-            browser.notify_preferences_observers();
-            if let Some((entries, focused, positions)) = result {
-                browser.emit(BrowserEvent::EntriesReplaced { depth, entries });
-                if let Some(focused) = focused {
-                    browser.emit(BrowserEvent::SelectionSetChanged {
-                        depth,
-                        positions,
-                        focused,
-                        take_focus: false,
-                    });
-                }
-            }
-            browser.pending_sort.set(None);
-            browser.emit(BrowserEvent::SortingFinished { depth });
         });
+    }
+
+    fn apply_debounced_sort(
+        self: &Rc<Self>,
+        depth: usize,
+        generation: u64,
+        update: impl FnOnce(&mut ViewPreferences),
+    ) {
+        if self.pending_sort.get() != Some((generation, depth)) {
+            return;
+        }
+        let result = {
+            let mut state = self.state.borrow_mut();
+            let Some(mut preferences) = state.column_preferences(depth) else {
+                drop(state);
+                self.pending_sort.set(None);
+                self.emit(BrowserEvent::SortingFinished { depth });
+                return;
+            };
+            update(&mut preferences);
+            // Size and date sorts need the metadata the streaming
+            // enumeration skipped. Fill the whole column first behind the
+            // sort spinner instead of sorting placeholders.
+            let targets = state.column_unknown_metadata(depth).unwrap_or_default();
+            if matches!(preferences.sort_key, SortKey::Size | SortKey::Modified)
+                && !targets.is_empty()
+            {
+                drop(state);
+                self.request_sort_fill(depth, generation, preferences, targets);
+                return;
+            }
+            let result = state.apply_sort_preferences(depth, preferences);
+            self.preferences.set(preferences);
+            let request_id = state.request_id_for_depth(depth);
+            let total = state.columns.get(depth).map(|column| column.entries.len());
+            result.map(|(focused, positions)| (request_id, total, focused, positions))
+        };
+        self.notify_preferences_observers();
+        if let Some((request_id, total, focused, positions)) = result {
+            // Staged publication carries the new order; the sorting
+            // terminal waits for its final tail.
+            if let (Some(request_id), Some(total)) = (request_id, total) {
+                self.publish_staged(
+                    depth,
+                    request_id,
+                    total,
+                    focused,
+                    positions,
+                    PublishTerminal::SortingFinished,
+                );
+            } else {
+                self.pending_sort.set(None);
+                self.emit(BrowserEvent::SortingFinished { depth });
+            }
+        } else {
+            self.pending_sort.set(None);
+            self.emit(BrowserEvent::SortingFinished { depth });
+        }
     }
 
     pub fn can_go_back(&self) -> bool {
@@ -761,6 +943,17 @@ impl Browser {
         self.state.borrow().entry_at(depth, position)
     }
 
+    pub fn with_entries<R>(
+        &self,
+        depth: usize,
+        range: std::ops::Range<usize>,
+        read: impl FnOnce(&[FileEntry]) -> R,
+    ) -> Option<R> {
+        let state = self.state.borrow();
+        let entries = &state.columns.get(depth)?.entries;
+        Some(read(entries.get(range)?))
+    }
+
     pub fn column_preferences(&self, depth: usize) -> Option<ViewPreferences> {
         self.state.borrow().column_preferences(depth)
     }
@@ -770,7 +963,6 @@ impl Browser {
         let column = state.columns.get(depth)?;
         Some(BrowserColumnSnapshot {
             location: column.location.clone(),
-            entries: column.entries.clone(),
             selected_positions: state.selected_positions(depth),
             loading: column.load_state == crate::app::navigation::LoadState::Loading,
             error: match &column.load_state {
@@ -803,6 +995,9 @@ impl Browser {
     pub fn selected_entries(&self) -> Vec<FileEntry> {
         self.state.borrow().selected_entries()
     }
+    pub fn selected_positions(&self, depth: usize) -> Vec<usize> {
+        self.state.borrow().selected_positions(depth)
+    }
 
     pub fn deletion_entries(&self) -> Vec<FileEntry> {
         let state = self.state.borrow();
@@ -825,7 +1020,7 @@ impl Browser {
         if state.set_selection(depth, positions, focused) {
             tracing::debug!(
                 depth,
-                selected = state.selected_entries().len(),
+                selected = state.selected_count(),
                 "selection changed"
             );
         }
@@ -1520,6 +1715,7 @@ impl Browser {
         self.close_peek();
         self.loads.borrow_mut().clear();
         self.monitors.borrow_mut().clear();
+        self.cancel_deferred_work();
         let loads: Vec<_> = path
             .locations()
             .iter()
@@ -1551,7 +1747,7 @@ impl Browser {
     }
 
     fn start_load(self: &Rc<Self>, depth: usize, location: Location, request_id: RequestId) {
-        let handle = self.request_directory(location.clone(), request_id);
+        let handle = self.request_directory(depth, location.clone(), request_id);
         self.loads.borrow_mut().push(handle);
 
         let monitor = self.install_monitor(depth, location);
@@ -1570,18 +1766,919 @@ impl Browser {
             .watch(location, self.preferences.get().show_hidden, notify)
     }
 
-    fn request_directory(self: &Rc<Self>, location: Location, request_id: RequestId) -> LoadHandle {
+    /// Merges one wire batch (or one coalesced group) and emits its UI
+    /// events: the single choke point behind immediate, coalesced, and
+    /// straggler application alike.
+    fn apply_owned_batch(self: &Rc<Self>, request_id: RequestId, entries: Vec<FileEntry>) {
+        let install_started = std::time::Instant::now();
+        let mut state = self.state.borrow_mut();
+        let batch_len = entries.len();
+        let Some((depth, insertions)) = state.apply_batch(request_id, entries) else {
+            // The load went away between queueing and flush.
+            return;
+        };
+        tracing::debug!(
+            request_id = request_id.0,
+            location = %state.columns[depth].location.diagnostic_path(),
+            entries = batch_len,
+            "directory batch accepted"
+        );
+        let selected = state.columns[depth].selected;
+        drop(state);
+        crate::metrics::record_stage(
+            "state-install",
+            install_started.elapsed().as_millis() as u64,
+        );
+        self.emit(BrowserEvent::EntriesInserted { depth, insertions });
+        // The full-column scan below is the most expensive per-batch work
+        // after the merge itself; skip it entirely when nothing is selected.
+        if let Some(focused) = selected {
+            let positions = self.state.borrow().selected_positions(depth);
+            let current = (request_id, positions.clone(), focused);
+            let mut last = self.last_batch_selection.borrow_mut();
+            if last.get(&depth) != Some(&current) {
+                last.insert(depth, current);
+                drop(last);
+                self.emit(BrowserEvent::SelectionSetChanged {
+                    depth,
+                    positions,
+                    focused,
+                    take_focus: false,
+                });
+            }
+        }
+    }
+
+    /// Stages one native wire batch: appended to the depth's staging load
+    /// with no merge walk and no UI events. Sorting, installation, and
+    /// publication all wait for enumeration to finish.
+    fn stage_batch(self: &Rc<Self>, request_id: RequestId, depth: usize, entries: Vec<FileEntry>) {
+        let mut staging = self.staging.borrow_mut();
+        let slot = staging.entry(depth).or_insert_with(|| StagingLoad {
+            request_id,
+            entries: Vec::new(),
+            removed: HashSet::new(),
+            deltas: Vec::new(),
+        });
+        if slot.request_id != request_id {
+            // A reload replaced the load mid-stream: the old staging
+            // belongs to a discarded load, so restart it instead of mixing
+            // generations.
+            *slot = StagingLoad {
+                request_id,
+                entries,
+                removed: HashSet::new(),
+                deltas: Vec::new(),
+            };
+            return;
+        }
+        if slot.entries.is_empty() {
+            slot.entries = entries;
+        } else {
+            slot.entries.extend(entries);
+        }
+    }
+
+    fn accumulate_batch(
+        self: &Rc<Self>,
+        request_id: RequestId,
+        depth: usize,
+        entries: Vec<FileEntry>,
+    ) {
+        // Remote loads only: a 50 ms timer bounds first-result latency so a
+        // slow link never waits solely for the count threshold.
+        let mut pending = self.coalesce_pending.borrow_mut();
+        let slot = pending
+            .entry(depth)
+            .or_insert_with(|| (request_id, Vec::new()));
+        if slot.0 != request_id {
+            // A reload replaced the load mid-stream: the old accumulation
+            // belongs to a discarded load, so drop it instead of mixing
+            // generations.
+            *slot = (request_id, Vec::new());
+        }
+        slot.1.extend(entries);
+        let full = slot.1.len() >= COALESCE_ENTRIES;
+        drop(pending);
+        if full {
+            self.flush_coalesced_capped(Some(depth));
+        } else {
+            self.arm_remote_flush_timer();
+        }
+    }
+
+    /// Flushes coalesced remote batches, capped per depth per fire so one
+    /// timer fire never becomes a multi-frame GTK mutation. Leftovers stay
+    /// queued behind a re-armed timer.
+    fn flush_coalesced_capped(self: &Rc<Self>, depth: Option<usize>) {
+        let depths: Vec<usize> = match depth {
+            Some(depth) => vec![depth],
+            None => self.coalesce_pending.borrow().keys().copied().collect(),
+        };
+        for depth in depths {
+            self.drain_publish(depth);
+            let chunk: Option<(RequestId, Vec<FileEntry>)> = self
+                .coalesce_pending
+                .borrow_mut()
+                .get_mut(&depth)
+                .and_then(|slot| {
+                    if slot.1.is_empty() {
+                        return None;
+                    }
+                    let take = slot.1.len().min(REMOTE_FLUSH_CAP);
+                    let entries: Vec<FileEntry> = slot.1.drain(..take).collect();
+                    Some((slot.0, entries))
+                });
+            if let Some((request_id, entries)) = chunk {
+                self.apply_owned_batch(request_id, entries);
+            }
+        }
+        self.coalesce_pending
+            .borrow_mut()
+            .retain(|_, (_, entries)| !entries.is_empty());
+        if self.coalesce_pending.borrow().is_empty() {
+            if let Some(source) = self.remote_flush_timer.borrow_mut().take() {
+                source.remove();
+            }
+        } else {
+            self.arm_remote_flush_timer();
+        }
+    }
+
+    fn arm_remote_flush_timer(self: &Rc<Self>) {
+        if self.remote_flush_timer.borrow().is_some() {
+            return;
+        }
+        let weak: Weak<Self> = Rc::downgrade(self);
+        let source = gio::glib::timeout_add_local_once(REMOTE_FLUSH_DELAY, move || {
+            if let Some(browser) = weak.upgrade() {
+                // Spent: disarm before flushing, since the flush disarms an
+                // armed timer by removing it (a fired id refuses removal).
+                browser.remote_flush_timer.borrow_mut().take();
+                browser.flush_coalesced_capped(None);
+            }
+        });
+        *self.remote_flush_timer.borrow_mut() = Some(source);
+    }
+
+    /// Sorts a staged native snapshot off the main thread, then installs,
+    /// reconciles, and publishes it. The loading state stays up throughout:
+    /// no provisional list is ever exposed for a faster first row.
+    fn finish_staged_load(self: &Rc<Self>, depth: usize, request_id: RequestId, truncated: bool) {
+        let staging = self.staging.borrow_mut().remove(&depth);
+        let Some(staging) = staging.filter(|staged| staged.request_id == request_id) else {
+            return;
+        };
+        let preferences = self
+            .state
+            .borrow()
+            .column_preferences(depth)
+            .unwrap_or_else(|| self.preferences.get());
+        let removed = staging.removed;
+        let mut entries = staging.entries;
+        entries.retain(|entry| !removed.contains(&entry.location));
+        let deltas = staging.deltas;
+        self.sorting
+            .borrow_mut()
+            .insert(depth, SortingLoad { request_id, deltas });
+        self.run_sort_task(depth, request_id, entries, preferences, truncated);
+    }
+
+    /// Sorts a snapshot inline below the threshold, or in a blocking worker
+    /// above it with completion back on the main thread. Small sorts stay
+    /// synchronous (no context, no pump); large ones never block input.
+    fn run_sort_task(
+        self: &Rc<Self>,
+        depth: usize,
+        request_id: RequestId,
+        entries: Vec<FileEntry>,
+        preferences: ViewPreferences,
+        truncated: bool,
+    ) {
+        if entries.len() <= SORT_INLINE_LIMIT {
+            let sorted = sort_entries(entries, preferences);
+            self.finish_staged_sort(depth, request_id, sorted, preferences, truncated);
+            return;
+        }
+        let weak: Weak<Self> = Rc::downgrade(self);
+        glib::MainContext::default().spawn_local(async move {
+            let sorted = gio::spawn_blocking(move || sort_entries(entries, preferences)).await;
+            let Some(browser) = weak.upgrade() else {
+                return;
+            };
+            match sorted {
+                Ok(sorted) => {
+                    browser.finish_staged_sort(depth, request_id, sorted, preferences, truncated)
+                }
+                Err(_) => browser.fail_staged_sort(depth, request_id),
+            }
+        });
+    }
+
+    /// Installs a sorted staged snapshot, reconciles monitor deltas queued
+    /// while it sorted, and publishes. Drops everything when the load was
+    /// superseded mid-sort.
+    fn finish_staged_sort(
+        self: &Rc<Self>,
+        depth: usize,
+        request_id: RequestId,
+        sorted: Vec<FileEntry>,
+        staged_preferences: ViewPreferences,
+        truncated: bool,
+    ) {
+        let sorting = self.sorting.borrow_mut().remove(&depth);
+        let Some(sorting) = sorting.filter(|sorting| sorting.request_id == request_id) else {
+            return;
+        };
+        if self.state.borrow().request_id_for_depth(depth) != Some(request_id) {
+            return;
+        }
+        if self
+            .state
+            .borrow_mut()
+            .install_snapshot(request_id, sorted)
+            .is_none()
+        {
+            return;
+        }
+        // Reconcile silently: the UI model is still empty, so delta events
+        // would splice invalid positions. State converges first (in sort
+        // order, since reconciled inserts stay sorted), then one staged
+        // publication carries the reconciled order.
+        for (watched, change) in sorting.deltas {
+            if matches!(change, DirectoryChange::Rescan) {
+                continue;
+            }
+            let _applied = self
+                .state
+                .borrow_mut()
+                .apply_directory_change(depth, &watched, change);
+        }
+        let current = self
+            .state
+            .borrow()
+            .column_preferences(depth)
+            .unwrap_or_else(|| self.preferences.get());
+        if current != staged_preferences {
+            // Resorted mid-load: route through the standard metadata-aware
+            // sort path when fields are still missing, else re-sort
+            // off-thread with the current preferences. The loading terminal
+            // fires exactly once, on whichever path finishes the load.
+            if matches!(current.sort_key, SortKey::Size | SortKey::Modified)
+                && self.state.borrow().column_unknown_metadata(depth).is_some()
+            {
+                self.state.borrow_mut().finish(request_id, truncated);
+                self.emit(BrowserEvent::LoadFinished { depth, truncated });
+                self.ensure_sorted_after_load(depth);
+            } else {
+                self.resort_installed_column(depth, request_id, current, truncated);
+            }
+            return;
+        }
+        let focused = self
+            .state
+            .borrow()
+            .columns
+            .get(depth)
+            .and_then(|column| column.selected);
+        let positions = self.state.borrow().selected_positions(depth);
+        let total = self
+            .state
+            .borrow()
+            .columns
+            .get(depth)
+            .map(|column| column.entries.len())
+            .unwrap_or(0);
+        self.state.borrow_mut().finish(request_id, truncated);
+        self.publish_staged(
+            depth,
+            request_id,
+            total,
+            focused,
+            positions,
+            PublishTerminal::LoadFinished { truncated },
+        );
+    }
+
+    /// Re-sorts an installed column off-thread after a mid-load preference
+    /// change, then publishes the new order through the staged path.
+    fn resort_installed_column(
+        self: &Rc<Self>,
+        depth: usize,
+        request_id: RequestId,
+        preferences: ViewPreferences,
+        truncated: bool,
+    ) {
+        let Some(entries) = self
+            .state
+            .borrow()
+            .columns
+            .get(depth)
+            .map(|column| column.entries.clone())
+        else {
+            return;
+        };
+        self.sorting.borrow_mut().insert(
+            depth,
+            SortingLoad {
+                request_id,
+                deltas: Vec::new(),
+            },
+        );
+        self.run_sort_task(depth, request_id, entries, preferences, truncated);
+    }
+
+    /// Fails a staged load whose sort task died: the column keeps its
+    /// loading state replaced by an error, exactly like a failed
+    /// enumeration, so no spinner hangs.
+    fn fail_staged_sort(self: &Rc<Self>, depth: usize, request_id: RequestId) {
+        self.sorting.borrow_mut().remove(&depth);
+        let mut state = self.state.borrow_mut();
+        if state
+            .fail(request_id, "Sorting the directory failed.".to_owned())
+            .is_some()
+        {
+            drop(state);
+            self.emit(BrowserEvent::LoadFailed {
+                depth,
+                message: "Sorting the directory failed.".to_owned(),
+            });
+        }
+    }
+
+    /// Publishes an installed column in stages: the first viewport-sized
+    /// prefix replaces the model synchronously for fast first correct rows,
+    /// then contiguous tails stream from idle callbacks inside a work
+    /// budget so no publication callback exceeds a frame. Selection and the
+    /// terminal event wait for the final tail.
+    fn publish_staged(
+        self: &Rc<Self>,
+        depth: usize,
+        request_id: RequestId,
+        total: usize,
+        focused: Option<usize>,
+        positions: Vec<usize>,
+        terminal: PublishTerminal,
+    ) {
+        self.drain_publish(depth);
+        if total <= STAGE_INLINE_LIMIT {
+            if self.state.borrow().columns.get(depth).is_none() {
+                return;
+            }
+            self.emit(BrowserEvent::EntriesReplaced {
+                depth,
+                count: total,
+            });
+            if let Some(focused) = focused {
+                self.emit(BrowserEvent::SelectionSetChanged {
+                    depth,
+                    positions,
+                    focused,
+                    take_focus: false,
+                });
+            }
+            self.emit_publish_terminal(depth, terminal);
+            return;
+        }
+        let published = self
+            .state
+            .borrow()
+            .columns
+            .get(depth)
+            .map_or(0, |column| column.entries.len().min(FIRST_PUBLISH_COUNT));
+        self.emit(BrowserEvent::EntriesReplaced {
+            depth,
+            count: published,
+        });
+        self.staged_publishes.borrow_mut().insert(
+            depth,
+            StagedPublish {
+                request_id,
+                published,
+                total,
+                focused,
+                positions,
+                terminal,
+            },
+        );
+        self.arm_publish_timer();
+    }
+
+    /// Emits a staged publication's terminal event.
+    fn emit_publish_terminal(&self, depth: usize, terminal: PublishTerminal) {
+        match terminal {
+            PublishTerminal::LoadFinished { truncated } => {
+                self.emit(BrowserEvent::LoadFinished { depth, truncated })
+            }
+            PublishTerminal::SortingFinished => self.emit(BrowserEvent::SortingFinished { depth }),
+        }
+    }
+
+    /// Completes a staged publication synchronously: emits the remainder,
+    /// the deferred selection, and the terminal. Called before any mutation
+    /// that assumes the model converged with authoritative state.
+    fn drain_publish(self: &Rc<Self>, depth: usize) {
+        let staged = self.staged_publishes.borrow_mut().remove(&depth);
+        let Some(staged) = staged else {
+            return;
+        };
+        let remainder = self.state.borrow().columns.get(depth).map_or(0, |column| {
+            column.entries.len().saturating_sub(staged.published)
+        });
+        if remainder > 0 {
+            self.emit(BrowserEvent::EntriesPublished {
+                depth,
+                position: staged.published,
+                count: remainder,
+            });
+        }
+        if let Some(focused) = staged.focused {
+            self.emit(BrowserEvent::SelectionSetChanged {
+                depth,
+                positions: staged.positions,
+                focused,
+                take_focus: false,
+            });
+        }
+        self.emit_publish_terminal(depth, staged.terminal);
+    }
+
+    /// Drops a staged publication without emitting: the model and state are
+    /// both being reset, so nothing is owed.
+    fn cancel_publish(&self, depth: usize) {
+        self.staged_publishes.borrow_mut().remove(&depth);
+        if self.staged_publishes.borrow().is_empty()
+            && let Some(source) = self.publish_timer.borrow_mut().take()
+        {
+            source.remove();
+        }
+    }
+
+    fn arm_publish_timer(self: &Rc<Self>) {
+        if self.publish_timer.borrow().is_some() {
+            return;
+        }
+        let weak: Weak<Self> = Rc::downgrade(self);
+        // Idle priority: tails yield to input, paint, and higher-priority
+        // sources, streaming rows behind an interactive UI.
+        let source = gio::glib::idle_add_local_once(move || {
+            if let Some(browser) = weak.upgrade() {
+                browser.fire_publish_tails();
+            }
+        });
+        *self.publish_timer.borrow_mut() = Some(source);
+    }
+
+    /// Appends one bounded tail chunk per staged depth, then the deferred
+    /// selection and terminal for depths that complete. Stops after the
+    /// slice budget so sustained publishing never starves the main loop.
+    /// Tails whose load was superseded drop without emitting.
+    fn fire_publish_tails(self: &Rc<Self>) {
+        self.publish_timer.borrow_mut().take();
+        let started = std::time::Instant::now();
+        loop {
+            let depth = self.staged_publishes.borrow().keys().copied().next();
+            let Some(depth) = depth else {
+                return;
+            };
+            let current = self
+                .staged_publishes
+                .borrow()
+                .get(&depth)
+                .map(|staged| staged.request_id);
+            if current.is_some_and(|id| self.state.borrow().request_id_for_depth(depth) != Some(id))
+            {
+                // Superseded mid-publish: drop without emitting.
+                self.staged_publishes.borrow_mut().remove(&depth);
+                continue;
+            }
+            if started.elapsed() >= PUBLISH_SLICE_BUDGET {
+                self.arm_publish_timer();
+                return;
+            }
+            let chunk: Option<(usize, usize)> = self
+                .staged_publishes
+                .borrow()
+                .get(&depth)
+                .and_then(|staged| {
+                    self.state.borrow().columns.get(depth).map(|column| {
+                        let end = (staged.published + PUBLISH_TAIL_CHUNK)
+                            .min(column.entries.len())
+                            .min(staged.total);
+                        (staged.published, end.saturating_sub(staged.published))
+                    })
+                });
+            let Some((position, chunk)) = chunk else {
+                // The column went away mid-publish: drop the tail.
+                self.staged_publishes.borrow_mut().remove(&depth);
+                continue;
+            };
+            if chunk == 0 {
+                let staged = self.staged_publishes.borrow_mut().remove(&depth);
+                let Some(staged) = staged else {
+                    continue;
+                };
+                if let Some(focused) = staged.focused {
+                    self.emit(BrowserEvent::SelectionSetChanged {
+                        depth,
+                        positions: staged.positions,
+                        focused,
+                        take_focus: false,
+                    });
+                }
+                self.emit_publish_terminal(depth, staged.terminal);
+                continue;
+            }
+            self.emit(BrowserEvent::EntriesPublished {
+                depth,
+                position,
+                count: chunk,
+            });
+            if let Some(staged) = self.staged_publishes.borrow_mut().get_mut(&depth) {
+                staged.published += chunk;
+            }
+        }
+    }
+    pub fn request_metadata_fill(
+        self: &Rc<Self>,
+        depth: usize,
+        position: usize,
+        location: Location,
+    ) {
+        // Ask the provider what it supports instead of rejecting remote
+        // locations owner-side: remote and GVfs fills stay on cancellable
+        // GIO, and unsupported sources simply answer `Unsupported`.
+        if !self.source.supports_metadata_fill(&location) {
+            return;
+        }
+        {
+            let mut pending = self.metadata_pending.borrow_mut();
+            let queued = pending.entry(depth).or_default();
+            if queued.len() < MAX_PENDING_FILL_LOCATIONS
+                && !queued.iter().any(|target| target.location == location)
+            {
+                queued.push(ViewportTarget { position, location });
+            }
+        }
+        // True settle timer: every newly visible row restarts the debounce,
+        // so a continuous fling never fires mid-scroll for stale rows.
+        if let Some(source) = self.metadata_timer.borrow_mut().take() {
+            source.remove();
+        }
+        let weak: Weak<Self> = Rc::downgrade(self);
+        let source = gio::glib::timeout_add_local_once(METADATA_FILL_DEBOUNCE, move || {
+            if let Some(browser) = weak.upgrade() {
+                browser.flush_metadata_fills();
+            }
+        });
+        *self.metadata_timer.borrow_mut() = Some(source);
+    }
+
+    /// Stats a whole column for a size/date sort behind the sort spinner,
+    /// then sorts once the pass lands.
+    fn request_sort_fill(
+        self: &Rc<Self>,
+        depth: usize,
+        generation: u64,
+        preferences: ViewPreferences,
+        targets: Vec<(usize, Location)>,
+    ) {
+        let Some(request_id) = self.state.borrow().request_id_for_depth(depth) else {
+            self.pending_sort.set(None);
+            self.emit(BrowserEvent::SortingFinished { depth });
+            return;
+        };
+        self.sort_awaiting_fill
+            .borrow_mut()
+            .replace((generation, depth, request_id, preferences));
         let weak: Weak<Self> = Rc::downgrade(self);
         let emit = Rc::new(move |event| {
             if let Some(browser) = weak.upgrade() {
                 browser.handle_directory_event(event);
             }
         });
+        let handle = self.source.fill_metadata(
+            MetadataRequest {
+                id: request_id,
+                entries: targets.into_iter().map(|(_, location)| location).collect(),
+                full: true,
+                time_budget: DIRECTORY_LOAD_TIME_BUDGET,
+            },
+            emit,
+        );
+        self.sort_loads.borrow_mut().insert(depth, handle);
+    }
+
+    fn finish_awaited_sort(
+        self: &Rc<Self>,
+        depth: usize,
+        generation: u64,
+        preferences: ViewPreferences,
+    ) {
+        self.sort_awaiting_fill.borrow_mut().take();
+        self.sort_loads.borrow_mut().remove(&depth);
+        let outcome = {
+            let mut state = self.state.borrow_mut();
+            if self.pending_sort.get() != Some((generation, depth)) {
+                return;
+            }
+            let outcome = state.apply_sort_preferences(depth, preferences);
+            self.preferences.set(preferences);
+            self.pending_sort.set(None);
+            outcome.map(|(focused, positions)| {
+                let request_id = state.request_id_for_depth(depth);
+                let total = state.columns.get(depth).map(|column| column.entries.len());
+                (request_id, total, focused, positions)
+            })
+        };
+        self.notify_preferences_observers();
+        match outcome {
+            Some((Some(request_id), Some(total), focused, positions)) => {
+                self.publish_staged(
+                    depth,
+                    request_id,
+                    total,
+                    focused,
+                    positions,
+                    PublishTerminal::SortingFinished,
+                );
+            }
+            _ => {
+                self.emit(BrowserEvent::SortingFinished { depth });
+            }
+        }
+    }
+    /// `Complete`; any other outcome abandons the sort without reordering so
+    /// a partial pass is never published as correct. Viewport fills need no
+    /// outcome handling beyond dropping their handle: unfilled rows keep
+    /// their placeholders and retry on their next bind.
+    fn handle_metadata_finished(self: &Rc<Self>, request_id: RequestId, outcome: MetadataOutcome) {
+        let awaiting = *self.sort_awaiting_fill.borrow();
+        if let Some((generation, depth, fill_request, preferences)) = awaiting
+            && fill_request == request_id
+        {
+            self.sort_loads.borrow_mut().remove(&depth);
+            if outcome == MetadataOutcome::Complete
+                && self.pending_sort.get() == Some((generation, depth))
+            {
+                self.finish_awaited_sort(depth, generation, preferences);
+            } else {
+                self.abandon_awaited_sort(depth, generation, outcome);
+            }
+            return;
+        }
+        // A viewport fill (or a superseded sort fill) ending: drop its
+        // handle. A superseded sort whose column reloaded already had its
+        // indicator closed by the reload path; belt-and-braces abandon here
+        // in case the reload raced the terminal.
+        if let Some(depth) = self.state.borrow().depth_for_request(request_id) {
+            self.metadata_loads.borrow_mut().remove(&depth);
+        }
+        if let Some((generation, depth, _, _)) = awaiting
+            && self.state.borrow().depth_for_request(request_id).is_none()
+            && self.pending_sort.get() == Some((generation, depth))
+        {
+            self.abandon_awaited_sort(depth, generation, outcome);
+        }
+    }
+
+    /// Abandons a waiting sort after a non-complete fill: the prior correct
+    /// order is preserved, the indicator stops, and the failure is logged so
+    /// a re-sort retry starts from clean state. Every `SortingStarted` still
+    /// pairs with exactly one `SortingFinished`.
+    fn abandon_awaited_sort(&self, depth: usize, generation: u64, outcome: MetadataOutcome) {
+        self.sort_awaiting_fill.borrow_mut().take();
+        self.sort_loads.borrow_mut().remove(&depth);
+        if self.pending_sort.get() != Some((generation, depth)) {
+            return;
+        }
+        self.pending_sort.set(None);
+        tracing::warn!(
+            depth,
+            generation,
+            ?outcome,
+            "metadata sort abandoned; prior order preserved"
+        );
+        self.emit(BrowserEvent::SortingFinished { depth });
+    }
+    fn cancel_pending_sort_for(&self, depth: usize) {
+        let awaiting = *self.sort_awaiting_fill.borrow();
+        if let Some((generation, awaiting_depth, _, _)) = awaiting
+            && awaiting_depth == depth
+        {
+            self.abandon_awaited_sort(depth, generation, MetadataOutcome::Cancelled);
+            return;
+        }
+        self.sort_loads.borrow_mut().remove(&depth);
+        if self
+            .pending_sort
+            .get()
+            .is_some_and(|(_, pending_depth)| pending_depth == depth)
+        {
+            // Sort debounce armed but its fill never started: no provider
+            // work to cancel, just close the indicator.
+            self.pending_sort.set(None);
+            self.emit(BrowserEvent::SortingFinished { depth });
+        }
+    }
+
+    /// Drops everything deferred for columns at or beyond `len`: viewport
+    /// truncation, navigation, reload, and close path.
+    fn truncate_deferred_from(self: &Rc<Self>, len: usize) {
+        if let Some(source) = self.metadata_timer.borrow_mut().take() {
+            source.remove();
+        }
+        self.metadata_pending
+            .borrow_mut()
+            .retain(|depth, _| *depth < len);
+        // Re-arm the settle timer when younger depths still queue fills.
+        if !self.metadata_pending.borrow().is_empty() {
+            let weak: Weak<Self> = Rc::downgrade(self);
+            let source = gio::glib::timeout_add_local_once(METADATA_FILL_DEBOUNCE, move || {
+                if let Some(browser) = weak.upgrade() {
+                    browser.flush_metadata_fills();
+                }
+            });
+            *self.metadata_timer.borrow_mut() = Some(source);
+        }
+        self.metadata_loads
+            .borrow_mut()
+            .retain(|depth, _| *depth < len);
+        let state = self.state.borrow();
+        self.fill_tokens.borrow_mut().retain(|request_id, _| {
+            state
+                .depth_for_request(*request_id)
+                .is_some_and(|depth| depth < len)
+        });
+        let awaiting = *self.sort_awaiting_fill.borrow();
+        if let Some((generation, depth, _, _)) = awaiting
+            && depth >= len
+        {
+            self.abandon_awaited_sort(depth, generation, MetadataOutcome::Cancelled);
+        } else {
+            self.sort_loads.borrow_mut().retain(|depth, _| *depth < len);
+        }
+        self.coalesce_pending
+            .borrow_mut()
+            .retain(|depth, _| *depth < len);
+        self.last_batch_selection
+            .borrow_mut()
+            .retain(|depth, _| *depth < len);
+        // Staged loads and sorts die with their columns; staged publishes
+        // cancel without emitting, since both model and state reset.
+        self.staging.borrow_mut().retain(|depth, _| *depth < len);
+        self.sorting.borrow_mut().retain(|depth, _| *depth < len);
+        self.staged_publishes
+            .borrow_mut()
+            .retain(|depth, _| *depth < len);
+        if self.staged_publishes.borrow().is_empty()
+            && let Some(source) = self.publish_timer.borrow_mut().take()
+        {
+            source.remove();
+        }
+    }
+
+    /// Re-sorts a freshly loaded column whose sort key needs metadata the
+    /// streaming enumeration skipped. Name and type sorts never land here.
+    fn ensure_sorted_after_load(self: &Rc<Self>, depth: usize) {
+        let (needs, preferences) = {
+            let state = self.state.borrow();
+            let Some(preferences) = state.column_preferences(depth) else {
+                return;
+            };
+            let needs = matches!(preferences.sort_key, SortKey::Size | SortKey::Modified)
+                && state.column_unknown_metadata(depth).is_some();
+            (needs, preferences)
+        };
+        if !needs {
+            return;
+        }
+        let generation = self
+            .pending_sort
+            .get()
+            .map_or(1, |(generation, _)| generation.saturating_add(1));
+        if let Some((_, previous_depth)) = self.pending_sort.replace(Some((generation, depth))) {
+            self.emit(BrowserEvent::SortingFinished {
+                depth: previous_depth,
+            });
+        }
+        self.emit(BrowserEvent::SortingStarted { depth });
+        let targets = self
+            .state
+            .borrow()
+            .column_unknown_metadata(depth)
+            .unwrap_or_default();
+        self.request_sort_fill(depth, generation, preferences, targets);
+    }
+
+    fn flush_metadata_fills(self: &Rc<Self>) {
+        self.metadata_timer.borrow_mut().take();
+        let pending: Vec<(usize, Vec<ViewportTarget>)> =
+            self.metadata_pending.borrow_mut().drain().collect();
+        for (depth, targets) in pending {
+            // Refresh the load identity: the column may have reloaded while
+            // these rows queued, and a superseded fill must not apply.
+            let Some(request_id) = self.state.borrow().request_id_for_depth(depth) else {
+                continue;
+            };
+            let weak: Weak<Self> = Rc::downgrade(self);
+            let emit = Rc::new(move |event| {
+                if let Some(browser) = weak.upgrade() {
+                    browser.handle_directory_event(event);
+                }
+            });
+            let tokens: Vec<(usize, Location)> = targets
+                .iter()
+                .map(|target| (target.position, target.location.clone()))
+                .collect();
+            // Stored before the provider runs: synchronous fills answer
+            // inside the call, and their chunks join against these tokens.
+            self.fill_tokens.borrow_mut().insert(request_id, tokens);
+            let handle = self.source.fill_metadata(
+                MetadataRequest {
+                    id: request_id,
+                    entries: targets.into_iter().map(|target| target.location).collect(),
+                    full: false,
+                    time_budget: METADATA_FILL_TIME_BUDGET,
+                },
+                emit,
+            );
+            self.metadata_loads.borrow_mut().insert(depth, handle);
+        }
+    }
+
+    /// Drops everything a discarded load queued: metadata fills and
+    /// coalesced batches alike. Coalesced rows are safe to drop because
+    /// every site that clears loads replaces the data source wholesale.
+    /// A pending sort's indicator closes here: its fill handle is dropped,
+    /// which aborts provider work without a terminal event.
+    fn cancel_deferred_work(&self) {
+        if let Some(source) = self.metadata_timer.borrow_mut().take() {
+            source.remove();
+        }
+        self.metadata_pending.borrow_mut().clear();
+        self.metadata_loads.borrow_mut().clear();
+        self.fill_tokens.borrow_mut().clear();
+        let awaiting = self.sort_awaiting_fill.borrow_mut().take();
+        if let Some((generation, depth, _, _)) = awaiting {
+            self.abandon_awaited_sort(depth, generation, MetadataOutcome::Cancelled);
+        } else {
+            self.sort_loads.borrow_mut().clear();
+            if let Some((_, depth)) = self.pending_sort.take() {
+                // Sort debounce armed but its fill never started.
+                self.emit(BrowserEvent::SortingFinished { depth });
+            }
+        }
+        self.coalesce_pending.borrow_mut().clear();
+        self.last_batch_selection.borrow_mut().clear();
+        // Staged snapshots, in-flight sorts, and staged publications die
+        // with their loads: late completions find no staging entry and a
+        // retired request id, so they publish nothing.
+        self.staging.borrow_mut().clear();
+        self.sorting.borrow_mut().clear();
+        self.staged_publishes.borrow_mut().clear();
+        if let Some(source) = self.publish_timer.borrow_mut().take() {
+            source.remove();
+        }
+        if let Some(source) = self.remote_flush_timer.borrow_mut().take() {
+            source.remove();
+        }
+    }
+
+    fn request_directory(
+        self: &Rc<Self>,
+        depth: usize,
+        location: Location,
+        request_id: RequestId,
+    ) -> LoadHandle {
+        let weak: Weak<Self> = Rc::downgrade(self);
+        let emit = Rc::new(move |event| {
+            if let Some(browser) = weak.upgrade() {
+                browser.handle_directory_event(event);
+            }
+        });
+        let batch_size = if location.native_path().is_some() {
+            NATIVE_DIRECTORY_BATCH_SIZE
+        } else {
+            REMOTE_DIRECTORY_BATCH_SIZE
+        };
+        // Loads sorted by size or date stat inline: the column's own key
+        // decides, falling back to the application preference for columns
+        // that do not exist yet. Sorting placeholders and re-sorting a full
+        // directory afterwards costs more than one stat per file up front.
+        let sort_key = self
+            .state
+            .borrow()
+            .column_preferences(depth)
+            .map(|preferences| preferences.sort_key)
+            .unwrap_or_else(|| self.preferences.get().sort_key);
+        let include_metadata = matches!(sort_key, SortKey::Size | SortKey::Modified);
         self.source.enumerate(
             DirectoryRequest {
                 id: request_id,
                 location,
-                batch_size: 128,
+                batch_size,
+                include_metadata,
                 max_entries: MAX_DIRECTORY_ENTRIES,
                 time_budget: DIRECTORY_LOAD_TIME_BUDGET,
             },
@@ -1677,10 +2774,25 @@ impl Browser {
             return;
         };
         self.emit(BrowserEvent::ColumnReloaded { depth });
-        let handle = self.request_directory(location, request_id);
+        let handle = self.request_directory(depth, location, request_id);
         if let Some(load) = self.loads.borrow_mut().get_mut(depth) {
             *load = handle;
         }
+        self.metadata_loads.borrow_mut().remove(&depth);
+        self.metadata_pending.borrow_mut().remove(&depth);
+        self.coalesce_pending.borrow_mut().remove(&depth);
+        self.last_batch_selection.borrow_mut().remove(&depth);
+        self.cancel_pending_sort_for(depth);
+        // The retired load's staging, sort, and publication die with it;
+        // late completions find a retired request id and publish nothing.
+        self.staging.borrow_mut().remove(&depth);
+        self.sorting.borrow_mut().remove(&depth);
+        self.cancel_publish(depth);
+        // Tokens belong to live loads: the retired request id no longer
+        // resolves, so its tokens drop here instead of leaking.
+        self.fill_tokens
+            .borrow_mut()
+            .retain(|request_id, _| self.state.borrow().depth_for_request(*request_id).is_some());
     }
 
     pub fn reload_active(self: &Rc<Self>) {
@@ -1735,6 +2847,16 @@ impl Browser {
         });
     }
 
+    /// Depth and nativeness of a column load, if `request_id` still owns
+    /// one. Nativeness splits publication policy: native loads stage and
+    /// sort once, remote loads stream progressively.
+    fn load_target(&self, request_id: RequestId) -> Option<(usize, bool)> {
+        let state = self.state.borrow();
+        let depth = state.depth_for_request(request_id)?;
+        let native = state.location_at(depth)?.native_path().is_some();
+        Some((depth, native))
+    }
+
     fn handle_directory_change(
         self: &Rc<Self>,
         depth: usize,
@@ -1745,6 +2867,35 @@ impl Browser {
             self.refresh_column(depth);
             return;
         }
+        // A staged or sorting load owns no published rows yet: queue the
+        // delta for the completion's single reconcile instead of racing the
+        // snapshot. Removed locations also filter staged batches so a late
+        // batch never resurrects them; an upserted location leaves the set
+        // so recreations still land.
+        if let Some(staging) = self.staging.borrow_mut().get_mut(&depth) {
+            match &change {
+                DirectoryChange::Remove(location) => {
+                    staging.removed.insert(location.clone());
+                }
+                DirectoryChange::Upsert(entry) => {
+                    staging.removed.remove(&entry.location);
+                }
+                DirectoryChange::Move { from, entry } => {
+                    staging.removed.insert(from.clone());
+                    staging.removed.remove(&entry.location);
+                }
+                DirectoryChange::Rescan => {}
+            }
+            staging.deltas.push((watched.clone(), change));
+            return;
+        }
+        if let Some(sorting) = self.sorting.borrow_mut().get_mut(&depth) {
+            sorting.deltas.push((watched.clone(), change));
+            return;
+        }
+        // A staged publication covers a converged model again first: deltas
+        // splice positions that only exist past the tails.
+        self.drain_publish(depth);
         let path_update = self
             .state
             .borrow()
@@ -1753,7 +2904,6 @@ impl Browser {
             self.restore_path(path);
             return;
         }
-
         let application = self
             .state
             .borrow_mut()
@@ -1780,67 +2930,106 @@ impl Browser {
         }
     }
 
-    fn handle_directory_event(&self, event: DirectoryEvent) {
+    fn handle_directory_event(self: &Rc<Self>, event: DirectoryEvent) {
         match event {
             DirectoryEvent::Batch {
                 request_id,
                 entries,
             } => {
-                let mut state = self.state.borrow_mut();
-                let application = state.apply_batch(request_id, entries.clone());
-                if let Some((depth, insertions)) = application {
-                    tracing::debug!(
-                        request_id = request_id.0,
-                        location = %state.columns[depth].location.diagnostic_path(),
-                        entries = entries.len(),
-                        "directory batch accepted"
-                    );
-                    let selected = state.columns[depth].selected;
-                    let positions = state.selected_positions(depth);
-                    drop(state);
-                    self.emit(BrowserEvent::EntriesInserted { depth, insertions });
-                    if let Some(focused) = selected {
-                        self.emit(BrowserEvent::SelectionSetChanged {
-                            depth,
-                            positions,
-                            focused,
-                            take_focus: false,
-                        });
+                // Native open loads stage identity batches with no merge
+                // walk and no UI events; everything else stays progressive
+                // (remote first paint, peek batches, stragglers).
+                let target = self.load_target(request_id);
+                let open = self.state.borrow().open_load_depth(request_id);
+                match (target, open) {
+                    (Some((depth, true)), Some(_)) => {
+                        self.stage_batch(request_id, depth, entries);
                     }
-                } else {
-                    let peek_entries: Vec<_> = if self.preferences.get().show_hidden {
-                        entries
-                    } else {
-                        entries
-                            .into_iter()
-                            .filter(|entry| !entry.is_hidden)
-                            .collect()
-                    };
-                    if state.apply_peek_batch(request_id, &peek_entries) {
-                        drop(state);
-                        self.emit(BrowserEvent::PeekEntriesAdded {
-                            entries: peek_entries,
-                        });
+                    (Some((depth, false)), Some(_)) => {
+                        let entry_count = self
+                            .state
+                            .borrow()
+                            .loading_column(request_id)
+                            .map(|(_, count)| count)
+                            .unwrap_or(0);
+                        if entry_count == 0 {
+                            self.apply_owned_batch(request_id, entries);
+                        } else {
+                            self.accumulate_batch(request_id, depth, entries);
+                        }
+                    }
+                    _ => {
+                        let peek_entries: Vec<_> = if self.preferences.get().show_hidden {
+                            entries
+                        } else {
+                            entries
+                                .into_iter()
+                                .filter(|entry| !entry.is_hidden)
+                                .collect()
+                        };
+                        let mut state = self.state.borrow_mut();
+                        if state.apply_peek_batch(request_id, &peek_entries) {
+                            drop(state);
+                            self.emit(BrowserEvent::PeekEntriesAdded {
+                                entries: peek_entries,
+                            });
+                        }
                     }
                 }
             }
+
             DirectoryEvent::Finished {
                 request_id,
                 truncated,
             } => {
-                let mut state = self.state.borrow_mut();
-                if let Some(depth) = state.finish(request_id, truncated) {
-                    drop(state);
-                    self.emit(BrowserEvent::LoadFinished { depth, truncated });
-                } else if state.finish_peek(request_id) {
-                    drop(state);
-                    self.emit(BrowserEvent::PeekFinished);
+                // A staged native load sorts off-thread and publishes
+                // staged; everything else lands coalesced rows first, then
+                // closes the load. Bound to a variable first: an if-let
+                // scrutinee borrow would stay live across the flush and
+                // panic inside it.
+                let target = self.load_target(request_id);
+                let open = self.state.borrow().open_load_depth(request_id);
+                match (target, open) {
+                    (Some((depth, true)), Some(_)) => {
+                        self.finish_staged_load(depth, request_id, truncated);
+                    }
+                    (Some((depth, _)), Some(_)) => {
+                        self.flush_coalesced_capped(Some(depth));
+                        let mut state = self.state.borrow_mut();
+                        if let Some(depth) = state.finish(request_id, truncated) {
+                            drop(state);
+                            self.emit(BrowserEvent::LoadFinished { depth, truncated });
+                            // A column sorted by size or date loaded
+                            // placeholders; stat the column and sort once
+                            // the pass lands.
+                            self.ensure_sorted_after_load(depth);
+                        }
+                    }
+                    _ => {
+                        let mut state = self.state.borrow_mut();
+                        if state.finish_peek(request_id) {
+                            drop(state);
+                            self.emit(BrowserEvent::PeekFinished);
+                        }
+                    }
                 }
             }
             DirectoryEvent::Failed {
                 request_id,
                 message,
             } => {
+                // Staged and sorting loads die with the enumeration: drop
+                // their state so no late sort can publish, then follow the
+                // standard failure path.
+                let target = self.load_target(request_id);
+                let open = self.state.borrow().open_load_depth(request_id);
+                if let Some((depth, true)) = target.filter(|_| open.is_some()) {
+                    self.staging.borrow_mut().remove(&depth);
+                    self.sorting.borrow_mut().remove(&depth);
+                    self.cancel_publish(depth);
+                } else if let Some((depth, _)) = target {
+                    self.flush_coalesced_capped(Some(depth));
+                }
                 let mut state = self.state.borrow_mut();
                 if let Some(depth) = state.fail(request_id, message.clone()) {
                     drop(state);
@@ -1850,13 +3039,91 @@ impl Browser {
                     self.emit(BrowserEvent::PeekFailed { message });
                 }
             }
+            DirectoryEvent::MetadataFilled {
+                request_id,
+                updates,
+            } => {
+                // Full sort fills apply by location: the column is about to
+                // be re-sorted wholesale, so positional tokens would only add
+                // validation churn to an already O(n log n) path.
+                let awaiting_sort = self
+                    .sort_awaiting_fill
+                    .borrow()
+                    .is_some_and(|(_, _, fill_id, _)| fill_id == request_id);
+                if awaiting_sort {
+                    let mut state = self.state.borrow_mut();
+                    if let Some((depth, positions)) = state.apply_metadata(request_id, updates) {
+                        let filled = filled_entries(&state, depth, &positions);
+                        tracing::debug!(
+                            request_id = request_id.0,
+                            depth,
+                            filled = positions.len(),
+                            "metadata fill applied"
+                        );
+                        drop(state);
+                        self.emit(BrowserEvent::MetadataFilled {
+                            depth,
+                            updates: filled,
+                        });
+                    }
+                    // Sorts wait for the fill's terminal outcome, never for a
+                    // chunk: sorting here would publish a partially statted
+                    // column as correctly ordered.
+                    return;
+                }
+                // Viewport fills apply in O(requested rows) against the
+                // tokens captured at bind time. Rows that moved under the
+                // fill go stale and keep their placeholders; their next bind
+                // re-requests them, so only stale rows retry.
+                let tokens = self.fill_tokens.borrow().get(&request_id).cloned();
+                let Some(tokens) = tokens else {
+                    return;
+                };
+                let token_positions: HashMap<&Location, usize> = tokens
+                    .iter()
+                    .map(|(position, location)| (location, *position))
+                    .collect();
+                let mut positioned = Vec::with_capacity(updates.len());
+                for update in &updates {
+                    if let Some(position) = token_positions.get(&update.location) {
+                        positioned.push((*position, update.clone()));
+                    }
+                }
+                let mut state = self.state.borrow_mut();
+                if let Some((depth, positions, stale)) =
+                    state.apply_positioned_metadata(request_id, positioned)
+                {
+                    let filled = filled_entries(&state, depth, &positions);
+                    tracing::debug!(
+                        request_id = request_id.0,
+                        depth,
+                        filled = positions.len(),
+                        stale = stale.len(),
+                        "metadata fill applied"
+                    );
+                    drop(state);
+                    if !filled.is_empty() {
+                        self.emit(BrowserEvent::MetadataFilled {
+                            depth,
+                            updates: filled,
+                        });
+                    }
+                }
+            }
+            DirectoryEvent::MetadataFinished {
+                request_id,
+                outcome,
+            } => {
+                self.fill_tokens.borrow_mut().remove(&request_id);
+                self.handle_metadata_finished(request_id, outcome);
+            }
         }
     }
 
     fn emit(&self, event: BrowserEvent) {
         let observers = self.observers.borrow().clone();
-        for observer in observers {
-            observer(event.clone());
+        for observer in &observers {
+            observer(&event);
         }
     }
 
@@ -1865,6 +3132,21 @@ impl Browser {
         self.next_request.set(id.saturating_add(1));
         RequestId(id)
     }
+}
+
+/// Clones the freshly filled entries for a view refresh payload.
+fn filled_entries(
+    state: &NavigationState,
+    depth: usize,
+    positions: &[usize],
+) -> Vec<(usize, FileEntry)> {
+    positions
+        .iter()
+        .filter_map(|position| {
+            let entry = state.columns.get(depth)?.entries.get(*position)?.clone();
+            Some((*position, entry))
+        })
+        .collect()
 }
 
 fn location_or_ancestor_is_affected(location: &Location, roots: &HashSet<Location>) -> bool {

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -2993,6 +2993,7 @@ impl Browser {
                 let open = self.state.borrow().open_load_depth(request_id);
                 match (target, open) {
                     (Some((depth, true)), Some(_)) => {
+                        self.stage_batch(request_id, depth, Vec::new());
                         self.finish_staged_load(depth, request_id, truncated);
                     }
                     (Some((depth, _)), Some(_)) => {

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -44,6 +44,7 @@ const PEEK_TIME_BUDGET: Duration = Duration::from_secs(3);
 #[derive(Clone, Debug)]
 pub struct BrowserColumnSnapshot {
     pub location: Location,
+    pub count: usize,
     pub selected_positions: Vec<usize>,
     pub loading: bool,
     pub error: Option<String>,
@@ -963,6 +964,7 @@ impl Browser {
         let column = state.columns.get(depth)?;
         Some(BrowserColumnSnapshot {
             location: column.location.clone(),
+            count: column.entries.len(),
             selected_positions: state.selected_positions(depth),
             loading: column.load_state == crate::app::navigation::LoadState::Loading,
             error: match &column.load_state {

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -27,10 +27,8 @@ use crate::{
 const MAX_DIRECTORY_ENTRIES: usize = 100_000;
 const DIRECTORY_LOAD_TIME_BUDGET: Duration = Duration::from_secs(10);
 
-/// GIO batch size for local directories. Fewer, larger batches cut the
-/// per-batch merge, selection scan, and GTK splice count ~4x on large
-/// listings. Remote (GVfs) locations keep small batches so first paint
-/// doesn't wait out high per-file latency on slow links.
+/// Larger GIO batches cut per-batch merge, selection scan, and GTK splice
+/// cost on large listings; remote locations keep small batches for fast first paint.
 const NATIVE_DIRECTORY_BATCH_SIZE: usize = 512;
 const REMOTE_DIRECTORY_BATCH_SIZE: usize = 128;
 
@@ -69,9 +67,8 @@ pub enum BrowserEvent {
         depth: usize,
         count: usize,
     },
-    /// A contiguous range already installed in authoritative state. Views
-    /// borrow that range during synchronous dispatch instead of receiving a
-    /// deep clone of every entry.
+    /// A range already installed in authoritative state; views borrow it during
+    /// synchronous dispatch instead of receiving a deep clone.
     EntriesPublished {
         depth: usize,
         position: usize,
@@ -88,9 +85,7 @@ pub enum BrowserEvent {
         splices: Vec<EntrySplice>,
         selected: Option<usize>,
     },
-    /// Size/mtime arrivals for already-rendered rows: positions with their
-    /// refreshed entries, for an in-place same-count model refresh. The order
-    /// never changes here; sorting by size or date runs its own full pass.
+    /// Refreshed entries for already-rendered rows; the order never changes here.
     MetadataFilled {
         depth: usize,
         updates: Vec<(usize, FileEntry)>,
@@ -205,13 +200,9 @@ pub enum BrowserEvent {
     TransferCompleted,
 }
 
-/// Observers receive the event by reference during synchronous dispatch:
-/// listing payloads (`Vec<FileEntry>`) move exactly once from the provider
-/// into authoritative state and the single emitted event, and fan-out to
-/// every observer borrows instead of deep-cloning per observer. Consumers
-/// that retain data clone only the small field they store. The observer
-/// list itself is cloned before dispatch so add/remove/reentrant emission
-/// stays safe.
+/// Events dispatch by reference: payloads move once into authoritative state,
+/// observers borrow, and the observer list is cloned up front so reentrant
+/// emission stays safe.
 type Observer = Rc<dyn Fn(&BrowserEvent)>;
 type PreferencesObserver = Rc<dyn Fn(ViewPreferences)>;
 
@@ -286,54 +277,61 @@ const METADATA_FILL_TIME_BUDGET: Duration = Duration::from_secs(5);
 /// Defensive cap per depth: the UI only ever asks for its visible window.
 const MAX_PENDING_FILL_LOCATIONS: usize = 1024;
 
-/// Accumulates this many entries before flushing early: first paint applies
-/// at once, later batches merge, scan, and splice in groups of four.
-/// Remote loads only; native loads stage instead (see `StagingLoad`).
+/// Remote loads only (native loads stage instead): entries accumulate this far
+/// before an early flush bounds first-result latency.
 const COALESCE_ENTRIES: usize = 2048;
 /// Bounds one remote progressive flush: a slow link must not turn one timer
 /// fire into a multi-frame GTK mutation.
 const REMOTE_FLUSH_CAP: usize = 512;
-/// Maximum latency for remote progressive rows: later batches flush on the
-/// next idle/frame instead of waiting solely for the count threshold.
+/// Latency bound so later remote batches flush on the next idle/frame.
 const REMOTE_FLUSH_DELAY: Duration = Duration::from_millis(50);
 /// Rows published synchronously with a staged load or sort; the rest stream
 /// from idle callbacks inside an 8 ms work budget.
 const FIRST_PUBLISH_COUNT: usize = 128;
-/// Loads at or below this size publish in one synchronous replace.
 const STAGE_INLINE_LIMIT: usize = 512;
-/// Snapshots at or below this size sort synchronously on the calling
-/// thread: sub-millisecond work that needs no off-thread hop and no main
-/// context. Larger snapshots sort in a blocking worker.
+/// Snapshots at or below this size sort synchronously; larger ones sort in a
+/// blocking worker.
 const SORT_INLINE_LIMIT: usize = 2048;
-/// Rows per publication tail callback.
 const PUBLISH_TAIL_CHUNK: usize = 2048;
-/// Main-thread work budget per publication tail callback.
 const PUBLISH_SLICE_BUDGET: Duration = Duration::from_millis(8);
 
-/// Last selection event emitted per depth on the batch path, keyed by request
-/// so a new load re-emits even when it selects the same rows. Lets background
-/// batches skip the redundant per-pane selection refresh (and its scroll)
-/// when nothing moved.
+/// Last selection emitted per depth on the batch path, keyed by request so a
+/// new load re-emits; lets background batches skip redundant refreshes.
 type BatchSelectionState = HashMap<usize, (RequestId, Vec<usize>, usize)>;
 
-/// One bound row's viewport fill request: the stable location plus the source
-/// position it occupied when bound, so fills apply in O(requested rows)
-/// after validating the row has not moved.
+/// One bound row's fill request: stable location plus its source position, so
+/// fills apply after validating the row has not moved.
 struct ViewportTarget {
     position: usize,
     location: Location,
 }
 
-/// A native initial load in flight. Identity batches accumulate here with no
-/// merge walk and no UI events; monitor deltas arriving mid-stage queue for
-/// one reconcile instead of racing the snapshot. Removed locations filter
-/// later batches, so a removed entry is never resurrected by a stale batch
-/// while an upserted one still lands.
+/// Routing for one metadata request: own ids, validated against the owning
+/// directory request.
+struct ViewportFill {
+    depth: usize,
+    directory_request: RequestId,
+    tokens: Vec<(usize, Location)>,
+}
+
+#[derive(Clone, Copy)]
+struct SortFill {
+    generation: u64,
+    depth: usize,
+    fill_request: RequestId,
+    directory_request: RequestId,
+    preferences: ViewPreferences,
+}
+
+/// A native initial load in flight: batches accumulate with no merge walk and
+/// no UI events; monitor deltas queue for one reconcile, and removed locations
+/// filter later batches so stale batches never resurrect deleted entries.
 struct StagingLoad {
     request_id: RequestId,
     entries: Vec<FileEntry>,
     removed: HashSet<Location>,
     deltas: Vec<(Location, DirectoryChange)>,
+    metadata_incomplete: bool,
 }
 
 /// A native load sorting off-thread after enumeration finished. Deltas
@@ -343,18 +341,35 @@ struct SortingLoad {
     deltas: Vec<(Location, DirectoryChange)>,
 }
 
-/// Terminal event owed after a staged publication's final tail.
+#[derive(Clone, Copy)]
+struct SortPlan {
+    ordering_preferences: ViewPreferences,
+    staged_preferences: ViewPreferences,
+    retry_metadata: bool,
+}
+
 enum PublishTerminal {
-    LoadFinished { truncated: bool },
+    LoadFinished {
+        truncated: bool,
+        retry_metadata: bool,
+    },
     SortingFinished,
 }
 
-/// A staged publication streaming to the UI: the prefix is already in the
-/// model, and idle callbacks append contiguous tails inside a work budget.
-/// Chunks clone from authoritative state at fire time, so no full-vector
-/// copy ever crosses the publish path. Selection and the terminal event
-/// wait for the final tail, so no out-of-range selection and no premature
-/// completion is ever published.
+enum RemoteTerminal {
+    Finished {
+        request_id: RequestId,
+        truncated: bool,
+    },
+    Failed {
+        request_id: RequestId,
+        message: String,
+    },
+}
+
+/// A staged publication streaming to the UI: the prefix is already in the model,
+/// tails append from idle callbacks in a work budget, and selection plus the
+/// terminal event wait for the final tail.
 struct StagedPublish {
     request_id: RequestId,
     published: usize,
@@ -372,20 +387,18 @@ pub struct Browser {
     metadata_pending: RefCell<HashMap<usize, Vec<ViewportTarget>>>,
     metadata_timer: RefCell<Option<gio::glib::SourceId>>,
     staging: RefCell<HashMap<usize, StagingLoad>>,
-    /// Native loads whose snapshot is sorting off-thread. Monitor deltas
-    /// arriving mid-sort queue here for the same silent reconcile.
     sorting: RefCell<HashMap<usize, SortingLoad>>,
     staged_publishes: RefCell<HashMap<usize, StagedPublish>>,
     publish_timer: RefCell<Option<gio::glib::SourceId>>,
     remote_flush_timer: RefCell<Option<gio::glib::SourceId>>,
+    remote_terminals: RefCell<HashMap<usize, RemoteTerminal>>,
     metadata_loads: RefCell<HashMap<usize, LoadHandle>>,
-    /// Stable `(position, Location)` tokens per in-flight viewport fill, so
-    fill_tokens: RefCell<HashMap<RequestId, Vec<(usize, Location)>>>,
+    fill_tokens: RefCell<HashMap<RequestId, ViewportFill>>,
     /// Full-column sort fills, kept apart from viewport fills so a viewport
     /// settle timer can never overwrite or cancel an active full sort.
     sort_loads: RefCell<HashMap<usize, LoadHandle>>,
     coalesce_pending: RefCell<HashMap<usize, (RequestId, Vec<FileEntry>)>>,
-    sort_awaiting_fill: RefCell<Option<(u64, usize, RequestId, ViewPreferences)>>,
+    sort_awaiting_fill: RefCell<Option<SortFill>>,
     last_batch_selection: RefCell<BatchSelectionState>,
     peek_load: RefCell<Option<LoadHandle>>,
     validation_load: RefCell<Option<LoadHandle>>,
@@ -424,6 +437,7 @@ impl Browser {
             staged_publishes: RefCell::new(HashMap::new()),
             publish_timer: RefCell::new(None),
             remote_flush_timer: RefCell::new(None),
+            remote_terminals: RefCell::new(HashMap::new()),
             metadata_loads: RefCell::new(HashMap::new()),
             fill_tokens: RefCell::new(HashMap::new()),
             sort_loads: RefCell::new(HashMap::new()),
@@ -706,8 +720,7 @@ impl Browser {
                 browser.handle_directory_event(event);
             }
         });
-        // Peeks stay small and show metadata immediately, so they keep the
-        // old always-stat behavior instead of the streaming split.
+        // Peeks stay small and show metadata immediately, so they skip the streaming split.
         let handle = self.source.enumerate(
             DirectoryRequest {
                 id: request_id,
@@ -857,9 +870,8 @@ impl Browser {
                 return;
             };
             update(&mut preferences);
-            // Size and date sorts need the metadata the streaming
-            // enumeration skipped. Fill the whole column first behind the
-            // sort spinner instead of sorting placeholders.
+            // Size/date sorts need the metadata streaming enumeration skipped:
+            // fill the whole column first instead of sorting placeholders.
             let targets = state.column_unknown_metadata(depth).unwrap_or_default();
             if matches!(preferences.sort_key, SortKey::Size | SortKey::Modified)
                 && !targets.is_empty()
@@ -876,8 +888,6 @@ impl Browser {
         };
         self.notify_preferences_observers();
         if let Some((request_id, total, focused, positions)) = result {
-            // Staged publication carries the new order; the sorting
-            // terminal waits for its final tail.
             if let (Some(request_id), Some(total)) = (request_id, total) {
                 self.publish_staged(
                     depth,
@@ -1768,15 +1778,11 @@ impl Browser {
             .watch(location, self.preferences.get().show_hidden, notify)
     }
 
-    /// Merges one wire batch (or one coalesced group) and emits its UI
-    /// events: the single choke point behind immediate, coalesced, and
-    /// straggler application alike.
     fn apply_owned_batch(self: &Rc<Self>, request_id: RequestId, entries: Vec<FileEntry>) {
         let install_started = std::time::Instant::now();
         let mut state = self.state.borrow_mut();
         let batch_len = entries.len();
         let Some((depth, insertions)) = state.apply_batch(request_id, entries) else {
-            // The load went away between queueing and flush.
             return;
         };
         tracing::debug!(
@@ -1792,8 +1798,7 @@ impl Browser {
             install_started.elapsed().as_millis() as u64,
         );
         self.emit(BrowserEvent::EntriesInserted { depth, insertions });
-        // The full-column scan below is the most expensive per-batch work
-        // after the merge itself; skip it entirely when nothing is selected.
+        // The full-column scan is the most expensive per-batch work after the merge.
         if let Some(focused) = selected {
             let positions = self.state.borrow().selected_positions(depth);
             let current = (request_id, positions.clone(), focused);
@@ -1811,9 +1816,6 @@ impl Browser {
         }
     }
 
-    /// Stages one native wire batch: appended to the depth's staging load
-    /// with no merge walk and no UI events. Sorting, installation, and
-    /// publication all wait for enumeration to finish.
     fn stage_batch(self: &Rc<Self>, request_id: RequestId, depth: usize, entries: Vec<FileEntry>) {
         let mut staging = self.staging.borrow_mut();
         let slot = staging.entry(depth).or_insert_with(|| StagingLoad {
@@ -1821,16 +1823,15 @@ impl Browser {
             entries: Vec::new(),
             removed: HashSet::new(),
             deltas: Vec::new(),
+            metadata_incomplete: false,
         });
         if slot.request_id != request_id {
-            // A reload replaced the load mid-stream: the old staging
-            // belongs to a discarded load, so restart it instead of mixing
-            // generations.
             *slot = StagingLoad {
                 request_id,
                 entries,
                 removed: HashSet::new(),
                 deltas: Vec::new(),
+                metadata_incomplete: false,
             };
             return;
         }
@@ -1847,16 +1848,11 @@ impl Browser {
         depth: usize,
         entries: Vec<FileEntry>,
     ) {
-        // Remote loads only: a 50 ms timer bounds first-result latency so a
-        // slow link never waits solely for the count threshold.
         let mut pending = self.coalesce_pending.borrow_mut();
         let slot = pending
             .entry(depth)
             .or_insert_with(|| (request_id, Vec::new()));
         if slot.0 != request_id {
-            // A reload replaced the load mid-stream: the old accumulation
-            // belongs to a discarded load, so drop it instead of mixing
-            // generations.
             *slot = (request_id, Vec::new());
         }
         slot.1.extend(entries);
@@ -1869,15 +1865,12 @@ impl Browser {
         }
     }
 
-    /// Flushes coalesced remote batches, capped per depth per fire so one
-    /// timer fire never becomes a multi-frame GTK mutation. Leftovers stay
-    /// queued behind a re-armed timer.
     fn flush_coalesced_capped(self: &Rc<Self>, depth: Option<usize>) {
         let depths: Vec<usize> = match depth {
             Some(depth) => vec![depth],
             None => self.coalesce_pending.borrow().keys().copied().collect(),
         };
-        for depth in depths {
+        for &depth in &depths {
             self.drain_publish(depth);
             let chunk: Option<(RequestId, Vec<FileEntry>)> = self
                 .coalesce_pending
@@ -1905,6 +1898,39 @@ impl Browser {
         } else {
             self.arm_remote_flush_timer();
         }
+        for depth in depths {
+            self.finish_remote_if_drained(depth);
+        }
+    }
+
+    fn finish_remote_if_drained(self: &Rc<Self>, depth: usize) {
+        if self.coalesce_pending.borrow().contains_key(&depth) {
+            return;
+        }
+        let Some(terminal) = self.remote_terminals.borrow_mut().remove(&depth) else {
+            return;
+        };
+        match terminal {
+            RemoteTerminal::Finished {
+                request_id,
+                truncated,
+            } => {
+                let finished = self.state.borrow_mut().finish(request_id, truncated);
+                if let Some(depth) = finished {
+                    self.emit(BrowserEvent::LoadFinished { depth, truncated });
+                    self.ensure_sorted_after_load(depth);
+                }
+            }
+            RemoteTerminal::Failed {
+                request_id,
+                message,
+            } => {
+                let failed = self.state.borrow_mut().fail(request_id, message.clone());
+                if let Some(depth) = failed {
+                    self.emit(BrowserEvent::LoadFailed { depth, message });
+                }
+            }
+        }
     }
 
     fn arm_remote_flush_timer(self: &Rc<Self>) {
@@ -1914,8 +1940,7 @@ impl Browser {
         let weak: Weak<Self> = Rc::downgrade(self);
         let source = gio::glib::timeout_add_local_once(REMOTE_FLUSH_DELAY, move || {
             if let Some(browser) = weak.upgrade() {
-                // Spent: disarm before flushing, since the flush disarms an
-                // armed timer by removing it (a fired id refuses removal).
+                // Spent: disarm before flushing; a fired id refuses removal.
                 browser.remote_flush_timer.borrow_mut().take();
                 browser.flush_coalesced_capped(None);
             }
@@ -1923,9 +1948,8 @@ impl Browser {
         *self.remote_flush_timer.borrow_mut() = Some(source);
     }
 
-    /// Sorts a staged native snapshot off the main thread, then installs,
-    /// reconciles, and publishes it. The loading state stays up throughout:
-    /// no provisional list is ever exposed for a faster first row.
+    /// Sorts a staged snapshot off-thread, then installs, reconciles, and publishes
+    /// it with the loading state up throughout: no provisional list is exposed.
     fn finish_staged_load(self: &Rc<Self>, depth: usize, request_id: RequestId, truncated: bool) {
         let staging = self.staging.borrow_mut().remove(&depth);
         let Some(staging) = staging.filter(|staged| staged.request_id == request_id) else {
@@ -1939,47 +1963,76 @@ impl Browser {
         let removed = staging.removed;
         let mut entries = staging.entries;
         entries.retain(|entry| !removed.contains(&entry.location));
+        let retry_metadata = staging.metadata_incomplete
+            && matches!(preferences.sort_key, SortKey::Size | SortKey::Modified);
+        let ordering_preferences = if retry_metadata {
+            ViewPreferences {
+                sort_key: SortKey::Name,
+                ..preferences
+            }
+        } else {
+            preferences
+        };
         let deltas = staging.deltas;
         self.sorting
             .borrow_mut()
             .insert(depth, SortingLoad { request_id, deltas });
-        self.run_sort_task(depth, request_id, entries, preferences, truncated);
+        self.run_sort_task(
+            depth,
+            request_id,
+            entries,
+            SortPlan {
+                ordering_preferences,
+                staged_preferences: preferences,
+                retry_metadata,
+            },
+            truncated,
+        );
     }
 
-    /// Sorts a snapshot inline below the threshold, or in a blocking worker
-    /// above it with completion back on the main thread. Small sorts stay
-    /// synchronous (no context, no pump); large ones never block input.
+    /// Small snapshots sort synchronously; large ones sort in a blocking worker
+    /// with completion back on the main thread.
     fn run_sort_task(
         self: &Rc<Self>,
         depth: usize,
         request_id: RequestId,
         entries: Vec<FileEntry>,
-        preferences: ViewPreferences,
+        plan: SortPlan,
         truncated: bool,
     ) {
         if entries.len() <= SORT_INLINE_LIMIT {
-            let sorted = sort_entries(entries, preferences);
-            self.finish_staged_sort(depth, request_id, sorted, preferences, truncated);
+            let sorted = sort_entries(entries, plan.ordering_preferences);
+            self.finish_staged_sort(
+                depth,
+                request_id,
+                sorted,
+                plan.staged_preferences,
+                truncated,
+                plan.retry_metadata,
+            );
             return;
         }
         let weak: Weak<Self> = Rc::downgrade(self);
         glib::MainContext::default().spawn_local(async move {
-            let sorted = gio::spawn_blocking(move || sort_entries(entries, preferences)).await;
+            let sorted =
+                gio::spawn_blocking(move || sort_entries(entries, plan.ordering_preferences)).await;
             let Some(browser) = weak.upgrade() else {
                 return;
             };
             match sorted {
-                Ok(sorted) => {
-                    browser.finish_staged_sort(depth, request_id, sorted, preferences, truncated)
-                }
+                Ok(sorted) => browser.finish_staged_sort(
+                    depth,
+                    request_id,
+                    sorted,
+                    plan.staged_preferences,
+                    truncated,
+                    plan.retry_metadata,
+                ),
                 Err(_) => browser.fail_staged_sort(depth, request_id),
             }
         });
     }
 
-    /// Installs a sorted staged snapshot, reconciles monitor deltas queued
-    /// while it sorted, and publishes. Drops everything when the load was
-    /// superseded mid-sort.
     fn finish_staged_sort(
         self: &Rc<Self>,
         depth: usize,
@@ -1987,6 +2040,7 @@ impl Browser {
         sorted: Vec<FileEntry>,
         staged_preferences: ViewPreferences,
         truncated: bool,
+        retry_metadata: bool,
     ) {
         let sorting = self.sorting.borrow_mut().remove(&depth);
         let Some(sorting) = sorting.filter(|sorting| sorting.request_id == request_id) else {
@@ -2003,10 +2057,8 @@ impl Browser {
         {
             return;
         }
-        // Reconcile silently: the UI model is still empty, so delta events
-        // would splice invalid positions. State converges first (in sort
-        // order, since reconciled inserts stay sorted), then one staged
-        // publication carries the reconciled order.
+        // Reconcile silently: the UI model is still empty, so delta events would
+        // splice invalid positions; one staged publication carries the result.
         for (watched, change) in sorting.deltas {
             if matches!(change, DirectoryChange::Rescan) {
                 continue;
@@ -2022,10 +2074,8 @@ impl Browser {
             .column_preferences(depth)
             .unwrap_or_else(|| self.preferences.get());
         if current != staged_preferences {
-            // Resorted mid-load: route through the standard metadata-aware
-            // sort path when fields are still missing, else re-sort
-            // off-thread with the current preferences. The loading terminal
-            // fires exactly once, on whichever path finishes the load.
+            // Resorted mid-load: re-sort with the current preferences; the loading
+            // terminal fires exactly once, on whichever path finishes the load.
             if matches!(current.sort_key, SortKey::Size | SortKey::Modified)
                 && self.state.borrow().column_unknown_metadata(depth).is_some()
             {
@@ -2058,12 +2108,13 @@ impl Browser {
             total,
             focused,
             positions,
-            PublishTerminal::LoadFinished { truncated },
+            PublishTerminal::LoadFinished {
+                truncated,
+                retry_metadata,
+            },
         );
     }
 
-    /// Re-sorts an installed column off-thread after a mid-load preference
-    /// change, then publishes the new order through the staged path.
     fn resort_installed_column(
         self: &Rc<Self>,
         depth: usize,
@@ -2087,12 +2138,20 @@ impl Browser {
                 deltas: Vec::new(),
             },
         );
-        self.run_sort_task(depth, request_id, entries, preferences, truncated);
+        self.run_sort_task(
+            depth,
+            request_id,
+            entries,
+            SortPlan {
+                ordering_preferences: preferences,
+                staged_preferences: preferences,
+                retry_metadata: false,
+            },
+            truncated,
+        );
     }
 
-    /// Fails a staged load whose sort task died: the column keeps its
-    /// loading state replaced by an error, exactly like a failed
-    /// enumeration, so no spinner hangs.
+    /// Fails a staged load whose sort task died, so no spinner hangs.
     fn fail_staged_sort(self: &Rc<Self>, depth: usize, request_id: RequestId) {
         self.sorting.borrow_mut().remove(&depth);
         let mut state = self.state.borrow_mut();
@@ -2108,11 +2167,9 @@ impl Browser {
         }
     }
 
-    /// Publishes an installed column in stages: the first viewport-sized
-    /// prefix replaces the model synchronously for fast first correct rows,
-    /// then contiguous tails stream from idle callbacks inside a work
-    /// budget so no publication callback exceeds a frame. Selection and the
-    /// terminal event wait for the final tail.
+    /// Publishes an installed column in stages: a synchronous prefix for fast first
+    /// rows, tails from idle callbacks in a work budget, and deferred selection
+    /// plus terminal on the final tail.
     fn publish_staged(
         self: &Rc<Self>,
         depth: usize,
@@ -2166,19 +2223,23 @@ impl Browser {
         self.arm_publish_timer();
     }
 
-    /// Emits a staged publication's terminal event.
-    fn emit_publish_terminal(&self, depth: usize, terminal: PublishTerminal) {
+    fn emit_publish_terminal(self: &Rc<Self>, depth: usize, terminal: PublishTerminal) {
         match terminal {
-            PublishTerminal::LoadFinished { truncated } => {
-                self.emit(BrowserEvent::LoadFinished { depth, truncated })
+            PublishTerminal::LoadFinished {
+                truncated,
+                retry_metadata,
+            } => {
+                self.emit(BrowserEvent::LoadFinished { depth, truncated });
+                if retry_metadata {
+                    self.ensure_sorted_after_load(depth);
+                }
             }
             PublishTerminal::SortingFinished => self.emit(BrowserEvent::SortingFinished { depth }),
         }
     }
 
-    /// Completes a staged publication synchronously: emits the remainder,
-    /// the deferred selection, and the terminal. Called before any mutation
-    /// that assumes the model converged with authoritative state.
+    /// Completes a staged publication synchronously before any mutation assuming a
+    /// converged model.
     fn drain_publish(self: &Rc<Self>, depth: usize) {
         let staged = self.staged_publishes.borrow_mut().remove(&depth);
         let Some(staged) = staged else {
@@ -2205,8 +2266,6 @@ impl Browser {
         self.emit_publish_terminal(depth, staged.terminal);
     }
 
-    /// Drops a staged publication without emitting: the model and state are
-    /// both being reset, so nothing is owed.
     fn cancel_publish(&self, depth: usize) {
         self.staged_publishes.borrow_mut().remove(&depth);
         if self.staged_publishes.borrow().is_empty()
@@ -2221,20 +2280,17 @@ impl Browser {
             return;
         }
         let weak: Weak<Self> = Rc::downgrade(self);
-        // Idle priority: tails yield to input, paint, and higher-priority
-        // sources, streaming rows behind an interactive UI.
-        let source = gio::glib::idle_add_local_once(move || {
+        // Run after GDK redraw (priority 120), but before default idle (200):
+        // frames stay smooth without letting continuous frame work starve tails.
+        let source = gio::glib::idle_add_local_full(glib::Priority::from(130), move || {
             if let Some(browser) = weak.upgrade() {
                 browser.fire_publish_tails();
             }
+            glib::ControlFlow::Break
         });
         *self.publish_timer.borrow_mut() = Some(source);
     }
 
-    /// Appends one bounded tail chunk per staged depth, then the deferred
-    /// selection and terminal for depths that complete. Stops after the
-    /// slice budget so sustained publishing never starves the main loop.
-    /// Tails whose load was superseded drop without emitting.
     fn fire_publish_tails(self: &Rc<Self>) {
         self.publish_timer.borrow_mut().take();
         let started = std::time::Instant::now();
@@ -2250,7 +2306,6 @@ impl Browser {
                 .map(|staged| staged.request_id);
             if current.is_some_and(|id| self.state.borrow().request_id_for_depth(depth) != Some(id))
             {
-                // Superseded mid-publish: drop without emitting.
                 self.staged_publishes.borrow_mut().remove(&depth);
                 continue;
             }
@@ -2271,7 +2326,6 @@ impl Browser {
                     })
                 });
             let Some((position, chunk)) = chunk else {
-                // The column went away mid-publish: drop the tail.
                 self.staged_publishes.borrow_mut().remove(&depth);
                 continue;
             };
@@ -2307,9 +2361,8 @@ impl Browser {
         position: usize,
         location: Location,
     ) {
-        // Ask the provider what it supports instead of rejecting remote
-        // locations owner-side: remote and GVfs fills stay on cancellable
-        // GIO, and unsupported sources simply answer `Unsupported`.
+        // Defer to the provider instead of rejecting remote locations owner-side:
+        // unsupported sources answer `Unsupported`.
         if !self.source.supports_metadata_fill(&location) {
             return;
         }
@@ -2322,8 +2375,6 @@ impl Browser {
                 queued.push(ViewportTarget { position, location });
             }
         }
-        // True settle timer: every newly visible row restarts the debounce,
-        // so a continuous fling never fires mid-scroll for stale rows.
         if let Some(source) = self.metadata_timer.borrow_mut().take() {
             source.remove();
         }
@@ -2336,8 +2387,6 @@ impl Browser {
         *self.metadata_timer.borrow_mut() = Some(source);
     }
 
-    /// Stats a whole column for a size/date sort behind the sort spinner,
-    /// then sorts once the pass lands.
     fn request_sort_fill(
         self: &Rc<Self>,
         depth: usize,
@@ -2345,14 +2394,19 @@ impl Browser {
         preferences: ViewPreferences,
         targets: Vec<(usize, Location)>,
     ) {
-        let Some(request_id) = self.state.borrow().request_id_for_depth(depth) else {
+        let Some(directory_request) = self.state.borrow().request_id_for_depth(depth) else {
             self.pending_sort.set(None);
             self.emit(BrowserEvent::SortingFinished { depth });
             return;
         };
-        self.sort_awaiting_fill
-            .borrow_mut()
-            .replace((generation, depth, request_id, preferences));
+        let fill_request = self.new_request_id();
+        self.sort_awaiting_fill.borrow_mut().replace(SortFill {
+            generation,
+            depth,
+            fill_request,
+            directory_request,
+            preferences,
+        });
         let weak: Weak<Self> = Rc::downgrade(self);
         let emit = Rc::new(move |event| {
             if let Some(browser) = weak.upgrade() {
@@ -2361,14 +2415,21 @@ impl Browser {
         });
         let handle = self.source.fill_metadata(
             MetadataRequest {
-                id: request_id,
+                id: fill_request,
                 entries: targets.into_iter().map(|(_, location)| location).collect(),
                 full: true,
                 time_budget: DIRECTORY_LOAD_TIME_BUDGET,
             },
             emit,
         );
-        self.sort_loads.borrow_mut().insert(depth, handle);
+        if self
+            .sort_awaiting_fill
+            .borrow()
+            .as_ref()
+            .is_some_and(|fill| fill.fill_request == fill_request)
+        {
+            self.sort_loads.borrow_mut().insert(depth, handle);
+        }
     }
 
     fn finish_awaited_sort(
@@ -2410,44 +2471,31 @@ impl Browser {
             }
         }
     }
-    /// `Complete`; any other outcome abandons the sort without reordering so
-    /// a partial pass is never published as correct. Viewport fills need no
-    /// outcome handling beyond dropping their handle: unfilled rows keep
-    /// their placeholders and retry on their next bind.
+    /// Only `Complete` sorts: a partial pass is never published as correct, and
+    /// unfilled rows keep placeholders for their next bind.
     fn handle_metadata_finished(self: &Rc<Self>, request_id: RequestId, outcome: MetadataOutcome) {
         let awaiting = *self.sort_awaiting_fill.borrow();
-        if let Some((generation, depth, fill_request, preferences)) = awaiting
-            && fill_request == request_id
+        if let Some(awaiting) = awaiting
+            && awaiting.fill_request == request_id
         {
-            self.sort_loads.borrow_mut().remove(&depth);
+            self.sort_loads.borrow_mut().remove(&awaiting.depth);
             if outcome == MetadataOutcome::Complete
-                && self.pending_sort.get() == Some((generation, depth))
+                && self.pending_sort.get() == Some((awaiting.generation, awaiting.depth))
             {
-                self.finish_awaited_sort(depth, generation, preferences);
+                self.finish_awaited_sort(awaiting.depth, awaiting.generation, awaiting.preferences);
             } else {
-                self.abandon_awaited_sort(depth, generation, outcome);
+                self.abandon_awaited_sort(awaiting.depth, awaiting.generation, outcome);
             }
             return;
         }
-        // A viewport fill (or a superseded sort fill) ending: drop its
-        // handle. A superseded sort whose column reloaded already had its
-        // indicator closed by the reload path; belt-and-braces abandon here
-        // in case the reload raced the terminal.
-        if let Some(depth) = self.state.borrow().depth_for_request(request_id) {
-            self.metadata_loads.borrow_mut().remove(&depth);
-        }
-        if let Some((generation, depth, _, _)) = awaiting
-            && self.state.borrow().depth_for_request(request_id).is_none()
-            && self.pending_sort.get() == Some((generation, depth))
-        {
-            self.abandon_awaited_sort(depth, generation, outcome);
+        // Only a fill's own id releases its handle; terminals from superseded fills
+        // cannot affect a sort or a newer request.
+        if let Some(fill) = self.fill_tokens.borrow_mut().remove(&request_id) {
+            self.metadata_loads.borrow_mut().remove(&fill.depth);
         }
     }
 
-    /// Abandons a waiting sort after a non-complete fill: the prior correct
-    /// order is preserved, the indicator stops, and the failure is logged so
-    /// a re-sort retry starts from clean state. Every `SortingStarted` still
-    /// pairs with exactly one `SortingFinished`.
+    /// Every `SortingStarted` still pairs with exactly one `SortingFinished`.
     fn abandon_awaited_sort(&self, depth: usize, generation: u64, outcome: MetadataOutcome) {
         self.sort_awaiting_fill.borrow_mut().take();
         self.sort_loads.borrow_mut().remove(&depth);
@@ -2465,10 +2513,10 @@ impl Browser {
     }
     fn cancel_pending_sort_for(&self, depth: usize) {
         let awaiting = *self.sort_awaiting_fill.borrow();
-        if let Some((generation, awaiting_depth, _, _)) = awaiting
-            && awaiting_depth == depth
+        if let Some(awaiting) = awaiting
+            && awaiting.depth == depth
         {
-            self.abandon_awaited_sort(depth, generation, MetadataOutcome::Cancelled);
+            self.abandon_awaited_sort(depth, awaiting.generation, MetadataOutcome::Cancelled);
             return;
         }
         self.sort_loads.borrow_mut().remove(&depth);
@@ -2477,15 +2525,11 @@ impl Browser {
             .get()
             .is_some_and(|(_, pending_depth)| pending_depth == depth)
         {
-            // Sort debounce armed but its fill never started: no provider
-            // work to cancel, just close the indicator.
             self.pending_sort.set(None);
             self.emit(BrowserEvent::SortingFinished { depth });
         }
     }
 
-    /// Drops everything deferred for columns at or beyond `len`: viewport
-    /// truncation, navigation, reload, and close path.
     fn truncate_deferred_from(self: &Rc<Self>, len: usize) {
         if let Some(source) = self.metadata_timer.borrow_mut().take() {
             source.remove();
@@ -2493,7 +2537,6 @@ impl Browser {
         self.metadata_pending
             .borrow_mut()
             .retain(|depth, _| *depth < len);
-        // Re-arm the settle timer when younger depths still queue fills.
         if !self.metadata_pending.borrow().is_empty() {
             let weak: Weak<Self> = Rc::downgrade(self);
             let source = gio::glib::timeout_add_local_once(METADATA_FILL_DEBOUNCE, move || {
@@ -2507,27 +2550,31 @@ impl Browser {
             .borrow_mut()
             .retain(|depth, _| *depth < len);
         let state = self.state.borrow();
-        self.fill_tokens.borrow_mut().retain(|request_id, _| {
-            state
-                .depth_for_request(*request_id)
-                .is_some_and(|depth| depth < len)
+        self.fill_tokens.borrow_mut().retain(|_, fill| {
+            fill.depth < len
+                && state.request_id_for_depth(fill.depth) == Some(fill.directory_request)
         });
         let awaiting = *self.sort_awaiting_fill.borrow();
-        if let Some((generation, depth, _, _)) = awaiting
-            && depth >= len
+        if let Some(awaiting) = awaiting
+            && awaiting.depth >= len
         {
-            self.abandon_awaited_sort(depth, generation, MetadataOutcome::Cancelled);
+            self.abandon_awaited_sort(
+                awaiting.depth,
+                awaiting.generation,
+                MetadataOutcome::Cancelled,
+            );
         } else {
             self.sort_loads.borrow_mut().retain(|depth, _| *depth < len);
         }
         self.coalesce_pending
             .borrow_mut()
             .retain(|depth, _| *depth < len);
+        self.remote_terminals
+            .borrow_mut()
+            .retain(|depth, _| *depth < len);
         self.last_batch_selection
             .borrow_mut()
             .retain(|depth, _| *depth < len);
-        // Staged loads and sorts die with their columns; staged publishes
-        // cancel without emitting, since both model and state reset.
         self.staging.borrow_mut().retain(|depth, _| *depth < len);
         self.sorting.borrow_mut().retain(|depth, _| *depth < len);
         self.staged_publishes
@@ -2540,8 +2587,6 @@ impl Browser {
         }
     }
 
-    /// Re-sorts a freshly loaded column whose sort key needs metadata the
-    /// streaming enumeration skipped. Name and type sorts never land here.
     fn ensure_sorted_after_load(self: &Rc<Self>, depth: usize) {
         let (needs, preferences) = {
             let state = self.state.borrow();
@@ -2578,11 +2623,10 @@ impl Browser {
         let pending: Vec<(usize, Vec<ViewportTarget>)> =
             self.metadata_pending.borrow_mut().drain().collect();
         for (depth, targets) in pending {
-            // Refresh the load identity: the column may have reloaded while
-            // these rows queued, and a superseded fill must not apply.
-            let Some(request_id) = self.state.borrow().request_id_for_depth(depth) else {
+            let Some(directory_request) = self.state.borrow().request_id_for_depth(depth) else {
                 continue;
             };
+            let fill_request = self.new_request_id();
             let weak: Weak<Self> = Rc::downgrade(self);
             let emit = Rc::new(move |event| {
                 if let Some(browser) = weak.upgrade() {
@@ -2593,27 +2637,37 @@ impl Browser {
                 .iter()
                 .map(|target| (target.position, target.location.clone()))
                 .collect();
-            // Stored before the provider runs: synchronous fills answer
-            // inside the call, and their chunks join against these tokens.
-            self.fill_tokens.borrow_mut().insert(request_id, tokens);
+            // Stored before the provider runs: synchronous fills answer inside the call.
+            self.fill_tokens
+                .borrow_mut()
+                .retain(|_, fill| fill.depth != depth);
+            self.metadata_loads.borrow_mut().remove(&depth);
+            self.fill_tokens.borrow_mut().insert(
+                fill_request,
+                ViewportFill {
+                    depth,
+                    directory_request,
+                    tokens,
+                },
+            );
             let handle = self.source.fill_metadata(
                 MetadataRequest {
-                    id: request_id,
+                    id: fill_request,
                     entries: targets.into_iter().map(|target| target.location).collect(),
                     full: false,
                     time_budget: METADATA_FILL_TIME_BUDGET,
                 },
                 emit,
             );
-            self.metadata_loads.borrow_mut().insert(depth, handle);
+            if self.fill_tokens.borrow().contains_key(&fill_request) {
+                self.metadata_loads.borrow_mut().insert(depth, handle);
+            }
         }
     }
 
-    /// Drops everything a discarded load queued: metadata fills and
-    /// coalesced batches alike. Coalesced rows are safe to drop because
-    /// every site that clears loads replaces the data source wholesale.
-    /// A pending sort's indicator closes here: its fill handle is dropped,
-    /// which aborts provider work without a terminal event.
+    /// Drops everything a discarded load queued. Coalesced rows are safe to drop
+    /// because every site that clears loads replaces the data source wholesale;
+    /// dropping a sort's fill handle aborts provider work without a terminal event.
     fn cancel_deferred_work(&self) {
         if let Some(source) = self.metadata_timer.borrow_mut().take() {
             source.remove();
@@ -2622,20 +2676,21 @@ impl Browser {
         self.metadata_loads.borrow_mut().clear();
         self.fill_tokens.borrow_mut().clear();
         let awaiting = self.sort_awaiting_fill.borrow_mut().take();
-        if let Some((generation, depth, _, _)) = awaiting {
-            self.abandon_awaited_sort(depth, generation, MetadataOutcome::Cancelled);
+        if let Some(awaiting) = awaiting {
+            self.abandon_awaited_sort(
+                awaiting.depth,
+                awaiting.generation,
+                MetadataOutcome::Cancelled,
+            );
         } else {
             self.sort_loads.borrow_mut().clear();
             if let Some((_, depth)) = self.pending_sort.take() {
-                // Sort debounce armed but its fill never started.
                 self.emit(BrowserEvent::SortingFinished { depth });
             }
         }
         self.coalesce_pending.borrow_mut().clear();
+        self.remote_terminals.borrow_mut().clear();
         self.last_batch_selection.borrow_mut().clear();
-        // Staged snapshots, in-flight sorts, and staged publications die
-        // with their loads: late completions find no staging entry and a
-        // retired request id, so they publish nothing.
         self.staging.borrow_mut().clear();
         self.sorting.borrow_mut().clear();
         self.staged_publishes.borrow_mut().clear();
@@ -2664,10 +2719,8 @@ impl Browser {
         } else {
             REMOTE_DIRECTORY_BATCH_SIZE
         };
-        // Loads sorted by size or date stat inline: the column's own key
-        // decides, falling back to the application preference for columns
-        // that do not exist yet. Sorting placeholders and re-sorting a full
-        // directory afterwards costs more than one stat per file up front.
+        // Size/date loads stat inline: sorting placeholders and re-sorting afterwards
+        // costs more than one stat per file up front.
         let sort_key = self
             .state
             .borrow()
@@ -2783,18 +2836,15 @@ impl Browser {
         self.metadata_loads.borrow_mut().remove(&depth);
         self.metadata_pending.borrow_mut().remove(&depth);
         self.coalesce_pending.borrow_mut().remove(&depth);
+        self.remote_terminals.borrow_mut().remove(&depth);
         self.last_batch_selection.borrow_mut().remove(&depth);
         self.cancel_pending_sort_for(depth);
-        // The retired load's staging, sort, and publication die with it;
-        // late completions find a retired request id and publish nothing.
         self.staging.borrow_mut().remove(&depth);
         self.sorting.borrow_mut().remove(&depth);
         self.cancel_publish(depth);
-        // Tokens belong to live loads: the retired request id no longer
-        // resolves, so its tokens drop here instead of leaking.
-        self.fill_tokens
-            .borrow_mut()
-            .retain(|request_id, _| self.state.borrow().depth_for_request(*request_id).is_some());
+        self.fill_tokens.borrow_mut().retain(|_, fill| {
+            self.state.borrow().request_id_for_depth(fill.depth) == Some(fill.directory_request)
+        });
     }
 
     pub fn reload_active(self: &Rc<Self>) {
@@ -2849,9 +2899,6 @@ impl Browser {
         });
     }
 
-    /// Depth and nativeness of a column load, if `request_id` still owns
-    /// one. Nativeness splits publication policy: native loads stage and
-    /// sort once, remote loads stream progressively.
     fn load_target(&self, request_id: RequestId) -> Option<(usize, bool)> {
         let state = self.state.borrow();
         let depth = state.depth_for_request(request_id)?;
@@ -2869,11 +2916,6 @@ impl Browser {
             self.refresh_column(depth);
             return;
         }
-        // A staged or sorting load owns no published rows yet: queue the
-        // delta for the completion's single reconcile instead of racing the
-        // snapshot. Removed locations also filter staged batches so a late
-        // batch never resurrects them; an upserted location leaves the set
-        // so recreations still land.
         if let Some(staging) = self.staging.borrow_mut().get_mut(&depth) {
             match &change {
                 DirectoryChange::Remove(location) => {
@@ -2895,8 +2937,8 @@ impl Browser {
             sorting.deltas.push((watched.clone(), change));
             return;
         }
-        // A staged publication covers a converged model again first: deltas
-        // splice positions that only exist past the tails.
+        // A staged publication converges the model first: deltas splice positions
+        // that only exist past the tails.
         self.drain_publish(depth);
         let path_update = self
             .state
@@ -2938,9 +2980,6 @@ impl Browser {
                 request_id,
                 entries,
             } => {
-                // Native open loads stage identity batches with no merge
-                // walk and no UI events; everything else stays progressive
-                // (remote first paint, peek batches, stragglers).
                 let target = self.load_target(request_id);
                 let open = self.state.borrow().open_load_depth(request_id);
                 match (target, open) {
@@ -2984,11 +3023,8 @@ impl Browser {
                 request_id,
                 truncated,
             } => {
-                // A staged native load sorts off-thread and publishes
-                // staged; everything else lands coalesced rows first, then
-                // closes the load. Bound to a variable first: an if-let
-                // scrutinee borrow would stay live across the flush and
-                // panic inside it.
+                // Bound to a variable first: an if-let scrutinee borrow would stay live
+                // across the flush and panic inside it.
                 let target = self.load_target(request_id);
                 let open = self.state.borrow().open_load_depth(request_id);
                 match (target, open) {
@@ -2997,16 +3033,14 @@ impl Browser {
                         self.finish_staged_load(depth, request_id, truncated);
                     }
                     (Some((depth, _)), Some(_)) => {
+                        self.remote_terminals.borrow_mut().insert(
+                            depth,
+                            RemoteTerminal::Finished {
+                                request_id,
+                                truncated,
+                            },
+                        );
                         self.flush_coalesced_capped(Some(depth));
-                        let mut state = self.state.borrow_mut();
-                        if let Some(depth) = state.finish(request_id, truncated) {
-                            drop(state);
-                            self.emit(BrowserEvent::LoadFinished { depth, truncated });
-                            // A column sorted by size or date loaded
-                            // placeholders; stat the column and sort once
-                            // the pass lands.
-                            self.ensure_sorted_after_load(depth);
-                        }
                     }
                     _ => {
                         let mut state = self.state.borrow_mut();
@@ -3017,21 +3051,36 @@ impl Browser {
                     }
                 }
             }
+            DirectoryEvent::MetadataIncomplete { request_id } => {
+                let target = self.load_target(request_id);
+                let open = self.state.borrow().open_load_depth(request_id);
+                if let Some((depth, true)) = target.filter(|_| open.is_some()) {
+                    self.stage_batch(request_id, depth, Vec::new());
+                    if let Some(staging) = self.staging.borrow_mut().get_mut(&depth) {
+                        staging.metadata_incomplete = true;
+                    }
+                }
+            }
             DirectoryEvent::Failed {
                 request_id,
                 message,
             } => {
-                // Staged and sorting loads die with the enumeration: drop
-                // their state so no late sort can publish, then follow the
-                // standard failure path.
                 let target = self.load_target(request_id);
                 let open = self.state.borrow().open_load_depth(request_id);
                 if let Some((depth, true)) = target.filter(|_| open.is_some()) {
                     self.staging.borrow_mut().remove(&depth);
                     self.sorting.borrow_mut().remove(&depth);
                     self.cancel_publish(depth);
-                } else if let Some((depth, _)) = target {
+                } else if let Some((depth, false)) = target.filter(|_| open.is_some()) {
+                    self.remote_terminals.borrow_mut().insert(
+                        depth,
+                        RemoteTerminal::Failed {
+                            request_id,
+                            message,
+                        },
+                    );
                     self.flush_coalesced_capped(Some(depth));
+                    return;
                 }
                 let mut state = self.state.borrow_mut();
                 if let Some(depth) = state.fail(request_id, message.clone()) {
@@ -3046,16 +3095,19 @@ impl Browser {
                 request_id,
                 updates,
             } => {
-                // Full sort fills apply by location: the column is about to
-                // be re-sorted wholesale, so positional tokens would only add
+                // Full sort fills apply by location: positional tokens would only add
                 // validation churn to an already O(n log n) path.
                 let awaiting_sort = self
                     .sort_awaiting_fill
                     .borrow()
-                    .is_some_and(|(_, _, fill_id, _)| fill_id == request_id);
-                if awaiting_sort {
+                    .as_ref()
+                    .copied()
+                    .filter(|fill| fill.fill_request == request_id);
+                if let Some(awaiting) = awaiting_sort {
                     let mut state = self.state.borrow_mut();
-                    if let Some((depth, positions)) = state.apply_metadata(request_id, updates) {
+                    if let Some((depth, positions)) =
+                        state.apply_metadata(awaiting.directory_request, updates)
+                    {
                         let filled = filled_entries(&state, depth, &positions);
                         tracing::debug!(
                             request_id = request_id.0,
@@ -3069,17 +3121,14 @@ impl Browser {
                             updates: filled,
                         });
                     }
-                    // Sorts wait for the fill's terminal outcome, never for a
-                    // chunk: sorting here would publish a partially statted
-                    // column as correctly ordered.
                     return;
                 }
-                // Viewport fills apply in O(requested rows) against the
-                // tokens captured at bind time. Rows that moved under the
-                // fill go stale and keep their placeholders; their next bind
-                // re-requests them, so only stale rows retry.
-                let tokens = self.fill_tokens.borrow().get(&request_id).cloned();
-                let Some(tokens) = tokens else {
+                let fill = self
+                    .fill_tokens
+                    .borrow()
+                    .get(&request_id)
+                    .map(|fill| (fill.directory_request, fill.tokens.clone()));
+                let Some((directory_request, tokens)) = fill else {
                     return;
                 };
                 let token_positions: HashMap<&Location, usize> = tokens
@@ -3094,7 +3143,7 @@ impl Browser {
                 }
                 let mut state = self.state.borrow_mut();
                 if let Some((depth, positions, stale)) =
-                    state.apply_positioned_metadata(request_id, positioned)
+                    state.apply_positioned_metadata(directory_request, positioned)
                 {
                     let filled = filled_entries(&state, depth, &positions);
                     tracing::debug!(
@@ -3117,7 +3166,6 @@ impl Browser {
                 request_id,
                 outcome,
             } => {
-                self.fill_tokens.borrow_mut().remove(&request_id);
                 self.handle_metadata_finished(request_id, outcome);
             }
         }
@@ -3137,7 +3185,6 @@ impl Browser {
     }
 }
 
-/// Clones the freshly filled entries for a view refresh payload.
 fn filled_entries(
     state: &NavigationState,
     depth: usize,

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -5,7 +5,10 @@ use std::{cell::Cell, ffi::OsString};
 use super::*;
 use crate::{
     model::{EntryKind, MetadataValue},
-    services::{CancelledOperation, CompressRequest, ExtractRequest, LoadHandle},
+    services::{
+        CancelledOperation, CompressRequest, ExtractRequest, LoadHandle, MetadataOutcome,
+        MetadataRequest, MetadataUpdate,
+    },
 };
 
 #[test]
@@ -44,7 +47,7 @@ fn assert_invalid_creation_is_rejected(create: impl FnOnce(&Rc<Browser>)) {
     let browser = Browser::new(Rc::new(FakeFileSource));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
-    browser.observe(move |event| observed.borrow_mut().push(event));
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
 
     create(&browser);
 
@@ -345,7 +348,7 @@ fn large_restore_progress_defers_model_removal() {
     browser.navigate(Location::uri("trash:///"));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
-    browser.observe(move |event| observed.borrow_mut().push(event));
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
     let request_id = browser.begin_operation();
     browser.restoration_operation.set(true);
     let emit = browser.operation_callback(request_id, false, HashSet::new());
@@ -385,7 +388,7 @@ fn cancellation_refreshes_an_affected_remote_root_and_its_open_descendants() {
 
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
-    browser.observe(move |event| observed.borrow_mut().push(event));
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
     let cancellations = Rc::new(Cell::new(0));
     let cancellations_for_handle = cancellations.clone();
     let request_id = browser.begin_operation();
@@ -454,7 +457,7 @@ fn transfer_failure_reports_moves_completed_before_the_error() {
     let browser = Browser::new(Rc::new(FakeFileSource));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
-    browser.observe(move |event| observed.borrow_mut().push(event));
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
     let request_id = browser.begin_operation();
     browser.transfer_operation.set(Some(true));
     let emit = browser.operation_callback(request_id, false, HashSet::new());
@@ -566,6 +569,7 @@ fn a_completed_trash_operation_can_be_undone_once() {
         kind: EntryKind::File,
         size: MetadataValue::Unknown,
         modified_unix_seconds: MetadataValue::Unknown,
+        is_hidden: false,
         is_hidden: false,
     };
 
@@ -723,14 +727,13 @@ fn restored_sorting_applies_to_the_initial_navigation_load() {
     browser.navigate(Location::local("/fixture"));
 
     let snapshot = browser.column_snapshot(0).expect("initial column");
-    assert_eq!(
-        snapshot
-            .entries
-            .iter()
-            .map(|entry| entry.display_name.as_str())
-            .collect::<Vec<_>>(),
-        ["large", "small"]
-    );
+    assert_eq!(snapshot.selected_positions, Vec::<usize>::new());
+    let names: Vec<_> = browser.state.borrow().columns[0]
+        .entries
+        .iter()
+        .map(|entry| entry.display_name.clone())
+        .collect();
+    assert_eq!(names, vec!["large".to_owned(), "small".to_owned()]);
     assert_eq!(
         browser
             .column_preferences(0)
@@ -751,11 +754,15 @@ fn selecting_entries_by_name_preserves_the_full_matching_selection() {
     let selected_names: Vec<_> = snapshot
         .selected_positions
         .iter()
-        .map(|&position| snapshot.entries[position].display_name.as_str())
+        .map(|&position| {
+            browser
+                .entry_at(0, position)
+                .expect("selected positions should resolve")
+                .display_name
+        })
         .collect();
     assert_eq!(selected_names, ["large", "small"]);
 }
-
 #[test]
 fn navigation_events_are_delivered_to_every_observer() {
     let browser = Browser::new(Rc::new(FakeFileSource));
@@ -788,7 +795,7 @@ fn filesystem_notifications_update_the_affected_column_incrementally() {
     }));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
-    browser.observe(move |event| observed.borrow_mut().push(event));
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
     browser.navigate(Location::local("/fixture"));
     browser.move_selection(1);
     events.borrow_mut().clear();
@@ -836,7 +843,7 @@ fn ambiguous_filesystem_notifications_fall_back_to_reload() {
     }));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
-    browser.observe(move |event| observed.borrow_mut().push(event));
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
     browser.navigate(Location::local("/fixture"));
     events.borrow_mut().clear();
 
@@ -875,7 +882,7 @@ fn retrying_a_failed_column_preserves_navigation_history() {
     }));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
-    browser.observe(move |event| observed.borrow_mut().push(event));
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
     browser.navigate(Location::local("/fixture"));
     events.borrow_mut().clear();
 
@@ -892,7 +899,7 @@ fn retrying_a_failed_column_preserves_navigation_history() {
         events
             .borrow()
             .iter()
-            .any(|event| matches!(event, BrowserEvent::EntriesInserted { depth: 0, .. }))
+            .any(|event| matches!(event, BrowserEvent::EntriesReplaced { depth: 0, .. }))
     );
     assert!(
         !events
@@ -979,7 +986,7 @@ fn completed_deletions_remove_entries_without_reloading_the_column() {
     browser.navigate(Location::local("/fixture"));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
-    browser.observe(move |event| observed.borrow_mut().push(event));
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
 
     browser.remove_deleted_locations(&[Location::local("/fixture/child")]);
 
@@ -1002,15 +1009,16 @@ fn file_source_can_be_replaced_without_constructing_the_ui() {
     let browser = Browser::new(Rc::new(FakeFileSource));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
-    browser.observe(move |event| observed.borrow_mut().push(event));
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
 
     browser.navigate(Location::local("/fixture"));
 
-    assert!(events.borrow().iter().any(|event| matches!(
-        event,
-        BrowserEvent::EntriesInserted { insertions, .. }
-            if insertions.iter().map(|insertion| insertion.entries.len()).sum::<usize>() == 1
-    )));
+    assert!(
+        events
+            .borrow()
+            .iter()
+            .any(|event| matches!(event, BrowserEvent::EntriesReplaced { count: 1, .. }))
+    );
     assert!(
         events
             .borrow()
@@ -1024,7 +1032,7 @@ fn valid_location_input_navigates_through_the_controller() {
     let browser = Browser::new(Rc::new(FakeFileSource));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
-    browser.observe(move |event| observed.borrow_mut().push(event));
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
     browser.navigate(Location::local("/fixture"));
     events.borrow_mut().clear();
 
@@ -1087,7 +1095,7 @@ fn sidebar_location_navigation_validates_uris_but_navigates_native_paths_directl
     let remote_browser = Browser::new(Rc::new(NotMountedFileSource));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
-    remote_browser.observe(move |event| observed.borrow_mut().push(event));
+    remote_browser.observe(move |event| observed.borrow_mut().push(event.clone()));
 
     let remote = Location::uri("smb://host/share");
     remote_browser.navigate_location(remote.clone());
@@ -1221,7 +1229,7 @@ fn location_input_reports_the_target_location_when_not_mounted() {
     let browser = Browser::new(Rc::new(NotMountedFileSource));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
-    browser.observe(move |event| observed.borrow_mut().push(event));
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
     browser.navigate(Location::local("/fixture"));
     events.borrow_mut().clear();
 
@@ -1240,7 +1248,7 @@ fn descending_into_an_unmounted_location_reports_it_for_retry() {
     let browser = Browser::new(Rc::new(NotMountedFileSource));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
-    browser.observe(move |event| observed.borrow_mut().push(event));
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
     browser.navigate(Location::local("/fixture"));
     events.borrow_mut().clear();
 
@@ -1261,7 +1269,7 @@ fn rejected_directory_activation_preserves_navigation_state() {
     let browser = Browser::new(Rc::new(RejectingFileSource));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
-    browser.observe(move |event| observed.borrow_mut().push(event));
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
     browser.navigate(Location::local("/fixture"));
     events.borrow_mut().clear();
 
@@ -1287,7 +1295,7 @@ fn rejected_location_input_preserves_navigation_state() {
     let browser = Browser::new(Rc::new(RejectingFileSource));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
-    browser.observe(move |event| observed.borrow_mut().push(event));
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
     browser.navigate(Location::local("/fixture"));
     events.borrow_mut().clear();
 
@@ -1325,7 +1333,7 @@ fn peeking_streams_results_without_committing_navigation_history() {
     let browser = Browser::new(Rc::new(FakeFileSource));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
-    browser.observe(move |event| observed.borrow_mut().push(event));
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
     browser.navigate(Location::local("/fixture"));
 
     browser.begin_peek(0, Location::local("/fixture/child"));
@@ -1361,7 +1369,7 @@ fn an_already_open_child_is_not_peeked() {
     let browser = Browser::new(Rc::new(FakeFileSource));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
-    browser.observe(move |event| observed.borrow_mut().push(event));
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
     let child = Location::local("/fixture/child");
     browser.navigate(Location::local("/fixture"));
     browser.descend(0, child.clone());
@@ -1382,7 +1390,7 @@ fn committing_a_peek_descends_and_creates_history() {
     let browser = Browser::new(Rc::new(FakeFileSource));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
-    browser.observe(move |event| observed.borrow_mut().push(event));
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
     browser.navigate(Location::local("/fixture"));
     browser.begin_peek(0, Location::local("/fixture/child"));
 
@@ -1407,7 +1415,7 @@ fn single_click_action_descends_into_directories() {
     let browser = Browser::new(Rc::new(FakeFileSource));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
-    browser.observe(move |event| observed.borrow_mut().push(event));
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
     browser.navigate(Location::local("/fixture"));
     events.borrow_mut().clear();
 
@@ -1426,7 +1434,7 @@ fn activating_an_open_list_item_closes_its_child_column() {
     let browser = Browser::new(Rc::new(FakeFileSource));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
-    browser.observe(move |event| observed.borrow_mut().push(event));
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
     browser.navigate(Location::local("/fixture"));
     browser.preview(0, 0);
     assert_eq!(browser.active_depth(), Some(1));
@@ -1448,7 +1456,7 @@ fn explorer_activation_replaces_the_directory_instead_of_adding_a_column() {
     let browser = Browser::new(Rc::new(FakeFileSource));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
-    browser.observe(move |event| observed.borrow_mut().push(event));
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
     browser.navigate(Location::local("/fixture"));
     events.borrow_mut().clear();
 
@@ -1489,7 +1497,7 @@ fn preview_and_open_are_distinct_file_actions() {
     let browser = Browser::new(Rc::new(FilePreviewSource));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
-    browser.observe(move |event| observed.borrow_mut().push(event));
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
     browser.navigate(Location::local("/fixture"));
     events.borrow_mut().clear();
 
@@ -1516,7 +1524,7 @@ fn keyboard_selection_and_activation_descend_without_the_ui() {
     let browser = Browser::new(Rc::new(FakeFileSource));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
-    browser.observe(move |event| observed.borrow_mut().push(event));
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
     browser.navigate(Location::local("/fixture"));
 
     browser.move_selection(1);
@@ -1558,7 +1566,7 @@ fn escape_closes_a_peek_before_the_deepest_column() {
     let browser = Browser::new(Rc::new(FakeFileSource));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
-    browser.observe(move |event| observed.borrow_mut().push(event));
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
     browser.navigate(Location::local("/fixture"));
     browser.move_selection(1);
     browser.activate_focused();
@@ -1586,6 +1594,1604 @@ fn escape_closes_a_peek_before_the_deepest_column() {
             .borrow()
             .iter()
             .any(|event| matches!(event, BrowserEvent::ColumnsTruncated { len: 1 }))
+    );
+}
+
+type CapturedLoad = Rc<RefCell<Option<(RequestId, Rc<dyn Fn(DirectoryEvent)>)>>>;
+
+struct BatchReplaySource {
+    captured: CapturedLoad,
+}
+
+impl FileSource for BatchReplaySource {
+    fn validate_location(&self, _location: &Location) -> Result<(), LocationValidationError> {
+        Ok(())
+    }
+
+    fn enumerate(&self, request: DirectoryRequest, emit: Rc<dyn Fn(DirectoryEvent)>) -> LoadHandle {
+        self.captured.replace(Some((request.id, emit)));
+        LoadHandle::new(|| {})
+    }
+
+    fn watch(
+        &self,
+        _location: Location,
+        _include_hidden: bool,
+        _notify: Rc<dyn Fn(DirectoryChange)>,
+    ) -> Option<LoadHandle> {
+        None
+    }
+}
+
+fn batch_entry(name: &str) -> FileEntry {
+    FileEntry {
+        location: Location::local(format!("/fixture/{name}")),
+        native_name: OsString::from(name),
+        display_name: name.into(),
+        kind: EntryKind::File,
+        size: MetadataValue::Unknown,
+        modified_unix_seconds: MetadataValue::Unknown,
+    }
+}
+
+#[test]
+fn repeated_identical_batches_emit_selection_only_once() {
+    // Remote loads stay progressive, so this covers the coalescing path;
+    // native loads stage instead (see the staging tests below).
+    let _serial = crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
+    let captured: CapturedLoad = Rc::new(RefCell::new(None));
+    let browser = Browser::new(Rc::new(BatchReplaySource {
+        captured: captured.clone(),
+    }));
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let observed = events.clone();
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
+
+    browser.navigate(Location::uri("sftp://host/fixture"));
+    let (request_id, emit) = captured
+        .borrow()
+        .clone()
+        .expect("navigate should start a directory load");
+    let batch = |names: &[&str]| DirectoryEvent::Batch {
+        request_id,
+        entries: names.iter().map(|name| batch_entry(name)).collect(),
+    };
+    emit(batch(&["alpha", "beta"]));
+    browser.select(0, 0);
+    emit(batch(&["mike"]));
+    emit(batch(&["zulu"]));
+    // Later batches coalesce instead of applying; flush them the way load
+    // finish does before asserting.
+    browser.flush_coalesced_capped(None);
+
+    let selections: Vec<_> = events
+        .borrow()
+        .iter()
+        .filter_map(|event| match event {
+            BrowserEvent::SelectionSetChanged {
+                positions, focused, ..
+            } => Some((positions.clone(), *focused)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(selections, vec![(vec![0], 0)]);
+    let inserted = events
+        .borrow()
+        .iter()
+        .filter(|event| matches!(event, BrowserEvent::EntriesInserted { .. }))
+        .count();
+    // First paint plus one coalesced group for the two later batches.
+    assert_eq!(inserted, 2);
+}
+
+/// A source whose listing carries no metadata and whose fill answers it
+/// synchronously, so the sort gate runs without waiting on I/O.
+struct SortFillSource;
+
+impl FileSource for SortFillSource {
+    fn validate_location(&self, _location: &Location) -> Result<(), LocationValidationError> {
+        Ok(())
+    }
+
+    fn enumerate(&self, request: DirectoryRequest, emit: Rc<dyn Fn(DirectoryEvent)>) -> LoadHandle {
+        emit(DirectoryEvent::Batch {
+            request_id: request.id,
+            entries: vec![batch_entry("alpha"), batch_entry("beta")],
+        });
+        emit(DirectoryEvent::Finished {
+            request_id: request.id,
+            truncated: false,
+        });
+        LoadHandle::new(|| {})
+    }
+    fn fill_metadata(
+        &self,
+        request: MetadataRequest,
+        emit: Rc<dyn Fn(DirectoryEvent)>,
+    ) -> LoadHandle {
+        emit(DirectoryEvent::MetadataFilled {
+            request_id: request.id,
+            updates: request
+                .entries
+                .iter()
+                .map(|location| {
+                    let size = if location.display_path().ends_with("beta") {
+                        1
+                    } else {
+                        100
+                    };
+                    MetadataUpdate {
+                        location: location.clone(),
+                        size: MetadataValue::Known(size),
+                        modified_unix_seconds: MetadataValue::Unknown,
+                    }
+                })
+                .collect(),
+        });
+        emit(DirectoryEvent::MetadataFinished {
+            request_id: request.id,
+            outcome: MetadataOutcome::Complete,
+        });
+        LoadHandle::new(|| {})
+    }
+
+    fn watch(
+        &self,
+        _location: Location,
+        _include_hidden: bool,
+        _notify: Rc<dyn Fn(DirectoryChange)>,
+    ) -> Option<LoadHandle> {
+        None
+    }
+}
+#[test]
+fn size_sort_waits_for_its_metadata_pass() {
+    let _serial = crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
+    let browser = Browser::new(Rc::new(SortFillSource));
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let waker: Rc<RefCell<Option<std::task::Waker>>> = Rc::new(RefCell::new(None));
+    let observed = events.clone();
+    let observed_waker = waker.clone();
+    browser.observe(move |event| {
+        let finished = matches!(event, BrowserEvent::SortingFinished { .. });
+        observed.borrow_mut().push(event.clone());
+        if finished && let Some(waker) = observed_waker.borrow_mut().take() {
+            waker.wake();
+        }
+    });
+
+    browser.navigate(Location::local("/fixture"));
+    // Name order out of the listing: alpha before beta. The public sort path
+    // debounces 16 ms on the main context; the fake fill answers
+    // synchronously once the debounce fires.
+    browser.set_sort(0, SortKey::Size, SortDirection::Ascending);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    gtk::glib::MainContext::default().block_on(std::future::poll_fn(|cx| {
+        let done = events
+            .borrow()
+            .iter()
+            .any(|event| matches!(event, BrowserEvent::SortingFinished { .. }));
+        if done || std::time::Instant::now() >= deadline {
+            std::task::Poll::Ready(())
+        } else {
+            *waker.borrow_mut() = Some(cx.waker().clone());
+            std::task::Poll::Pending
+        }
+    }));
+
+    let names: Vec<_> = browser.state.borrow().columns[0]
+        .entries
+        .iter()
+        .map(|entry| entry.display_name.clone())
+        .collect();
+    // Size order: beta (1 byte) before alpha (100 bytes).
+    assert_eq!(names, vec!["beta".to_owned(), "alpha".to_owned()]);
+    assert!(
+        events
+            .borrow()
+            .iter()
+            .any(|event| { matches!(event, BrowserEvent::MetadataFilled { .. }) })
+    );
+    // Total protocol: the sort's indicator opens once and closes once.
+    assert_eq!(
+        events
+            .borrow()
+            .iter()
+            .filter(|event| { matches!(event, BrowserEvent::SortingStarted { .. }) })
+            .count(),
+        1
+    );
+    assert_eq!(
+        events
+            .borrow()
+            .iter()
+            .filter(|event| { matches!(event, BrowserEvent::SortingFinished { .. }) })
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn load_finish_applies_rows_queued_behind_the_count_threshold() {
+    // Remote loads stay progressive, so this covers the coalesced straggler
+    // flush; native loads stage instead (see the staging tests below).
+    let _serial = crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
+    let captured: CapturedLoad = Rc::new(RefCell::new(None));
+    let browser = Browser::new(Rc::new(BatchReplaySource {
+        captured: captured.clone(),
+    }));
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let observed = events.clone();
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
+
+    browser.navigate(Location::uri("sftp://host/fixture"));
+    let (request_id, emit) = captured
+        .borrow()
+        .clone()
+        .expect("navigate should start a directory load");
+    // First paint applies at once; the rest coalesces below the threshold.
+    emit(DirectoryEvent::Batch {
+        request_id,
+        entries: vec![batch_entry("alpha")],
+    });
+    emit(DirectoryEvent::Batch {
+        request_id,
+        entries: vec![batch_entry("beta")],
+    });
+    // Used to panic: the straggler flush ran under the live scrutinee
+    // borrow instead of a bound depth.
+    emit(DirectoryEvent::Finished {
+        request_id,
+        truncated: false,
+    });
+
+    let names: Vec<_> = browser.state.borrow().columns[0]
+        .entries
+        .iter()
+        .map(|entry| entry.display_name.clone())
+        .collect();
+    assert_eq!(names, vec!["alpha".to_owned(), "beta".to_owned()]);
+    assert!(
+        events
+            .borrow()
+            .iter()
+            .any(|event| { matches!(event, BrowserEvent::LoadFinished { .. }) })
+    );
+}
+
+/// Scripted answers for one `fill_metadata` call, in call order.
+enum FillAnswer {
+    /// One chunk carrying `name -> size` pairs, then `Complete`.
+    Complete(Vec<(&'static str, u64)>),
+    /// Several chunks, then the given terminal outcome.
+    Chunks(Vec<Vec<(&'static str, u64)>>, MetadataOutcome),
+    /// No chunks, then `Complete`.
+    EmptyComplete,
+    /// No chunks, then the given terminal outcome.
+    TerminalOnly(MetadataOutcome),
+    /// Capture the emit for the test to fire later.
+    Never,
+}
+
+struct FillCall {
+    id: RequestId,
+    full: bool,
+    entries: Vec<Location>,
+    emit: DirectoryEmit,
+}
+
+type DirectoryEmit = Rc<dyn Fn(DirectoryEvent)>;
+
+/// Listings carry no metadata; every fill answers from a script so the
+/// terminal protocol is fully deterministic without I/O or timers.
+struct ScriptedSource {
+    files: Vec<&'static str>,
+    dirs: Vec<&'static str>,
+    uri_base: Option<&'static str>,
+    script: RefCell<Vec<FillAnswer>>,
+    fill_calls: RefCell<Vec<FillCall>>,
+    enumerate_calls: RefCell<Vec<(RequestId, DirectoryEmit)>>,
+    manual_enumerate: bool,
+}
+
+impl ScriptedSource {
+    fn scripted(files: Vec<&'static str>, script: Vec<FillAnswer>) -> Self {
+        Self {
+            files,
+            dirs: Vec::new(),
+            uri_base: None,
+            script: RefCell::new(script),
+            fill_calls: RefCell::new(Vec::new()),
+            enumerate_calls: RefCell::new(Vec::new()),
+            manual_enumerate: false,
+        }
+    }
+
+    fn manual(files: Vec<&'static str>, script: Vec<FillAnswer>) -> Self {
+        Self {
+            files,
+            dirs: Vec::new(),
+            uri_base: None,
+            script: RefCell::new(script),
+            fill_calls: RefCell::new(Vec::new()),
+            enumerate_calls: RefCell::new(Vec::new()),
+            manual_enumerate: true,
+        }
+    }
+
+    fn entry_location(&self, name: &str) -> Location {
+        match self.uri_base {
+            Some(base) => Location::uri(format!("{base}/{name}")),
+            None => Location::local(format!("/fixture/{name}")),
+        }
+    }
+
+    fn listed_entry(&self, name: &'static str, is_dir: bool) -> FileEntry {
+        FileEntry {
+            location: self.entry_location(name),
+            native_name: std::ffi::OsString::from(name),
+            display_name: name.into(),
+            kind: if is_dir {
+                EntryKind::Directory
+            } else {
+                EntryKind::File
+            },
+            size: MetadataValue::Unknown,
+            modified_unix_seconds: MetadataValue::Unknown,
+            is_hidden: false,
+        }
+    }
+    fn answer(
+        id: RequestId,
+        uri_base: Option<&str>,
+        answer: FillAnswer,
+        emit: &Rc<dyn Fn(DirectoryEvent)>,
+    ) {
+        let locate = |name: &str| match uri_base {
+            Some(base) => Location::uri(format!("{base}/{name}")),
+            None => Location::local(format!("/fixture/{name}")),
+        };
+        let chunk = |rows: &[(&'static str, u64)]| DirectoryEvent::MetadataFilled {
+            request_id: id,
+            updates: rows
+                .iter()
+                .map(|(name, size)| MetadataUpdate {
+                    location: locate(name),
+                    size: MetadataValue::Known(*size),
+                    modified_unix_seconds: MetadataValue::Known(7),
+                })
+                .collect(),
+        };
+        match answer {
+            FillAnswer::Complete(rows) => {
+                emit(chunk(&rows));
+                emit(DirectoryEvent::MetadataFinished {
+                    request_id: id,
+                    outcome: MetadataOutcome::Complete,
+                });
+            }
+            FillAnswer::Chunks(chunks, outcome) => {
+                for rows in &chunks {
+                    emit(chunk(rows));
+                }
+                emit(DirectoryEvent::MetadataFinished {
+                    request_id: id,
+                    outcome,
+                });
+            }
+            FillAnswer::EmptyComplete => emit(DirectoryEvent::MetadataFinished {
+                request_id: id,
+                outcome: MetadataOutcome::Complete,
+            }),
+            FillAnswer::TerminalOnly(outcome) => emit(DirectoryEvent::MetadataFinished {
+                request_id: id,
+                outcome,
+            }),
+            FillAnswer::Never => {}
+        }
+    }
+}
+
+impl FileSource for ScriptedSource {
+    fn validate_location(&self, _location: &Location) -> Result<(), LocationValidationError> {
+        Ok(())
+    }
+
+    fn supports_metadata_fill(&self, _location: &Location) -> bool {
+        true
+    }
+    fn enumerate(&self, request: DirectoryRequest, emit: Rc<dyn Fn(DirectoryEvent)>) -> LoadHandle {
+        if self.manual_enumerate {
+            self.enumerate_calls.borrow_mut().push((request.id, emit));
+            return LoadHandle::new(|| {});
+        }
+        emit(DirectoryEvent::Batch {
+            request_id: request.id,
+            entries: self
+                .files
+                .iter()
+                .map(|name| self.listed_entry(name, false))
+                .chain(self.dirs.iter().map(|name| self.listed_entry(name, true)))
+                .collect(),
+        });
+        emit(DirectoryEvent::Finished {
+            request_id: request.id,
+            truncated: false,
+        });
+        LoadHandle::new(|| {})
+    }
+
+    fn fill_metadata(
+        &self,
+        request: MetadataRequest,
+        emit: Rc<dyn Fn(DirectoryEvent)>,
+    ) -> LoadHandle {
+        let id = request.id;
+        let full = request.full;
+        let entries = request.entries.clone();
+        let answer = self.script.borrow_mut().pop();
+        match answer {
+            Some(FillAnswer::Never) | None => {
+                self.fill_calls.borrow_mut().push(FillCall {
+                    id,
+                    full,
+                    entries,
+                    emit,
+                });
+            }
+            Some(answer) => {
+                self.fill_calls.borrow_mut().push(FillCall {
+                    id,
+                    full,
+                    entries,
+                    emit: emit.clone(),
+                });
+                Self::answer(id, self.uri_base, answer, &emit);
+            }
+        }
+        LoadHandle::new(|| {})
+    }
+
+    fn watch(
+        &self,
+        _location: Location,
+        _include_hidden: bool,
+        _notify: Rc<dyn Fn(DirectoryChange)>,
+    ) -> Option<LoadHandle> {
+        None
+    }
+}
+
+fn scripted_browser(
+    source: ScriptedSource,
+) -> (
+    Rc<Browser>,
+    Rc<RefCell<Vec<BrowserEvent>>>,
+    Rc<ScriptedSource>,
+) {
+    let source = Rc::new(source);
+    let browser = Browser::new(source.clone());
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let observed = events.clone();
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
+    (browser, events, source)
+}
+
+/// Pumps the main context until `condition` holds or the deadline passes.
+/// Callers assert on the resulting state; the deadline only turns a hang
+/// into a deterministic failure.
+fn pump_until(condition: impl Fn() -> bool) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while !condition() && std::time::Instant::now() < deadline {
+        gtk::glib::MainContext::default().iteration(true);
+    }
+}
+
+fn finish_count(events: &RefCell<Vec<BrowserEvent>>) -> usize {
+    events
+        .borrow()
+        .iter()
+        .filter(|event| matches!(event, BrowserEvent::SortingFinished { .. }))
+        .count()
+}
+
+fn start_count(events: &RefCell<Vec<BrowserEvent>>) -> usize {
+    events
+        .borrow()
+        .iter()
+        .filter(|event| matches!(event, BrowserEvent::SortingStarted { .. }))
+        .count()
+}
+
+fn replaced_count(events: &RefCell<Vec<BrowserEvent>>) -> usize {
+    events
+        .borrow()
+        .iter()
+        .filter(|event| matches!(event, BrowserEvent::EntriesReplaced { .. }))
+        .count()
+}
+
+fn column_names(browser: &Browser, depth: usize) -> Vec<String> {
+    browser.state.borrow().columns[depth]
+        .entries
+        .iter()
+        .map(|entry| entry.display_name.clone())
+        .collect()
+}
+
+#[test]
+fn multi_chunk_fill_sorts_once_on_its_terminal() {
+    let _serial = crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
+    let (browser, events, _) = scripted_browser(ScriptedSource::scripted(
+        vec!["alpha", "beta", "gamma"],
+        vec![FillAnswer::Chunks(
+            vec![vec![("alpha", 30)], vec![("beta", 10), ("gamma", 20)]],
+            MetadataOutcome::Complete,
+        )],
+    ));
+    // Script answers pop from the back; with one answer the order is fixed.
+    browser.navigate(Location::local("/fixture"));
+    browser.set_sort(0, SortKey::Size, SortDirection::Ascending);
+    pump_until(|| finish_count(&events) == 1);
+
+    // Sorted once, on the complete pass: never on the first partial chunk.
+    assert_eq!(replaced_count(&events), 2);
+    assert_eq!(start_count(&events), 1);
+    assert_eq!(
+        column_names(&browser, 0),
+        vec!["beta".to_owned(), "gamma".to_owned(), "alpha".to_owned()]
+    );
+}
+
+#[test]
+fn truncated_fill_preserves_the_prior_order() {
+    let _serial = crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
+    let (browser, events, _) = scripted_browser(ScriptedSource::scripted(
+        vec!["alpha", "beta", "gamma"],
+        vec![FillAnswer::Chunks(
+            vec![vec![("alpha", 30)]],
+            MetadataOutcome::Truncated,
+        )],
+    ));
+    browser.navigate(Location::local("/fixture"));
+    browser.set_sort(0, SortKey::Size, SortDirection::Ascending);
+    pump_until(|| finish_count(&events) == 1);
+
+    assert_eq!(replaced_count(&events), 1);
+    assert_eq!(start_count(&events), 1);
+    assert_eq!(
+        column_names(&browser, 0),
+        vec!["alpha".to_owned(), "beta".to_owned(), "gamma".to_owned()]
+    );
+}
+
+#[test]
+fn unsupported_fill_abandons_the_sort_in_order() {
+    let _serial = crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
+    let (browser, events, _) = scripted_browser(ScriptedSource::scripted(
+        vec!["alpha", "beta"],
+        vec![FillAnswer::TerminalOnly(MetadataOutcome::Unsupported)],
+    ));
+    browser.navigate(Location::local("/fixture"));
+    browser.set_sort(0, SortKey::Size, SortDirection::Ascending);
+    pump_until(|| finish_count(&events) == 1);
+
+    assert_eq!(replaced_count(&events), 1);
+    assert_eq!(start_count(&events), 1);
+    assert_eq!(
+        column_names(&browser, 0),
+        vec!["alpha".to_owned(), "beta".to_owned()]
+    );
+}
+
+#[test]
+fn failed_fill_abandons_the_sort_in_order() {
+    let _serial = crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
+    let (browser, events, _) = scripted_browser(ScriptedSource::scripted(
+        vec!["alpha", "beta"],
+        vec![FillAnswer::Chunks(
+            vec![vec![("alpha", 30), ("beta", 10)]],
+            MetadataOutcome::Failed,
+        )],
+    ));
+    browser.navigate(Location::local("/fixture"));
+    browser.set_sort(0, SortKey::Size, SortDirection::Ascending);
+    pump_until(|| finish_count(&events) == 1);
+
+    // Chunks still apply to rows, but the failed pass never reorders.
+    assert_eq!(replaced_count(&events), 1);
+    assert_eq!(start_count(&events), 1);
+    assert_eq!(
+        column_names(&browser, 0),
+        vec!["alpha".to_owned(), "beta".to_owned()]
+    );
+}
+
+#[test]
+fn empty_fill_still_closes_the_sort() {
+    let _serial = crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
+    let (browser, events, _) = scripted_browser(ScriptedSource::scripted(
+        vec!["alpha", "beta"],
+        vec![FillAnswer::EmptyComplete],
+    ));
+    browser.navigate(Location::local("/fixture"));
+    browser.set_sort(0, SortKey::Size, SortDirection::Ascending);
+    pump_until(|| finish_count(&events) == 1);
+
+    // A zero-row result is a complete pass, not a hang.
+    assert_eq!(start_count(&events), 1);
+    assert_eq!(replaced_count(&events), 2);
+}
+
+#[test]
+fn navigation_cancels_an_awaiting_sort_without_stale_commit() {
+    let _serial = crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
+    let (browser, events, source) = scripted_browser(ScriptedSource::scripted(
+        vec!["alpha", "beta"],
+        vec![FillAnswer::Never],
+    ));
+    browser.navigate(Location::local("/fixture"));
+    // The initial load publishes synchronously through staging.
+    let published = replaced_count(&events);
+    assert_eq!(published, 1);
+    browser.set_sort(0, SortKey::Size, SortDirection::Ascending);
+    pump_until(|| !source.fill_calls.borrow().is_empty());
+    assert_eq!(start_count(&events), 1);
+
+    browser.navigate(Location::local("/elsewhere"));
+    assert_eq!(finish_count(&events), 1);
+    assert!(browser.sort_awaiting_fill.borrow().is_none());
+    assert!(browser.pending_sort.get().is_none());
+
+    // The abandoned fill's late terminal lands on a superseded load and
+    // must not commit anything.
+    let old = source.fill_calls.borrow();
+    let old_emit = old[0].emit.clone();
+    let old_id = old[0].id;
+    drop(old);
+    old_emit(DirectoryEvent::MetadataFilled {
+        request_id: old_id,
+        updates: vec![MetadataUpdate {
+            location: Location::local("/fixture/alpha"),
+            size: MetadataValue::Known(1),
+            modified_unix_seconds: MetadataValue::Known(7),
+        }],
+    });
+    old_emit(DirectoryEvent::MetadataFinished {
+        request_id: old_id,
+        outcome: MetadataOutcome::Complete,
+    });
+    // The elsewhere load publishes once through staging; the stale fill
+    // and terminal add nothing further.
+    assert_eq!(replaced_count(&events), published + 1);
+    assert_eq!(finish_count(&events), 1);
+    assert_eq!(
+        column_names(&browser, 0),
+        vec!["alpha".to_owned(), "beta".to_owned()]
+    );
+}
+
+#[test]
+fn reload_cancels_an_awaiting_sort_and_ignores_its_terminal() {
+    let _serial = crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
+    let (browser, events, source) = scripted_browser(ScriptedSource::scripted(
+        vec!["alpha", "beta"],
+        vec![FillAnswer::Never],
+    ));
+    browser.navigate(Location::local("/fixture"));
+    let published = replaced_count(&events);
+    assert_eq!(published, 1);
+    browser.set_sort(0, SortKey::Size, SortDirection::Ascending);
+    pump_until(|| !source.fill_calls.borrow().is_empty());
+
+    browser.reload_active();
+    assert_eq!(finish_count(&events), 1);
+    assert!(browser.sort_awaiting_fill.borrow().is_none());
+
+    let old = source.fill_calls.borrow();
+    let old_emit = old[0].emit.clone();
+    let old_id = old[0].id;
+    drop(old);
+    old_emit(DirectoryEvent::MetadataFinished {
+        request_id: old_id,
+        outcome: MetadataOutcome::Complete,
+    });
+    assert_eq!(replaced_count(&events), published + 1);
+    assert_eq!(finish_count(&events), 1);
+}
+
+#[test]
+fn viewport_flush_never_disturbs_an_active_sort() {
+    let _serial = crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
+    let (browser, events, source) = scripted_browser(ScriptedSource::scripted(
+        vec!["alpha", "beta"],
+        vec![
+            FillAnswer::Complete(vec![("alpha", 30), ("beta", 10)]),
+            FillAnswer::Never,
+        ],
+    ));
+    browser.navigate(Location::local("/fixture"));
+    // A viewport fill queued directly (no settle timer) starts first.
+    browser.metadata_pending.borrow_mut().insert(
+        0,
+        vec![
+            ViewportTarget {
+                position: 0,
+                location: Location::local("/fixture/alpha"),
+            },
+            ViewportTarget {
+                position: 1,
+                location: Location::local("/fixture/beta"),
+            },
+        ],
+    );
+    browser.flush_metadata_fills();
+    assert_eq!(source.fill_calls.borrow().len(), 1);
+    assert!(!source.fill_calls.borrow()[0].full);
+
+    // The full sort starts while the viewport fill is still in flight; each
+    // keeps its own handle. The scripted sort answers synchronously.
+    browser.set_sort(0, SortKey::Size, SortDirection::Ascending);
+    pump_until(|| finish_count(&events) == 1);
+    assert!(source.fill_calls.borrow()[1].full);
+
+    // The sort completed on its own terminal while the viewport fill was
+    // still in flight: one reorder, balanced indicator.
+    assert_eq!(replaced_count(&events), 2);
+    assert_eq!(
+        column_names(&browser, 0),
+        vec!["beta".to_owned(), "alpha".to_owned()]
+    );
+    assert!(browser.metadata_loads.borrow().contains_key(&0));
+
+    // The late viewport chunk still applies to its row without re-sorting.
+    let viewport = source.fill_calls.borrow();
+    let viewport_emit = viewport[0].emit.clone();
+    let viewport_id = viewport[0].id;
+    drop(viewport);
+    viewport_emit(DirectoryEvent::MetadataFilled {
+        request_id: viewport_id,
+        updates: vec![MetadataUpdate {
+            location: Location::local("/fixture/alpha"),
+            size: MetadataValue::Known(30),
+            modified_unix_seconds: MetadataValue::Known(7),
+        }],
+    });
+    assert_eq!(replaced_count(&events), 2);
+    assert_eq!(finish_count(&events), 1);
+}
+
+#[test]
+fn refresh_drops_staging_and_its_sort() {
+    let _serial = crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
+    let (browser, events, source) = scripted_browser(ScriptedSource::manual(
+        vec!["alpha", "beta"],
+        vec![FillAnswer::Never],
+    ));
+    browser.navigate(Location::local("/fixture"));
+    let (request_id, emit) = source.enumerate_calls.borrow()[0].clone();
+    // Batches stage with no merge and no UI events until enumeration ends.
+    emit(DirectoryEvent::Batch {
+        request_id,
+        entries: vec![batch_entry("alpha")],
+    });
+    emit(DirectoryEvent::Batch {
+        request_id,
+        entries: vec![batch_entry("beta")],
+    });
+    assert_eq!(
+        browser
+            .staging
+            .borrow()
+            .get(&0)
+            .map(|staged| staged.entries.len()),
+        Some(2)
+    );
+    assert_eq!(replaced_count(&events), 0);
+
+    // A reload discards the staged snapshot before it ever publishes.
+    browser.refresh_column(0);
+    assert!(!browser.staging.borrow().contains_key(&0));
+    assert_eq!(replaced_count(&events), 0);
+
+    // The reloaded column stages and publishes on its own finish.
+    let (request_id, emit) = source.enumerate_calls.borrow()[1].clone();
+    emit(DirectoryEvent::Batch {
+        request_id,
+        entries: vec![batch_entry("alpha"), batch_entry("beta")],
+    });
+    emit(DirectoryEvent::Finished {
+        request_id,
+        truncated: false,
+    });
+    assert_eq!(replaced_count(&events), 1);
+    assert_eq!(
+        column_names(&browser, 0),
+        vec!["alpha".to_owned(), "beta".to_owned()]
+    );
+
+    // A sort fill in flight is still cancelled by a later reload.
+    browser.set_sort(0, SortKey::Size, SortDirection::Ascending);
+    pump_until(|| !source.fill_calls.borrow().is_empty());
+    assert!(browser.sort_awaiting_fill.borrow().is_some());
+    browser.refresh_column(0);
+    assert!(browser.sort_awaiting_fill.borrow().is_none());
+    assert!(browser.pending_sort.get().is_none());
+    assert_eq!(start_count(&events), 1);
+    assert_eq!(finish_count(&events), 1);
+    assert_eq!(replaced_count(&events), 1);
+}
+
+#[test]
+fn close_column_clears_the_truncated_depth() {
+    let _serial = crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
+    let (browser, events, source) = scripted_browser(ScriptedSource::manual(
+        vec!["alpha", "beta"],
+        vec![FillAnswer::Never],
+    ));
+    browser.navigate(Location::local("/fixture"));
+    let (request_id, emit) = source.enumerate_calls.borrow()[0].clone();
+    emit(DirectoryEvent::Batch {
+        request_id,
+        entries: vec![batch_entry("alpha"), batch_entry("beta")],
+    });
+    emit(DirectoryEvent::Finished {
+        request_id,
+        truncated: false,
+    });
+
+    browser.descend(0, Location::local("/fixture/sub"));
+    let (sub_id, sub_emit) = source.enumerate_calls.borrow()[1].clone();
+    sub_emit(DirectoryEvent::Batch {
+        request_id: sub_id,
+        entries: vec![batch_entry("alpha"), batch_entry("beta")],
+    });
+    sub_emit(DirectoryEvent::Finished {
+        request_id: sub_id,
+        truncated: false,
+    });
+    let published = replaced_count(&events);
+    assert_eq!(published, 2);
+
+    // A sort fill in flight at the child depth.
+    browser.set_sort(1, SortKey::Size, SortDirection::Ascending);
+    pump_until(|| !source.fill_calls.borrow().is_empty());
+    assert!(browser.sort_awaiting_fill.borrow().is_some());
+
+    // A grandchild load still staging its first batches.
+    browser.descend(1, Location::local("/fixture/sub/deep"));
+    let (deep_id, deep_emit) = source.enumerate_calls.borrow()[2].clone();
+    deep_emit(DirectoryEvent::Batch {
+        request_id: deep_id,
+        entries: vec![batch_entry("alpha")],
+    });
+    assert!(browser.staging.borrow().contains_key(&2));
+
+    browser.close_column(1);
+    assert!(!browser.staging.borrow().contains_key(&2));
+    assert!(!browser.metadata_pending.borrow().contains_key(&1));
+    assert!(!browser.sort_loads.borrow().contains_key(&1));
+    assert!(browser.sort_awaiting_fill.borrow().is_none());
+    assert!(browser.pending_sort.get().is_none());
+    assert_eq!(start_count(&events), 1);
+    assert_eq!(finish_count(&events), 1);
+    assert_eq!(replaced_count(&events), published);
+}
+
+#[test]
+fn settle_timer_restarts_while_rows_keep_arriving() {
+    let _serial = crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
+    let (browser, _, source) = scripted_browser(ScriptedSource::scripted(
+        vec!["alpha", "beta"],
+        vec![FillAnswer::Never],
+    ));
+    browser.navigate(Location::local("/fixture"));
+    browser.request_metadata_fill(0, 0, Location::local("/fixture/alpha"));
+    // Non-blocking iterations plus wall-clock sleeps: blocking iterations
+    // would overshoot the wall-clock checkpoints below.
+    let pump_until_elapsed = |millis: u64, start: std::time::Instant| {
+        while start.elapsed() < std::time::Duration::from_millis(millis) {
+            gtk::glib::MainContext::default().iteration(false);
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+    };
+    // Wait past half the debounce, then bind another row: the settle timer
+    // restarts instead of firing for the first row alone.
+    let start = std::time::Instant::now();
+    pump_until_elapsed(80, start);
+    browser.request_metadata_fill(0, 1, Location::local("/fixture/beta"));
+    pump_until_elapsed(140, start);
+    // Past the first row's deadline: nothing flushed yet.
+    assert!(source.fill_calls.borrow().is_empty());
+    pump_until_elapsed(400, start);
+    // One flush carrying both settled rows.
+    assert_eq!(source.fill_calls.borrow().len(), 1);
+    assert!(!source.fill_calls.borrow()[0].full);
+}
+
+#[test]
+fn shifted_viewport_rows_go_stale_without_repaint() {
+    let _serial = crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
+    let (browser, events, source) = scripted_browser(ScriptedSource::scripted(
+        vec!["alpha", "beta", "gamma"],
+        vec![FillAnswer::Never],
+    ));
+    browser.navigate(Location::local("/fixture"));
+    // Token captured at bind time: beta sits at source position 1.
+    browser.metadata_pending.borrow_mut().insert(
+        0,
+        vec![ViewportTarget {
+            position: 1,
+            location: Location::local("/fixture/beta"),
+        }],
+    );
+    browser.flush_metadata_fills();
+    assert_eq!(source.fill_calls.borrow().len(), 1);
+
+    // The head row leaves before the fill lands: beta shifts to position 0,
+    // so the token no longer validates.
+    browser.state.borrow_mut().columns[0].entries.remove(0);
+    let fill = source.fill_calls.borrow();
+    let emit = fill[0].emit.clone();
+    let id = fill[0].id;
+    drop(fill);
+    emit(DirectoryEvent::MetadataFilled {
+        request_id: id,
+        updates: vec![MetadataUpdate {
+            location: Location::local("/fixture/beta"),
+            size: MetadataValue::Known(10),
+            modified_unix_seconds: MetadataValue::Known(7),
+        }],
+    });
+    // Stale: no repaint, and the placeholder survives for the next bind's
+    // retry instead of painting the wrong row.
+    assert_eq!(replaced_count(&events), 1);
+    assert!(
+        !events
+            .borrow()
+            .iter()
+            .any(|event| { matches!(event, BrowserEvent::MetadataFilled { .. }) })
+    );
+    assert_eq!(
+        browser.state.borrow().columns[0].entries[0].size,
+        MetadataValue::Unknown
+    );
+}
+
+#[test]
+fn remote_name_listing_fills_visible_metadata() {
+    let _serial = crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
+    let mut src = ScriptedSource::scripted(
+        vec!["photo.jpg", "notes.txt"],
+        vec![FillAnswer::Complete(vec![
+            ("photo.jpg", 100),
+            ("notes.txt", 50),
+        ])],
+    );
+    src.uri_base = Some("sftp://host/share");
+    let (browser, events, source) = scripted_browser(src);
+    browser.navigate(Location::uri("sftp://host/share"));
+    // Remote Name listings used to keep blank metadata forever: the owner
+    // no longer rejects them, so the visible rows fill.
+    browser.metadata_pending.borrow_mut().insert(
+        0,
+        vec![
+            ViewportTarget {
+                position: 1,
+                location: Location::uri("sftp://host/share/photo.jpg"),
+            },
+            ViewportTarget {
+                position: 0,
+                location: Location::uri("sftp://host/share/notes.txt"),
+            },
+        ],
+    );
+    browser.flush_metadata_fills();
+    assert_eq!(source.fill_calls.borrow().len(), 1);
+    assert!(
+        events
+            .borrow()
+            .iter()
+            .any(|event| matches!(event, BrowserEvent::MetadataFilled { .. }))
+    );
+    let sizes: Vec<_> = browser.state.borrow().columns[0]
+        .entries
+        .iter()
+        .map(|entry| entry.size.clone())
+        .collect();
+    assert_eq!(
+        sizes,
+        vec![MetadataValue::Known(50), MetadataValue::Known(100)]
+    );
+}
+
+#[test]
+fn modified_sort_fills_directory_mtimes() {
+    let _serial = crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
+    let mut src = ScriptedSource::scripted(vec!["b.txt"], vec![FillAnswer::Never]);
+    src.dirs = vec!["sub"];
+    let (browser, events, source) = scripted_browser(src);
+    browser.navigate(Location::local("/fixture"));
+    browser.set_sort(0, SortKey::Modified, SortDirection::Ascending);
+    pump_until(|| !source.fill_calls.borrow().is_empty());
+    // The sort fill covers the directory's mtime, not just file fields.
+    let fill = source.fill_calls.borrow();
+    assert!(fill[0].full);
+    assert!(fill[0].entries.contains(&Location::local("/fixture/sub")));
+    let emit = fill[0].emit.clone();
+    let id = fill[0].id;
+    drop(fill);
+    emit(DirectoryEvent::MetadataFilled {
+        request_id: id,
+        updates: vec![
+            MetadataUpdate {
+                location: Location::local("/fixture/sub"),
+                size: MetadataValue::Unknown,
+                modified_unix_seconds: MetadataValue::Known(200),
+            },
+            MetadataUpdate {
+                location: Location::local("/fixture/b.txt"),
+                size: MetadataValue::Known(10),
+                modified_unix_seconds: MetadataValue::Known(100),
+            },
+        ],
+    });
+    emit(DirectoryEvent::MetadataFinished {
+        request_id: id,
+        outcome: MetadataOutcome::Complete,
+    });
+    assert_eq!(finish_count(&events), 1);
+    assert_eq!(replaced_count(&events), 2);
+    let column = &browser.state.borrow().columns[0].entries;
+    let sub = column
+        .iter()
+        .find(|entry| entry.location == Location::local("/fixture/sub"))
+        .expect("the directory row should still be listed");
+    // Directory mtime filled for Modified sorting, while directory size
+    // stays explicitly unavailable.
+    assert_eq!(sub.modified_unix_seconds, MetadataValue::Known(200));
+    assert_eq!(sub.size, MetadataValue::Unknown);
+}
+
+#[test]
+fn fan_out_shares_one_event_with_every_observer() {
+    let browser = Browser::new(Rc::new(SortFillSource));
+    let first = Rc::new(RefCell::new(Vec::new()));
+    let second = Rc::new(RefCell::new(Vec::new()));
+    let third = Rc::new(RefCell::new(Vec::new()));
+    for collected in [first.clone(), second.clone(), third.clone()] {
+        browser.observe(move |event| collected.borrow_mut().push(event.clone()));
+    }
+
+    browser.navigate(Location::local("/fixture"));
+    // One owned event per emission, borrowed N ways: every observer sees
+    // the same staged publication payloads with no per-observer clone.
+    for collected in [first.clone(), second.clone(), third.clone()] {
+        let published: Vec<_> = collected
+            .borrow()
+            .iter()
+            .filter_map(|event| match event {
+                BrowserEvent::EntriesReplaced { count, .. } => Some(*count),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(published, vec![2]);
+    }
+    assert_eq!(first.borrow().len(), second.borrow().len());
+    assert_eq!(second.borrow().len(), third.borrow().len());
+}
+
+#[test]
+fn observers_added_or_cleared_mid_dispatch_do_not_corrupt_it() {
+    let browser = Browser::new(Rc::new(SortFillSource));
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let observed = events.clone();
+    let late = Rc::new(RefCell::new(Vec::new()));
+    let late_events = late.clone();
+    let browser_for_observer = browser.clone();
+    browser.observe(move |event| {
+        observed.borrow_mut().push(event.clone());
+        // Mutating the observer list mid-dispatch acts on the next emission:
+        // dispatch iterates the list cloned up front.
+        let value = late_events.clone();
+        browser_for_observer.observe(move |event| {
+            value.borrow_mut().push(event.clone());
+        });
+        browser_for_observer.clear_observer();
+    });
+
+    browser.navigate(Location::local("/fixture"));
+    let first_wave = events.borrow().len();
+    assert!(first_wave > 0);
+    assert!(late.borrow().is_empty());
+
+    // The mid-dispatch clear took effect: the next navigation notifies the
+    // observer added mid-dispatch... which was also cleared, so nobody runs.
+    browser.navigate(Location::local("/elsewhere"));
+    assert_eq!(events.borrow().len(), first_wave);
+}
+
+#[test]
+fn nested_emission_during_dispatch_is_safe() {
+    let browser = Browser::new(Rc::new(SortFillSource));
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let observed = events.clone();
+    let browser_for_observer = browser.clone();
+    browser.observe(move |event| {
+        let select_now =
+            matches!(event, BrowserEvent::EntriesReplaced { .. }) && observed.borrow().len() < 4;
+        observed.borrow_mut().push(event.clone());
+        if select_now {
+            // Reentrant emission while the outer dispatch holds no borrows:
+            // the observer list was cloned up front.
+            browser_for_observer.select(0, 0);
+        }
+    });
+
+    browser.navigate(Location::local("/fixture"));
+    assert!(
+        events.borrow().iter().any(|event| {
+            matches!(
+                event,
+                BrowserEvent::FocusChanged {
+                    position: Some(0),
+                    ..
+                }
+            )
+        }),
+        "the nested select should have been dispatched"
+    );
+}
+
+fn staged_entry(name: &str, kind: EntryKind, size: MetadataValue<u64>, modified: i64) -> FileEntry {
+    FileEntry {
+        location: Location::local(format!("/fixture/{name}")),
+        native_name: std::ffi::OsString::from(name),
+        display_name: name.into(),
+        kind,
+        size,
+        modified_unix_seconds: MetadataValue::Known(modified),
+        is_hidden: false,
+    }
+}
+
+#[test]
+fn native_initial_load_publishes_sorted_once() {
+    let (browser, events, source) = scripted_browser(ScriptedSource::manual(vec![], vec![]));
+    browser.navigate(Location::local("/fixture"));
+    let (request_id, emit) = source.enumerate_calls.borrow()[0].clone();
+    // Wire batches arrive out of order and stage with no merge walk and no
+    // UI events: nothing is exposed until the complete scan can sort.
+    emit(DirectoryEvent::Batch {
+        request_id,
+        entries: vec![batch_entry("gamma"), batch_entry("alpha")],
+    });
+    emit(DirectoryEvent::Batch {
+        request_id,
+        entries: vec![batch_entry("beta")],
+    });
+    assert!(browser.staging.borrow().contains_key(&0));
+    assert!(
+        !events.borrow().iter().any(|event| {
+            matches!(
+                event,
+                BrowserEvent::EntriesInserted { .. }
+                    | BrowserEvent::EntriesPublished { .. }
+                    | BrowserEvent::EntriesReplaced { .. }
+            )
+        }),
+        "staging must not publish provisional rows"
+    );
+    emit(DirectoryEvent::Finished {
+        request_id,
+        truncated: false,
+    });
+    // Small snapshots sort inline and publish synchronously: one exact
+    // replacement plus the load terminal, nothing else.
+    assert_eq!(replaced_count(&events), 1);
+    assert_eq!(
+        column_names(&browser, 0),
+        vec!["alpha".to_owned(), "beta".to_owned(), "gamma".to_owned()]
+    );
+    assert!(
+        events
+            .borrow()
+            .iter()
+            .any(|event| matches!(event, BrowserEvent::LoadFinished { .. }))
+    );
+    assert!(browser.staging.borrow().is_empty());
+}
+
+#[test]
+fn staged_load_reconciles_monitor_deltas_without_resurrection() {
+    let (browser, events, source) = scripted_browser(ScriptedSource::manual(vec![], vec![]));
+    browser.navigate(Location::local("/fixture"));
+    let (request_id, emit) = source.enumerate_calls.borrow()[0].clone();
+    emit(DirectoryEvent::Batch {
+        request_id,
+        entries: vec![batch_entry("alpha"), batch_entry("beta")],
+    });
+    // Monitor traffic mid-stage queues instead of racing the snapshot.
+    browser.handle_directory_change(
+        0,
+        &Location::local("/fixture"),
+        DirectoryChange::Remove(Location::local("/fixture/beta")),
+    );
+    browser.handle_directory_change(
+        0,
+        &Location::local("/fixture"),
+        DirectoryChange::Upsert(batch_entry("gamma")),
+    );
+    assert!(
+        !events.borrow().iter().any(|event| {
+            matches!(
+                event,
+                BrowserEvent::EntriesSpliced { .. }
+                    | BrowserEvent::EntriesPublished { .. }
+                    | BrowserEvent::EntriesReplaced { .. }
+            )
+        }),
+        "queued deltas must not touch the UI before the reconcile"
+    );
+    emit(DirectoryEvent::Finished {
+        request_id,
+        truncated: false,
+    });
+    // The removed row never resurrects from the staged batch; the upserted
+    // row appears exactly once.
+    assert_eq!(
+        column_names(&browser, 0),
+        vec!["alpha".to_owned(), "gamma".to_owned()]
+    );
+}
+
+#[test]
+fn staged_sorts_order_every_key_in_both_directions() {
+    use crate::model::{SortDirection, SortKey, ViewPreferences};
+    let entries = || {
+        vec![
+            staged_entry("b.txt", EntryKind::File, MetadataValue::Known(20), 100),
+            staged_entry("sub", EntryKind::Directory, MetadataValue::Unknown, 150),
+            staged_entry("a.txt", EntryKind::File, MetadataValue::Known(10), 200),
+        ]
+    };
+    let cases: &[(SortKey, SortDirection, bool, [&str; 3])] = &[
+        (
+            SortKey::Name,
+            SortDirection::Ascending,
+            true,
+            ["sub", "a.txt", "b.txt"],
+        ),
+        (
+            SortKey::Name,
+            SortDirection::Ascending,
+            false,
+            ["a.txt", "b.txt", "sub"],
+        ),
+        (
+            SortKey::Name,
+            SortDirection::Descending,
+            true,
+            ["sub", "b.txt", "a.txt"],
+        ),
+        (
+            SortKey::Name,
+            SortDirection::Descending,
+            false,
+            ["sub", "b.txt", "a.txt"],
+        ),
+        (
+            SortKey::Type,
+            SortDirection::Ascending,
+            true,
+            ["sub", "a.txt", "b.txt"],
+        ),
+        (
+            SortKey::Type,
+            SortDirection::Ascending,
+            false,
+            ["sub", "a.txt", "b.txt"],
+        ),
+        (
+            SortKey::Type,
+            SortDirection::Descending,
+            true,
+            ["sub", "a.txt", "b.txt"],
+        ),
+        (
+            SortKey::Type,
+            SortDirection::Descending,
+            false,
+            ["a.txt", "b.txt", "sub"],
+        ),
+        (
+            SortKey::Size,
+            SortDirection::Ascending,
+            true,
+            ["sub", "a.txt", "b.txt"],
+        ),
+        (
+            SortKey::Size,
+            SortDirection::Ascending,
+            false,
+            ["a.txt", "b.txt", "sub"],
+        ),
+        (
+            SortKey::Size,
+            SortDirection::Descending,
+            true,
+            ["sub", "b.txt", "a.txt"],
+        ),
+        (
+            SortKey::Size,
+            SortDirection::Descending,
+            false,
+            ["sub", "b.txt", "a.txt"],
+        ),
+        (
+            SortKey::Modified,
+            SortDirection::Ascending,
+            true,
+            ["sub", "b.txt", "a.txt"],
+        ),
+        (
+            SortKey::Modified,
+            SortDirection::Ascending,
+            false,
+            ["b.txt", "sub", "a.txt"],
+        ),
+        (
+            SortKey::Modified,
+            SortDirection::Descending,
+            true,
+            ["sub", "a.txt", "b.txt"],
+        ),
+        (
+            SortKey::Modified,
+            SortDirection::Descending,
+            false,
+            ["a.txt", "sub", "b.txt"],
+        ),
+    ];
+    for (key, direction, folders_first, expected) in cases {
+        let source: Rc<ScriptedSource> = Rc::new(ScriptedSource::manual(vec![], vec![]));
+        let browser = Browser::with_preferences(
+            source.clone(),
+            ViewPreferences {
+                sort_key: *key,
+                sort_direction: *direction,
+                folders_first: *folders_first,
+                ..ViewPreferences::default()
+            },
+        );
+        let events = Rc::new(RefCell::new(Vec::new()));
+        let observed = events.clone();
+        browser.observe(move |event| observed.borrow_mut().push(event.clone()));
+        browser.navigate(Location::local("/fixture"));
+        let (request_id, emit) = source.enumerate_calls.borrow()[0].clone();
+        emit(DirectoryEvent::Batch {
+            request_id,
+            entries: entries(),
+        });
+        emit(DirectoryEvent::Finished {
+            request_id,
+            truncated: false,
+        });
+        assert_eq!(
+            column_names(&browser, 0),
+            expected
+                .iter()
+                .map(|name| name.to_string())
+                .collect::<Vec<_>>(),
+            "key {key:?} direction {direction:?} folders_first {folders_first}"
+        );
+        assert_eq!(replaced_count(&events), 1);
+    }
+}
+
+#[test]
+fn large_load_streams_prefix_then_tails_with_terminal_last() {
+    let _serial = crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
+    let (browser, events, source) = scripted_browser(ScriptedSource::manual(vec![], vec![]));
+    browser.navigate(Location::local("/fixture"));
+    let (request_id, emit) = source.enumerate_calls.borrow()[0].clone();
+    // 700 rows in reverse: the staged sort restores order, and publication
+    // slices past the inline limit.
+    let first: Vec<FileEntry> = (0..400)
+        .rev()
+        .map(|index| batch_entry(&format!("file-{index:03}")))
+        .collect();
+    let second: Vec<FileEntry> = (400..700)
+        .rev()
+        .map(|index| batch_entry(&format!("file-{index:03}")))
+        .collect();
+    emit(DirectoryEvent::Batch {
+        request_id,
+        entries: first,
+    });
+    emit(DirectoryEvent::Batch {
+        request_id,
+        entries: second,
+    });
+    emit(DirectoryEvent::Finished {
+        request_id,
+        truncated: false,
+    });
+    // Small snapshots sort inline without touching the main context, but
+    // publication tails ride idle callbacks: pump them to completion.
+    pump_until(|| {
+        events
+            .borrow()
+            .iter()
+            .any(|event| matches!(event, BrowserEvent::LoadFinished { .. }))
+    });
+    let kinds: Vec<(usize, usize)> = events
+        .borrow()
+        .iter()
+        .filter_map(|event| match event {
+            BrowserEvent::EntriesReplaced { count, .. } => Some((0, *count)),
+            BrowserEvent::EntriesPublished { count, .. } => Some((1, *count)),
+            BrowserEvent::EntriesInserted { insertions, .. } => Some((
+                1,
+                insertions
+                    .iter()
+                    .map(|insertion| insertion.entries.len())
+                    .sum(),
+            )),
+            BrowserEvent::LoadFinished { .. } => Some((2, 0)),
+            _ => None,
+        })
+        .collect();
+    // Prefix first, tails next, terminal last. No callback in this chain
+    // may exceed a frame; the terminal proves the stream converged.
+    assert!(!kinds.is_empty());
+    assert_eq!(kinds[0], (0, 128));
+    assert_eq!(
+        *kinds.last().expect("a terminal should close the stream"),
+        (2, 0)
+    );
+    let streamed: usize = kinds.iter().map(|(_, count)| count).sum();
+    assert_eq!(streamed, 700);
+    let names = column_names(&browser, 0);
+    let mut sorted = names.clone();
+    sorted.sort();
+    assert_eq!(names, sorted);
+    assert!(browser.staged_publishes.borrow().is_empty());
+}
+
+#[test]
+fn remote_rows_flush_within_the_latency_bound() {
+    let _serial = crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
+    let (browser, events, source) = scripted_browser(ScriptedSource::manual(vec![], vec![]));
+    browser.navigate(Location::uri("sftp://host/share"));
+    let (request_id, emit) = source.enumerate_calls.borrow()[0].clone();
+    // First paint applies at once.
+    emit(DirectoryEvent::Batch {
+        request_id,
+        entries: vec![batch_entry("alpha")],
+    });
+    assert_eq!(column_names(&browser, 0), vec!["alpha".to_owned()]);
+    // Later batches never wait solely for the count threshold: the latency
+    // timer flushes them.
+    emit(DirectoryEvent::Batch {
+        request_id,
+        entries: vec![batch_entry("beta")],
+    });
+    assert_eq!(column_names(&browser, 0), vec!["alpha".to_owned()]);
+    let start = std::time::Instant::now();
+    while column_names(&browser, 0).len() < 2 && start.elapsed() < std::time::Duration::from_secs(5)
+    {
+        gtk::glib::MainContext::default().iteration(true);
+    }
+    assert_eq!(
+        column_names(&browser, 0),
+        vec!["alpha".to_owned(), "beta".to_owned()]
+    );
+    assert!(
+        !events
+            .borrow()
+            .iter()
+            .any(|event| { matches!(event, BrowserEvent::LoadFinished { .. }) }),
+        "the load is still open; only the latency flush fired"
+    );
+    emit(DirectoryEvent::Finished {
+        request_id,
+        truncated: false,
+    });
+    assert!(
+        events
+            .borrow()
+            .iter()
+            .any(|event| { matches!(event, BrowserEvent::LoadFinished { .. }) })
+    );
+}
+
+#[test]
+fn resort_after_mid_load_preference_change_republishes() {
+    // The staged sort ran under stale preferences while the user resorted:
+    // the completion hands off to a re-sort with the current preferences
+    // instead of publishing a stale order.
+    let (browser, events, _) =
+        scripted_browser(ScriptedSource::scripted(vec!["b.txt", "a.txt"], vec![]));
+    browser.navigate(Location::local("/fixture"));
+    assert_eq!(
+        column_names(&browser, 0),
+        vec!["a.txt".to_owned(), "b.txt".to_owned()]
+    );
+    let request_id = browser
+        .state
+        .borrow()
+        .request_id_for_depth(0)
+        .expect("the load should still own its request");
+    // Simulate a sort task finishing after a mid-load preference change:
+    // entries arrive sorted by size while the column now wants names.
+    browser.sorting.borrow_mut().insert(
+        0,
+        SortingLoad {
+            request_id,
+            deltas: Vec::new(),
+        },
+    );
+    let sorted = vec![batch_entry("b.txt"), batch_entry("a.txt")];
+    browser.finish_staged_sort(
+        0,
+        request_id,
+        sorted,
+        ViewPreferences {
+            sort_key: crate::model::SortKey::Size,
+            ..ViewPreferences::default()
+        },
+        false,
+    );
+    // Handed off, not published stale: the re-sort restores name order and
+    // the load terminal still fires exactly once per emission chain.
+    assert_eq!(
+        column_names(&browser, 0),
+        vec!["a.txt".to_owned(), "b.txt".to_owned()]
+    );
+    assert!(
+        events
+            .borrow()
+            .iter()
+            .any(|event| { matches!(event, BrowserEvent::LoadFinished { .. }) })
     );
 }
 
@@ -1633,7 +3239,7 @@ fn peek_filters_hidden_entries_before_item_limit() {
     let browser = Browser::new(Rc::new(MixedPeekFileSource));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
-    browser.observe(move |event| observed.borrow_mut().push(event));
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
     browser.navigate(Location::local("/fixture"));
     browser.begin_peek(0, Location::local("/fixture/peek_target"));
 

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -570,7 +570,6 @@ fn a_completed_trash_operation_can_be_undone_once() {
         size: MetadataValue::Unknown,
         modified_unix_seconds: MetadataValue::Unknown,
         is_hidden: false,
-        is_hidden: false,
     };
 
     browser.delete(vec![entry], false);
@@ -1631,6 +1630,7 @@ fn batch_entry(name: &str) -> FileEntry {
         kind: EntryKind::File,
         size: MetadataValue::Unknown,
         modified_unix_seconds: MetadataValue::Unknown,
+        is_hidden: false,
     }
 }
 

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -1636,8 +1636,6 @@ fn batch_entry(name: &str) -> FileEntry {
 
 #[test]
 fn repeated_identical_batches_emit_selection_only_once() {
-    // Remote loads stay progressive, so this covers the coalescing path;
-    // native loads stage instead (see the staging tests below).
     let _serial = crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT
         .lock()
         .expect("the async test lock should not be poisoned");
@@ -1662,8 +1660,6 @@ fn repeated_identical_batches_emit_selection_only_once() {
     browser.select(0, 0);
     emit(batch(&["mike"]));
     emit(batch(&["zulu"]));
-    // Later batches coalesce instead of applying; flush them the way load
-    // finish does before asserting.
     browser.flush_coalesced_capped(None);
 
     let selections: Vec<_> = events
@@ -1682,12 +1678,9 @@ fn repeated_identical_batches_emit_selection_only_once() {
         .iter()
         .filter(|event| matches!(event, BrowserEvent::EntriesInserted { .. }))
         .count();
-    // First paint plus one coalesced group for the two later batches.
     assert_eq!(inserted, 2);
 }
 
-/// A source whose listing carries no metadata and whose fill answers it
-/// synchronously, so the sort gate runs without waiting on I/O.
 struct SortFillSource;
 
 impl FileSource for SortFillSource {
@@ -1765,9 +1758,6 @@ fn size_sort_waits_for_its_metadata_pass() {
     });
 
     browser.navigate(Location::local("/fixture"));
-    // Name order out of the listing: alpha before beta. The public sort path
-    // debounces 16 ms on the main context; the fake fill answers
-    // synchronously once the debounce fires.
     browser.set_sort(0, SortKey::Size, SortDirection::Ascending);
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
     gtk::glib::MainContext::default().block_on(std::future::poll_fn(|cx| {
@@ -1788,7 +1778,6 @@ fn size_sort_waits_for_its_metadata_pass() {
         .iter()
         .map(|entry| entry.display_name.clone())
         .collect();
-    // Size order: beta (1 byte) before alpha (100 bytes).
     assert_eq!(names, vec!["beta".to_owned(), "alpha".to_owned()]);
     assert!(
         events
@@ -1796,7 +1785,6 @@ fn size_sort_waits_for_its_metadata_pass() {
             .iter()
             .any(|event| { matches!(event, BrowserEvent::MetadataFilled { .. }) })
     );
-    // Total protocol: the sort's indicator opens once and closes once.
     assert_eq!(
         events
             .borrow()
@@ -1817,8 +1805,6 @@ fn size_sort_waits_for_its_metadata_pass() {
 
 #[test]
 fn load_finish_applies_rows_queued_behind_the_count_threshold() {
-    // Remote loads stay progressive, so this covers the coalesced straggler
-    // flush; native loads stage instead (see the staging tests below).
     let _serial = crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT
         .lock()
         .expect("the async test lock should not be poisoned");
@@ -1835,7 +1821,6 @@ fn load_finish_applies_rows_queued_behind_the_count_threshold() {
         .borrow()
         .clone()
         .expect("navigate should start a directory load");
-    // First paint applies at once; the rest coalesces below the threshold.
     emit(DirectoryEvent::Batch {
         request_id,
         entries: vec![batch_entry("alpha")],
@@ -1844,8 +1829,6 @@ fn load_finish_applies_rows_queued_behind_the_count_threshold() {
         request_id,
         entries: vec![batch_entry("beta")],
     });
-    // Used to panic: the straggler flush ran under the live scrutinee
-    // borrow instead of a bound depth.
     emit(DirectoryEvent::Finished {
         request_id,
         truncated: false,
@@ -1865,17 +1848,121 @@ fn load_finish_applies_rows_queued_behind_the_count_threshold() {
     );
 }
 
-/// Scripted answers for one `fill_metadata` call, in call order.
+#[test]
+fn remote_load_finishes_only_after_every_queued_row_is_applied() {
+    let _serial = crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
+    let captured: CapturedLoad = Rc::new(RefCell::new(None));
+    let browser = Browser::new(Rc::new(BatchReplaySource {
+        captured: captured.clone(),
+    }));
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let observed = events.clone();
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
+
+    browser.navigate(Location::uri("sftp://host/fixture"));
+    let (request_id, emit) = captured
+        .borrow()
+        .clone()
+        .expect("navigate should start a directory load");
+    emit(DirectoryEvent::Batch {
+        request_id,
+        entries: vec![batch_entry("first")],
+    });
+    emit(DirectoryEvent::Batch {
+        request_id,
+        entries: (0..1025)
+            .map(|index| batch_entry(&format!("queued-{index:04}")))
+            .collect(),
+    });
+    emit(DirectoryEvent::Finished {
+        request_id,
+        truncated: false,
+    });
+
+    assert!(
+        !events
+            .borrow()
+            .iter()
+            .any(|event| matches!(event, BrowserEvent::LoadFinished { .. }))
+    );
+    assert_eq!(browser.state.borrow().columns[0].entries.len(), 513);
+
+    browser.flush_coalesced_capped(Some(0));
+    assert!(
+        !events
+            .borrow()
+            .iter()
+            .any(|event| matches!(event, BrowserEvent::LoadFinished { .. }))
+    );
+    browser.flush_coalesced_capped(Some(0));
+
+    let events = events.borrow();
+    let finish = events
+        .iter()
+        .position(|event| matches!(event, BrowserEvent::LoadFinished { .. }))
+        .expect("the drained load should finish");
+    let last_insert = events
+        .iter()
+        .rposition(|event| matches!(event, BrowserEvent::EntriesInserted { .. }))
+        .expect("the final queued rows should be inserted");
+    assert!(finish > last_insert);
+    assert_eq!(browser.state.borrow().columns[0].entries.len(), 1026);
+}
+
+#[test]
+fn remote_load_failure_waits_for_queued_rows() {
+    let _serial = crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
+    let captured: CapturedLoad = Rc::new(RefCell::new(None));
+    let browser = Browser::new(Rc::new(BatchReplaySource {
+        captured: captured.clone(),
+    }));
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let observed = events.clone();
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
+
+    browser.navigate(Location::uri("sftp://host/fixture"));
+    let (request_id, emit) = captured
+        .borrow()
+        .clone()
+        .expect("navigate should start a directory load");
+    emit(DirectoryEvent::Batch {
+        request_id,
+        entries: vec![batch_entry("first")],
+    });
+    emit(DirectoryEvent::Batch {
+        request_id,
+        entries: (0..513)
+            .map(|index| batch_entry(&format!("queued-{index:04}")))
+            .collect(),
+    });
+    emit(DirectoryEvent::Failed {
+        request_id,
+        message: "remote failure".to_owned(),
+    });
+
+    assert!(
+        !events
+            .borrow()
+            .iter()
+            .any(|event| matches!(event, BrowserEvent::LoadFailed { .. }))
+    );
+    browser.flush_coalesced_capped(Some(0));
+    assert!(events.borrow().iter().any(|event| matches!(
+        event,
+        BrowserEvent::LoadFailed { message, .. } if message == "remote failure"
+    )));
+    assert_eq!(browser.state.borrow().columns[0].entries.len(), 514);
+}
+
 enum FillAnswer {
-    /// One chunk carrying `name -> size` pairs, then `Complete`.
     Complete(Vec<(&'static str, u64)>),
-    /// Several chunks, then the given terminal outcome.
     Chunks(Vec<Vec<(&'static str, u64)>>, MetadataOutcome),
-    /// No chunks, then `Complete`.
     EmptyComplete,
-    /// No chunks, then the given terminal outcome.
     TerminalOnly(MetadataOutcome),
-    /// Capture the emit for the test to fire later.
     Never,
 }
 
@@ -1888,8 +1975,6 @@ struct FillCall {
 
 type DirectoryEmit = Rc<dyn Fn(DirectoryEvent)>;
 
-/// Listings carry no metadata; every fill answers from a script so the
-/// terminal protocol is fully deterministic without I/O or timers.
 struct ScriptedSource {
     files: Vec<&'static str>,
     dirs: Vec<&'static str>,
@@ -2083,9 +2168,7 @@ fn scripted_browser(
     (browser, events, source)
 }
 
-/// Pumps the main context until `condition` holds or the deadline passes.
-/// Callers assert on the resulting state; the deadline only turns a hang
-/// into a deterministic failure.
+/// The deadline only turns a hang into a deterministic failure.
 fn pump_until(condition: impl Fn() -> bool) {
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
     while !condition() && std::time::Instant::now() < deadline {
@@ -2137,12 +2220,10 @@ fn multi_chunk_fill_sorts_once_on_its_terminal() {
             MetadataOutcome::Complete,
         )],
     ));
-    // Script answers pop from the back; with one answer the order is fixed.
     browser.navigate(Location::local("/fixture"));
     browser.set_sort(0, SortKey::Size, SortDirection::Ascending);
     pump_until(|| finish_count(&events) == 1);
 
-    // Sorted once, on the complete pass: never on the first partial chunk.
     assert_eq!(replaced_count(&events), 2);
     assert_eq!(start_count(&events), 1);
     assert_eq!(
@@ -2212,7 +2293,6 @@ fn failed_fill_abandons_the_sort_in_order() {
     browser.set_sort(0, SortKey::Size, SortDirection::Ascending);
     pump_until(|| finish_count(&events) == 1);
 
-    // Chunks still apply to rows, but the failed pass never reorders.
     assert_eq!(replaced_count(&events), 1);
     assert_eq!(start_count(&events), 1);
     assert_eq!(
@@ -2234,7 +2314,6 @@ fn empty_fill_still_closes_the_sort() {
     browser.set_sort(0, SortKey::Size, SortDirection::Ascending);
     pump_until(|| finish_count(&events) == 1);
 
-    // A zero-row result is a complete pass, not a hang.
     assert_eq!(start_count(&events), 1);
     assert_eq!(replaced_count(&events), 2);
 }
@@ -2249,7 +2328,6 @@ fn navigation_cancels_an_awaiting_sort_without_stale_commit() {
         vec![FillAnswer::Never],
     ));
     browser.navigate(Location::local("/fixture"));
-    // The initial load publishes synchronously through staging.
     let published = replaced_count(&events);
     assert_eq!(published, 1);
     browser.set_sort(0, SortKey::Size, SortDirection::Ascending);
@@ -2261,8 +2339,6 @@ fn navigation_cancels_an_awaiting_sort_without_stale_commit() {
     assert!(browser.sort_awaiting_fill.borrow().is_none());
     assert!(browser.pending_sort.get().is_none());
 
-    // The abandoned fill's late terminal lands on a superseded load and
-    // must not commit anything.
     let old = source.fill_calls.borrow();
     let old_emit = old[0].emit.clone();
     let old_id = old[0].id;
@@ -2279,8 +2355,6 @@ fn navigation_cancels_an_awaiting_sort_without_stale_commit() {
         request_id: old_id,
         outcome: MetadataOutcome::Complete,
     });
-    // The elsewhere load publishes once through staging; the stale fill
-    // and terminal add nothing further.
     assert_eq!(replaced_count(&events), published + 1);
     assert_eq!(finish_count(&events), 1);
     assert_eq!(
@@ -2327,13 +2401,9 @@ fn viewport_flush_never_disturbs_an_active_sort() {
         .expect("the async test lock should not be poisoned");
     let (browser, events, source) = scripted_browser(ScriptedSource::scripted(
         vec!["alpha", "beta"],
-        vec![
-            FillAnswer::Complete(vec![("alpha", 30), ("beta", 10)]),
-            FillAnswer::Never,
-        ],
+        vec![FillAnswer::Never, FillAnswer::Never],
     ));
     browser.navigate(Location::local("/fixture"));
-    // A viewport fill queued directly (no settle timer) starts first.
     browser.metadata_pending.borrow_mut().insert(
         0,
         vec![
@@ -2351,26 +2421,17 @@ fn viewport_flush_never_disturbs_an_active_sort() {
     assert_eq!(source.fill_calls.borrow().len(), 1);
     assert!(!source.fill_calls.borrow()[0].full);
 
-    // The full sort starts while the viewport fill is still in flight; each
-    // keeps its own handle. The scripted sort answers synchronously.
     browser.set_sort(0, SortKey::Size, SortDirection::Ascending);
-    pump_until(|| finish_count(&events) == 1);
-    assert!(source.fill_calls.borrow()[1].full);
+    pump_until(|| source.fill_calls.borrow().len() == 2);
+    let calls = source.fill_calls.borrow();
+    let viewport_id = calls[0].id;
+    let viewport_emit = calls[0].emit.clone();
+    let sort_id = calls[1].id;
+    let sort_emit = calls[1].emit.clone();
+    assert!(calls[1].full);
+    assert_ne!(viewport_id, sort_id);
+    drop(calls);
 
-    // The sort completed on its own terminal while the viewport fill was
-    // still in flight: one reorder, balanced indicator.
-    assert_eq!(replaced_count(&events), 2);
-    assert_eq!(
-        column_names(&browser, 0),
-        vec!["beta".to_owned(), "alpha".to_owned()]
-    );
-    assert!(browser.metadata_loads.borrow().contains_key(&0));
-
-    // The late viewport chunk still applies to its row without re-sorting.
-    let viewport = source.fill_calls.borrow();
-    let viewport_emit = viewport[0].emit.clone();
-    let viewport_id = viewport[0].id;
-    drop(viewport);
     viewport_emit(DirectoryEvent::MetadataFilled {
         request_id: viewport_id,
         updates: vec![MetadataUpdate {
@@ -2379,8 +2440,39 @@ fn viewport_flush_never_disturbs_an_active_sort() {
             modified_unix_seconds: MetadataValue::Known(7),
         }],
     });
+    viewport_emit(DirectoryEvent::MetadataFinished {
+        request_id: viewport_id,
+        outcome: MetadataOutcome::Complete,
+    });
+    assert_eq!(replaced_count(&events), 1);
+    assert_eq!(finish_count(&events), 0);
+    assert!(browser.sort_awaiting_fill.borrow().is_some());
+
+    sort_emit(DirectoryEvent::MetadataFilled {
+        request_id: sort_id,
+        updates: vec![
+            MetadataUpdate {
+                location: Location::local("/fixture/alpha"),
+                size: MetadataValue::Known(30),
+                modified_unix_seconds: MetadataValue::Known(7),
+            },
+            MetadataUpdate {
+                location: Location::local("/fixture/beta"),
+                size: MetadataValue::Known(10),
+                modified_unix_seconds: MetadataValue::Known(7),
+            },
+        ],
+    });
+    sort_emit(DirectoryEvent::MetadataFinished {
+        request_id: sort_id,
+        outcome: MetadataOutcome::Complete,
+    });
     assert_eq!(replaced_count(&events), 2);
     assert_eq!(finish_count(&events), 1);
+    assert_eq!(
+        column_names(&browser, 0),
+        vec!["beta".to_owned(), "alpha".to_owned()]
+    );
 }
 
 #[test]
@@ -2394,7 +2486,6 @@ fn refresh_drops_staging_and_its_sort() {
     ));
     browser.navigate(Location::local("/fixture"));
     let (request_id, emit) = source.enumerate_calls.borrow()[0].clone();
-    // Batches stage with no merge and no UI events until enumeration ends.
     emit(DirectoryEvent::Batch {
         request_id,
         entries: vec![batch_entry("alpha")],
@@ -2413,12 +2504,10 @@ fn refresh_drops_staging_and_its_sort() {
     );
     assert_eq!(replaced_count(&events), 0);
 
-    // A reload discards the staged snapshot before it ever publishes.
     browser.refresh_column(0);
     assert!(!browser.staging.borrow().contains_key(&0));
     assert_eq!(replaced_count(&events), 0);
 
-    // The reloaded column stages and publishes on its own finish.
     let (request_id, emit) = source.enumerate_calls.borrow()[1].clone();
     emit(DirectoryEvent::Batch {
         request_id,
@@ -2434,7 +2523,6 @@ fn refresh_drops_staging_and_its_sort() {
         vec!["alpha".to_owned(), "beta".to_owned()]
     );
 
-    // A sort fill in flight is still cancelled by a later reload.
     browser.set_sort(0, SortKey::Size, SortDirection::Ascending);
     pump_until(|| !source.fill_calls.borrow().is_empty());
     assert!(browser.sort_awaiting_fill.borrow().is_some());
@@ -2479,12 +2567,10 @@ fn close_column_clears_the_truncated_depth() {
     let published = replaced_count(&events);
     assert_eq!(published, 2);
 
-    // A sort fill in flight at the child depth.
     browser.set_sort(1, SortKey::Size, SortDirection::Ascending);
     pump_until(|| !source.fill_calls.borrow().is_empty());
     assert!(browser.sort_awaiting_fill.borrow().is_some());
 
-    // A grandchild load still staging its first batches.
     browser.descend(1, Location::local("/fixture/sub/deep"));
     let (deep_id, deep_emit) = source.enumerate_calls.borrow()[2].clone();
     deep_emit(DirectoryEvent::Batch {
@@ -2515,24 +2601,18 @@ fn settle_timer_restarts_while_rows_keep_arriving() {
     ));
     browser.navigate(Location::local("/fixture"));
     browser.request_metadata_fill(0, 0, Location::local("/fixture/alpha"));
-    // Non-blocking iterations plus wall-clock sleeps: blocking iterations
-    // would overshoot the wall-clock checkpoints below.
     let pump_until_elapsed = |millis: u64, start: std::time::Instant| {
         while start.elapsed() < std::time::Duration::from_millis(millis) {
             gtk::glib::MainContext::default().iteration(false);
             std::thread::sleep(std::time::Duration::from_millis(2));
         }
     };
-    // Wait past half the debounce, then bind another row: the settle timer
-    // restarts instead of firing for the first row alone.
     let start = std::time::Instant::now();
     pump_until_elapsed(80, start);
     browser.request_metadata_fill(0, 1, Location::local("/fixture/beta"));
     pump_until_elapsed(140, start);
-    // Past the first row's deadline: nothing flushed yet.
     assert!(source.fill_calls.borrow().is_empty());
     pump_until_elapsed(400, start);
-    // One flush carrying both settled rows.
     assert_eq!(source.fill_calls.borrow().len(), 1);
     assert!(!source.fill_calls.borrow()[0].full);
 }
@@ -2547,7 +2627,6 @@ fn shifted_viewport_rows_go_stale_without_repaint() {
         vec![FillAnswer::Never],
     ));
     browser.navigate(Location::local("/fixture"));
-    // Token captured at bind time: beta sits at source position 1.
     browser.metadata_pending.borrow_mut().insert(
         0,
         vec![ViewportTarget {
@@ -2558,8 +2637,6 @@ fn shifted_viewport_rows_go_stale_without_repaint() {
     browser.flush_metadata_fills();
     assert_eq!(source.fill_calls.borrow().len(), 1);
 
-    // The head row leaves before the fill lands: beta shifts to position 0,
-    // so the token no longer validates.
     browser.state.borrow_mut().columns[0].entries.remove(0);
     let fill = source.fill_calls.borrow();
     let emit = fill[0].emit.clone();
@@ -2573,8 +2650,6 @@ fn shifted_viewport_rows_go_stale_without_repaint() {
             modified_unix_seconds: MetadataValue::Known(7),
         }],
     });
-    // Stale: no repaint, and the placeholder survives for the next bind's
-    // retry instead of painting the wrong row.
     assert_eq!(replaced_count(&events), 1);
     assert!(
         !events
@@ -2603,8 +2678,6 @@ fn remote_name_listing_fills_visible_metadata() {
     src.uri_base = Some("sftp://host/share");
     let (browser, events, source) = scripted_browser(src);
     browser.navigate(Location::uri("sftp://host/share"));
-    // Remote Name listings used to keep blank metadata forever: the owner
-    // no longer rejects them, so the visible rows fill.
     browser.metadata_pending.borrow_mut().insert(
         0,
         vec![
@@ -2648,7 +2721,6 @@ fn modified_sort_fills_directory_mtimes() {
     browser.navigate(Location::local("/fixture"));
     browser.set_sort(0, SortKey::Modified, SortDirection::Ascending);
     pump_until(|| !source.fill_calls.borrow().is_empty());
-    // The sort fill covers the directory's mtime, not just file fields.
     let fill = source.fill_calls.borrow();
     assert!(fill[0].full);
     assert!(fill[0].entries.contains(&Location::local("/fixture/sub")));
@@ -2681,8 +2753,6 @@ fn modified_sort_fills_directory_mtimes() {
         .iter()
         .find(|entry| entry.location == Location::local("/fixture/sub"))
         .expect("the directory row should still be listed");
-    // Directory mtime filled for Modified sorting, while directory size
-    // stays explicitly unavailable.
     assert_eq!(sub.modified_unix_seconds, MetadataValue::Known(200));
     assert_eq!(sub.size, MetadataValue::Unknown);
 }
@@ -2698,8 +2768,6 @@ fn fan_out_shares_one_event_with_every_observer() {
     }
 
     browser.navigate(Location::local("/fixture"));
-    // One owned event per emission, borrowed N ways: every observer sees
-    // the same staged publication payloads with no per-observer clone.
     for collected in [first.clone(), second.clone(), third.clone()] {
         let published: Vec<_> = collected
             .borrow()
@@ -2725,8 +2793,6 @@ fn observers_added_or_cleared_mid_dispatch_do_not_corrupt_it() {
     let browser_for_observer = browser.clone();
     browser.observe(move |event| {
         observed.borrow_mut().push(event.clone());
-        // Mutating the observer list mid-dispatch acts on the next emission:
-        // dispatch iterates the list cloned up front.
         let value = late_events.clone();
         browser_for_observer.observe(move |event| {
             value.borrow_mut().push(event.clone());
@@ -2739,8 +2805,6 @@ fn observers_added_or_cleared_mid_dispatch_do_not_corrupt_it() {
     assert!(first_wave > 0);
     assert!(late.borrow().is_empty());
 
-    // The mid-dispatch clear took effect: the next navigation notifies the
-    // observer added mid-dispatch... which was also cleared, so nobody runs.
     browser.navigate(Location::local("/elsewhere"));
     assert_eq!(events.borrow().len(), first_wave);
 }
@@ -2756,8 +2820,6 @@ fn nested_emission_during_dispatch_is_safe() {
             matches!(event, BrowserEvent::EntriesReplaced { .. }) && observed.borrow().len() < 4;
         observed.borrow_mut().push(event.clone());
         if select_now {
-            // Reentrant emission while the outer dispatch holds no borrows:
-            // the observer list was cloned up front.
             browser_for_observer.select(0, 0);
         }
     });
@@ -2794,8 +2856,6 @@ fn native_initial_load_publishes_sorted_once() {
     let (browser, events, source) = scripted_browser(ScriptedSource::manual(vec![], vec![]));
     browser.navigate(Location::local("/fixture"));
     let (request_id, emit) = source.enumerate_calls.borrow()[0].clone();
-    // Wire batches arrive out of order and stage with no merge walk and no
-    // UI events: nothing is exposed until the complete scan can sort.
     emit(DirectoryEvent::Batch {
         request_id,
         entries: vec![batch_entry("gamma"), batch_entry("alpha")],
@@ -2820,8 +2880,6 @@ fn native_initial_load_publishes_sorted_once() {
         request_id,
         truncated: false,
     });
-    // Small snapshots sort inline and publish synchronously: one exact
-    // replacement plus the load terminal, nothing else.
     assert_eq!(replaced_count(&events), 1);
     assert_eq!(
         column_names(&browser, 0),
@@ -2859,6 +2917,46 @@ fn empty_native_initial_load_finishes_without_a_batch() {
 }
 
 #[test]
+fn incomplete_native_metadata_uses_name_order_until_a_full_retry_finishes() {
+    let source = Rc::new(ScriptedSource::manual(vec![], vec![FillAnswer::Never]));
+    let browser = Browser::with_preferences(
+        source.clone(),
+        ViewPreferences {
+            sort_key: SortKey::Size,
+            ..ViewPreferences::default()
+        },
+    );
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let observed = events.clone();
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
+    browser.navigate(Location::local("/fixture"));
+    let (request_id, emit) = source.enumerate_calls.borrow()[0].clone();
+    emit(DirectoryEvent::Batch {
+        request_id,
+        entries: vec![
+            staged_entry("beta", EntryKind::File, MetadataValue::Known(1), 1),
+            staged_entry("alpha", EntryKind::File, MetadataValue::Unknown, 1),
+        ],
+    });
+    emit(DirectoryEvent::MetadataIncomplete { request_id });
+    emit(DirectoryEvent::Finished {
+        request_id,
+        truncated: false,
+    });
+
+    assert_eq!(
+        column_names(&browser, 0),
+        vec!["alpha".to_owned(), "beta".to_owned()]
+    );
+    assert_eq!(start_count(&events), 1);
+    assert!(browser.sort_awaiting_fill.borrow().is_some());
+    let fills = source.fill_calls.borrow();
+    assert_eq!(fills.len(), 1);
+    assert!(fills[0].full);
+    assert_ne!(fills[0].id, request_id);
+}
+
+#[test]
 fn staged_load_reconciles_monitor_deltas_without_resurrection() {
     let (browser, events, source) = scripted_browser(ScriptedSource::manual(vec![], vec![]));
     browser.navigate(Location::local("/fixture"));
@@ -2867,7 +2965,6 @@ fn staged_load_reconciles_monitor_deltas_without_resurrection() {
         request_id,
         entries: vec![batch_entry("alpha"), batch_entry("beta")],
     });
-    // Monitor traffic mid-stage queues instead of racing the snapshot.
     browser.handle_directory_change(
         0,
         &Location::local("/fixture"),
@@ -2893,8 +2990,6 @@ fn staged_load_reconciles_monitor_deltas_without_resurrection() {
         request_id,
         truncated: false,
     });
-    // The removed row never resurrects from the staged batch; the upserted
-    // row appears exactly once.
     assert_eq!(
         column_names(&browser, 0),
         vec!["alpha".to_owned(), "gamma".to_owned()]
@@ -3053,8 +3148,6 @@ fn large_load_streams_prefix_then_tails_with_terminal_last() {
     let (browser, events, source) = scripted_browser(ScriptedSource::manual(vec![], vec![]));
     browser.navigate(Location::local("/fixture"));
     let (request_id, emit) = source.enumerate_calls.borrow()[0].clone();
-    // 700 rows in reverse: the staged sort restores order, and publication
-    // slices past the inline limit.
     let first: Vec<FileEntry> = (0..400)
         .rev()
         .map(|index| batch_entry(&format!("file-{index:03}")))
@@ -3075,8 +3168,6 @@ fn large_load_streams_prefix_then_tails_with_terminal_last() {
         request_id,
         truncated: false,
     });
-    // Small snapshots sort inline without touching the main context, but
-    // publication tails ride idle callbacks: pump them to completion.
     pump_until(|| {
         events
             .borrow()
@@ -3100,8 +3191,6 @@ fn large_load_streams_prefix_then_tails_with_terminal_last() {
             _ => None,
         })
         .collect();
-    // Prefix first, tails next, terminal last. No callback in this chain
-    // may exceed a frame; the terminal proves the stream converged.
     assert!(!kinds.is_empty());
     assert_eq!(kinds[0], (0, 128));
     assert_eq!(
@@ -3125,14 +3214,11 @@ fn remote_rows_flush_within_the_latency_bound() {
     let (browser, events, source) = scripted_browser(ScriptedSource::manual(vec![], vec![]));
     browser.navigate(Location::uri("sftp://host/share"));
     let (request_id, emit) = source.enumerate_calls.borrow()[0].clone();
-    // First paint applies at once.
     emit(DirectoryEvent::Batch {
         request_id,
         entries: vec![batch_entry("alpha")],
     });
     assert_eq!(column_names(&browser, 0), vec!["alpha".to_owned()]);
-    // Later batches never wait solely for the count threshold: the latency
-    // timer flushes them.
     emit(DirectoryEvent::Batch {
         request_id,
         entries: vec![batch_entry("beta")],
@@ -3168,9 +3254,6 @@ fn remote_rows_flush_within_the_latency_bound() {
 
 #[test]
 fn resort_after_mid_load_preference_change_republishes() {
-    // The staged sort ran under stale preferences while the user resorted:
-    // the completion hands off to a re-sort with the current preferences
-    // instead of publishing a stale order.
     let (browser, events, _) =
         scripted_browser(ScriptedSource::scripted(vec!["b.txt", "a.txt"], vec![]));
     browser.navigate(Location::local("/fixture"));
@@ -3183,8 +3266,6 @@ fn resort_after_mid_load_preference_change_republishes() {
         .borrow()
         .request_id_for_depth(0)
         .expect("the load should still own its request");
-    // Simulate a sort task finishing after a mid-load preference change:
-    // entries arrive sorted by size while the column now wants names.
     browser.sorting.borrow_mut().insert(
         0,
         SortingLoad {
@@ -3202,9 +3283,8 @@ fn resort_after_mid_load_preference_change_republishes() {
             ..ViewPreferences::default()
         },
         false,
+        false,
     );
-    // Handed off, not published stale: the re-sort restores name order and
-    // the load terminal still fires exactly once per emission chain.
     assert_eq!(
         column_names(&browser, 0),
         vec!["a.txt".to_owned(), "b.txt".to_owned()]

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -2837,6 +2837,28 @@ fn native_initial_load_publishes_sorted_once() {
 }
 
 #[test]
+fn empty_native_initial_load_finishes_without_a_batch() {
+    let (browser, events, source) = scripted_browser(ScriptedSource::manual(vec![], vec![]));
+    browser.navigate(Location::local("/fixture"));
+    let (request_id, emit) = source.enumerate_calls.borrow()[0].clone();
+
+    emit(DirectoryEvent::Finished {
+        request_id,
+        truncated: false,
+    });
+
+    assert_eq!(replaced_count(&events), 1);
+    assert!(column_names(&browser, 0).is_empty());
+    assert!(events.borrow().iter().any(|event| matches!(
+        event,
+        BrowserEvent::LoadFinished {
+            depth: 0,
+            truncated: false
+        }
+    )));
+}
+
+#[test]
 fn staged_load_reconciles_monitor_deltas_without_resurrection() {
     let (browser, events, source) = scripted_browser(ScriptedSource::manual(vec![], vec![]));
     browser.navigate(Location::local("/fixture"));

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use std::{cmp::Ordering, collections::HashSet};
+use std::{
+    cmp::Ordering,
+    collections::{HashMap, HashSet},
+};
 
 use crate::{
     app::peek::PeekState,
     model::{FileEntry, Location, MetadataValue, SortDirection, SortKey, ViewPreferences},
-    services::{DirectoryChange, RequestId},
+    services::{DirectoryChange, MetadataUpdate, RequestId},
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -287,6 +290,106 @@ impl NavigationState {
         Some((depth, insertions))
     }
 
+    /// Installs a complete staged snapshot for a native initial load,
+    /// entries arrive pre-sorted, so no merge walk runs. Restores the pending
+    /// selection target and first-on-load selection exactly like a batch
+    /// would; the caller marks the load finished and publishes afterwards.
+    pub fn install_snapshot(
+        &mut self,
+        request_id: RequestId,
+        entries: Vec<FileEntry>,
+    ) -> Option<usize> {
+        let (depth, column) = self.column_for_request_mut(request_id)?;
+        column.entries = entries;
+        if let Some(selected_location) = column.selection_target.clone() {
+            column.selected = column
+                .entries
+                .iter()
+                .position(|entry| entry.location == selected_location);
+            if column.selected.is_some() {
+                column.selection_target = None;
+            }
+        }
+        if column.select_first_on_load && !column.entries.is_empty() {
+            let location = column.entries[0].location.clone();
+            column.selected = Some(0);
+            column.selected_locations.clear();
+            column.selected_locations.insert(location.clone());
+            column.selection_anchor = Some(location);
+            column.select_first_on_load = false;
+        }
+        Some(depth)
+    }
+
+    /// Depth of a still-open native load, if `request_id` belongs to one.
+    /// Finished, failed, peek, and unknown requests report `None`.
+    pub fn open_load_depth(&self, request_id: RequestId) -> Option<usize> {
+        self.columns.iter().enumerate().find_map(|(depth, column)| {
+            (column.request_id == request_id && column.load_state == LoadState::Loading)
+                .then_some(depth)
+        })
+    }
+    /// Returns the depth and the changed positions so views can refresh those
+    /// rows in place; the order never changes here. Fills for a superseded
+    /// load match no column and are dropped. Fields arrive independently: a
+    /// fill that only learned the mtime must not clobber a known size with
+    /// a placeholder, and rows whose values did not change are not reported.
+    pub fn apply_metadata(
+        &mut self,
+        request_id: RequestId,
+        updates: Vec<MetadataUpdate>,
+    ) -> Option<(usize, Vec<usize>)> {
+        let (depth, column) = self.column_for_request_mut(request_id)?;
+        let updates: HashMap<&Location, &MetadataUpdate> = updates
+            .iter()
+            .map(|update| (&update.location, update))
+            .collect();
+        let mut positions = Vec::new();
+        for (position, entry) in column.entries.iter_mut().enumerate() {
+            if let Some(update) = updates.get(&entry.location)
+                && apply_metadata_update(entry, update)
+            {
+                positions.push(position);
+            }
+        }
+        if positions.is_empty() {
+            return None;
+        }
+        Some((depth, positions))
+    }
+
+    /// Applies fill updates captured with stable `(position, Location)`
+    /// tokens, in O(number of requested rows). Each token is validated: the
+    /// same location must still occupy the position, otherwise the row moved
+    /// under the fill and the update is reported stale. Stale rows keep
+    /// their placeholders and are re-requested on their next bind, so only
+    /// stale rows retry. Returns the depth, the applied positions, and the
+    /// stale locations.
+    pub fn apply_positioned_metadata(
+        &mut self,
+        request_id: RequestId,
+        updates: Vec<(usize, MetadataUpdate)>,
+    ) -> Option<(usize, Vec<usize>, Vec<Location>)> {
+        let (depth, column) = self.column_for_request_mut(request_id)?;
+        let mut positions = Vec::new();
+        let mut stale = Vec::new();
+        for (position, update) in &updates {
+            let current = column.entries.get(*position);
+            if current.is_some_and(|entry| entry.location == update.location) {
+                let entry = column.entries.get_mut(*position).expect("position checked");
+                if apply_metadata_update(entry, update) {
+                    positions.push(*position);
+                }
+            } else {
+                stale.push(update.location.clone());
+            }
+        }
+        if positions.is_empty() && stale.is_empty() {
+            return None;
+        }
+        Some((depth, positions, stale))
+    }
+
     pub fn apply_directory_change(
         &mut self,
         depth: usize,
@@ -422,11 +525,11 @@ impl NavigationState {
         self.columns.get(depth).map(|column| column.preferences)
     }
 
-    pub fn set_column_preferences(
+    pub fn apply_sort_preferences(
         &mut self,
         depth: usize,
         preferences: ViewPreferences,
-    ) -> Option<(Vec<FileEntry>, Option<usize>, Vec<usize>)> {
+    ) -> Option<(Option<usize>, Vec<usize>)> {
         if depth >= self.columns.len() {
             return None;
         }
@@ -439,6 +542,8 @@ impl NavigationState {
             .and_then(|position| column.entries.get(position))
             .map(|entry| entry.location.clone());
         column.preferences = preferences;
+        // Unstable, matching sort-once publication: display-name and location
+        // tie-breakers in `compare_entries` keep distinct entries ordered.
         column
             .entries
             .sort_unstable_by(|left, right| compare_entries(left, right, preferences));
@@ -459,7 +564,7 @@ impl NavigationState {
                     .then_some(position)
             })
             .collect();
-        Some((column.entries.clone(), column.selected, selected_positions))
+        Some((column.selected, selected_positions))
     }
 
     pub fn active_focus(&self) -> Option<(usize, Option<usize>)> {
@@ -670,6 +775,18 @@ impl NavigationState {
             })
             .collect()
     }
+    /// Number of selected entries in the active column. Clone-free: the
+    /// hot selection paths log and gate on this instead of materializing
+    /// `selected_entries()` just to take its length.
+    pub fn selected_count(&self) -> usize {
+        let Some(depth) = self.active_column else {
+            return 0;
+        };
+        let Some(column) = self.columns.get(depth) else {
+            return 0;
+        };
+        column.selected_locations.len()
+    }
 
     pub fn selected_entries(&self) -> Vec<FileEntry> {
         let Some(depth) = self.active_column else {
@@ -818,7 +935,50 @@ impl NavigationState {
         let entry = column.entries.get(position)?.clone();
         Some((depth, position, entry))
     }
+    /// Depth and current entry count for an owned in-flight load. Callers
+    /// use the count to tell first paint (applies at once) from later
+    /// batches (which coalesce), and the depth to accumulate per column.
+    pub fn loading_column(&self, request_id: RequestId) -> Option<(usize, usize)> {
+        self.columns.iter().enumerate().find_map(|(depth, column)| {
+            (column.request_id == request_id).then_some((depth, column.entries.len()))
+        })
+    }
 
+    /// Positions and locations of listed entries still missing size or
+    /// modification time. Directories qualify for their modification time;
+    /// directory size stays unknown by design and never qualifies.
+    pub fn column_unknown_metadata(&self, depth: usize) -> Option<Vec<(usize, Location)>> {
+        let column = self.columns.get(depth)?;
+        let gap: Vec<(usize, Location)> = column
+            .entries
+            .iter()
+            .enumerate()
+            .filter(|(_, entry)| {
+                entry.modified_unix_seconds == MetadataValue::Unknown
+                    || (!entry.is_directory() && entry.size == MetadataValue::Unknown)
+            })
+            .map(|(position, entry)| (position, entry.location.clone()))
+            .collect();
+        if gap.is_empty() {
+            return None;
+        }
+        Some(gap)
+    }
+
+    /// Current load request for a depth, for follow-up requests (metadata
+    /// fills) that must die with a reload.
+    pub fn request_id_for_depth(&self, depth: usize) -> Option<RequestId> {
+        self.columns.get(depth).map(|column| column.request_id)
+    }
+
+    /// Depth currently owned by a load request, for routing fill terminals
+    /// back to their column. Returns `None` for superseded loads whose
+    /// columns reloaded or truncated away.
+    pub fn depth_for_request(&self, request_id: RequestId) -> Option<usize> {
+        self.columns
+            .iter()
+            .position(|column| column.request_id == request_id)
+    }
     fn column_for_request_mut(
         &mut self,
         request_id: RequestId,
@@ -828,6 +988,23 @@ impl NavigationState {
             .enumerate()
             .find(|(_, column)| column.request_id == request_id)
     }
+}
+
+/// Applies one fill update to an entry without clobbering known fields with
+/// placeholders. Returns whether any field actually changed.
+fn apply_metadata_update(entry: &mut FileEntry, update: &MetadataUpdate) -> bool {
+    let mut changed = false;
+    if update.size != MetadataValue::Unknown && entry.size != update.size {
+        entry.size = update.size.clone();
+        changed = true;
+    }
+    if update.modified_unix_seconds != MetadataValue::Unknown
+        && entry.modified_unix_seconds != update.modified_unix_seconds
+    {
+        entry.modified_unix_seconds = update.modified_unix_seconds.clone();
+        changed = true;
+    }
+    changed
 }
 
 fn merge_entries(
@@ -881,6 +1058,18 @@ fn merge_entries(
     }
 
     (merged, insertions)
+}
+
+/// Sorts a complete staged snapshot once, off the main thread. Unstable:
+/// display-name and location tie-breakers in `compare_entries` order
+/// distinct entries deterministically, so repeated loads present
+/// deterministic rows. Callers move the vector in and out with no copies.
+pub(crate) fn sort_entries(
+    mut entries: Vec<FileEntry>,
+    preferences: ViewPreferences,
+) -> Vec<FileEntry> {
+    entries.sort_unstable_by(|left, right| compare_entries(left, right, preferences));
+    entries
 }
 
 fn remove_monitored_entry(

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -290,10 +290,7 @@ impl NavigationState {
         Some((depth, insertions))
     }
 
-    /// Installs a complete staged snapshot for a native initial load,
-    /// entries arrive pre-sorted, so no merge walk runs. Restores the pending
-    /// selection target and first-on-load selection exactly like a batch
-    /// would; the caller marks the load finished and publishes afterwards.
+    /// Entries must arrive pre-sorted; the caller marks the load finished and publishes.
     pub fn install_snapshot(
         &mut self,
         request_id: RequestId,
@@ -311,29 +308,29 @@ impl NavigationState {
             }
         }
         if column.select_first_on_load && !column.entries.is_empty() {
-            let location = column.entries[0].location.clone();
-            column.selected = Some(0);
-            column.selected_locations.clear();
-            column.selected_locations.insert(location.clone());
-            column.selection_anchor = Some(location);
-            column.select_first_on_load = false;
+            let first_visible = column
+                .entries
+                .iter()
+                .position(|entry| column.preferences.show_hidden || !entry.is_hidden);
+            if let Some(position) = first_visible {
+                let location = column.entries[position].location.clone();
+                column.selected = Some(position);
+                column.selected_locations.clear();
+                column.selected_locations.insert(location.clone());
+                column.selection_anchor = Some(location);
+                column.select_first_on_load = false;
+            }
         }
         Some(depth)
     }
 
-    /// Depth of a still-open native load, if `request_id` belongs to one.
-    /// Finished, failed, peek, and unknown requests report `None`.
     pub fn open_load_depth(&self, request_id: RequestId) -> Option<usize> {
         self.columns.iter().enumerate().find_map(|(depth, column)| {
             (column.request_id == request_id && column.load_state == LoadState::Loading)
                 .then_some(depth)
         })
     }
-    /// Returns the depth and the changed positions so views can refresh those
-    /// rows in place; the order never changes here. Fills for a superseded
-    /// load match no column and are dropped. Fields arrive independently: a
-    /// fill that only learned the mtime must not clobber a known size with
-    /// a placeholder, and rows whose values did not change are not reported.
+    /// Order never changes, so views can refresh rows in place.
     pub fn apply_metadata(
         &mut self,
         request_id: RequestId,
@@ -358,13 +355,7 @@ impl NavigationState {
         Some((depth, positions))
     }
 
-    /// Applies fill updates captured with stable `(position, Location)`
-    /// tokens, in O(number of requested rows). Each token is validated: the
-    /// same location must still occupy the position, otherwise the row moved
-    /// under the fill and the update is reported stale. Stale rows keep
-    /// their placeholders and are re-requested on their next bind, so only
-    /// stale rows retry. Returns the depth, the applied positions, and the
-    /// stale locations.
+    /// Stale rows keep their placeholders and retry on the next bind.
     pub fn apply_positioned_metadata(
         &mut self,
         request_id: RequestId,
@@ -542,8 +533,7 @@ impl NavigationState {
             .and_then(|position| column.entries.get(position))
             .map(|entry| entry.location.clone());
         column.preferences = preferences;
-        // Unstable, matching sort-once publication: display-name and location
-        // tie-breakers in `compare_entries` keep distinct entries ordered.
+        // Unstable: tie-breakers in `compare_entries` keep distinct entries ordered.
         column
             .entries
             .sort_unstable_by(|left, right| compare_entries(left, right, preferences));
@@ -775,9 +765,7 @@ impl NavigationState {
             })
             .collect()
     }
-    /// Number of selected entries in the active column. Clone-free: the
-    /// hot selection paths log and gate on this instead of materializing
-    /// `selected_entries()` just to take its length.
+    /// Clone-free length for hot selection paths.
     pub fn selected_count(&self) -> usize {
         let Some(depth) = self.active_column else {
             return 0;
@@ -935,18 +923,13 @@ impl NavigationState {
         let entry = column.entries.get(position)?.clone();
         Some((depth, position, entry))
     }
-    /// Depth and current entry count for an owned in-flight load. Callers
-    /// use the count to tell first paint (applies at once) from later
-    /// batches (which coalesce), and the depth to accumulate per column.
     pub fn loading_column(&self, request_id: RequestId) -> Option<(usize, usize)> {
         self.columns.iter().enumerate().find_map(|(depth, column)| {
             (column.request_id == request_id).then_some((depth, column.entries.len()))
         })
     }
 
-    /// Positions and locations of listed entries still missing size or
-    /// modification time. Directories qualify for their modification time;
-    /// directory size stays unknown by design and never qualifies.
+    /// Directories qualify for mtime only; directory size stays unknown by design.
     pub fn column_unknown_metadata(&self, depth: usize) -> Option<Vec<(usize, Location)>> {
         let column = self.columns.get(depth)?;
         let gap: Vec<(usize, Location)> = column
@@ -965,15 +948,11 @@ impl NavigationState {
         Some(gap)
     }
 
-    /// Current load request for a depth, for follow-up requests (metadata
-    /// fills) that must die with a reload.
+    /// Follow-up fills using this request die with a reload.
     pub fn request_id_for_depth(&self, depth: usize) -> Option<RequestId> {
         self.columns.get(depth).map(|column| column.request_id)
     }
 
-    /// Depth currently owned by a load request, for routing fill terminals
-    /// back to their column. Returns `None` for superseded loads whose
-    /// columns reloaded or truncated away.
     pub fn depth_for_request(&self, request_id: RequestId) -> Option<usize> {
         self.columns
             .iter()
@@ -990,8 +969,6 @@ impl NavigationState {
     }
 }
 
-/// Applies one fill update to an entry without clobbering known fields with
-/// placeholders. Returns whether any field actually changed.
 fn apply_metadata_update(entry: &mut FileEntry, update: &MetadataUpdate) -> bool {
     let mut changed = false;
     if update.size != MetadataValue::Unknown && entry.size != update.size {
@@ -1060,10 +1037,6 @@ fn merge_entries(
     (merged, insertions)
 }
 
-/// Sorts a complete staged snapshot once, off the main thread. Unstable:
-/// display-name and location tie-breakers in `compare_entries` order
-/// distinct entries deterministically, so repeated loads present
-/// deterministic rows. Callers move the vector in and out with no copies.
 pub(crate) fn sort_entries(
     mut entries: Vec<FileEntry>,
     preferences: ViewPreferences,
@@ -1130,9 +1103,14 @@ fn compare_entries(left: &FileEntry, right: &FileEntry, preferences: ViewPrefere
 }
 
 fn compare_display_names(left: &str, right: &str) -> Ordering {
-    glib::casefold(left)
-        .cmp(&glib::casefold(right))
-        .then_with(|| left.cmp(right))
+    let folded = if left.is_ascii() && right.is_ascii() {
+        left.bytes()
+            .map(|byte| byte.to_ascii_lowercase())
+            .cmp(right.bytes().map(|byte| byte.to_ascii_lowercase()))
+    } else {
+        glib::casefold(left).cmp(&glib::casefold(right))
+    };
+    folded.then_with(|| left.cmp(right))
 }
 
 fn compare_metadata<T: Ord>(left: &MetadataValue<T>, right: &MetadataValue<T>) -> Ordering {

--- a/src/app/navigation/tests.rs
+++ b/src/app/navigation/tests.rs
@@ -25,7 +25,6 @@ fn named_entry(path: &str, name: &str) -> FileEntry {
         size: MetadataValue::Unknown,
         modified_unix_seconds: MetadataValue::Unknown,
         is_hidden: false,
-        is_hidden: false,
     }
 }
 
@@ -656,6 +655,7 @@ fn file_entry(path: &str, name: &str) -> FileEntry {
         kind: EntryKind::File,
         size: MetadataValue::Unknown,
         modified_unix_seconds: MetadataValue::Unknown,
+        is_hidden: false,
     }
 }
 

--- a/src/app/navigation/tests.rs
+++ b/src/app/navigation/tests.rs
@@ -25,6 +25,7 @@ fn named_entry(path: &str, name: &str) -> FileEntry {
         size: MetadataValue::Unknown,
         modified_unix_seconds: MetadataValue::Unknown,
         is_hidden: false,
+        is_hidden: false,
     }
 }
 
@@ -574,7 +575,7 @@ fn changing_sort_preferences_preserves_the_selected_entry() {
 
     assert!(
         state
-            .set_column_preferences(
+            .apply_sort_preferences(
                 0,
                 ViewPreferences {
                     sort_direction: SortDirection::Descending,
@@ -605,7 +606,7 @@ fn changed_sort_preferences_are_inherited_by_new_columns() {
         ..ViewPreferences::default()
     };
 
-    assert!(state.set_column_preferences(0, preferences).is_some());
+    assert!(state.apply_sort_preferences(0, preferences).is_some());
     assert!(state.descend(0, location("/fixture/child"), RequestId(2)));
 
     assert_eq!(state.column_preferences(1), Some(preferences));
@@ -633,7 +634,7 @@ fn changing_sort_preferences_only_reorders_the_target_column() {
 
     assert!(
         state
-            .set_column_preferences(
+            .apply_sort_preferences(
                 1,
                 ViewPreferences {
                     sort_direction: SortDirection::Descending,
@@ -645,4 +646,224 @@ fn changing_sort_preferences_only_reorders_the_target_column() {
 
     assert_eq!(state.columns[0].entries[0].display_name, "a");
     assert_eq!(state.columns[1].entries[0].display_name, "z");
+}
+
+fn file_entry(path: &str, name: &str) -> FileEntry {
+    FileEntry {
+        location: location(path),
+        native_name: OsString::from(name),
+        display_name: name.into(),
+        kind: EntryKind::File,
+        size: MetadataValue::Unknown,
+        modified_unix_seconds: MetadataValue::Unknown,
+    }
+}
+
+fn metadata_update(path: &str, size: u64, modified: i64) -> MetadataUpdate {
+    MetadataUpdate {
+        location: location(path),
+        size: MetadataValue::Known(size),
+        modified_unix_seconds: MetadataValue::Known(modified),
+    }
+}
+
+#[test]
+fn metadata_fill_updates_values_without_reordering() {
+    let mut state = NavigationState::default();
+    state.navigate(location("/fixture"), RequestId(1));
+    state.apply_batch(
+        RequestId(1),
+        vec![
+            file_entry("/fixture/bravo", "bravo"),
+            file_entry("/fixture/alpha", "alpha"),
+        ],
+    );
+    let order_before: Vec<_> = state.columns[0]
+        .entries
+        .iter()
+        .map(|entry| entry.display_name.clone())
+        .collect();
+
+    let applied = state.apply_metadata(
+        RequestId(1),
+        vec![
+            metadata_update("/fixture/alpha", 10, 100),
+            metadata_update("/fixture/bravo", 20, 200),
+        ],
+    );
+
+    assert_eq!(applied, Some((0, vec![0, 1])));
+    let entries = &state.columns[0].entries;
+    assert_eq!(entries[0].size, MetadataValue::Known(10));
+    assert_eq!(entries[1].modified_unix_seconds, MetadataValue::Known(200));
+    let order_after: Vec<_> = entries
+        .iter()
+        .map(|entry| entry.display_name.clone())
+        .collect();
+    assert_eq!(order_before, order_after);
+}
+
+#[test]
+fn metadata_fill_for_a_superseded_load_is_dropped() {
+    let mut state = NavigationState::default();
+    state.navigate(location("/fixture"), RequestId(1));
+    state.apply_batch(RequestId(1), vec![file_entry("/fixture/alpha", "alpha")]);
+
+    assert_eq!(
+        state.apply_metadata(
+            RequestId(2),
+            vec![metadata_update("/fixture/alpha", 10, 100)]
+        ),
+        None
+    );
+    assert_eq!(
+        state.apply_metadata(
+            RequestId(1),
+            vec![metadata_update("/fixture/ghost", 10, 100)]
+        ),
+        None
+    );
+    assert_eq!(state.columns[0].entries[0].size, MetadataValue::Unknown);
+}
+
+#[test]
+fn depth_for_request_tracks_live_loads_only() {
+    let mut state = NavigationState::default();
+    state.navigate(location("/fixture"), RequestId(1));
+    assert_eq!(state.depth_for_request(RequestId(1)), Some(0));
+    assert_eq!(state.depth_for_request(RequestId(9)), None);
+
+    assert!(state.descend(0, location("/fixture/sub"), RequestId(2)));
+    assert_eq!(state.depth_for_request(RequestId(2)), Some(1));
+
+    // Reloading a depth retires its old request identity.
+    state.reload_column(0, RequestId(3));
+    assert_eq!(state.depth_for_request(RequestId(1)), None);
+    assert_eq!(state.depth_for_request(RequestId(3)), Some(0));
+}
+
+#[test]
+fn positioned_fill_applies_in_place_and_flags_moved_rows() {
+    let mut state = NavigationState::default();
+    state.navigate(location("/fixture"), RequestId(1));
+    state.apply_batch(
+        RequestId(1),
+        vec![
+            file_entry("/fixture/alpha", "alpha"),
+            file_entry("/fixture/bravo", "bravo"),
+            file_entry("/fixture/charlie", "charlie"),
+        ],
+    );
+
+    // Tokens captured at bind time: everything lines up.
+    let applied = state.apply_positioned_metadata(
+        RequestId(1),
+        vec![
+            (0, metadata_update("/fixture/alpha", 30, 100)),
+            (2, metadata_update("/fixture/charlie", 10, 200)),
+        ],
+    );
+    assert!(
+        matches!(applied, Some((0, ref positions, ref stale)) if positions == &[0, 2] && stale.is_empty())
+    );
+    assert_eq!(state.columns[0].entries[0].size, MetadataValue::Known(30));
+
+    // The head row leaves: remaining rows shift, so old tokens go stale
+    // instead of painting the wrong rows.
+    state.columns[0].entries.remove(0);
+    let applied = state.apply_positioned_metadata(
+        RequestId(1),
+        vec![
+            (1, metadata_update("/fixture/bravo", 20, 150)),
+            (2, metadata_update("/fixture/charlie", 10, 200)),
+        ],
+    );
+    assert!(
+        matches!(applied, Some((0, ref positions, ref stale)) if positions.is_empty() && stale.len() == 2)
+    );
+    // Stale rows keep their placeholders for the next bind's retry.
+    assert_eq!(state.columns[0].entries[0].size, MetadataValue::Unknown);
+}
+
+#[test]
+fn fill_updates_never_clobber_known_fields() {
+    let mut state = NavigationState::default();
+    state.navigate(location("/fixture"), RequestId(1));
+    let mut half_known = file_entry("/fixture/half", "half");
+    half_known.size = MetadataValue::Known(50);
+    state.apply_batch(RequestId(1), vec![half_known]);
+
+    // The fill only learned the mtime: the known size survives.
+    let applied = state.apply_metadata(
+        RequestId(1),
+        vec![MetadataUpdate {
+            location: location("/fixture/half"),
+            size: MetadataValue::Unknown,
+            modified_unix_seconds: MetadataValue::Known(300),
+        }],
+    );
+    assert!(matches!(applied, Some((0, ref positions)) if positions == &[0]));
+    assert_eq!(state.columns[0].entries[0].size, MetadataValue::Known(50));
+    assert_eq!(
+        state.columns[0].entries[0].modified_unix_seconds,
+        MetadataValue::Known(300)
+    );
+
+    // A fill carrying nothing new reports nothing.
+    let applied = state.apply_metadata(
+        RequestId(1),
+        vec![MetadataUpdate {
+            location: location("/fixture/half"),
+            size: MetadataValue::Unknown,
+            modified_unix_seconds: MetadataValue::Unknown,
+        }],
+    );
+    assert_eq!(applied, None);
+}
+
+#[test]
+fn gap_targets_cover_directory_mtimes_but_never_directory_sizes() {
+    let mut state = NavigationState::default();
+    state.navigate(location("/fixture"), RequestId(1));
+    let mut complete_file = file_entry("/fixture/done", "done");
+    complete_file.size = MetadataValue::Known(5);
+    complete_file.modified_unix_seconds = MetadataValue::Known(60);
+    let mut half_file = file_entry("/fixture/half", "half");
+    half_file.size = MetadataValue::Known(50);
+    state.apply_batch(
+        RequestId(1),
+        vec![named_entry("/fixture/sub", "sub"), complete_file, half_file],
+    );
+
+    // The directory qualifies for its mtime and the half-known file for its
+    // mtime; the complete file needs nothing.
+    assert_eq!(
+        state.column_unknown_metadata(0).map(|targets| {
+            targets
+                .into_iter()
+                .map(|(position, location)| (position, location.display_path()))
+                .collect::<Vec<_>>()
+        }),
+        Some(vec![
+            (0, "/fixture/sub".to_owned()),
+            (2, "/fixture/half".to_owned()),
+        ])
+    );
+}
+
+#[test]
+fn selected_count_reports_without_cloning_entries() {
+    let mut state = NavigationState::default();
+    state.navigate(location("/fixture"), RequestId(1));
+    state.apply_batch(
+        RequestId(1),
+        vec![
+            named_entry("/fixture/alpha", "alpha"),
+            named_entry("/fixture/bravo", "bravo"),
+            named_entry("/fixture/charlie", "charlie"),
+        ],
+    );
+    assert_eq!(state.selected_count(), 0);
+    assert!(state.set_selection(0, &[0, 2], Some(2)));
+    assert_eq!(state.selected_count(), 2);
 }

--- a/src/app/navigation/tests.rs
+++ b/src/app/navigation/tests.rs
@@ -423,6 +423,25 @@ fn keyboard_selection_skips_hidden_entries_when_hidden_files_are_not_shown() {
 }
 
 #[test]
+fn staged_keyboard_descent_selects_the_first_visible_entry() {
+    let mut state = NavigationState::default();
+    state.navigate(location("/home"), RequestId(1));
+    state.select_first_on_load(0);
+    state.install_snapshot(
+        RequestId(1),
+        vec![
+            hidden_entry("/home/.hidden", ".hidden"),
+            named_entry("/home/visible", "visible"),
+        ],
+    );
+
+    assert_eq!(
+        state.focused_entry().map(|(_, position, _)| position),
+        Some(1)
+    );
+}
+
+#[test]
 fn keyboard_selection_extension_skips_hidden_entries() {
     let mut state = NavigationState::default();
     state.navigate(location("/home"), RequestId(1));
@@ -736,7 +755,6 @@ fn depth_for_request_tracks_live_loads_only() {
     assert!(state.descend(0, location("/fixture/sub"), RequestId(2)));
     assert_eq!(state.depth_for_request(RequestId(2)), Some(1));
 
-    // Reloading a depth retires its old request identity.
     state.reload_column(0, RequestId(3));
     assert_eq!(state.depth_for_request(RequestId(1)), None);
     assert_eq!(state.depth_for_request(RequestId(3)), Some(0));
@@ -755,7 +773,6 @@ fn positioned_fill_applies_in_place_and_flags_moved_rows() {
         ],
     );
 
-    // Tokens captured at bind time: everything lines up.
     let applied = state.apply_positioned_metadata(
         RequestId(1),
         vec![
@@ -768,8 +785,6 @@ fn positioned_fill_applies_in_place_and_flags_moved_rows() {
     );
     assert_eq!(state.columns[0].entries[0].size, MetadataValue::Known(30));
 
-    // The head row leaves: remaining rows shift, so old tokens go stale
-    // instead of painting the wrong rows.
     state.columns[0].entries.remove(0);
     let applied = state.apply_positioned_metadata(
         RequestId(1),
@@ -781,7 +796,6 @@ fn positioned_fill_applies_in_place_and_flags_moved_rows() {
     assert!(
         matches!(applied, Some((0, ref positions, ref stale)) if positions.is_empty() && stale.len() == 2)
     );
-    // Stale rows keep their placeholders for the next bind's retry.
     assert_eq!(state.columns[0].entries[0].size, MetadataValue::Unknown);
 }
 
@@ -793,7 +807,6 @@ fn fill_updates_never_clobber_known_fields() {
     half_known.size = MetadataValue::Known(50);
     state.apply_batch(RequestId(1), vec![half_known]);
 
-    // The fill only learned the mtime: the known size survives.
     let applied = state.apply_metadata(
         RequestId(1),
         vec![MetadataUpdate {
@@ -809,7 +822,6 @@ fn fill_updates_never_clobber_known_fields() {
         MetadataValue::Known(300)
     );
 
-    // A fill carrying nothing new reports nothing.
     let applied = state.apply_metadata(
         RequestId(1),
         vec![MetadataUpdate {
@@ -835,8 +847,6 @@ fn gap_targets_cover_directory_mtimes_but_never_directory_sizes() {
         vec![named_entry("/fixture/sub", "sub"), complete_file, half_file],
     );
 
-    // The directory qualifies for its mtime and the half-known file for its
-    // mtime; the complete file needs nothing.
     assert_eq!(
         state.column_unknown_metadata(0).map(|targets| {
             targets

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,13 +87,9 @@ fn restart_with_local_vfs_if_gvfs_is_unresponsive() {
     if std::env::var_os("GIO_USE_VFS").is_some() {
         return;
     }
-    // A healthy probe costs a full subprocess spawn (~60 ms warm) on every
-    // launch. Remember the probed daemon generation instead: a wedged GVfs
-    // daemon persists for the boot, so the first launch still catches it,
-    // while the rest skip straight to startup. A daemon restart changes its
-    // kernel pid, which re-arms the probe; a daemon wedging in place under
-    // the same pid is not detected (documented residual: the probe timeout
-    // bounded the original detection, and no cheap identity survives that).
+    // Skip the subprocess probe when the marker matches the current `gvfsd`
+    // generation; a daemon restart (new pid) re-arms it. A daemon wedging
+    // under the same pid is not detected.
     if gvfs_probe_marker_is_fresh() {
         return;
     }
@@ -114,9 +110,7 @@ fn restart_with_local_vfs_if_gvfs_is_unresponsive() {
         return;
     }
 
-    eprintln!(
-        "GVFS is unresponsive; using local filesystem and volume support for this session."
-    );
+    eprintln!("GVFS is unresponsive; using local filesystem and volume support for this session.");
     let error = std::process::Command::new(executable)
         .args(std::env::args_os().skip(1))
         .envs(GIO_FALLBACK_BACKENDS)
@@ -136,10 +130,8 @@ fn gvfs_probe_marker_path_in(runtime: Option<std::ffi::OsString>) -> Option<std:
     Some(std::path::Path::new(&runtime).join("strata-gvfs-probe-ok"))
 }
 
-/// Kernel pids currently owned by a `gvfsd` process, sorted. Read straight
-/// from `/proc` so a healthy launch pays directory reads instead of a
-/// subprocess spawn. Matches the `gvfsd*` family (daemon, fuse, trash):
-/// any of them restarting re-arms the probe.
+/// Kernel pids of `gvfsd*` processes, read from `/proc` to avoid a subprocess
+/// spawn; any restart re-arms the probe.
 fn gvfs_daemon_pids(proc_root: &std::path::Path) -> Vec<u32> {
     let mut pids = Vec::new();
     let Ok(entries) = std::fs::read_dir(proc_root) else {
@@ -172,8 +164,14 @@ fn gvfs_probe_marker_is_fresh() -> bool {
     let Some(path) = gvfs_probe_marker_path() else {
         return false;
     };
-    let stored = std::fs::read_to_string(&path).unwrap_or_default();
-    stored == encode_daemon_pids(&gvfs_daemon_pids(std::path::Path::new("/proc")))
+    gvfs_probe_marker_is_fresh_at(&path, std::path::Path::new("/proc"))
+}
+
+fn gvfs_probe_marker_is_fresh_at(path: &std::path::Path, proc_root: &std::path::Path) -> bool {
+    let Ok(stored) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    stored == encode_daemon_pids(&gvfs_daemon_pids(proc_root))
 }
 
 fn write_gvfs_probe_marker() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,8 @@ use gtk::{gio, prelude::*};
 const APPLICATION_ID: &str = "io.github.lgse.Strata";
 const GVFS_PROBE_ARGUMENT: &str = "--gvfs-probe";
 const GVFS_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+const GIO_FALLBACK_BACKENDS: [(&str, &str); 2] =
+    [("GIO_USE_VFS", "local"), ("GIO_USE_VOLUME_MONITOR", "unix")];
 
 fn main() -> gtk::glib::ExitCode {
     let arguments: Vec<_> = std::env::args().collect();
@@ -112,12 +114,14 @@ fn restart_with_local_vfs_if_gvfs_is_unresponsive() {
         return;
     }
 
-    eprintln!("GVFS is unresponsive; using local filesystem support for this session.");
+    eprintln!(
+        "GVFS is unresponsive; using local filesystem and volume support for this session."
+    );
     let error = std::process::Command::new(executable)
         .args(std::env::args_os().skip(1))
-        .env("GIO_USE_VFS", "local")
+        .envs(GIO_FALLBACK_BACKENDS)
         .exec();
-    eprintln!("Unable to restart Strata with local filesystem support: {error}");
+    eprintln!("Unable to restart Strata with local filesystem and volume support: {error}");
 }
 
 fn gvfs_probe_marker_path() -> Option<std::path::PathBuf> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,16 +44,29 @@ fn main() -> gtk::glib::ExitCode {
         return gtk::glib::ExitCode::SUCCESS;
     }
 
-    restart_with_local_vfs_if_gvfs_is_unresponsive();
-
     metrics::initialize();
     if let Err(error) = tracing_subscriber::fmt::try_init() {
         eprintln!("Unable to initialize logging: {error}");
     }
 
+    // Timed from here so `window presented` covers the whole launch, the way
+    // the field harness measures mapped from process start.
+    let launched = std::time::Instant::now();
+    restart_with_local_vfs_if_gvfs_is_unresponsive();
+    tracing::debug!(
+        elapsed_ms = launched.elapsed().as_millis() as u64,
+        "startup gvfs probe finished"
+    );
+
+    let assets_started = std::time::Instant::now();
     if let Err(error) = assets::prepare() {
         eprintln!("Unable to prepare bundled assets: {error}");
     }
+    tracing::debug!(
+        elapsed_ms = assets_started.elapsed().as_millis() as u64,
+        total_elapsed_ms = launched.elapsed().as_millis() as u64,
+        "startup bundled assets prepared"
+    );
 
     let application = gtk::Application::builder()
         .application_id(APPLICATION_ID)
@@ -72,6 +85,16 @@ fn restart_with_local_vfs_if_gvfs_is_unresponsive() {
     if std::env::var_os("GIO_USE_VFS").is_some() {
         return;
     }
+    // A healthy probe costs a full subprocess spawn (~60 ms warm) on every
+    // launch. Remember the probed daemon generation instead: a wedged GVfs
+    // daemon persists for the boot, so the first launch still catches it,
+    // while the rest skip straight to startup. A daemon restart changes its
+    // kernel pid, which re-arms the probe; a daemon wedging in place under
+    // the same pid is not detected (documented residual: the probe timeout
+    // bounded the original detection, and no cheap identity survives that).
+    if gvfs_probe_marker_is_fresh() {
+        return;
+    }
     let Ok(executable) = std::env::current_exe() else {
         return;
     };
@@ -85,6 +108,7 @@ fn restart_with_local_vfs_if_gvfs_is_unresponsive() {
     )
     .unwrap_or(true);
     if responsive {
+        write_gvfs_probe_marker();
         return;
     }
 
@@ -95,3 +119,69 @@ fn restart_with_local_vfs_if_gvfs_is_unresponsive() {
         .exec();
     eprintln!("Unable to restart Strata with local filesystem support: {error}");
 }
+
+fn gvfs_probe_marker_path() -> Option<std::path::PathBuf> {
+    gvfs_probe_marker_path_in(std::env::var_os("XDG_RUNTIME_DIR"))
+}
+
+fn gvfs_probe_marker_path_in(runtime: Option<std::ffi::OsString>) -> Option<std::path::PathBuf> {
+    let runtime = runtime?;
+    if runtime.is_empty() {
+        return None;
+    }
+    Some(std::path::Path::new(&runtime).join("strata-gvfs-probe-ok"))
+}
+
+/// Kernel pids currently owned by a `gvfsd` process, sorted. Read straight
+/// from `/proc` so a healthy launch pays directory reads instead of a
+/// subprocess spawn. Matches the `gvfsd*` family (daemon, fuse, trash):
+/// any of them restarting re-arms the probe.
+fn gvfs_daemon_pids(proc_root: &std::path::Path) -> Vec<u32> {
+    let mut pids = Vec::new();
+    let Ok(entries) = std::fs::read_dir(proc_root) else {
+        return pids;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(pid): Option<u32> = name.to_str().and_then(|name| name.parse().ok()) else {
+            continue;
+        };
+        let comm = entry.path().join("comm");
+        if std::fs::read_to_string(comm)
+            .is_ok_and(|contents| contents.trim_end().starts_with("gvfsd"))
+        {
+            pids.push(pid);
+        }
+    }
+    pids.sort_unstable();
+    pids
+}
+
+fn encode_daemon_pids(pids: &[u32]) -> String {
+    pids.iter()
+        .map(u32::to_string)
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn gvfs_probe_marker_is_fresh() -> bool {
+    let Some(path) = gvfs_probe_marker_path() else {
+        return false;
+    };
+    let stored = std::fs::read_to_string(&path).unwrap_or_default();
+    stored == encode_daemon_pids(&gvfs_daemon_pids(std::path::Path::new("/proc")))
+}
+
+fn write_gvfs_probe_marker() {
+    let Some(path) = gvfs_probe_marker_path() else {
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        let _ignored = std::fs::create_dir_all(parent);
+    }
+    let contents = encode_daemon_pids(&gvfs_daemon_pids(std::path::Path::new("/proc")));
+    let _ignored = std::fs::write(&path, contents);
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3,13 +3,23 @@
 use std::{
     sync::{
         OnceLock,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
     },
     time::Instant,
 };
 
 static STARTED: OnceLock<Instant> = OnceLock::new();
 static FIRST_BATCH_RENDERED: AtomicBool = AtomicBool::new(false);
+static FIRST_THEMED_FRAME: AtomicBool = AtomicBool::new(false);
+static FIRST_VISIBLE_ROW: AtomicBool = AtomicBool::new(false);
+
+static THUMB_ELIGIBLE: AtomicU64 = AtomicU64::new(0);
+static THUMB_REQUESTED: AtomicU64 = AtomicU64::new(0);
+static THUMB_STARTED: AtomicU64 = AtomicU64::new(0);
+static THUMB_COMPLETED: AtomicU64 = AtomicU64::new(0);
+static THUMB_APPLIED: AtomicU64 = AtomicU64::new(0);
+static THUMB_CANCELLED: AtomicU64 = AtomicU64::new(0);
+static THUMB_STALE: AtomicU64 = AtomicU64::new(0);
 
 pub fn initialize() {
     let _started = STARTED.set(Instant::now());
@@ -22,6 +32,51 @@ pub fn mark_window_presented() {
             "application window presented"
         );
     }
+}
+
+/// First themed frame / after-paint signal. Emitted once per process; the
+/// field harness parses this line for the cold/warm first-frame metric.
+pub fn mark_first_themed_frame() {
+    if FIRST_THEMED_FRAME.swap(true, Ordering::Relaxed) {
+        return;
+    }
+    if let Some(started) = STARTED.get() {
+        tracing::info!(
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "first themed frame painted"
+        );
+    }
+}
+
+/// First correct visible row installed into a GTK model. Emitted once per
+/// process so paired runs can compare identical-work first-content latency.
+pub fn mark_first_visible_row(entries: usize) {
+    if FIRST_VISIBLE_ROW.swap(true, Ordering::Relaxed) {
+        return;
+    }
+    if let Some(started) = STARTED.get() {
+        tracing::info!(
+            entries,
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "first correct visible row published"
+        );
+    }
+}
+
+/// Stage timing for enumeration, stat, sort, state-install, and UI
+/// publication slices. Narrowly scoped: callers time their own slice and
+/// report it here so the harness can attribute wall time without extra
+/// global state.
+pub fn record_stage(stage: &str, elapsed_ms: u64) {
+    tracing::debug!(stage, elapsed_ms, "directory stage completed");
+}
+
+/// Input-event to presented-frame latency probe. Callers capture the event
+/// instant and report it when the resulting frame is presented. Frame-clock
+/// plumbing lands with Task 11 (scroll/filter/select-all input paths).
+#[expect(dead_code, reason = "frame-clock plumbing lands with Task 11")]
+pub fn record_input_latency(elapsed_ms: u64) {
+    tracing::debug!(elapsed_ms, "input event to presented frame");
 }
 
 pub fn mark_batch_rendered(entries: usize, render_started: Instant) {
@@ -37,5 +92,98 @@ pub fn mark_batch_rendered(entries: usize, render_started: Instant) {
             elapsed_ms = started.elapsed().as_millis() as u64,
             "first directory batch rendered"
         );
+        mark_first_visible_row(entries);
     }
 }
+
+/// Thumbnail pipeline counters. Each transition logs at debug and bumps a
+/// process-wide counter the harness can scrape at settle time.
+pub fn mark_thumbnail_eligible(count: u64) {
+    THUMB_ELIGIBLE.fetch_add(count, Ordering::Relaxed);
+    tracing::debug!(
+        count,
+        total = THUMB_ELIGIBLE.load(Ordering::Relaxed),
+        "thumbnails eligible"
+    );
+}
+
+pub fn mark_thumbnail_requested(uri: &str) {
+    THUMB_REQUESTED.fetch_add(1, Ordering::Relaxed);
+    tracing::debug!(
+        uri,
+        total = THUMB_REQUESTED.load(Ordering::Relaxed),
+        "thumbnail requested"
+    );
+}
+
+pub fn mark_thumbnail_started(uri: &str) {
+    THUMB_STARTED.fetch_add(1, Ordering::Relaxed);
+    tracing::debug!(
+        uri,
+        total = THUMB_STARTED.load(Ordering::Relaxed),
+        "thumbnail started"
+    );
+}
+
+pub fn mark_thumbnail_completed(uri: &str) {
+    THUMB_COMPLETED.fetch_add(1, Ordering::Relaxed);
+    tracing::debug!(
+        uri,
+        total = THUMB_COMPLETED.load(Ordering::Relaxed),
+        "thumbnail completed"
+    );
+}
+
+pub fn mark_thumbnail_applied(uri: &str) {
+    THUMB_APPLIED.fetch_add(1, Ordering::Relaxed);
+    tracing::debug!(
+        uri,
+        total = THUMB_APPLIED.load(Ordering::Relaxed),
+        "thumbnail applied"
+    );
+}
+
+pub fn mark_thumbnail_cancelled(uri: &str) {
+    THUMB_CANCELLED.fetch_add(1, Ordering::Relaxed);
+    tracing::debug!(
+        uri,
+        total = THUMB_CANCELLED.load(Ordering::Relaxed),
+        "thumbnail cancelled"
+    );
+}
+
+pub fn mark_thumbnail_stale(uri: &str) {
+    THUMB_STALE.fetch_add(1, Ordering::Relaxed);
+    tracing::debug!(
+        uri,
+        total = THUMB_STALE.load(Ordering::Relaxed),
+        "thumbnail stale"
+    );
+}
+
+/// Snapshot of every pipeline counter for settle-time reporting.
+pub fn thumbnail_counts() -> ThumbnailCounts {
+    ThumbnailCounts {
+        eligible: THUMB_ELIGIBLE.load(Ordering::Relaxed),
+        requested: THUMB_REQUESTED.load(Ordering::Relaxed),
+        started: THUMB_STARTED.load(Ordering::Relaxed),
+        completed: THUMB_COMPLETED.load(Ordering::Relaxed),
+        applied: THUMB_APPLIED.load(Ordering::Relaxed),
+        cancelled: THUMB_CANCELLED.load(Ordering::Relaxed),
+        stale: THUMB_STALE.load(Ordering::Relaxed),
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ThumbnailCounts {
+    pub eligible: u64,
+    pub requested: u64,
+    pub started: u64,
+    pub completed: u64,
+    pub applied: u64,
+    pub cancelled: u64,
+    pub stale: u64,
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -99,55 +99,49 @@ pub fn mark_thumbnail_eligible(count: u64) {
     );
 }
 
-pub fn mark_thumbnail_requested(uri: &str) {
+pub fn mark_thumbnail_requested() {
     THUMB_REQUESTED.fetch_add(1, Ordering::Relaxed);
     tracing::debug!(
-        uri,
         total = THUMB_REQUESTED.load(Ordering::Relaxed),
         "thumbnail requested"
     );
 }
 
-pub fn mark_thumbnail_started(uri: &str) {
+pub fn mark_thumbnail_started() {
     THUMB_STARTED.fetch_add(1, Ordering::Relaxed);
     tracing::debug!(
-        uri,
         total = THUMB_STARTED.load(Ordering::Relaxed),
         "thumbnail started"
     );
 }
 
-pub fn mark_thumbnail_completed(uri: &str) {
+pub fn mark_thumbnail_completed() {
     THUMB_COMPLETED.fetch_add(1, Ordering::Relaxed);
     tracing::debug!(
-        uri,
         total = THUMB_COMPLETED.load(Ordering::Relaxed),
         "thumbnail completed"
     );
 }
 
-pub fn mark_thumbnail_applied(uri: &str) {
+pub fn mark_thumbnail_applied() {
     THUMB_APPLIED.fetch_add(1, Ordering::Relaxed);
     tracing::debug!(
-        uri,
         total = THUMB_APPLIED.load(Ordering::Relaxed),
         "thumbnail applied"
     );
 }
 
-pub fn mark_thumbnail_cancelled(uri: &str) {
+pub fn mark_thumbnail_cancelled() {
     THUMB_CANCELLED.fetch_add(1, Ordering::Relaxed);
     tracing::debug!(
-        uri,
         total = THUMB_CANCELLED.load(Ordering::Relaxed),
         "thumbnail cancelled"
     );
 }
 
-pub fn mark_thumbnail_stale(uri: &str) {
+pub fn mark_thumbnail_stale() {
     THUMB_STALE.fetch_add(1, Ordering::Relaxed);
     tracing::debug!(
-        uri,
         total = THUMB_STALE.load(Ordering::Relaxed),
         "thumbnail stale"
     );

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -34,8 +34,7 @@ pub fn mark_window_presented() {
     }
 }
 
-/// First themed frame / after-paint signal. Emitted once per process; the
-/// field harness parses this line for the cold/warm first-frame metric.
+/// The field harness parses this line for the cold/warm first-frame metric.
 pub fn mark_first_themed_frame() {
     if FIRST_THEMED_FRAME.swap(true, Ordering::Relaxed) {
         return;
@@ -48,8 +47,7 @@ pub fn mark_first_themed_frame() {
     }
 }
 
-/// First correct visible row installed into a GTK model. Emitted once per
-/// process so paired runs can compare identical-work first-content latency.
+/// Emitted once per process so paired runs can compare identical-work latency.
 pub fn mark_first_visible_row(entries: usize) {
     if FIRST_VISIBLE_ROW.swap(true, Ordering::Relaxed) {
         return;
@@ -63,17 +61,12 @@ pub fn mark_first_visible_row(entries: usize) {
     }
 }
 
-/// Stage timing for enumeration, stat, sort, state-install, and UI
-/// publication slices. Narrowly scoped: callers time their own slice and
-/// report it here so the harness can attribute wall time without extra
-/// global state.
+/// Callers time their own slice and report it here so the harness can
+/// attribute wall time without extra global state.
 pub fn record_stage(stage: &str, elapsed_ms: u64) {
     tracing::debug!(stage, elapsed_ms, "directory stage completed");
 }
 
-/// Input-event to presented-frame latency probe. Callers capture the event
-/// instant and report it when the resulting frame is presented. Frame-clock
-/// plumbing lands with Task 11 (scroll/filter/select-all input paths).
 #[expect(dead_code, reason = "frame-clock plumbing lands with Task 11")]
 pub fn record_input_latency(elapsed_ms: u64) {
     tracing::debug!(elapsed_ms, "input event to presented frame");
@@ -96,8 +89,7 @@ pub fn mark_batch_rendered(entries: usize, render_started: Instant) {
     }
 }
 
-/// Thumbnail pipeline counters. Each transition logs at debug and bumps a
-/// process-wide counter the harness can scrape at settle time.
+/// Each transition bumps a process-wide counter the harness scrapes at settle time.
 pub fn mark_thumbnail_eligible(count: u64) {
     THUMB_ELIGIBLE.fetch_add(count, Ordering::Relaxed);
     tracing::debug!(
@@ -161,7 +153,6 @@ pub fn mark_thumbnail_stale(uri: &str) {
     );
 }
 
-/// Snapshot of every pipeline counter for settle-time reporting.
 pub fn thumbnail_counts() -> ThumbnailCounts {
     ThumbnailCounts {
         eligible: THUMB_ELIGIBLE.load(Ordering::Relaxed),

--- a/src/metrics/tests.rs
+++ b/src/metrics/tests.rs
@@ -6,12 +6,12 @@ use super::*;
 fn thumbnail_counters_are_monotonic() {
     let before = thumbnail_counts();
     mark_thumbnail_eligible(2);
-    mark_thumbnail_requested("file:///a");
-    mark_thumbnail_started("file:///a");
-    mark_thumbnail_completed("file:///a");
-    mark_thumbnail_applied("file:///a");
-    mark_thumbnail_cancelled("file:///b");
-    mark_thumbnail_stale("file:///b");
+    mark_thumbnail_requested();
+    mark_thumbnail_started();
+    mark_thumbnail_completed();
+    mark_thumbnail_applied();
+    mark_thumbnail_cancelled();
+    mark_thumbnail_stale();
     let after = thumbnail_counts();
     assert_eq!(after.eligible, before.eligible + 2);
     assert_eq!(after.requested, before.requested + 1);

--- a/src/metrics/tests.rs
+++ b/src/metrics/tests.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use super::*;
+
+#[test]
+fn thumbnail_counters_are_monotonic() {
+    let before = thumbnail_counts();
+    mark_thumbnail_eligible(2);
+    mark_thumbnail_requested("file:///a");
+    mark_thumbnail_started("file:///a");
+    mark_thumbnail_completed("file:///a");
+    mark_thumbnail_applied("file:///a");
+    mark_thumbnail_cancelled("file:///b");
+    mark_thumbnail_stale("file:///b");
+    let after = thumbnail_counts();
+    assert_eq!(after.eligible, before.eligible + 2);
+    assert_eq!(after.requested, before.requested + 1);
+    assert_eq!(after.started, before.started + 1);
+    assert_eq!(after.completed, before.completed + 1);
+    assert_eq!(after.applied, before.applied + 1);
+    assert_eq!(after.cancelled, before.cancelled + 1);
+    assert_eq!(after.stale, before.stale + 1);
+}
+
+#[test]
+fn stage_probes_do_not_panic() {
+    record_stage("test-enumeration", 3);
+    mark_first_themed_frame();
+    mark_first_visible_row(1);
+    // Second calls are idempotent one-shots.
+    mark_first_themed_frame();
+    mark_first_visible_row(1);
+}

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -235,24 +235,56 @@ fn spawn_renderer(command: &mut Command) -> io::Result<Child> {
     command.process_group(0).spawn()
 }
 
+/// Opens a pidfd for prompt child-exit wakeups. `None` on kernels without
+/// pidfd support: both wait loops fall back to interval polling.
+fn child_pidfd(child: &Child) -> Option<rustix::fd::OwnedFd> {
+    let pid = rustix::process::Pid::from_raw(i32::try_from(child.id()).ok()?)?;
+    rustix::process::pidfd_open(pid, rustix::process::PidfdFlags::empty()).ok()
+}
+
+/// Sleeps until the child exits, the deadline passes, or a cancellation
+/// quantum elapses. A pidfd wakes the instant the child exits instead of up
+/// to a poll interval later; poll errors degrade to a short sleep and the
+/// loop's re-check, and the deadline bounds every path, so no syscall
+/// failure can spin, stall, or turn into a successful decoder verdict.
+fn wait_step(pidfd: Option<&rustix::fd::OwnedFd>, deadline: Instant) {
+    use rustix::event::{PollFd, PollFlags, Timespec, poll};
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    let quantum = remaining.min(Duration::from_millis(20));
+    let Some(pidfd) = pidfd else {
+        thread::sleep(quantum);
+        return;
+    };
+    let timespec = Timespec {
+        tv_sec: quantum.as_secs() as i64,
+        tv_nsec: i64::from(quantum.subsec_nanos()),
+    };
+    let mut fds = [PollFd::new(pidfd, PollFlags::IN)];
+    if poll(&mut fds, Some(&timespec)).is_err() {
+        thread::sleep(Duration::from_millis(1));
+    }
+}
+
 fn wait_for_renderer(
     child: &mut Child,
     cancellation: &Cancellation,
     wall_time_limit: Duration,
 ) -> Result<ExitStatus, String> {
     let started = Instant::now();
+    let deadline = started + wall_time_limit;
+    let pidfd = child_pidfd(child);
     loop {
         if cancellation.is_cancelled() {
             terminate(child);
             return Err("Preview cancelled".to_owned());
         }
-        if started.elapsed() >= wall_time_limit {
+        if Instant::now() >= deadline {
             terminate(child);
             return Err("The preview renderer timed out".to_owned());
         }
         match child.try_wait() {
             Ok(Some(status)) => return Ok(status),
-            Ok(None) => thread::sleep(Duration::from_millis(20)),
+            Ok(None) => wait_step(pidfd.as_ref(), deadline),
             Err(error) => {
                 terminate(child);
                 return Err(format!("Unable to monitor the preview renderer: {error}"));
@@ -281,6 +313,8 @@ fn wait_for_renderer_output(
         let _sent = sender.send(result);
     });
     let started = Instant::now();
+    let deadline = started + wall_time_limit;
+    let pidfd = child_pidfd(child);
     let mut status = None;
     let mut output = None;
     loop {
@@ -289,7 +323,7 @@ fn wait_for_renderer_output(
             let _joined = reader.join();
             return Err("Preview cancelled".to_owned());
         }
-        if started.elapsed() >= wall_time_limit {
+        if Instant::now() >= deadline {
             terminate(child);
             let _joined = reader.join();
             return Err("The preview renderer timed out".to_owned());
@@ -331,7 +365,7 @@ fn wait_for_renderer_output(
             let _joined = reader.join();
             return Ok((status, output));
         }
-        thread::sleep(Duration::from_millis(20));
+        wait_step(pidfd.as_ref(), deadline);
     }
 }
 
@@ -392,10 +426,11 @@ fn sandbox_command(
         "--ro-bind-try",
         "/etc/ImageMagick-6",
         "/etc/ImageMagick-6",
-        "--ro-bind",
     ]);
     let sandbox_input = sandbox_input_path(input);
-    command.arg(executable).arg("/app/strata");
+    if operation != ParseOperation::ThumbnailVideo {
+        command.arg("--ro-bind").arg(executable).arg("/app/strata");
+    }
     command.arg("--ro-bind").arg(input).arg(&sandbox_input);
     if operation != ParseOperation::PreviewMedia {
         command.arg("--bind").arg(output).arg("/output");
@@ -417,8 +452,24 @@ fn sandbox_command(
             .arg("/usr/bin/prlimit")
             .arg(format!("--as={ADDRESS_SPACE_LIMIT_BYTES}"))
             .arg("--cpu=10")
-            .arg(format!("--fsize={FILE_SIZE_LIMIT_BYTES}"))
+            .arg(format!(
+                "--fsize={}",
+                if operation == ParseOperation::ThumbnailVideo {
+                    MAX_OUTPUT_BYTES
+                } else {
+                    FILE_SIZE_LIMIT_BYTES
+                }
+            ))
             .arg("--");
+    }
+    if operation == ParseOperation::ThumbnailVideo {
+        command
+            .args(["/usr/bin/ffmpegthumbnailer", "-i", &sandbox_input, "-o"])
+            .arg(format!("/output/{}", operation.output_name()))
+            .arg("-s")
+            .arg(value.to_string())
+            .args(["-q", "8"]);
+        return command;
     }
     command.args([
         "/app/strata",

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -235,18 +235,14 @@ fn spawn_renderer(command: &mut Command) -> io::Result<Child> {
     command.process_group(0).spawn()
 }
 
-/// Opens a pidfd for prompt child-exit wakeups. `None` on kernels without
-/// pidfd support: both wait loops fall back to interval polling.
+/// `None` on kernels without pidfd support; wait loops fall back to interval polling.
 fn child_pidfd(child: &Child) -> Option<rustix::fd::OwnedFd> {
     let pid = rustix::process::Pid::from_raw(i32::try_from(child.id()).ok()?)?;
     rustix::process::pidfd_open(pid, rustix::process::PidfdFlags::empty()).ok()
 }
 
-/// Sleeps until the child exits, the deadline passes, or a cancellation
-/// quantum elapses. A pidfd wakes the instant the child exits instead of up
-/// to a poll interval later; poll errors degrade to a short sleep and the
-/// loop's re-check, and the deadline bounds every path, so no syscall
-/// failure can spin, stall, or turn into a successful decoder verdict.
+/// A pidfd wakes on child exit; poll errors degrade to a short sleep, and the
+/// deadline bounds every path.
 fn wait_step(pidfd: Option<&rustix::fd::OwnedFd>, deadline: Instant) {
     use rustix::event::{PollFd, PollFlags, Timespec, poll};
     let remaining = deadline.saturating_duration_since(Instant::now());

--- a/src/sandbox/tests.rs
+++ b/src/sandbox/tests.rs
@@ -352,6 +352,38 @@ fn non_media_sandboxes_never_expose_gpu_devices_or_sysfs() {
 }
 
 #[test]
+fn video_thumbnails_execute_directly_inside_the_bounded_sandbox() {
+    let command = sandbox_command(
+        Path::new("/tmp/strata"),
+        Path::new("/home/alice/Videos/untrusted.mkv"),
+        Path::new("/tmp/private-output"),
+        ParseOperation::ThumbnailVideo,
+        128,
+        MediaPreviewBackend::Software,
+        &[],
+    );
+    let joined = command
+        .get_args()
+        .map(|argument| argument.to_string_lossy())
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    assert!(joined.contains("--unshare-all"));
+    assert!(joined.contains("--ro-bind /home/alice/Videos/untrusted.mkv /input.mkv"));
+    assert!(joined.contains("--bind /tmp/private-output /output"));
+    assert!(joined.contains("--as=2147483648"));
+    assert!(joined.contains("--cpu=10"));
+    assert!(joined.contains("--fsize=33554432"));
+    assert!(
+        joined
+            .contains("/usr/bin/ffmpegthumbnailer -i /input.mkv -o /output/result.png -s 128 -q 8")
+    );
+    assert!(!joined.contains("/app/strata"));
+    assert!(!joined.contains("--preview-helper"));
+    assert!(!joined.contains("--share-net"));
+}
+
+#[test]
 fn accepts_only_bounded_png_webm_or_mp4_outputs() {
     assert!(valid_output(ParseOperation::ThumbnailImage, &png(256, 256)));
     assert!(!valid_output(ParseOperation::ThumbnailImage, &png(257, 1)));

--- a/src/services/file_source.rs
+++ b/src/services/file_source.rs
@@ -15,11 +15,8 @@ pub struct DirectoryRequest {
     pub id: RequestId,
     pub location: Location,
     pub batch_size: usize,
-    /// When true, every entry arrives with size and modification time (one
-    /// stat per file). Loads sorted by size or date set it, since sorting
-    /// placeholders and re-sorting afterwards costs more than statting
-    /// inline; name and type sorts stream identity only and fill the
-    /// visible window afterwards.
+    /// When true, entries arrive with size and modification time. Size/date sorts set it;
+    /// other sorts stream identity only and fill the visible window afterwards.
     pub include_metadata: bool,
     /// Caps how many entries a single load will retain/render, bounding worst-case time and
     /// memory on an adversarially large or unbounded directory.
@@ -189,24 +186,22 @@ pub enum DirectoryEvent {
         /// entry or time budget; already-emitted `Batch` entries are then a lower bound.
         truncated: bool,
     },
+    /// Consumers must not present these partial values as a completed sort.
+    MetadataIncomplete { request_id: RequestId },
     Failed {
         request_id: RequestId,
         message: String,
     },
-    /// Size/mtime arrivals for already-listed entries. Positions are resolved
-    /// by the receiver against stable locations, so fills never reorder.
-    /// Zero or more chunks arrive, followed by exactly one `MetadataFinished`
-    /// terminal outcome (unless the fill's `LoadHandle` is dropped first, in
-    /// which case the owner treats the fill as cancelled).
+    /// Size/mtime arrivals for already-listed entries, positioned by the receiver
+    /// against stable locations. Zero or more chunks, then exactly one `MetadataFinished`
+    /// (dropping the `LoadHandle` first cancels the fill with no terminal event).
     MetadataFilled {
         request_id: RequestId,
         updates: Vec<MetadataUpdate>,
     },
-    /// Terminal outcome for a metadata fill. Every fill ends with exactly
-    /// one of these, including empty fills (no chunks, then `Complete`) and
-    /// fills that statted nothing successfully. Sorts wait for this event,
-    /// never for a chunk, so a partial pass can never be mistaken for a
-    /// complete one.
+    /// Terminal outcome for a metadata fill: exactly one per fill, including empty fills.
+    /// Sorts wait for this event, never for a chunk, so a partial pass can never be
+    /// mistaken for a complete one.
     MetadataFinished {
         request_id: RequestId,
         outcome: MetadataOutcome,
@@ -216,26 +211,20 @@ pub enum DirectoryEvent {
 /// Terminal outcome for a metadata fill.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MetadataOutcome {
-    /// Every requested entry was attempted within budget.
     Complete,
-    /// The time budget expired partway; emitted chunks still apply and the
-    /// remaining rows keep their placeholders for a later retry.
+    /// The budget expired partway; emitted chunks still apply, the rest keep placeholders.
     Truncated,
-    /// The provider cannot stat these entries (for example a source without
-    /// per-entry metadata); rows keep their placeholders.
+    /// The provider cannot stat these entries; rows keep their placeholders.
     Unsupported,
-    /// The fill failed before producing a trustworthy pass; rows keep their
-    /// placeholders and any waiting sort is abandoned without reordering.
+    /// No trustworthy pass; rows keep placeholders and waiting sorts are abandoned.
     Failed,
-    /// The fill was dropped before finishing. Providers never emit this
-    /// (a dropped task cannot emit); owners synthesize it when they discard
-    /// a fill's `LoadHandle` while a sort still waits on it.
+    /// The fill was dropped before finishing. Providers never emit this; owners synthesize
+    /// it when they discard a fill's handle while a sort still waits on it.
     Cancelled,
 }
 
-/// Fresh size/mtime for one listed entry. Either field may stay
-/// `Unknown`/`Unavailable` when the entry vanished or the stat failed; the
-/// row keeps its placeholder and can be re-requested on its next bind.
+/// Fresh size/mtime for one listed entry. Either field may stay `Unknown`/`Unavailable`
+/// when the stat failed; the row keeps its placeholder for a later retry.
 #[derive(Clone, Debug)]
 pub struct MetadataUpdate {
     pub location: Location,
@@ -243,17 +232,13 @@ pub struct MetadataUpdate {
     pub modified_unix_seconds: MetadataValue<i64>,
 }
 
-/// A bounded request for [`MetadataUpdate`]s over already-listed entries.
 #[derive(Clone, Debug)]
 pub struct MetadataRequest {
-    /// The directory load these entries belong to; fills for a superseded
-    /// load are dropped rather than applied to a reloaded column.
+    /// Fills for a superseded load are dropped, never applied to a reloaded column.
     pub id: RequestId,
     pub entries: Vec<Location>,
-    /// When true, the whole entry list is statted (a sort's full pass);
-    /// otherwise the provider caps the fill to a viewport-sized window.
+    /// When true, stat the whole list (a sort's full pass); otherwise a viewport window.
     pub full: bool,
-    /// Caps how long a single fill may run; partial results still apply.
     pub time_budget: Duration,
 }
 
@@ -293,24 +278,13 @@ pub trait FileSource {
     }
 
     fn enumerate(&self, request: DirectoryRequest, emit: Rc<dyn Fn(DirectoryEvent)>) -> LoadHandle;
-    /// Whether `fill_metadata` can stat `location`. The owner asks the
-    /// provider instead of guessing from the location shape, so remote and
-    /// GVfs fills stay on cancellable provider I/O rather than being
-    /// rejected owner-side. The default implementation supports nothing and
-    /// answers `Unsupported`, so listings keep their placeholders.
     fn supports_metadata_fill(&self, _location: &Location) -> bool {
         false
     }
 
-    /// Fills size/mtime for already-listed entries (the visible window).
-    /// The default implementation reports `Unsupported`, so sources without
-    /// a cheap per-entry stat keep working; listings then keep their
-    /// `Unknown` placeholders and waiting sorts are abandoned in order.
-    ///
-    /// Overrides must emit zero or more `MetadataFilled` chunks followed by
-    /// exactly one `MetadataFinished` terminal outcome, including for empty
-    /// fills. Dropping the returned `LoadHandle` aborts the fill without
-    /// any terminal event; the owner then treats it as cancelled.
+    /// Overrides must emit zero or more `MetadataFilled` chunks followed by exactly one
+    /// `MetadataFinished` terminal outcome, including for empty fills. Dropping the
+    /// returned `LoadHandle` aborts the fill without any terminal event.
     fn fill_metadata(
         &self,
         request: MetadataRequest,

--- a/src/services/file_source.rs
+++ b/src/services/file_source.rs
@@ -5,7 +5,7 @@ mod tests;
 
 use std::{fmt, rc::Rc, time::Duration};
 
-use crate::model::{FileEntry, Location, uri_contains_credentials};
+use crate::model::{FileEntry, Location, MetadataValue, uri_contains_credentials};
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct RequestId(pub u64);
@@ -15,6 +15,12 @@ pub struct DirectoryRequest {
     pub id: RequestId,
     pub location: Location,
     pub batch_size: usize,
+    /// When true, every entry arrives with size and modification time (one
+    /// stat per file). Loads sorted by size or date set it, since sorting
+    /// placeholders and re-sorting afterwards costs more than statting
+    /// inline; name and type sorts stream identity only and fill the
+    /// visible window afterwards.
+    pub include_metadata: bool,
     /// Caps how many entries a single load will retain/render, bounding worst-case time and
     /// memory on an adversarially large or unbounded directory.
     pub max_entries: usize,
@@ -187,6 +193,68 @@ pub enum DirectoryEvent {
         request_id: RequestId,
         message: String,
     },
+    /// Size/mtime arrivals for already-listed entries. Positions are resolved
+    /// by the receiver against stable locations, so fills never reorder.
+    /// Zero or more chunks arrive, followed by exactly one `MetadataFinished`
+    /// terminal outcome (unless the fill's `LoadHandle` is dropped first, in
+    /// which case the owner treats the fill as cancelled).
+    MetadataFilled {
+        request_id: RequestId,
+        updates: Vec<MetadataUpdate>,
+    },
+    /// Terminal outcome for a metadata fill. Every fill ends with exactly
+    /// one of these, including empty fills (no chunks, then `Complete`) and
+    /// fills that statted nothing successfully. Sorts wait for this event,
+    /// never for a chunk, so a partial pass can never be mistaken for a
+    /// complete one.
+    MetadataFinished {
+        request_id: RequestId,
+        outcome: MetadataOutcome,
+    },
+}
+
+/// Terminal outcome for a metadata fill.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MetadataOutcome {
+    /// Every requested entry was attempted within budget.
+    Complete,
+    /// The time budget expired partway; emitted chunks still apply and the
+    /// remaining rows keep their placeholders for a later retry.
+    Truncated,
+    /// The provider cannot stat these entries (for example a source without
+    /// per-entry metadata); rows keep their placeholders.
+    Unsupported,
+    /// The fill failed before producing a trustworthy pass; rows keep their
+    /// placeholders and any waiting sort is abandoned without reordering.
+    Failed,
+    /// The fill was dropped before finishing. Providers never emit this
+    /// (a dropped task cannot emit); owners synthesize it when they discard
+    /// a fill's `LoadHandle` while a sort still waits on it.
+    Cancelled,
+}
+
+/// Fresh size/mtime for one listed entry. Either field may stay
+/// `Unknown`/`Unavailable` when the entry vanished or the stat failed; the
+/// row keeps its placeholder and can be re-requested on its next bind.
+#[derive(Clone, Debug)]
+pub struct MetadataUpdate {
+    pub location: Location,
+    pub size: MetadataValue<u64>,
+    pub modified_unix_seconds: MetadataValue<i64>,
+}
+
+/// A bounded request for [`MetadataUpdate`]s over already-listed entries.
+#[derive(Clone, Debug)]
+pub struct MetadataRequest {
+    /// The directory load these entries belong to; fills for a superseded
+    /// load are dropped rather than applied to a reloaded column.
+    pub id: RequestId,
+    pub entries: Vec<Location>,
+    /// When true, the whole entry list is statted (a sort's full pass);
+    /// otherwise the provider caps the fill to a viewport-sized window.
+    pub full: bool,
+    /// Caps how long a single fill may run; partial results still apply.
+    pub time_budget: Duration,
 }
 
 /// A cancellable directory load. Dropping it cancels any unfinished provider work.
@@ -225,6 +293,35 @@ pub trait FileSource {
     }
 
     fn enumerate(&self, request: DirectoryRequest, emit: Rc<dyn Fn(DirectoryEvent)>) -> LoadHandle;
+    /// Whether `fill_metadata` can stat `location`. The owner asks the
+    /// provider instead of guessing from the location shape, so remote and
+    /// GVfs fills stay on cancellable provider I/O rather than being
+    /// rejected owner-side. The default implementation supports nothing and
+    /// answers `Unsupported`, so listings keep their placeholders.
+    fn supports_metadata_fill(&self, _location: &Location) -> bool {
+        false
+    }
+
+    /// Fills size/mtime for already-listed entries (the visible window).
+    /// The default implementation reports `Unsupported`, so sources without
+    /// a cheap per-entry stat keep working; listings then keep their
+    /// `Unknown` placeholders and waiting sorts are abandoned in order.
+    ///
+    /// Overrides must emit zero or more `MetadataFilled` chunks followed by
+    /// exactly one `MetadataFinished` terminal outcome, including for empty
+    /// fills. Dropping the returned `LoadHandle` aborts the fill without
+    /// any terminal event; the owner then treats it as cancelled.
+    fn fill_metadata(
+        &self,
+        request: MetadataRequest,
+        emit: Rc<dyn Fn(DirectoryEvent)>,
+    ) -> LoadHandle {
+        emit(DirectoryEvent::MetadataFinished {
+            request_id: request.id,
+            outcome: MetadataOutcome::Unsupported,
+        });
+        LoadHandle::new(|| {})
+    }
 
     fn watch(
         &self,

--- a/src/services/file_source/tests.rs
+++ b/src/services/file_source/tests.rs
@@ -90,3 +90,50 @@ fn backend_unavailable_message_falls_back_for_unknown_schemes() {
     let message = backend_unavailable_message("dav://host/path");
     assert!(message.contains("dav://"));
 }
+
+#[test]
+fn default_fill_reports_unsupported_synchronously() {
+    use super::{
+        DirectoryEvent, FileSource, LoadHandle, MetadataOutcome, MetadataRequest, RequestId,
+    };
+    use crate::model::Location;
+    use std::rc::Rc;
+    use std::time::Duration;
+
+    struct NoMetadata;
+    impl FileSource for NoMetadata {
+        fn validate_location(
+            &self,
+            _location: &Location,
+        ) -> Result<(), super::LocationValidationError> {
+            Ok(())
+        }
+
+        fn enumerate(
+            &self,
+            _request: super::DirectoryRequest,
+            _emit: Rc<dyn Fn(DirectoryEvent)>,
+        ) -> LoadHandle {
+            LoadHandle::new(|| {})
+        }
+    }
+
+    let events = Rc::new(std::cell::RefCell::new(Vec::new()));
+    let collected = events.clone();
+    let _handle = NoMetadata.fill_metadata(
+        MetadataRequest {
+            id: RequestId(4),
+            entries: Vec::new(),
+            full: false,
+            time_budget: Duration::from_secs(1),
+        },
+        Rc::new(move |event| collected.borrow_mut().push(event)),
+    );
+    assert!(matches!(
+        events.borrow().as_slice(),
+        [DirectoryEvent::MetadataFinished {
+            request_id: RequestId(4),
+            outcome: MetadataOutcome::Unsupported,
+        }]
+    ));
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -11,8 +11,9 @@ mod update_install;
 
 pub use file_source::{
     DirectoryChange, DirectoryEvent, DirectoryRequest, FileSource, LoadHandle,
-    LocationValidationError, RequestId, UriCredentials, backend_unavailable_message,
-    sanitize_uri_credentials, validate_uri_credentials,
+    LocationValidationError, MetadataOutcome, MetadataRequest, MetadataUpdate, RequestId,
+    UriCredentials, backend_unavailable_message, sanitize_uri_credentials,
+    validate_uri_credentials,
 };
 pub(crate) use install_source::ensure_self_managed;
 pub use install_source::{InstallSource, ManagedInstall};

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,7 +2,7 @@
 
 use std::ffi::OsString;
 
-use super::{encode_daemon_pids, gvfs_daemon_pids, gvfs_probe_marker_path_in};
+use super::{GIO_FALLBACK_BACKENDS, encode_daemon_pids, gvfs_daemon_pids, gvfs_probe_marker_path_in};
 
 fn fake_proc(label: &str, processes: &[(&str, &str)]) -> std::path::PathBuf {
     let root = std::env::temp_dir().join(format!(
@@ -62,5 +62,16 @@ fn marker_path_needs_a_runtime_dir() {
         Some(std::path::PathBuf::from(
             "/run/user/1000/strata-gvfs-probe-ok"
         ))
+    );
+}
+
+#[test]
+fn gvfs_fallback_covers_files_and_volumes() {
+    assert_eq!(
+        GIO_FALLBACK_BACKENDS,
+        [
+            ("GIO_USE_VFS", "local"),
+            ("GIO_USE_VOLUME_MONITOR", "unix"),
+        ]
     );
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::ffi::OsString;
+
+use super::{encode_daemon_pids, gvfs_daemon_pids, gvfs_probe_marker_path_in};
+
+fn fake_proc(label: &str, processes: &[(&str, &str)]) -> std::path::PathBuf {
+    let root = std::env::temp_dir().join(format!(
+        "strata-gvfs-proc-{label}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("the clock should be set")
+            .as_nanos()
+    ));
+    for (pid, comm) in processes {
+        let dir = root.join(pid);
+        std::fs::create_dir_all(&dir).expect("the fake pid dir should exist");
+        std::fs::write(dir.join("comm"), comm).expect("the fake comm should exist");
+    }
+    root
+}
+
+#[test]
+fn daemon_identity_lists_gvfs_processes_sorted() {
+    let root = fake_proc(
+        "identity",
+        &[
+            ("9", "gvfsd-fuse\n"),
+            ("2200", "gvfsd\n"),
+            ("31", "bash\n"),
+            ("400", "gvfsd-trash\n"),
+            ("self", "test\n"),
+        ],
+    );
+    assert_eq!(gvfs_daemon_pids(&root), vec![9, 400, 2200]);
+    assert_eq!(encode_daemon_pids(&[9, 2200]), "9,2200");
+}
+
+#[test]
+fn daemon_restart_changes_the_identity() {
+    let before = fake_proc("restart-before", &[("100", "gvfsd\n")]);
+    let after = fake_proc("restart-after", &[("8400", "gvfsd\n")]);
+    assert_ne!(
+        encode_daemon_pids(&gvfs_daemon_pids(&before)),
+        encode_daemon_pids(&gvfs_daemon_pids(&after))
+    );
+}
+
+#[test]
+fn missing_proc_root_is_an_empty_identity() {
+    let missing = std::env::temp_dir().join("strata-gvfs-proc-definitely-missing");
+    assert_eq!(gvfs_daemon_pids(&missing), Vec::<u32>::new());
+}
+
+#[test]
+fn marker_path_needs_a_runtime_dir() {
+    assert_eq!(gvfs_probe_marker_path_in(None), None);
+    assert_eq!(gvfs_probe_marker_path_in(Some(OsString::from(""))), None);
+    assert_eq!(
+        gvfs_probe_marker_path_in(Some(OsString::from("/run/user/1000"))),
+        Some(std::path::PathBuf::from(
+            "/run/user/1000/strata-gvfs-probe-ok"
+        ))
+    );
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,7 +2,10 @@
 
 use std::ffi::OsString;
 
-use super::{GIO_FALLBACK_BACKENDS, encode_daemon_pids, gvfs_daemon_pids, gvfs_probe_marker_path_in};
+use super::{
+    GIO_FALLBACK_BACKENDS, encode_daemon_pids, gvfs_daemon_pids, gvfs_probe_marker_is_fresh_at,
+    gvfs_probe_marker_path_in,
+};
 
 fn fake_proc(label: &str, processes: &[(&str, &str)]) -> std::path::PathBuf {
     let root = std::env::temp_dir().join(format!(
@@ -66,12 +69,22 @@ fn marker_path_needs_a_runtime_dir() {
 }
 
 #[test]
+fn only_a_readable_matching_marker_is_fresh() {
+    let proc_root = fake_proc("marker", &[("31", "bash\n")]);
+    let marker = proc_root.join("marker");
+    assert!(!gvfs_probe_marker_is_fresh_at(&marker, &proc_root));
+
+    std::fs::write(&marker, "").expect("the empty identity marker should be written");
+    assert!(gvfs_probe_marker_is_fresh_at(&marker, &proc_root));
+
+    std::fs::write(&marker, [0xff]).expect("the unreadable marker should be written");
+    assert!(!gvfs_probe_marker_is_fresh_at(&marker, &proc_root));
+}
+
+#[test]
 fn gvfs_fallback_covers_files_and_volumes() {
     assert_eq!(
         GIO_FALLBACK_BACKENDS,
-        [
-            ("GIO_USE_VFS", "local"),
-            ("GIO_USE_VOLUME_MONITOR", "unix"),
-        ]
+        [("GIO_USE_VFS", "local"), ("GIO_USE_VOLUME_MONITOR", "unix"),]
     );
 }

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -65,9 +65,6 @@ struct ColumnView {
     presentation: LoadPresentation,
     model: EntryListModel,
     filtered_model: gtk::FilterListModel,
-    /// Cached visible<->source index translation. Shares the ViewState
-    /// model-generation clock, so every splice invalidates every column at
-    /// once; binds and selection syncs are O(1) afterwards.
     map: ViewMap,
     model_generation: Rc<Cell<u64>>,
     header_actions: gtk::Box,
@@ -80,8 +77,6 @@ struct ColumnView {
     bound_rows: Rc<RefCell<Vec<BoundRow>>>,
     entry_count: Rc<Cell<usize>>,
     spinner: gtk::Spinner,
-    /// Delayed initial-spinner timer: fast loads settle before it ever
-    /// fires, so no spinner flashes for work that finishes in ~120 ms.
     spinner_delay: Rc<RefCell<Option<glib::SourceId>>>,
     truncated_hint: gtk::Image,
     empty_trash_button: Option<gtk::Button>,
@@ -304,9 +299,6 @@ pub(super) struct ViewState {
     hovered_column: Cell<Option<usize>>,
     cut_locations: RefCell<Vec<Location>>,
     horizontal_scroll_generation: Rc<Cell<u64>>,
-    /// Bumped on every shared source-model mutation. Every column and mode
-    /// pane holds a clone and keys its cached position map on it, so one
-    /// counter invalidates every map at once with no per-view bookkeeping.
     source_generation: Rc<Cell<u64>>,
     peek: RefCell<Option<PeekView>>,
     pending_peek: RefCell<Option<glib::SourceId>>,
@@ -3755,9 +3747,6 @@ impl ViewState {
     }
 
     fn handle(self: &Rc<Self>, event: &BrowserEvent) {
-        // The Columns view owns every depth's source model and applies its
-        // own mutations first; mode views then borrow the settled models to
-        // wrap (never copy) for the active Grid/Explorer pane.
         match event {
             BrowserEvent::Reset => {
                 self.pending_location_credentials.take();
@@ -3784,8 +3773,7 @@ impl ViewState {
                         column.presentation.show_content();
                     }
                     for insertion in insertions {
-                        // Invalidate filtered position maps before the model
-                        // emits its synchronous items-changed notification.
+                        // Touch before splice: the model notifies synchronously.
                         touch_source_model(&column);
                         column.model.splice(
                             insertion.position as u32,
@@ -3797,8 +3785,6 @@ impl ViewState {
                     column.entry_count.set(count);
                     set_filter_placeholder(&column, count);
                     update_empty_trash_sensitivity(&column, count);
-                    // Correct rows arrived: assistive technology leaves the
-                    // busy state even while later batches still stream.
                     set_column_busy(&column, false);
                     crate::metrics::mark_batch_rendered(entry_count, render_started);
                     crate::metrics::record_stage(
@@ -3845,19 +3831,12 @@ impl ViewState {
                 }
             }
             BrowserEvent::MetadataFilled { depth, updates } => {
-                // Metadata waiters promote before any mode check: a row may
-                // wait in a hidden view while another mode is active.
                 for (_, entry) in updates.iter() {
                     super::thumbnail::note_metadata_entry(entry);
                 }
                 if self.mode_views.borrow().mode() == BrowserMode::Columns
                     && let Some(column) = self.columns.borrow().get(*depth).cloned()
                 {
-                    // In-place refresh of realized rows only: no model mutation,
-                    // so no rebind, thumbnail restart, or filter re-evaluation.
-                    // Realized rows resolve their current source position through
-                    // the filter mapping, so resort/insert shifts need no extra
-                    // bookkeeping and dead rows prune themselves here.
                     let filled: HashMap<usize, &FileEntry> = updates
                         .iter()
                         .map(|(position, entry)| (*position, entry))
@@ -4282,8 +4261,6 @@ impl ViewState {
                 }
             }
         }
-        // Active-path styling depends on row positions and the active child:
-        // recompute only for events that can move rows or the active child,
         if Self::event_refreshes_active_path(event) {
             self.refresh_active_path_rows();
         }
@@ -4351,9 +4328,6 @@ impl ViewState {
         column.list.grab_focus();
     }
 
-    /// Whether a browser event can move rows or the active child, requiring an
-    /// active-path styling pass. Pure so the fan-out gate stays unit-testable
-    /// without widgets.
     fn event_refreshes_active_path(event: &BrowserEvent) -> bool {
         matches!(
             event,
@@ -4573,10 +4547,6 @@ impl ViewState {
                 &query_for_filter,
                 settled,
             );
-            // The filter reshuffles visible positions, so the GTK bitset goes
-            // stale: re-assert it from the NavigationState truth (selected
-            // locations survive filtering by design) through the rebuilt map
-            // instead of leaving the highlight on the wrong rows.
             let Some(state) = weak_state_for_filter.upgrade() else {
                 return;
             };
@@ -4900,8 +4870,7 @@ impl ViewState {
                 }),
             );
             if let Some(entry) = entry.as_ref() {
-                // Like the grid and explorer binds: hidden views bind, but
-                // only the visible mode earns decodes and fills.
+                // Hidden views bind, but only the visible mode earns decodes and fills.
                 let mode_active = state
                     .as_ref()
                     .is_some_and(|state| state.mode_views.borrow().mode() == BrowserMode::Columns);
@@ -4918,9 +4887,6 @@ impl ViewState {
                 }
                 icon.set_opacity(if entry.is_directory() { 1.0 } else { 0.72 });
                 chevron.set_visible(entry.is_directory());
-                // Bound rows are the visible window: backfill the size/mtime
-                // the streaming enumeration skipped. Debounced per depth, so
-                // a fling binds hundreds of rows but stats one settled set.
                 if mode_active
                     && let Some(state) = state.as_ref()
                     && let Some(position) = source_position
@@ -5190,8 +5156,6 @@ impl ViewState {
             filter: filter_for_column,
         });
 
-        // Accessible loading state immediately; the prominent spinner only
-        // after the delay, so fast loads never flash it.
         if let Some(column) = self.columns.borrow().last() {
             set_column_busy(column, true);
             arm_column_spinner(column);
@@ -5541,16 +5505,11 @@ pub(super) fn format_file_size(bytes: u64) -> String {
     format!("{} {}", formatted.trim_end_matches(".0"), UNITS[unit])
 }
 
-/// Whether a bound row still needs a viewport metadata fill: files missing
-/// size or mtime, or directories missing mtime. Directory size stays unknown
-/// by design and never qualifies.
 pub(super) fn metadata_needs_fill(entry: &FileEntry) -> bool {
     entry.modified_unix_seconds == crate::model::MetadataValue::Unknown
         || (!entry.is_directory() && entry.size == crate::model::MetadataValue::Unknown)
 }
 
-/// Size label text for a columns row, shared by the bind and the in-place
-/// metadata refresh so both render identical strings.
 fn column_size_text(entry: Option<&FileEntry>) -> String {
     entry
         .filter(|entry| !entry.is_directory())
@@ -5561,11 +5520,8 @@ fn column_size_text(entry: Option<&FileEntry>) -> String {
         .unwrap_or_default()
 }
 
-/// Delay before a new column's header spinner becomes prominent. Fast loads
-/// settle first, so no spinner flashes for work that finishes in ~120 ms.
 const COLUMN_SPINNER_DELAY: std::time::Duration = std::time::Duration::from_millis(120);
 
-/// Arms the delayed initial spinner for a freshly appended column.
 fn arm_column_spinner(column: &ColumnView) {
     cancel_column_spinner(column);
     let spinner = column.spinner.clone();
@@ -5581,21 +5537,18 @@ fn arm_column_spinner(column: &ColumnView) {
         },
     ));
 }
-/// Cancels a pending delayed spinner without touching a running one.
 fn cancel_column_spinner(column: &ColumnView) {
     if let Some(source) = column.spinner_delay.borrow_mut().take() {
         source.remove();
     }
 }
 
-/// Stops a column's spinner outright, including a still-pending delay.
 fn stop_column_spinner(column: &ColumnView) {
     cancel_column_spinner(column);
     column.spinner.stop();
     column.spinner.set_visible(false);
 }
 
-/// Marks a column's list busy (or settled) for assistive technology.
 fn set_column_busy(column: &ColumnView, busy: bool) {
     column
         .list
@@ -5609,15 +5562,8 @@ fn set_filter_placeholder(column: &ColumnView, count: usize) {
         .set_placeholder_text(Some(&format!("Filter {count} {noun}…")));
 }
 
-/// Debounce applied to every filter entry: rapid keystrokes collapse into a
-/// single settled evaluation instead of one full re-filter per character.
-/// Re-filtering 100k rows costs far more than a frame, so per-keystroke
-/// evaluation is the typing jank; one evaluation per pause is not.
 pub(crate) const FILTER_DEBOUNCE_DELAY: Duration = Duration::from_millis(60);
 
-/// Routes a filter entry through the shared debounce: each edit cancels the
-/// pending evaluation and arms a fresh one, so only the latest query after
-/// a typing pause reaches `on_settled` with its settled text.
 pub(crate) fn debounce_filter_entry(entry: &gtk::Entry, on_settled: impl Fn(String) + 'static) {
     let pending: Rc<RefCell<Option<glib::SourceId>>> = Rc::new(RefCell::new(None));
     let on_settled = Rc::new(on_settled);
@@ -5635,10 +5581,6 @@ pub(crate) fn debounce_filter_entry(entry: &gtk::Entry, on_settled: impl Fn(Stri
         ));
     });
 }
-/// Picks the cheapest `FilterChange` for a settled query edit. Typing
-/// narrows the previous query, so matches can only shrink and the model
-/// skips already-hidden rows; deleting widens it and must reconsider them.
-/// Anything else re-evaluates everything.
 pub(crate) fn filter_change_for(previous: &str, settled: &str) -> gtk::FilterChange {
     if settled.starts_with(previous) && settled.len() > previous.len() {
         gtk::FilterChange::MoreStrict
@@ -5667,18 +5609,11 @@ pub(crate) fn apply_filter_query(
     }
 }
 
-/// Cached source<->visible index map for one (query, model generation). A
-/// full re-filter or model splice rebuilds it once in O(n); every bind,
-/// activation, and selection sync after that is O(1). With no query active
-/// the filter passes everything in order, so callers take the identity fast
-/// path and never build (or even touch) the map.
 #[derive(Default)]
 pub(crate) struct PositionMap {
     query: String,
     generation: u64,
-    /// Visible position -> source position, in visible order.
     forward: Vec<usize>,
-    /// Source position -> visible position (`NO_FILTERED_POSITION` = hidden).
     reverse: Vec<u32>,
 }
 
@@ -5710,11 +5645,6 @@ fn rebuild_position_map(
     }
 }
 
-/// Everything a view needs to translate between its visible positions and
-/// source positions: the shared model-generation clock, the folded query,
-/// the map cache, and the two models. Columns views carry no placeholder
-/// (`placeholder: None`); Grid/Explorer flatten a placeholder row above the
-/// filter output, so their visible positions shift by its live row count.
 #[derive(Clone)]
 pub(crate) struct ViewMap {
     cache: Rc<RefCell<PositionMap>>,
@@ -5752,9 +5682,6 @@ impl ViewMap {
             .map_or(0, |placeholder| placeholder.n_items())
     }
 
-    /// Visible (flatten) position -> source position. O(1): identity-checked
-    /// without a query, cache hit otherwise, one O(n) rebuild per
-    /// (query, generation) at most.
     pub(crate) fn source_position(&self, visible_position: u32) -> Option<usize> {
         let filter_position = visible_position.checked_sub(self.placeholder_count())?;
         let query = self.query.borrow();
@@ -5772,8 +5699,6 @@ impl ViewMap {
         cache.forward.get(filter_position as usize).copied()
     }
 
-    /// Source position -> visible (flatten) position. Same cost profile as
-    /// [`ViewMap::source_position`].
     pub(crate) fn view_position(&self, source_position: usize) -> Option<u32> {
         let query = self.query.borrow();
         if query.is_empty() && self.show_hidden.get() {
@@ -5792,8 +5717,6 @@ impl ViewMap {
         (position != NO_FILTERED_POSITION).then_some(position + self.placeholder_count())
     }
 
-    /// Batch variant for selection sync: one cache ensure, then O(1) per
-    /// position. Preserves the (visible, source) pair order of the input.
     pub(crate) fn source_positions(&self, visible_positions: &[u32]) -> Vec<(u32, usize)> {
         visible_positions
             .iter()
@@ -5805,9 +5728,6 @@ impl ViewMap {
     }
 }
 
-/// How a position list reaches the GTK selection: whole-model and single
-/// contiguous runs use native bulk ops (one call, no per-row round trips);
-/// only genuinely scattered sets fall back to per-item selection.
 pub(crate) enum SelectionPlan<'a> {
     All,
     Range { position: u32, count: u32 },
@@ -5829,8 +5749,6 @@ pub(crate) fn plan_selection(n_items: u32, positions: &[u32]) -> SelectionPlan<'
     }
 }
 
-/// Applies `positions` (visible indexes into a model of `n_items` rows)
-/// with the cheapest native op. Callers hold their syncing guard.
 pub(crate) fn apply_selection_plan(
     selection: &gtk::MultiSelection,
     n_items: u32,
@@ -5851,9 +5769,6 @@ pub(crate) fn apply_selection_plan(
         }
     }
 }
-/// Advances the shared source-model generation after a splice. Every column
-/// and mode pane keys its cached position map on this clock, so one bump
-/// invalidates every map at once with no per-view bookkeeping.
 fn touch_source_model(column: &ColumnView) {
     column
         .model_generation
@@ -5871,8 +5786,6 @@ fn set_column_selection(column: &ColumnView, position: u32) {
 
 fn set_column_selections(column: &ColumnView, positions: &[u32]) {
     column.syncing_selection.set(true);
-    // Select All over 100k rows used to issue 100k `select_item` calls;
-    // full coverage and single contiguous runs now use one native bulk op.
     apply_selection_plan(
         &column.selection,
         column.filtered_model.n_items(),
@@ -7920,9 +7833,6 @@ pub(super) fn entry_icon(entry: &FileEntry) -> &'static str {
     icon_for_name(&entry.display_name)
 }
 
-/// Full-directory filter predicate shared by every view mode. Source models
-/// carry `kind\tname` values; matching runs against the display name so a
-/// shared model filters identically in Columns, Grid, and Explorer.
 /// `query` must already be folded to lowercase by the caller.
 pub(super) fn pane_filter_matches(value: &str, query: &str) -> bool {
     query.is_empty() || model_display_name(value).to_lowercase().contains(query)

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -64,6 +64,11 @@ struct ColumnView {
     presentation: LoadPresentation,
     model: gtk::StringList,
     filtered_model: gtk::FilterListModel,
+    /// Cached visible<->source index translation. Shares the ViewState
+    /// model-generation clock, so every splice invalidates every column at
+    /// once; binds and selection syncs are O(1) afterwards.
+    map: ViewMap,
+    model_generation: Rc<Cell<u64>>,
     header_actions: gtk::Box,
     filter_entry: gtk::Entry,
     filter_button: gtk::ToggleButton,
@@ -74,6 +79,9 @@ struct ColumnView {
     bound_rows: Rc<RefCell<Vec<BoundRow>>>,
     entry_count: Rc<Cell<usize>>,
     spinner: gtk::Spinner,
+    /// Delayed initial-spinner timer: fast loads settle before it ever
+    /// fires, so no spinner flashes for work that finishes in ~120 ms.
+    spinner_delay: Rc<RefCell<Option<glib::SourceId>>>,
     truncated_hint: gtk::Image,
     empty_trash_button: Option<gtk::Button>,
     new_entry_row: gtk::Box,
@@ -295,6 +303,10 @@ pub(super) struct ViewState {
     hovered_column: Cell<Option<usize>>,
     cut_locations: RefCell<Vec<Location>>,
     horizontal_scroll_generation: Rc<Cell<u64>>,
+    /// Bumped on every shared source-model mutation. Every column and mode
+    /// pane holds a clone and keys its cached position map on it, so one
+    /// counter invalidates every map at once with no per-view bookkeeping.
+    source_generation: Rc<Cell<u64>>,
     peek: RefCell<Option<PeekView>>,
     pending_peek: RefCell<Option<glib::SourceId>>,
     pending_close: RefCell<Option<glib::SourceId>>,
@@ -434,6 +446,7 @@ impl BrowserView {
         browser.observe_preferences(move |sorting| {
             preferences_for_sorting.set_sort_preferences(sorting);
         });
+        let source_generation = Rc::new(Cell::new(0u64));
         let mode_views = ModeViews::new(&scroller, browser.clone());
         overlay.set_child(Some(&mode_views.widget()));
         let state = Rc::new(ViewState {
@@ -451,6 +464,7 @@ impl BrowserView {
             hovered_column: Cell::new(None),
             cut_locations: RefCell::new(Vec::new()),
             horizontal_scroll_generation: Rc::new(Cell::new(0)),
+            source_generation,
             peek: RefCell::new(None),
             pending_peek: RefCell::new(None),
             pending_close: RefCell::new(None),
@@ -696,7 +710,7 @@ impl BrowserView {
         let Some(column) = columns.get(depth) else {
             return false;
         };
-        if filtered_position_for_source(column, position) != Some(0) {
+        if column.map.view_position(position) != Some(0) {
             return false;
         }
         let mut control = column.header_actions.first_child();
@@ -1458,13 +1472,11 @@ impl ViewState {
                 let (Some(item), Some(row)) = (bound.item.upgrade(), bound.row.upgrade()) else {
                     return false;
                 };
-                let is_cut = source_position_for_filtered(
-                    &column.model,
-                    &column.filtered_model,
-                    item.position(),
-                )
-                .and_then(|position| self.browser.entry_at(depth, position))
-                .is_some_and(|entry| cut_lookup.contains(&entry.location));
+                let is_cut = column
+                    .map
+                    .source_position(item.position())
+                    .and_then(|position| self.browser.entry_at(depth, position))
+                    .is_some_and(|entry| cut_lookup.contains(&entry.location));
                 set_cut_path_style(&row, is_cut);
                 true
             });
@@ -3216,7 +3228,7 @@ impl ViewState {
         let Some(column) = columns.get(depth) else {
             return false;
         };
-        let Some(filtered_position) = filtered_position_for_source(column, source_position) else {
+        let Some(filtered_position) = column.map.view_position(source_position) else {
             return false;
         };
         let row = column.bound_rows.borrow().iter().find_map(|bound| {
@@ -3741,15 +3753,17 @@ impl ViewState {
         self.location_stack.set_visible_child_name("breadcrumbs");
     }
 
-    fn handle(self: &Rc<Self>, event: BrowserEvent) {
-        self.mode_views.borrow_mut().handle(&event);
+    fn handle(self: &Rc<Self>, event: &BrowserEvent) {
+        // The Columns view owns every depth's source model and applies its
+        // own mutations first; mode views then borrow the settled models to
+        // wrap (never copy) for the active Grid/Explorer pane.
         match event {
             BrowserEvent::Reset => {
                 self.pending_location_credentials.take();
                 self.truncate(0);
             }
             BrowserEvent::ColumnsTruncated { len } => {
-                self.truncate(len);
+                self.truncate(*len);
                 self.sync_active_location();
             }
             BrowserEvent::ColumnAdded { depth, location } => {
@@ -3764,52 +3778,132 @@ impl ViewState {
                     .iter()
                     .map(|insertion| insertion.entries.len())
                     .sum();
-                if let Some(column) = self.columns.borrow().get(depth).cloned() {
+                if let Some(column) = self.columns.borrow().get(*depth).cloned() {
                     if entry_count > 0 && !column.spinner.is_spinning() {
                         column.presentation.show_content();
                     }
                     for insertion in insertions {
-                        let labels: Vec<_> =
-                            insertion.entries.iter().map(entry_model_value).collect();
+                        let mut labels = Vec::with_capacity(insertion.entries.len());
+                        labels.extend(insertion.entries.iter().map(entry_model_value));
                         let labels: Vec<_> = labels.iter().map(String::as_str).collect();
                         column.model.splice(insertion.position as u32, 0, &labels);
+                        touch_source_model(&column);
                     }
                     let count = column.entry_count.get() + entry_count;
                     column.entry_count.set(count);
                     set_filter_placeholder(&column, count);
                     update_empty_trash_sensitivity(&column, count);
+                    // Correct rows arrived: assistive technology leaves the
+                    // busy state even while later batches still stream.
+                    set_column_busy(&column, false);
                     crate::metrics::mark_batch_rendered(entry_count, render_started);
+                    crate::metrics::record_stage(
+                        "ui-publication",
+                        render_started.elapsed().as_millis() as u64,
+                    );
                 }
             }
-            BrowserEvent::EntriesReplaced { depth, entries } => {
-                if self.mode_views.borrow().mode() == BrowserMode::Columns
-                    && let Some(column) = self.columns.borrow().get(depth).cloned()
-                {
-                    if !entries.is_empty() {
+            BrowserEvent::EntriesReplaced { depth, count } => {
+                if let Some(column) = self.columns.borrow().get(*depth).cloned() {
+                    if *count > 0 {
                         column.presentation.show_content();
+                        set_column_busy(&column, false);
                     }
-                    let labels: Vec<_> = entries.iter().map(entry_model_value).collect();
+                    let labels = entry_model_values(&self.browser, *depth, 0, *count);
                     let labels: Vec<_> = labels.iter().map(String::as_str).collect();
                     column.model.splice(0, column.model.n_items(), &labels);
-                    column.entry_count.set(entries.len());
-                    set_filter_placeholder(&column, entries.len());
-                    update_empty_trash_sensitivity(&column, entries.len());
+                    touch_source_model(&column);
+                    column.entry_count.set(*count);
+                    set_filter_placeholder(&column, *count);
+                    update_empty_trash_sensitivity(&column, *count);
+                }
+            }
+            BrowserEvent::EntriesPublished {
+                depth,
+                position,
+                count,
+            } => {
+                let render_started = Instant::now();
+                if let Some(column) = self.columns.borrow().get(*depth).cloned() {
+                    if *count > 0 && !column.spinner.is_spinning() {
+                        column.presentation.show_content();
+                    }
+                    let labels = entry_model_values(&self.browser, *depth, *position, *count);
+                    let labels: Vec<_> = labels.iter().map(String::as_str).collect();
+                    column.model.splice(*position as u32, 0, &labels);
+                    touch_source_model(&column);
+                    let total = column.entry_count.get().saturating_add(*count);
+                    column.entry_count.set(total);
+                    set_filter_placeholder(&column, total);
+                    update_empty_trash_sensitivity(&column, total);
+                    set_column_busy(&column, false);
+                    crate::metrics::mark_batch_rendered(*count, render_started);
+                    crate::metrics::record_stage(
+                        "ui-publication",
+                        render_started.elapsed().as_millis() as u64,
+                    );
+                }
+            }
+            BrowserEvent::MetadataFilled { depth, updates } => {
+                // Metadata waiters promote before any mode check: a row may
+                // wait in a hidden view while another mode is active.
+                for (_, entry) in updates.iter() {
+                    super::thumbnail::note_metadata_entry(entry);
+                }
+                if self.mode_views.borrow().mode() == BrowserMode::Columns
+                    && let Some(column) = self.columns.borrow().get(*depth).cloned()
+                {
+                    // In-place refresh of realized rows only: no model mutation,
+                    // so no rebind, thumbnail restart, or filter re-evaluation.
+                    // Realized rows resolve their current source position through
+                    // the filter mapping, so resort/insert shifts need no extra
+                    // bookkeeping and dead rows prune themselves here.
+                    let filled: HashMap<usize, &FileEntry> = updates
+                        .iter()
+                        .map(|(position, entry)| (*position, entry))
+                        .collect();
+                    if !filled.is_empty() {
+                        column.bound_rows.borrow_mut().retain(|bound| {
+                            let (Some(item), Some(row)) =
+                                (bound.item.upgrade(), bound.row.upgrade())
+                            else {
+                                return false;
+                            };
+                            let position = column.map.source_position(item.position());
+                            if let Some(position) = position
+                                && let Some(&entry) = filled.get(&position)
+                                && let Some(size) = row
+                                    .first_child()
+                                    .and_downcast::<gtk::Image>()
+                                    .and_then(|icon| icon.next_sibling())
+                                    .and_then(|middle| middle.downcast::<gtk::Overlay>().ok())
+                                    .and_then(|middle| middle.last_child())
+                                    .and_downcast::<gtk::Label>()
+                            {
+                                let text = column_size_text(Some(entry));
+                                size.set_label(&text);
+                                size.set_visible(!text.is_empty());
+                            }
+                            true
+                        });
+                    }
                 }
             }
             BrowserEvent::SortingStarted { depth } => {
                 self.overlay.set_cursor_from_name(Some("wait"));
-                if let Some(column) = self.columns.borrow().get(depth) {
+                if let Some(column) = self.columns.borrow().get(*depth) {
                     column.spinner.set_tooltip_text(Some("Sorting…"));
                     column.spinner.set_visible(true);
                     column.spinner.start();
+                    set_column_busy(column, true);
                 }
             }
             BrowserEvent::SortingFinished { depth } => {
                 self.overlay.set_cursor(None::<&gtk::gdk::Cursor>);
-                if let Some(column) = self.columns.borrow().get(depth) {
-                    column.spinner.stop();
-                    column.spinner.set_visible(false);
+                if let Some(column) = self.columns.borrow().get(*depth) {
+                    stop_column_spinner(column);
                     column.spinner.set_tooltip_text(None);
+                    set_column_busy(column, false);
                 }
             }
             BrowserEvent::EntriesSpliced {
@@ -3817,7 +3911,7 @@ impl ViewState {
                 splices,
                 selected,
             } => {
-                if let Some(column) = self.columns.borrow().get(depth) {
+                if let Some(column) = self.columns.borrow().get(*depth) {
                     let mut count = column.entry_count.get();
                     for splice in splices {
                         let labels: Vec<_> = splice.entries.iter().map(entry_model_value).collect();
@@ -3825,6 +3919,7 @@ impl ViewState {
                         column
                             .model
                             .splice(splice.position as u32, splice.removed as u32, &labels);
+                        touch_source_model(column);
                         count = count
                             .saturating_sub(splice.removed)
                             .saturating_add(splice.entries.len());
@@ -3834,7 +3929,7 @@ impl ViewState {
                     set_column_selection(
                         column,
                         selected
-                            .and_then(|position| filtered_position_for_source(column, position))
+                            .and_then(|position| column.map.view_position(position))
                             .unwrap_or(gtk::INVALID_LIST_POSITION),
                     );
                     if count == 0 {
@@ -3842,20 +3937,22 @@ impl ViewState {
                     } else {
                         column.presentation.show_content();
                     }
+                    set_column_busy(column, false);
                     update_empty_trash_sensitivity(column, count);
                 }
             }
             BrowserEvent::ColumnReloaded { depth } => {
-                if let Some(column) = self.columns.borrow().get(depth) {
+                if let Some(column) = self.columns.borrow().get(*depth) {
                     column.syncing_selection.set(true);
                     column.selection.set_model(None::<&gio::ListModel>);
-                    column.filtered_model.set_model(None::<&gio::ListModel>);
                     column.model.splice(0, column.model.n_items(), &[]);
+                    touch_source_model(column);
                     column.entry_count.set(0);
                     set_filter_placeholder(column, 0);
                     column.truncated_hint.set_visible(false);
                     column.spinner.set_visible(true);
                     column.spinner.start();
+                    set_column_busy(column, true);
                     column.presentation.show_loading();
                 }
             }
@@ -3867,24 +3964,24 @@ impl ViewState {
                 self.mode_views.borrow().set_show_hidden(show_hidden);
             }
             BrowserEvent::LoadFinished { depth, truncated } => {
-                if let Some(column) = self.columns.borrow().get(depth) {
+                if let Some(column) = self.columns.borrow().get(*depth) {
                     if column.selection.model().is_none() {
                         column.filtered_model.set_model(Some(&column.model));
                         column.selection.set_model(Some(&column.filtered_model));
                         column.syncing_selection.set(false);
                     }
-                    column.spinner.stop();
-                    column.spinner.set_visible(false);
-                    column.truncated_hint.set_visible(truncated);
+                    stop_column_spinner(column);
+                    column.truncated_hint.set_visible(*truncated);
                     let count = column.entry_count.get();
                     if count == 0 {
                         column.presentation.show_empty();
                     } else {
                         column.presentation.show_content();
                     }
+                    set_column_busy(column, false);
                     update_empty_trash_sensitivity(column, count);
                 }
-                if self.browser.active_depth() == Some(depth) {
+                if self.browser.active_depth() == Some(*depth) {
                     let names = self.pending_select.take();
                     if !names.is_empty() {
                         let weak = Rc::downgrade(self);
@@ -3897,26 +3994,26 @@ impl ViewState {
                 }
             }
             BrowserEvent::LoadFailed { depth, message } => {
-                if let Some(column) = self.columns.borrow().get(depth) {
+                if let Some(column) = self.columns.borrow().get(*depth) {
                     if column.selection.model().is_none() {
                         column.filtered_model.set_model(Some(&column.model));
                         column.selection.set_model(Some(&column.filtered_model));
                         column.syncing_selection.set(false);
                     }
-                    column.spinner.stop();
-                    column.spinner.set_visible(false);
+                    stop_column_spinner(column);
                     column
                         .presentation
                         .show_error(&format!("Unable to read this directory\n{message}"));
+                    set_column_busy(column, false);
                 }
             }
-            BrowserEvent::PeekStarted { location } => self.append_peek(&location),
+            BrowserEvent::PeekStarted { location } => self.append_peek(location),
             BrowserEvent::PeekEntriesAdded { entries } => {
                 if let Some(peek) = self.peek.borrow().as_ref() {
                     if !entries.is_empty() {
                         peek.presentation.show_content();
                     }
-                    append_peek_entries(peek, entries, self.peek_behavior.item_limit);
+                    append_peek_entries(peek, entries.clone(), self.peek_behavior.item_limit);
                 }
             }
             BrowserEvent::PeekFinished => {
@@ -3945,10 +4042,10 @@ impl ViewState {
                 focused,
                 take_focus,
             } => {
-                if let Some(column) = self.columns.borrow().get(depth) {
+                if let Some(column) = self.columns.borrow().get(*depth) {
                     let filtered_positions: Vec<_> = positions
-                        .into_iter()
-                        .filter_map(|position| filtered_position_for_source(column, position))
+                        .iter()
+                        .filter_map(|position| column.map.view_position(*position))
                         .collect();
                     set_column_selections(column, &filtered_positions);
                     // A background batch delivered for a column that already has a
@@ -3958,23 +4055,23 @@ impl ViewState {
                     if self.active_rename.borrow().is_none()
                         && self.active_new_entry.borrow().is_none()
                     {
-                        if let Some(focused) = filtered_position_for_source(column, focused) {
+                        if let Some(focused) = column.map.view_position(*focused) {
                             column
                                 .list
                                 .scroll_to(focused, gtk::ListScrollFlags::FOCUS, None);
                         }
-                        if take_focus && self.mode_views.borrow().mode() == BrowserMode::Columns {
+                        if *take_focus && self.mode_views.borrow().mode() == BrowserMode::Columns {
                             column.list.grab_focus();
                         }
                     }
                 }
             }
             BrowserEvent::FocusChanged { depth, position } => {
-                if let Some(column) = self.columns.borrow().get(depth) {
+                if let Some(column) = self.columns.borrow().get(*depth) {
                     let editing = self.active_rename.borrow().is_some()
                         || self.active_new_entry.borrow().is_some();
                     if let Some(filtered_position) =
-                        position.and_then(|position| filtered_position_for_source(column, position))
+                        position.and_then(|position| column.map.view_position(position))
                     {
                         set_column_selection(column, filtered_position);
                         if !editing {
@@ -3992,7 +4089,7 @@ impl ViewState {
             }
             BrowserEvent::PreviewRequested { .. } => {}
             BrowserEvent::OpenRequested { location } => {
-                open_location(&location, &self.overlay);
+                open_location(location, &self.overlay);
             }
             BrowserEvent::RenameCompleted => {
                 self.cancel_rename();
@@ -4002,20 +4099,20 @@ impl ViewState {
                 if let Some(rename) = self.active_rename.borrow().as_ref() {
                     rename.field.set_sensitive(true);
                     rename.field.add_css_class("error");
-                    rename.field.set_tooltip_text(Some(&message));
+                    rename.field.set_tooltip_text(Some(message));
                     rename.field.grab_focus();
                 }
             }
             BrowserEvent::TransferStarted { total, moving } => {
                 let browser = self.browser.clone();
                 self.show_file_operation_progress(
-                    total,
-                    if moving {
+                    *total,
+                    if *moving {
                         crate::assets::icons::FOLDER
                     } else {
                         crate::assets::icons::COPY
                     },
-                    if moving {
+                    if *moving {
                         "Moving items"
                     } else {
                         "Copying items"
@@ -4025,18 +4122,18 @@ impl ViewState {
                 );
             }
             BrowserEvent::TransferProgress { completed, total } => {
-                self.update_delete_progress(completed, total);
+                self.update_delete_progress(*completed, *total);
             }
             BrowserEvent::TransferFinished { moved_locations } => {
                 if !moved_locations.is_empty() {
-                    self.complete_cut_transfer(&moved_locations);
+                    self.complete_cut_transfer(moved_locations);
                 }
                 self.dismiss_delete_progress();
             }
             BrowserEvent::DeletionStarted { total } => {
                 let browser = self.browser.clone();
                 self.show_file_operation_progress(
-                    total,
+                    *total,
                     crate::assets::icons::TRASH,
                     "Deleting items",
                     "Cancelling will not undo completed changes",
@@ -4044,13 +4141,13 @@ impl ViewState {
                 );
             }
             BrowserEvent::DeletionProgress { completed, total } => {
-                self.update_delete_progress(completed, total);
+                self.update_delete_progress(*completed, *total);
             }
             BrowserEvent::DeletionFinished => self.dismiss_delete_progress(),
             BrowserEvent::RestorationStarted { total } => {
                 let browser = self.browser.clone();
                 self.show_file_operation_progress(
-                    total,
+                    *total,
                     crate::assets::icons::FOLDER,
                     "Restoring items",
                     "Cancelling will not undo completed changes",
@@ -4058,7 +4155,7 @@ impl ViewState {
                 );
             }
             BrowserEvent::RestorationProgress { completed, total } => {
-                self.update_delete_progress(completed, total);
+                self.update_delete_progress(*completed, *total);
             }
             BrowserEvent::RestorationFinished => self.dismiss_delete_progress(),
             BrowserEvent::OperationFailed { message } => {
@@ -4071,7 +4168,7 @@ impl ViewState {
                         return;
                     }
                 }
-                show_error_dialog(&self.overlay, "Unable to complete operation", &message);
+                show_error_dialog(&self.overlay, "Unable to complete operation", message);
             }
             BrowserEvent::OperationCompletedWithErrors {
                 message,
@@ -4107,23 +4204,24 @@ impl ViewState {
             } => {
                 let message = format!(
                     "{} completed, {} failed, and {} not attempted.\n\nCompleted changes were not reverted.",
-                    item_count_label(completed),
-                    item_count_label(failed),
-                    item_count_label(not_attempted),
+                    item_count_label(*completed),
+                    item_count_label(*failed),
+                    item_count_label(*not_attempted),
                 );
                 let browser = self.browser.clone();
+                let affected = affected_locations.clone();
                 show_error_dialog_after_close(
                     &self.overlay,
                     "Operation cancelled",
                     &message,
-                    Rc::new(move || browser.refresh_after_cancellation(&affected_locations)),
+                    Rc::new(move || browser.refresh_after_cancellation(&affected)),
                 );
             }
             BrowserEvent::NavigationRejected {
                 parent_depth,
                 error,
             } => {
-                self.handle_navigation_rejected(parent_depth, error);
+                self.handle_navigation_rejected(*parent_depth, error.clone());
             }
             BrowserEvent::EmptyTrashRequested => {
                 self.load_trash_summary();
@@ -4133,14 +4231,14 @@ impl ViewState {
                 match error {
                     LocationValidationError::NotMounted(location) => {
                         self.mount_then_navigate_with_credentials(
-                            location,
+                            location.clone(),
                             MountStrategy::EnclosingVolume,
                             credentials,
                         );
                     }
                     LocationValidationError::Mountable(location) => {
                         self.mount_then_navigate_with_credentials(
-                            location,
+                            location.clone(),
                             MountStrategy::Mountable,
                             credentials,
                         );
@@ -4155,7 +4253,7 @@ impl ViewState {
             BrowserEvent::ArchiveStarted { total } => {
                 let browser = self.browser.clone();
                 self.show_file_operation_progress(
-                    total,
+                    *total,
                     crate::assets::icons::FILE_ARCHIVE,
                     "Working",
                     "This may take a moment",
@@ -4163,13 +4261,13 @@ impl ViewState {
                 );
             }
             BrowserEvent::ArchiveProgress { completed, total } => {
-                self.update_archive_progress(completed, total);
+                self.update_archive_progress(*completed, *total);
             }
             BrowserEvent::ArchiveCompleted { select_name, .. } => {
                 self.dismiss_delete_progress();
                 self.pending_extract_retry.replace(None);
                 if !select_name.is_empty() {
-                    self.pending_select.borrow_mut().push(select_name);
+                    self.pending_select.borrow_mut().push(select_name.clone());
                 }
                 if let Some(dest) = self.pending_navigate.take() {
                     self.browser.navigate(dest);
@@ -4183,7 +4281,12 @@ impl ViewState {
                 }
             }
         }
-        self.refresh_active_path_rows();
+        // Active-path styling depends on row positions and the active child:
+        // recompute only for events that can move rows or the active child,
+        if Self::event_refreshes_active_path(event) {
+            self.refresh_active_path_rows();
+        }
+        self.mode_views.borrow_mut().handle(event);
     }
 
     fn rebuild_columns(self: &Rc<Self>) {
@@ -4252,12 +4355,30 @@ impl ViewState {
         column.list.grab_focus();
     }
 
+    /// Whether a browser event can move rows or the active child, requiring an
+    /// active-path styling pass. Pure so the fan-out gate stays unit-testable
+    /// without widgets.
+    fn event_refreshes_active_path(event: &BrowserEvent) -> bool {
+        matches!(
+            event,
+            BrowserEvent::Reset
+                | BrowserEvent::ColumnAdded { .. }
+                | BrowserEvent::ColumnsTruncated { .. }
+                | BrowserEvent::FocusChanged { .. }
+                | BrowserEvent::SelectionSetChanged { .. }
+                | BrowserEvent::EntriesInserted { .. }
+                | BrowserEvent::EntriesPublished { .. }
+                | BrowserEvent::EntriesSpliced { .. }
+                | BrowserEvent::EntriesReplaced { .. }
+        )
+    }
+
     fn refresh_active_path_rows(&self) {
         for (depth, column) in self.columns.borrow().iter().enumerate() {
             let active = self
                 .browser
                 .active_child_position(depth)
-                .and_then(|position| filtered_position_for_source(column, position));
+                .and_then(|position| column.map.view_position(position));
             column.bound_rows.borrow_mut().retain(|bound| {
                 let (Some(item), Some(row)) = (bound.item.upgrade(), bound.row.upgrade()) else {
                     return false;
@@ -4305,7 +4426,7 @@ impl ViewState {
         heading_box.append(&heading);
         heading_box.append(&truncated_hint);
         let spinner = gtk::Spinner::new();
-        spinner.start();
+        spinner.set_visible(false);
         header.append(&heading_box);
         header.append(&spinner);
         let header_actions = gtk::Box::new(gtk::Orientation::Horizontal, 0);
@@ -4384,13 +4505,19 @@ impl ViewState {
         let show_hidden = Rc::new(Cell::new(initial_show_hidden));
         let filter = entry_filter(show_hidden.clone(), filter_query.clone());
         let filtered_model = gtk::FilterListModel::new(Some(model.clone()), Some(filter.clone()));
+        let map = ViewMap::new(
+            filter_query.clone(),
+            self.source_generation.clone(),
+            model.clone(),
+            filtered_model.clone(),
+            None,
+        );
         let selection = gtk::MultiSelection::new(Some(filtered_model.clone()));
         let syncing_selection = Rc::new(Cell::new(false));
         let modified_selection = Rc::new(Cell::new(false));
         let focused_filtered = Rc::new(Cell::new(None::<u32>));
         let weak_browser = Rc::downgrade(&self.browser);
-        let source_for_selection = model.clone();
-        let filtered_for_selection = filtered_model.clone();
+        let map_for_selection = map.clone();
         let syncing_selection_changed = syncing_selection.clone();
         let focused_filtered_changed = focused_filtered.clone();
         let filter_for_column = filter.clone();
@@ -4399,11 +4526,7 @@ impl ViewState {
                 return;
             }
             let filtered_positions = bitset_positions(&selection.selection());
-            let mapped_positions = source_positions_for_filtered(
-                &source_for_selection,
-                &filtered_for_selection,
-                &filtered_positions,
-            );
+            let mapped_positions = map_for_selection.source_positions(&filtered_positions);
             let source_positions: Vec<_> = mapped_positions
                 .iter()
                 .map(|(_, source_position)| *source_position)
@@ -4430,9 +4553,43 @@ impl ViewState {
                 browser.set_selection(depth, &source_positions, focused_source);
             }
         });
-        filter_entry.connect_changed(move |entry| {
-            *filter_query.borrow_mut() = entry.text().to_lowercase();
-            filter.changed(gtk::FilterChange::Different);
+        let map_for_filter = map.clone();
+        let query_for_filter = filter_query.clone();
+        let filter_for_settled = filter.clone();
+        let model_for_filter = filtered_model.clone();
+        let weak_state_for_filter = Rc::downgrade(self);
+        let selection_for_filter = selection.clone();
+        let syncing_for_filter = syncing_selection.clone();
+        debounce_filter_entry(&filter_entry, move |text| {
+            let settled = text.to_lowercase();
+            apply_filter_query(
+                &model_for_filter,
+                &filter_for_settled,
+                &query_for_filter,
+                settled,
+            );
+            // The filter reshuffles visible positions, so the GTK bitset goes
+            // stale: re-assert it from the NavigationState truth (selected
+            // locations survive filtering by design) through the rebuilt map
+            // instead of leaving the highlight on the wrong rows.
+            let Some(state) = weak_state_for_filter.upgrade() else {
+                return;
+            };
+            let positions: Vec<u32> = state
+                .browser
+                .selected_positions(depth)
+                .into_iter()
+                .filter_map(|position| map_for_filter.view_position(position))
+                .collect();
+            if let Some(column) = state.columns.borrow().get(depth) {
+                syncing_for_filter.set(true);
+                apply_selection_plan(
+                    &selection_for_filter,
+                    column.filtered_model.n_items(),
+                    &positions,
+                );
+                syncing_for_filter.set(false);
+            }
         });
 
         let factory = gtk::SignalListItemFactory::new();
@@ -4442,8 +4599,7 @@ impl ViewState {
         let modified_selection_for_rows = modified_selection.clone();
         let selection_for_rows = selection.clone();
         let mouse_selection_anchor = Rc::new(Cell::new(None::<u32>));
-        let source_for_hover = model.clone();
-        let filtered_for_hover = filtered_model.clone();
+        let map_for_hover = map.clone();
         let mouse_selection_anchor_for_background = mouse_selection_anchor.clone();
         factory.connect_setup(move |_, item| {
             let Some(item) = item.downcast_ref::<gtk::ListItem>() else {
@@ -4497,15 +4653,10 @@ impl ViewState {
             let list_item = item.clone();
             let anchor: gtk::Widget = row.clone().upcast();
             let weak_state_for_enter = weak_state.clone();
-            let source_for_enter = source_for_hover.clone();
-            let filtered_for_enter = filtered_for_hover.clone();
+            let map_for_enter = map_for_hover.clone();
             motion.connect_enter(move |_, _, _| {
                 if let Some(state) = weak_state_for_enter.upgrade() {
-                    let source_position = source_position_for_filtered(
-                        &source_for_enter,
-                        &filtered_for_enter,
-                        list_item.position(),
-                    );
+                    let source_position = map_for_enter.source_position(list_item.position());
                     let entry = source_position
                         .and_then(|position| state.browser.entry_at(depth, position));
                     if let Some(entry) = entry {
@@ -4531,15 +4682,10 @@ impl ViewState {
                 .build();
             let weak_state_for_drag = weak_state.clone();
             let dragged_item = item.clone();
-            let source_for_drag = source_for_hover.clone();
-            let filtered_for_drag = filtered_for_hover.clone();
+            let map_for_drag = map_for_hover.clone();
             drag.connect_prepare(move |source, x, y| {
                 let state = weak_state_for_drag.upgrade()?;
-                let source_position = source_position_for_filtered(
-                    &source_for_drag,
-                    &filtered_for_drag,
-                    dragged_item.position(),
-                )?;
+                let source_position = map_for_drag.source_position(dragged_item.position())?;
                 let entry = state.browser.entry_at(depth, source_position)?;
                 let selected = state.browser.selected_entries();
                 let entries = if selected
@@ -4568,18 +4714,14 @@ impl ViewState {
             drop.connect_motion(|target, _, _| file_drop_action(target));
             let weak_state_for_accept = weak_state.clone();
             let accepted_item = item.clone();
-            let source_for_accept = source_for_hover.clone();
-            let filtered_for_accept = filtered_for_hover.clone();
+            let map_for_accept = map_for_hover.clone();
             drop.connect_accept(move |_, offered| {
                 let Some(state) = weak_state_for_accept.upgrade() else {
                     return false;
                 };
-                let entry = source_position_for_filtered(
-                    &source_for_accept,
-                    &filtered_for_accept,
-                    accepted_item.position(),
-                )
-                .and_then(|position| state.browser.entry_at(depth, position));
+                let entry = map_for_accept
+                    .source_position(accepted_item.position())
+                    .and_then(|position| state.browser.entry_at(depth, position));
                 entry.is_some_and(|entry| {
                     entry.is_directory()
                         && offered
@@ -4589,20 +4731,17 @@ impl ViewState {
             });
             let weak_state_for_drop = weak_state.clone();
             let dropped_item = item.clone();
-            let source_for_drop = source_for_hover.clone();
-            let filtered_for_drop = filtered_for_hover.clone();
+            let map_for_drop = map_for_hover.clone();
             drop.connect_drop(move |target, value, _, _| {
                 let Some(state) = weak_state_for_drop.upgrade() else {
                     return false;
                 };
-                let Some(destination) = source_position_for_filtered(
-                    &source_for_drop,
-                    &filtered_for_drop,
-                    dropped_item.position(),
-                )
-                .and_then(|position| state.browser.entry_at(depth, position))
-                .filter(FileEntry::is_directory)
-                .map(|entry| entry.location) else {
+                let Some(destination) = map_for_drop
+                    .source_position(dropped_item.position())
+                    .and_then(|position| state.browser.entry_at(depth, position))
+                    .filter(FileEntry::is_directory)
+                    .map(|entry| entry.location)
+                else {
                     return false;
                 };
                 transfer_dropped_files(&state, target, value, destination)
@@ -4610,15 +4749,14 @@ impl ViewState {
             row.add_controller(drop);
 
             let selection_click = gtk::GestureClick::new();
+            let weak_state_for_click = weak_state.clone();
             selection_click.set_button(1);
             selection_click.set_propagation_phase(gtk::PropagationPhase::Capture);
             let clicked_item = item.clone();
             let selection_for_click = selection_for_rows.clone();
             let selection_anchor_for_click = mouse_selection_anchor.clone();
             let modified_for_click = modified_selection_for_rows.clone();
-            let weak_state_for_click = weak_state.clone();
-            let source_for_click = source_for_hover.clone();
-            let filtered_for_click = filtered_for_hover.clone();
+            let map_for_click = map_for_hover.clone();
             selection_click.connect_pressed(move |gesture, press_count, _, _| {
                 let position = clicked_item.position();
                 if position == gtk::INVALID_LIST_POSITION {
@@ -4657,8 +4795,7 @@ impl ViewState {
                 }
                 modified_for_click.set(false);
 
-                let source_position =
-                    source_position_for_filtered(&source_for_click, &filtered_for_click, position);
+                let source_position = map_for_click.source_position(position);
                 if let (Some(state), Some(source_position)) =
                     (weak_state_for_click.upgrade(), source_position)
                 {
@@ -4698,8 +4835,7 @@ impl ViewState {
                 row: weak_row,
             });
         });
-        let source_for_bind = model.clone();
-        let filtered_for_bind = filtered_model.clone();
+        let map_for_bind = map.clone();
         let weak_state_for_bind = Rc::downgrade(self);
         factory.connect_bind(move |_, item| {
             let Some(item) = item.downcast_ref::<gtk::ListItem>() else {
@@ -4739,8 +4875,7 @@ impl ViewState {
             rename.set_visible(false);
             label.set_visible(true);
             spacer.set_visible(true);
-            let source_position =
-                source_position_for_filtered(&source_for_bind, &filtered_for_bind, item.position());
+            let source_position = map_for_bind.source_position(item.position());
             let state = weak_state_for_bind.upgrade();
             let browser = state.as_ref().map(|state| &state.browser);
             let entry = source_position.and_then(|position| browser?.entry_at(depth, position));
@@ -4760,22 +4895,42 @@ impl ViewState {
                 }),
             );
             if let Some(entry) = entry.as_ref() {
-                super::thumbnail::set_thumbnail_or_icon(&icon, entry, entry_icon(entry), 17, 17);
+                // Like the grid and explorer binds: hidden views bind, but
+                // only the visible mode earns decodes and fills.
+                let mode_active = state
+                    .as_ref()
+                    .is_some_and(|state| state.mode_views.borrow().mode() == BrowserMode::Columns);
+                if mode_active {
+                    super::thumbnail::set_thumbnail_or_icon(
+                        &icon,
+                        entry,
+                        entry_icon(entry),
+                        17,
+                        17,
+                    );
+                } else {
+                    crate::assets::set_primary_icon(&icon, entry_icon(entry));
+                }
                 icon.set_opacity(if entry.is_directory() { 1.0 } else { 0.72 });
                 chevron.set_visible(entry.is_directory());
+                // Bound rows are the visible window: backfill the size/mtime
+                // the streaming enumeration skipped. Debounced per depth, so
+                // a fling binds hundreds of rows but stats one settled set.
+                if mode_active
+                    && let Some(state) = state.as_ref()
+                    && let Some(position) = source_position
+                    && metadata_needs_fill(entry)
+                {
+                    state
+                        .browser
+                        .request_metadata_fill(depth, position, entry.location.clone());
+                }
             } else {
                 super::thumbnail::show_fallback_icon(&icon, crate::assets::icons::DOCUMENTS, 17);
                 icon.set_opacity(0.72);
                 chevron.set_visible(false);
             }
-            let size_text = entry
-                .filter(|entry| !entry.is_directory())
-                .and_then(|entry| match entry.size {
-                    crate::model::MetadataValue::Known(bytes) => Some(format_file_size(bytes)),
-                    crate::model::MetadataValue::Unknown
-                    | crate::model::MetadataValue::Unavailable => None,
-                })
-                .unwrap_or_default();
+            let size_text = column_size_text(entry.as_ref());
             size.set_label(&size_text);
             size.set_visible(!size_text.is_empty());
         });
@@ -4824,14 +4979,9 @@ impl ViewState {
         list.add_controller(selection_keys);
 
         let weak_browser = Rc::downgrade(&self.browser);
-        let source_for_activation = model.clone();
-        let filtered_for_activation = filtered_model.clone();
+        let map_for_activation = map.clone();
         list.connect_activate(move |_, position| {
-            let source_position = source_position_for_filtered(
-                &source_for_activation,
-                &filtered_for_activation,
-                position,
-            );
+            let source_position = map_for_activation.source_position(position);
             if let (Some(browser), Some(source_position)) =
                 (weak_browser.upgrade(), source_position)
             {
@@ -4927,11 +5077,8 @@ impl ViewState {
                 (row == picked).then_some(item.position())
             })
         });
-        let source_for_context = model.clone();
-        let filtered_for_context = filtered_model.clone();
-        let source_position = Rc::new(move |position| {
-            source_position_for_filtered(&source_for_context, &filtered_for_context, position)
-        });
+        let map_for_context = map.clone();
+        let source_position = Rc::new(move |position| map_for_context.source_position(position));
         install_item_context_menu(
             self,
             list.upcast_ref(),
@@ -5016,6 +5163,8 @@ impl ViewState {
             presentation,
             model,
             filtered_model,
+            map,
+            model_generation: self.source_generation.clone(),
             header_actions,
             filter_entry,
             filter_button,
@@ -5026,6 +5175,7 @@ impl ViewState {
             bound_rows,
             entry_count,
             spinner,
+            spinner_delay: Rc::new(RefCell::new(None)),
             truncated_hint,
             empty_trash_button: is_trash.then_some(empty_trash),
             new_entry_row,
@@ -5035,11 +5185,16 @@ impl ViewState {
             filter: filter_for_column,
         });
 
+        // Accessible loading state immediately; the prominent spinner only
+        // after the delay, so fast loads never flash it.
+        if let Some(column) = self.columns.borrow().last() {
+            set_column_busy(column, true);
+            arm_column_spinner(column);
+        }
         self.refresh_active_path_rows();
         animate_column_entry(&shell, &column, &animation_generation);
         self.reveal_column(shell);
     }
-
     fn reveal_column(self: &Rc<Self>, shell: gtk::Box) {
         let animation_id = self.horizontal_scroll_generation.get().saturating_add(1);
         self.horizontal_scroll_generation.set(animation_id);
@@ -5381,6 +5536,67 @@ pub(super) fn format_file_size(bytes: u64) -> String {
     format!("{} {}", formatted.trim_end_matches(".0"), UNITS[unit])
 }
 
+/// Whether a bound row still needs a viewport metadata fill: files missing
+/// size or mtime, or directories missing mtime. Directory size stays unknown
+/// by design and never qualifies.
+pub(super) fn metadata_needs_fill(entry: &FileEntry) -> bool {
+    entry.modified_unix_seconds == crate::model::MetadataValue::Unknown
+        || (!entry.is_directory() && entry.size == crate::model::MetadataValue::Unknown)
+}
+
+/// Size label text for a columns row, shared by the bind and the in-place
+/// metadata refresh so both render identical strings.
+fn column_size_text(entry: Option<&FileEntry>) -> String {
+    entry
+        .filter(|entry| !entry.is_directory())
+        .and_then(|entry| match entry.size {
+            crate::model::MetadataValue::Known(bytes) => Some(format_file_size(bytes)),
+            crate::model::MetadataValue::Unknown | crate::model::MetadataValue::Unavailable => None,
+        })
+        .unwrap_or_default()
+}
+
+/// Delay before a new column's header spinner becomes prominent. Fast loads
+/// settle first, so no spinner flashes for work that finishes in ~120 ms.
+const COLUMN_SPINNER_DELAY: std::time::Duration = std::time::Duration::from_millis(120);
+
+/// Arms the delayed initial spinner for a freshly appended column.
+fn arm_column_spinner(column: &ColumnView) {
+    cancel_column_spinner(column);
+    let spinner = column.spinner.clone();
+    let delay = column.spinner_delay.clone();
+    *column.spinner_delay.borrow_mut() = Some(glib::timeout_add_local_once(
+        COLUMN_SPINNER_DELAY,
+        move || {
+            // Spent: disarm so a later cancel never removes a fired id
+            // (GLib refuses, and the unwrap would abort the main loop).
+            delay.borrow_mut().take();
+            spinner.set_visible(true);
+            spinner.start();
+        },
+    ));
+}
+/// Cancels a pending delayed spinner without touching a running one.
+fn cancel_column_spinner(column: &ColumnView) {
+    if let Some(source) = column.spinner_delay.borrow_mut().take() {
+        source.remove();
+    }
+}
+
+/// Stops a column's spinner outright, including a still-pending delay.
+fn stop_column_spinner(column: &ColumnView) {
+    cancel_column_spinner(column);
+    column.spinner.stop();
+    column.spinner.set_visible(false);
+}
+
+/// Marks a column's list busy (or settled) for assistive technology.
+fn set_column_busy(column: &ColumnView, busy: bool) {
+    column
+        .list
+        .update_state(&[gtk::accessible::State::Busy(busy)]);
+}
+
 fn set_filter_placeholder(column: &ColumnView, count: usize) {
     let noun = if count == 1 { "item" } else { "items" };
     column
@@ -5388,39 +5604,262 @@ fn set_filter_placeholder(column: &ColumnView, count: usize) {
         .set_placeholder_text(Some(&format!("Filter {count} {noun}…")));
 }
 
-fn source_position_for_filtered(
-    source: &gtk::StringList,
-    filtered: &gtk::FilterListModel,
-    filtered_position: u32,
-) -> Option<usize> {
-    source_positions_for_filtered(source, filtered, &[filtered_position])
-        .first()
-        .map(|(_, source)| *source)
+/// Debounce applied to every filter entry: rapid keystrokes collapse into a
+/// single settled evaluation instead of one full re-filter per character.
+/// Re-filtering 100k rows costs far more than a frame, so per-keystroke
+/// evaluation is the typing jank; one evaluation per pause is not.
+pub(crate) const FILTER_DEBOUNCE_DELAY: Duration = Duration::from_millis(60);
+
+/// Routes a filter entry through the shared debounce: each edit cancels the
+/// pending evaluation and arms a fresh one, so only the latest query after
+/// a typing pause reaches `on_settled` with its settled text.
+pub(crate) fn debounce_filter_entry(entry: &gtk::Entry, on_settled: impl Fn(String) + 'static) {
+    let pending: Rc<RefCell<Option<glib::SourceId>>> = Rc::new(RefCell::new(None));
+    let on_settled = Rc::new(on_settled);
+    entry.connect_changed(move |entry| {
+        cancel_source(&pending);
+        let slot = pending.clone();
+        let callback = on_settled.clone();
+        let text = entry.text().to_string();
+        *pending.borrow_mut() = Some(glib::timeout_add_local_once(
+            FILTER_DEBOUNCE_DELAY,
+            move || {
+                slot.borrow_mut().take();
+                callback(text);
+            },
+        ));
+    });
+}
+/// Picks the cheapest `FilterChange` for a settled query edit. Typing
+/// narrows the previous query, so matches can only shrink and the model
+/// skips already-hidden rows; deleting widens it and must reconsider them.
+/// Anything else re-evaluates everything.
+pub(crate) fn filter_change_for(previous: &str, settled: &str) -> gtk::FilterChange {
+    if settled.starts_with(previous) && settled.len() > previous.len() {
+        gtk::FilterChange::MoreStrict
+    } else if previous.starts_with(settled) && previous.len() > settled.len() {
+        gtk::FilterChange::LessStrict
+    } else {
+        gtk::FilterChange::Different
+    }
 }
 
-fn source_positions_for_filtered(
+pub(crate) fn apply_filter_query(
+    model: &gtk::FilterListModel,
+    filter: &gtk::CustomFilter,
+    query: &RefCell<String>,
+    settled: String,
+) {
+    let previous = query.borrow().clone();
+    let change = filter_change_for(&previous, &settled);
+    *query.borrow_mut() = settled;
+    if query.borrow().is_empty() {
+        model.set_filter(None::<&gtk::Filter>);
+    } else if previous.is_empty() {
+        model.set_filter(Some(filter));
+    } else {
+        filter.changed(change);
+    }
+}
+
+/// Cached source<->visible index map for one (query, model generation). A
+/// full re-filter or model splice rebuilds it once in O(n); every bind,
+/// activation, and selection sync after that is O(1). With no query active
+/// the filter passes everything in order, so callers take the identity fast
+/// path and never build (or even touch) the map.
+#[derive(Default)]
+pub(crate) struct PositionMap {
+    query: String,
+    generation: u64,
+    /// Visible position -> source position, in visible order.
+    forward: Vec<usize>,
+    /// Source position -> visible position (`NO_FILTERED_POSITION` = hidden).
+    reverse: Vec<u32>,
+}
+
+pub(crate) const NO_FILTERED_POSITION: u32 = u32::MAX;
+
+/// Rebuilds the map in a single monotonic pass over both models: the filter
+/// preserves source order, so one joint walk emits both directions.
+fn rebuild_position_map(
     source: &gtk::StringList,
     filtered: &gtk::FilterListModel,
-    filtered_positions: &[u32],
-) -> Vec<(u32, usize)> {
+    query: &str,
+    generation: u64,
+) -> PositionMap {
+    let mut forward = Vec::with_capacity(filtered.n_items() as usize);
+    let mut reverse = vec![NO_FILTERED_POSITION; source.n_items() as usize];
+    let n_source = source.n_items();
     let mut source_position = 0;
-    filtered_positions
-        .iter()
-        .filter_map(|filtered_position| {
-            let item = filtered.item(*filtered_position)?;
-            while source_position < source.n_items() {
-                let candidate_position = source_position;
-                source_position += 1;
-                if source
-                    .item(candidate_position)
-                    .is_some_and(|candidate| candidate == item)
-                {
-                    return Some((*filtered_position, candidate_position as usize));
-                }
+    for filtered_position in 0..filtered.n_items() {
+        let Some(item) = filtered.item(filtered_position) else {
+            continue;
+        };
+        while source_position < n_source {
+            let candidate = source_position;
+            source_position += 1;
+            if source.item(candidate).is_some_and(|value| value == item) {
+                forward.push(candidate as usize);
+                reverse[candidate as usize] = filtered_position;
+                break;
             }
-            None
-        })
-        .collect()
+        }
+    }
+    PositionMap {
+        query: query.to_owned(),
+        generation,
+        forward,
+        reverse,
+    }
+}
+
+/// Everything a view needs to translate between its visible positions and
+/// source positions: the shared model-generation clock, the folded query,
+/// the map cache, and the two models. Columns views carry no placeholder
+/// (`placeholder: None`); Grid/Explorer flatten a placeholder row above the
+/// filter output, so their visible positions shift by its live row count.
+#[derive(Clone)]
+pub(crate) struct ViewMap {
+    cache: Rc<RefCell<PositionMap>>,
+    query: Rc<RefCell<String>>,
+    generation: Rc<Cell<u64>>,
+    source: gtk::StringList,
+    filter: gtk::FilterListModel,
+    placeholder: Option<gtk::StringList>,
+}
+
+impl ViewMap {
+    pub(crate) fn new(
+        query: Rc<RefCell<String>>,
+        generation: Rc<Cell<u64>>,
+        source: gtk::StringList,
+        filter: gtk::FilterListModel,
+        placeholder: Option<gtk::StringList>,
+    ) -> Self {
+        Self {
+            cache: Rc::new(RefCell::new(PositionMap::default())),
+            query,
+            generation,
+            source,
+            filter,
+            placeholder,
+        }
+    }
+
+    fn placeholder_count(&self) -> u32 {
+        self.placeholder
+            .as_ref()
+            .map_or(0, |placeholder| placeholder.n_items())
+    }
+
+    /// Visible (flatten) position -> source position. O(1): identity-checked
+    /// without a query, cache hit otherwise, one O(n) rebuild per
+    /// (query, generation) at most.
+    pub(crate) fn source_position(&self, visible_position: u32) -> Option<usize> {
+        let filter_position = visible_position.checked_sub(self.placeholder_count())?;
+        let query = self.query.borrow();
+        if query.is_empty() {
+            // No query: the filter passes everything in order. Cross-check
+            // both models so a transitional state degrades to a safe miss
+            // instead of a wrong row; no scan, no map, same cost at row 10
+            // and row 90,000.
+            let source_item = self.source.item(filter_position)?;
+            let visible_item = self.filter.item(filter_position)?;
+            return (source_item == visible_item).then_some(filter_position as usize);
+        }
+        let mut cache = self.cache.borrow_mut();
+        let generation = self.generation.get();
+        if cache.query != *query || cache.generation != generation {
+            *cache = rebuild_position_map(&self.source, &self.filter, &query, generation);
+        }
+        cache.forward.get(filter_position as usize).copied()
+    }
+
+    /// Source position -> visible (flatten) position. Same cost profile as
+    /// [`ViewMap::source_position`].
+    pub(crate) fn view_position(&self, source_position: usize) -> Option<u32> {
+        let query = self.query.borrow();
+        if query.is_empty() {
+            let position = source_position as u32;
+            let source_item = self.source.item(position)?;
+            let visible_item = self.filter.item(position)?;
+            return (source_item == visible_item).then_some(position + self.placeholder_count());
+        }
+        let mut cache = self.cache.borrow_mut();
+        let generation = self.generation.get();
+        if cache.query != *query || cache.generation != generation {
+            *cache = rebuild_position_map(&self.source, &self.filter, &query, generation);
+        }
+        let position = *cache.reverse.get(source_position)?;
+        (position != NO_FILTERED_POSITION).then_some(position + self.placeholder_count())
+    }
+
+    /// Batch variant for selection sync: one cache ensure, then O(1) per
+    /// position. Preserves the (visible, source) pair order of the input.
+    pub(crate) fn source_positions(&self, visible_positions: &[u32]) -> Vec<(u32, usize)> {
+        visible_positions
+            .iter()
+            .filter_map(|position| {
+                self.source_position(*position)
+                    .map(|source| (*position, source))
+            })
+            .collect()
+    }
+}
+
+/// How a position list reaches the GTK selection: whole-model and single
+/// contiguous runs use native bulk ops (one call, no per-row round trips);
+/// only genuinely scattered sets fall back to per-item selection.
+pub(crate) enum SelectionPlan<'a> {
+    All,
+    Range { position: u32, count: u32 },
+    Items(&'a [u32]),
+}
+
+pub(crate) fn plan_selection(n_items: u32, positions: &[u32]) -> SelectionPlan<'_> {
+    let contiguous =
+        !positions.is_empty() && positions.windows(2).all(|pair| pair[1] == pair[0] + 1);
+    if contiguous && positions.len() as u32 == n_items && positions[0] == 0 {
+        SelectionPlan::All
+    } else if contiguous {
+        SelectionPlan::Range {
+            position: positions[0],
+            count: positions.len() as u32,
+        }
+    } else {
+        SelectionPlan::Items(positions)
+    }
+}
+
+/// Applies `positions` (visible indexes into a model of `n_items` rows)
+/// with the cheapest native op. Callers hold their syncing guard.
+pub(crate) fn apply_selection_plan(
+    selection: &gtk::MultiSelection,
+    n_items: u32,
+    positions: &[u32],
+) {
+    match plan_selection(n_items, positions) {
+        SelectionPlan::All => {
+            selection.select_all();
+        }
+        SelectionPlan::Range { position, count } => {
+            selection.select_range(position, count, true);
+        }
+        SelectionPlan::Items(items) => {
+            selection.unselect_all();
+            for position in items {
+                selection.select_item(*position, false);
+            }
+        }
+    }
+}
+/// Advances the shared source-model generation after a splice. Every column
+/// and mode pane keys its cached position map on this clock, so one bump
+/// invalidates every map at once with no per-view bookkeeping.
+fn touch_source_model(column: &ColumnView) {
+    column
+        .model_generation
+        .set(column.model_generation.get().saturating_add(1));
 }
 
 fn set_column_selection(column: &ColumnView, position: u32) {
@@ -5434,10 +5873,13 @@ fn set_column_selection(column: &ColumnView, position: u32) {
 
 fn set_column_selections(column: &ColumnView, positions: &[u32]) {
     column.syncing_selection.set(true);
-    column.selection.unselect_all();
-    for position in positions {
-        column.selection.select_item(*position, false);
-    }
+    // Select All over 100k rows used to issue 100k `select_item` calls;
+    // full coverage and single contiguous runs now use one native bulk op.
+    apply_selection_plan(
+        &column.selection,
+        column.filtered_model.n_items(),
+        positions,
+    );
     column.syncing_selection.set(false);
 }
 
@@ -5446,16 +5888,6 @@ fn bitset_positions(bitset: &gtk::Bitset) -> Vec<u32> {
         return Vec::new();
     };
     std::iter::once(first).chain(iterator).collect()
-}
-
-fn filtered_position_for_source(column: &ColumnView, source_position: usize) -> Option<u32> {
-    let item = column.model.item(source_position as u32)?;
-    (0..column.filtered_model.n_items()).find(|position| {
-        column
-            .filtered_model
-            .item(*position)
-            .is_some_and(|candidate| candidate == item)
-    })
 }
 
 pub(super) fn install_folder_context_menu(
@@ -7377,7 +7809,26 @@ pub(super) fn entry_model_value(entry: &FileEntry) -> String {
         'f'
     };
     let hidden = if entry.is_hidden { 'h' } else { 'v' };
-    format!("{kind}{hidden}\t{}", entry.display_name)
+    let name = entry.display_name.as_str();
+    let mut value = String::with_capacity(name.len() + 3);
+    value.push(kind);
+    value.push(hidden);
+    value.push('\t');
+    value.push_str(name);
+    value
+}
+
+fn entry_model_values(
+    browser: &Browser,
+    depth: usize,
+    position: usize,
+    count: usize,
+) -> Vec<String> {
+    browser
+        .with_entries(depth, position..position.saturating_add(count), |entries| {
+            entries.iter().map(entry_model_value).collect()
+        })
+        .unwrap_or_default()
 }
 
 fn model_display_name(value: &str) -> &str {
@@ -7484,6 +7935,14 @@ pub(super) fn entry_icon(entry: &FileEntry) -> &'static str {
     icon_for_name(&entry.display_name)
 }
 
+/// Full-directory filter predicate shared by every view mode. Source models
+/// carry `kind\tname` values; matching runs against the display name so a
+/// shared model filters identically in Columns, Grid, and Explorer.
+/// `query` must already be folded to lowercase by the caller.
+pub(super) fn pane_filter_matches(value: &str, query: &str) -> bool {
+    query.is_empty() || model_display_name(value).to_lowercase().contains(query)
+}
+
 fn icon_for_name(name: &str) -> &'static str {
     let extension = name
         .rsplit_once('.')
@@ -7576,12 +8035,12 @@ fn peek_horizontal_placement(
 fn append_peek_entries(peek: &PeekView, entries: Vec<FileEntry>, limit: usize) {
     let remaining = limit.max(1).saturating_sub(peek.entry_count.get());
     let entries = entries.into_iter().take(remaining).collect::<Vec<_>>();
-    let values = entries.iter().map(entry_model_value).collect::<Vec<_>>();
+    let mut values = Vec::with_capacity(entries.len());
+    values.extend(entries.iter().map(entry_model_value));
     peek.entry_count.set(peek.entry_count.get() + entries.len());
     peek.entries.borrow_mut().extend(entries);
-    for value in values {
-        peek.model.append(&value);
-    }
+    let refs: Vec<_> = values.iter().map(String::as_str).collect();
+    peek.model.splice(peek.model.n_items(), 0, &refs);
 }
 
 fn cancel_source(source: &RefCell<Option<glib::SourceId>>) {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -34,6 +34,7 @@ use super::{
         message_dialog_description, message_dialog_layout, modal_layout, segmented_control,
         wrap_dialog_text,
     },
+    entry_list_model::EntryListModel,
     motion::{animations_enabled, emphasized_deceleration},
 };
 
@@ -62,7 +63,7 @@ struct ColumnView {
     shell: gtk::Box,
     animation_generation: Rc<Cell<u64>>,
     presentation: LoadPresentation,
-    model: gtk::StringList,
+    model: EntryListModel,
     filtered_model: gtk::FilterListModel,
     /// Cached visible<->source index translation. Shares the ViewState
     /// model-generation clock, so every splice invalidates every column at
@@ -3767,9 +3768,9 @@ impl ViewState {
                 self.sync_active_location();
             }
             BrowserEvent::ColumnAdded { depth, location } => {
-                self.set_location(&location);
+                self.set_location(location);
                 if self.mode_views.borrow().mode() == BrowserMode::Columns {
-                    self.append_column(depth, &location);
+                    self.append_column(*depth, location);
                 }
             }
             BrowserEvent::EntriesInserted { depth, insertions } => {
@@ -3783,11 +3784,14 @@ impl ViewState {
                         column.presentation.show_content();
                     }
                     for insertion in insertions {
-                        let mut labels = Vec::with_capacity(insertion.entries.len());
-                        labels.extend(insertion.entries.iter().map(entry_model_value));
-                        let labels: Vec<_> = labels.iter().map(String::as_str).collect();
-                        column.model.splice(insertion.position as u32, 0, &labels);
+                        // Invalidate filtered position maps before the model
+                        // emits its synchronous items-changed notification.
                         touch_source_model(&column);
+                        column.model.splice(
+                            insertion.position as u32,
+                            0,
+                            insertion.entries.len() as u32,
+                        );
                     }
                     let count = column.entry_count.get() + entry_count;
                     column.entry_count.set(count);
@@ -3809,10 +3813,8 @@ impl ViewState {
                         column.presentation.show_content();
                         set_column_busy(&column, false);
                     }
-                    let labels = entry_model_values(&self.browser, *depth, 0, *count);
-                    let labels: Vec<_> = labels.iter().map(String::as_str).collect();
-                    column.model.splice(0, column.model.n_items(), &labels);
                     touch_source_model(&column);
+                    column.model.replace(*count as u32);
                     column.entry_count.set(*count);
                     set_filter_placeholder(&column, *count);
                     update_empty_trash_sensitivity(&column, *count);
@@ -3828,10 +3830,8 @@ impl ViewState {
                     if *count > 0 && !column.spinner.is_spinning() {
                         column.presentation.show_content();
                     }
-                    let labels = entry_model_values(&self.browser, *depth, *position, *count);
-                    let labels: Vec<_> = labels.iter().map(String::as_str).collect();
-                    column.model.splice(*position as u32, 0, &labels);
                     touch_source_model(&column);
+                    column.model.splice(*position as u32, 0, *count as u32);
                     let total = column.entry_count.get().saturating_add(*count);
                     column.entry_count.set(total);
                     set_filter_placeholder(&column, total);
@@ -3914,12 +3914,12 @@ impl ViewState {
                 if let Some(column) = self.columns.borrow().get(*depth) {
                     let mut count = column.entry_count.get();
                     for splice in splices {
-                        let labels: Vec<_> = splice.entries.iter().map(entry_model_value).collect();
-                        let labels: Vec<_> = labels.iter().map(String::as_str).collect();
-                        column
-                            .model
-                            .splice(splice.position as u32, splice.removed as u32, &labels);
                         touch_source_model(column);
+                        column.model.splice(
+                            splice.position as u32,
+                            splice.removed as u32,
+                            splice.entries.len() as u32,
+                        );
                         count = count
                             .saturating_sub(splice.removed)
                             .saturating_add(splice.entries.len());
@@ -3945,8 +3945,8 @@ impl ViewState {
                 if let Some(column) = self.columns.borrow().get(*depth) {
                     column.syncing_selection.set(true);
                     column.selection.set_model(None::<&gio::ListModel>);
-                    column.model.splice(0, column.model.n_items(), &[]);
                     touch_source_model(column);
+                    column.model.replace(0);
                     column.entry_count.set(0);
                     set_filter_placeholder(column, 0);
                     column.truncated_hint.set_visible(false);
@@ -3958,10 +3958,11 @@ impl ViewState {
             }
             BrowserEvent::HiddenToggled { show_hidden } => {
                 for column in self.columns.borrow().iter() {
-                    column.show_hidden.set(show_hidden);
+                    column.show_hidden.set(*show_hidden);
+                    touch_source_model(column);
                     column.filter.changed(gtk::FilterChange::Different);
                 }
-                self.mode_views.borrow().set_show_hidden(show_hidden);
+                self.mode_views.borrow().set_show_hidden(*show_hidden);
             }
             BrowserEvent::LoadFinished { depth, truncated } => {
                 if let Some(column) = self.columns.borrow().get(*depth) {
@@ -4177,15 +4178,15 @@ impl ViewState {
             } => {
                 let retryable_entries = retryable_delete_entries(
                     self.pending_delete_entries.take(),
-                    &retryable_locations,
+                    retryable_locations,
                 );
                 if retryable_entries.is_empty() {
-                    show_error_dialog(&self.overlay, "Completed with errors", &message);
-                } else if has_non_retryable_failures {
+                    show_error_dialog(&self.overlay, "Completed with errors", message);
+                } else if *has_non_retryable_failures {
                     let weak_state = Rc::downgrade(self);
                     show_delete_error_dialog(
                         &self.overlay,
-                        &message,
+                        message,
                         Rc::new(move || {
                             if let Some(state) = weak_state.upgrade() {
                                 state.show_delete_confirmation(retryable_entries.clone());
@@ -4299,21 +4300,16 @@ impl ViewState {
             self.append_column(depth, &snapshot.location);
         }
         for (column, snapshot) in self.columns.borrow().iter().zip(snapshots) {
-            let labels = snapshot
-                .entries
-                .iter()
-                .map(entry_model_value)
-                .collect::<Vec<_>>();
-            let labels = labels.iter().map(String::as_str).collect::<Vec<_>>();
-            column.model.splice(0, column.model.n_items(), &labels);
-            column.entry_count.set(snapshot.entries.len());
-            set_filter_placeholder(column, snapshot.entries.len());
-            update_empty_trash_sensitivity(column, snapshot.entries.len());
+            touch_source_model(column);
+            column.model.replace(snapshot.count as u32);
+            column.entry_count.set(snapshot.count);
+            set_filter_placeholder(column, snapshot.count);
+            update_empty_trash_sensitivity(column, snapshot.count);
             column.truncated_hint.set_visible(snapshot.truncated);
             let positions = snapshot
                 .selected_positions
                 .into_iter()
-                .filter_map(|position| filtered_position_for_source(column, position))
+                .filter_map(|position| column.map.view_position(position))
                 .collect::<Vec<_>>();
             set_column_selections(column, &positions);
             if snapshot.loading {
@@ -4326,7 +4322,7 @@ impl ViewState {
                     column
                         .presentation
                         .show_error(&format!("Unable to read this directory\n{message}"));
-                } else if snapshot.entries.is_empty() {
+                } else if snapshot.count == 0 {
                     column.presentation.show_empty();
                 } else {
                     column.presentation.show_content();
@@ -4346,7 +4342,7 @@ impl ViewState {
         };
         if let Some((focused_depth, position, _)) = self.browser.focused_item()
             && focused_depth == depth
-            && let Some(position) = filtered_position_for_source(column, position)
+            && let Some(position) = column.map.view_position(position)
         {
             column
                 .list
@@ -4496,7 +4492,15 @@ impl ViewState {
         column.append(&filter_revealer);
 
         let entry_count = Rc::new(Cell::new(0));
-        let model = gtk::StringList::new(&[]);
+        let browser_for_model = self.browser.clone();
+        let model = EntryListModel::new(Rc::new(move |position| {
+            let position = position as usize;
+            browser_for_model
+                .with_entries(depth, position..position.saturating_add(1), |entries| {
+                    entries.first().map(entry_model_value)
+                })
+                .flatten()
+        }));
         let filter_query = Rc::new(RefCell::new(String::new()));
         let initial_show_hidden = self
             .browser
@@ -4507,6 +4511,7 @@ impl ViewState {
         let filtered_model = gtk::FilterListModel::new(Some(model.clone()), Some(filter.clone()));
         let map = ViewMap::new(
             filter_query.clone(),
+            show_hidden.clone(),
             self.source_generation.clone(),
             model.clone(),
             filtered_model.clone(),
@@ -5679,30 +5684,22 @@ pub(crate) struct PositionMap {
 
 pub(crate) const NO_FILTERED_POSITION: u32 = u32::MAX;
 
-/// Rebuilds the map in a single monotonic pass over both models: the filter
-/// preserves source order, so one joint walk emits both directions.
 fn rebuild_position_map(
-    source: &gtk::StringList,
-    filtered: &gtk::FilterListModel,
+    source: &EntryListModel,
     query: &str,
+    show_hidden: bool,
     generation: u64,
 ) -> PositionMap {
-    let mut forward = Vec::with_capacity(filtered.n_items() as usize);
-    let mut reverse = vec![NO_FILTERED_POSITION; source.n_items() as usize];
-    let n_source = source.n_items();
-    let mut source_position = 0;
-    for filtered_position in 0..filtered.n_items() {
-        let Some(item) = filtered.item(filtered_position) else {
+    let n_source = source.n_items() as usize;
+    let mut forward = Vec::new();
+    let mut reverse = vec![NO_FILTERED_POSITION; n_source];
+    for (source_position, filtered_position) in reverse.iter_mut().enumerate() {
+        let Some(text) = source.value(source_position as u32) else {
             continue;
         };
-        while source_position < n_source {
-            let candidate = source_position;
-            source_position += 1;
-            if source.item(candidate).is_some_and(|value| value == item) {
-                forward.push(candidate as usize);
-                reverse[candidate as usize] = filtered_position;
-                break;
-            }
+        if (show_hidden || !model_is_hidden(&text)) && pane_filter_matches(&text, query) {
+            *filtered_position = forward.len() as u32;
+            forward.push(source_position);
         }
     }
     PositionMap {
@@ -5722,8 +5719,9 @@ fn rebuild_position_map(
 pub(crate) struct ViewMap {
     cache: Rc<RefCell<PositionMap>>,
     query: Rc<RefCell<String>>,
+    show_hidden: Rc<Cell<bool>>,
     generation: Rc<Cell<u64>>,
-    source: gtk::StringList,
+    source: EntryListModel,
     filter: gtk::FilterListModel,
     placeholder: Option<gtk::StringList>,
 }
@@ -5731,14 +5729,16 @@ pub(crate) struct ViewMap {
 impl ViewMap {
     pub(crate) fn new(
         query: Rc<RefCell<String>>,
+        show_hidden: Rc<Cell<bool>>,
         generation: Rc<Cell<u64>>,
-        source: gtk::StringList,
+        source: EntryListModel,
         filter: gtk::FilterListModel,
         placeholder: Option<gtk::StringList>,
     ) -> Self {
         Self {
             cache: Rc::new(RefCell::new(PositionMap::default())),
             query,
+            show_hidden,
             generation,
             source,
             filter,
@@ -5758,19 +5758,16 @@ impl ViewMap {
     pub(crate) fn source_position(&self, visible_position: u32) -> Option<usize> {
         let filter_position = visible_position.checked_sub(self.placeholder_count())?;
         let query = self.query.borrow();
-        if query.is_empty() {
-            // No query: the filter passes everything in order. Cross-check
-            // both models so a transitional state degrades to a safe miss
-            // instead of a wrong row; no scan, no map, same cost at row 10
-            // and row 90,000.
-            let source_item = self.source.item(filter_position)?;
-            let visible_item = self.filter.item(filter_position)?;
-            return (source_item == visible_item).then_some(filter_position as usize);
+        if query.is_empty() && self.show_hidden.get() {
+            if filter_position < self.source.n_items() && filter_position < self.filter.n_items() {
+                return Some(filter_position as usize);
+            }
+            return None;
         }
         let mut cache = self.cache.borrow_mut();
         let generation = self.generation.get();
         if cache.query != *query || cache.generation != generation {
-            *cache = rebuild_position_map(&self.source, &self.filter, &query, generation);
+            *cache = rebuild_position_map(&self.source, &query, self.show_hidden.get(), generation);
         }
         cache.forward.get(filter_position as usize).copied()
     }
@@ -5779,16 +5776,17 @@ impl ViewMap {
     /// [`ViewMap::source_position`].
     pub(crate) fn view_position(&self, source_position: usize) -> Option<u32> {
         let query = self.query.borrow();
-        if query.is_empty() {
-            let position = source_position as u32;
-            let source_item = self.source.item(position)?;
-            let visible_item = self.filter.item(position)?;
-            return (source_item == visible_item).then_some(position + self.placeholder_count());
+        if query.is_empty() && self.show_hidden.get() {
+            let position = source_position as u64;
+            if position < self.source.n_items() as u64 && position < self.filter.n_items() as u64 {
+                return Some(position as u32 + self.placeholder_count());
+            }
+            return None;
         }
         let mut cache = self.cache.borrow_mut();
         let generation = self.generation.get();
         if cache.query != *query || cache.generation != generation {
-            *cache = rebuild_position_map(&self.source, &self.filter, &query, generation);
+            *cache = rebuild_position_map(&self.source, &query, self.show_hidden.get(), generation);
         }
         let position = *cache.reverse.get(source_position)?;
         (position != NO_FILTERED_POSITION).then_some(position + self.placeholder_count())
@@ -7816,19 +7814,6 @@ pub(super) fn entry_model_value(entry: &FileEntry) -> String {
     value.push('\t');
     value.push_str(name);
     value
-}
-
-fn entry_model_values(
-    browser: &Browser,
-    depth: usize,
-    position: usize,
-    count: usize,
-) -> Vec<String> {
-    browser
-        .with_entries(depth, position..position.saturating_add(count), |entries| {
-            entries.iter().map(entry_model_value).collect()
-        })
-        .unwrap_or_default()
 }
 
 fn model_display_name(value: &str) -> &str {

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -690,9 +690,36 @@ impl ModeViews {
                     }
                 }
             }
-            BrowserEvent::EntriesReplaced { depth, entries } => {
+            BrowserEvent::EntriesReplaced { depth, count } => {
                 for pane in self.panes_at(*depth) {
-                    replace_entries(pane, entries);
+                    replace_entries(pane, &self.browser, *count);
+                }
+            }
+            BrowserEvent::EntriesPublished {
+                depth,
+                position,
+                count,
+            } => {
+                for pane in self.panes_at(*depth) {
+                    let values = self
+                        .browser
+                        .with_entries(
+                            *depth,
+                            *position..position.saturating_add(*count),
+                            |entries| {
+                                entries
+                                    .iter()
+                                    .map(super::browser::entry_model_value)
+                                    .collect::<Vec<_>>()
+                            },
+                        )
+                        .unwrap_or_default();
+                    let values: Vec<_> = values.iter().map(String::as_str).collect();
+                    pane.model.splice(*position as u32, 0, &values);
+                    sync_grid_groups(pane);
+                    if !pane.spinner.is_spinning() {
+                        show_count(pane);
+                    }
                 }
             }
             BrowserEvent::SortingStarted { depth } => {
@@ -911,7 +938,7 @@ impl ModeViews {
             &snapshot.location.display_name(),
         );
         configure_grid_density(&pane, self.density);
-        apply_snapshot(&pane, &snapshot);
+        apply_snapshot(&pane, &snapshot, &self.browser);
         self.install_context_menu(&pane);
         self.grid_root.append(&pane.shell);
         self.grid_panes.push(pane);
@@ -942,7 +969,7 @@ impl ModeViews {
             depth,
             &snapshot.location.display_name(),
         );
-        apply_snapshot(&pane, &snapshot);
+        apply_snapshot(&pane, &snapshot, &self.browser);
         self.install_context_menu(&pane);
         self.explorer_root.append(&pane.shell);
         self.explorer_pane = Some(pane);
@@ -2939,11 +2966,15 @@ fn refresh_cut_pane(pane: &Pane, browser: &Browser, cuts: &[Location]) {
     }
 }
 
-fn replace_entries(pane: &Pane, entries: &[FileEntry]) {
-    let values: Vec<String> = entries
-        .iter()
-        .map(super::browser::entry_model_value)
-        .collect();
+fn replace_entries(pane: &Pane, browser: &Browser, count: usize) {
+    let values = browser
+        .with_entries(pane.depth, 0..count, |entries| {
+            entries
+                .iter()
+                .map(super::browser::entry_model_value)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
     let values_ref: Vec<&str> = values.iter().map(String::as_str).collect();
     pane.model.splice(0, pane.model.n_items(), &values_ref);
     sync_grid_groups(pane);
@@ -2977,8 +3008,8 @@ fn show_count(pane: &Pane) {
     }
 }
 
-fn apply_snapshot(pane: &Pane, snapshot: &BrowserColumnSnapshot) {
-    replace_entries(pane, &snapshot.entries);
+fn apply_snapshot(pane: &Pane, snapshot: &BrowserColumnSnapshot, browser: &Browser) {
+    replace_entries(pane, browser, snapshot.count);
     set_selections(pane, &snapshot.selected_positions);
     pane.truncated_hint.set_visible(snapshot.truncated);
     if snapshot.loading {

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -1584,7 +1584,8 @@ fn build_grid_view(
         };
         let source_position =
             source_position_for_view(&source_for_bind, Some(&filtered_for_bind), item.position());
-        let entry = browser_for_bind.upgrade().and_then(|browser| {
+        let browser = browser_for_bind.upgrade();
+        let entry = browser.as_ref().and_then(|browser| {
             source_position.and_then(|position| browser.entry_at(depth, position))
         });
         if let Some(entry) = entry {
@@ -1600,6 +1601,11 @@ fn build_grid_view(
                 26,
                 thumbnail_size_for_bind.get(),
             );
+            if let Some(position) = metadata_fill_position(source_position, &entry)
+                && let Some(browser) = browser.as_ref()
+            {
+                browser.request_metadata_fill(depth, position, entry.location.clone());
+            }
             icon.set_opacity(if entry.is_directory() { 1.0 } else { 0.72 });
         } else {
             card.remove_css_class("cut-item");
@@ -2305,7 +2311,8 @@ fn build_explorer_pane(
             Some(&view_model_for_bind),
             item.position(),
         );
-        let entry = browser_for_bind.upgrade().and_then(|browser| {
+        let browser = browser_for_bind.upgrade();
+        let entry = browser.as_ref().and_then(|browser| {
             source_position.and_then(|position| browser.entry_at(depth, position))
         });
         if let Some(entry) = entry {
@@ -2319,6 +2326,11 @@ fn build_explorer_pane(
                 18,
                 18,
             );
+            if let Some(position) = metadata_fill_position(source_position, &entry)
+                && let Some(browser) = browser.as_ref()
+            {
+                browser.request_metadata_fill(depth, position, entry.location.clone());
+            }
             name.set_label(&entry.display_name);
             size.set_label(&entry_size(&entry));
             kind.set_label(entry_type(&entry));
@@ -2824,6 +2836,10 @@ fn source_position_for_view(
     (0..source.n_items())
         .find(|candidate| source.item(*candidate).is_some_and(|value| value == item))
         .map(|position| position as usize)
+}
+
+fn metadata_fill_position(position: Option<usize>, entry: &FileEntry) -> Option<usize> {
+    position.filter(|_| super::browser::metadata_needs_fill(entry))
 }
 
 fn view_position_for_source(

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -692,6 +692,10 @@ impl ModeViews {
             }
             BrowserEvent::EntriesReplaced { depth, count } => {
                 for pane in self.panes_at(*depth) {
+                    if *count > 0 {
+                        pane.spinner.stop();
+                        pane.spinner.set_visible(false);
+                    }
                     replace_entries(pane, &self.browser, *count);
                 }
             }

--- a/src/ui/browser_modes/tests.rs
+++ b/src/ui/browser_modes/tests.rs
@@ -2,9 +2,10 @@
 
 use super::{
     BrowserMode, ClickActivation, ClickCount, EXPLORER_COLUMN_MIN_WIDTHS, EXPLORER_COLUMN_WIDTHS,
-    compare_type_groups, explorer_column_width, should_activate_pointer_click, type_groups_of,
-    value_type_group,
+    compare_type_groups, explorer_column_width, metadata_fill_position,
+    should_activate_pointer_click, type_groups_of, value_type_group,
 };
+use crate::model::{EntryKind, FileEntry, Location, MetadataValue};
 
 /// Model values as the panes store them: kind, hidden flag, then the display name.
 fn value(kind: char, name: &str) -> String {
@@ -67,6 +68,27 @@ fn single_click_activation_distinguishes_files_and_folders() {
     assert!(should_activate_pointer_click(1, true, activation));
     assert!(!should_activate_pointer_click(1, false, activation));
     assert!(!should_activate_pointer_click(2, true, activation));
+}
+
+#[test]
+fn alternate_modes_request_missing_metadata_for_bound_entries() {
+    let mut entry = FileEntry {
+        location: Location::local("/fixture/photo.jpg"),
+        native_name: "photo.jpg".into(),
+        display_name: "photo.jpg".into(),
+        kind: EntryKind::File,
+        size: MetadataValue::Unknown,
+        modified_unix_seconds: MetadataValue::Unknown,
+        is_hidden: false,
+    };
+
+    assert_eq!(metadata_fill_position(Some(7), &entry), Some(7));
+    assert_eq!(metadata_fill_position(None, &entry), None);
+
+    entry.size = MetadataValue::Known(100);
+    assert_eq!(metadata_fill_position(Some(7), &entry), Some(7));
+    entry.modified_unix_seconds = MetadataValue::Known(1);
+    assert_eq!(metadata_fill_position(Some(7), &entry), None);
 }
 
 #[test]

--- a/src/ui/entry_list_model.rs
+++ b/src/ui/entry_list_model.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::{
+    cell::{Cell, RefCell},
+    rc::Rc,
+};
+
+use gio::subclass::prelude::ListModelImpl;
+use gtk::{gio, glib, prelude::*, subclass::prelude::*};
+
+pub(crate) type ResolveFn = Rc<dyn Fn(u32) -> Option<String>>;
+
+mod imp {
+    use super::*;
+
+    #[derive(Default)]
+    pub struct EntryListModel {
+        pub count: Cell<u32>,
+        pub resolve: RefCell<Option<ResolveFn>>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for EntryListModel {
+        const NAME: &'static str = "StrataEntryListModel";
+        type Type = super::EntryListModel;
+        type Interfaces = (gio::ListModel,);
+    }
+
+    impl ObjectImpl for EntryListModel {}
+
+    impl ListModelImpl for EntryListModel {
+        fn item_type(&self) -> glib::Type {
+            gtk::StringObject::static_type()
+        }
+
+        fn n_items(&self) -> u32 {
+            self.count.get()
+        }
+
+        fn item(&self, position: u32) -> Option<glib::Object> {
+            if position >= self.count.get() {
+                return None;
+            }
+            let resolve = self.resolve.borrow().clone()?;
+            resolve(position).map(|text| gtk::StringObject::new(&text).upcast())
+        }
+    }
+}
+
+glib::wrapper! {
+    pub struct EntryListModel(ObjectSubclass<imp::EntryListModel>)
+        @implements gio::ListModel;
+}
+
+impl EntryListModel {
+    pub(crate) fn new(resolve: ResolveFn) -> Self {
+        let model: Self = glib::Object::new();
+        model.imp().resolve.replace(Some(resolve));
+        model
+    }
+
+    pub(crate) fn value(&self, position: u32) -> Option<String> {
+        if position >= self.imp().count.get() {
+            return None;
+        }
+        let resolve = self.imp().resolve.borrow().clone()?;
+        resolve(position)
+    }
+
+    pub(crate) fn replace(&self, count: u32) {
+        let removed = self.imp().count.replace(count);
+        // The authoritative entries may have been reordered or replaced
+        // without changing their count, so every non-empty replacement must
+        // invalidate the corresponding GTK items.
+        if removed > 0 || count > 0 {
+            self.items_changed(0, removed, count);
+        }
+    }
+
+    pub(crate) fn splice(&self, position: u32, removed: u32, added: u32) {
+        let count = self.imp().count.get();
+        let position = position.min(count);
+        let removed = removed.min(count - position);
+        self.imp()
+            .count
+            .set((count - removed).saturating_add(added));
+        if removed > 0 || added > 0 {
+            self.items_changed(position, removed, added);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/ui/entry_list_model/tests.rs
+++ b/src/ui/entry_list_model/tests.rs
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::{
+    cell::{Cell, RefCell},
+    process::Command,
+    rc::Rc,
+};
+
+use super::EntryListModel;
+use gtk::{gio, prelude::*};
+
+const GTK_CHILD: &str = "STRATA_ENTRY_LIST_MODEL_GTK_CHILD";
+const TEST_NAME: &str = "ui::entry_list_model::tests::lazy_model_counts_items_splices_and_types";
+
+fn values_model(count: u32) -> (EntryListModel, Rc<Cell<u32>>) {
+    let calls = Rc::new(Cell::new(0u32));
+    let calls_for_resolve = calls.clone();
+    let model = EntryListModel::new(Rc::new(move |position| {
+        calls_for_resolve.set(calls_for_resolve.get().saturating_add(1));
+        (position < count).then(|| format!("f\tfile-{position:04}"))
+    }));
+    model.replace(count);
+    calls.set(0);
+    (model, calls)
+}
+
+#[test]
+fn lazy_model_counts_items_splices_and_types() {
+    if std::env::var_os(GTK_CHILD).is_some() {
+        if gtk::init().is_err() {
+            return;
+        }
+        let (items, calls) = values_model(8);
+        let item = items
+            .item(3)
+            .and_downcast::<gtk::StringObject>()
+            .expect("position 3 should resolve to a string object");
+        assert_eq!(item.string(), "f\tfile-0003");
+        let list = items.upcast::<gio::ListModel>();
+        list.item(0)
+            .and_downcast::<gtk::StringObject>()
+            .expect("items should stay string objects");
+        assert_eq!(calls.get(), 2);
+        return;
+    }
+
+    let (model, calls) = values_model(0);
+    model.replace(100_000);
+    model.splice(10, 0, 500);
+    model.splice(0, 100_000, 7);
+    assert_eq!(model.n_items(), 507);
+    assert_eq!(calls.get(), 0);
+
+    let replacement_events: Rc<RefCell<Vec<(u32, u32, u32)>>> = Default::default();
+    let observed = replacement_events.clone();
+    model.connect_items_changed(move |_, position, removed, added| {
+        observed.borrow_mut().push((position, removed, added));
+    });
+    model.replace(507);
+    assert_eq!(*replacement_events.borrow(), vec![(0, 507, 507)]);
+    assert_eq!(calls.get(), 0);
+
+    let seen: Rc<RefCell<Vec<u32>>> = Default::default();
+    let observed = seen.clone();
+    let items = EntryListModel::new(Rc::new(move |position| {
+        observed.borrow_mut().push(position);
+        Some(format!("f\tfile-{position:04}"))
+    }));
+    items.replace(8);
+    assert_eq!(items.value(7).as_deref(), Some("f\tfile-0007"));
+    assert_eq!(*seen.borrow(), vec![7]);
+    assert!(items.item(8).is_none());
+    assert!(items.value(8).is_none());
+    assert!(items.item(u32::MAX).is_none());
+    assert_eq!(*seen.borrow(), vec![7]);
+
+    let missing = EntryListModel::new(Rc::new(|_| None));
+    missing.replace(4);
+    assert_eq!(missing.n_items(), 4);
+    assert!(missing.item(0).is_none());
+    assert!(missing.value(0).is_none());
+
+    let (spliced, _) = values_model(0);
+    let splice_events: Rc<RefCell<Vec<(u32, u32, u32)>>> = Default::default();
+    let observed = splice_events.clone();
+    spliced.connect_items_changed(move |_, position, removed, added| {
+        observed.borrow_mut().push((position, removed, added));
+    });
+    spliced.replace(10);
+    spliced.splice(2, 0, 3);
+    spliced.splice(0, 10, 0);
+    spliced.splice(1_000, 500, 2);
+    spliced.replace(0);
+    assert_eq!(spliced.n_items(), 0);
+    assert_eq!(
+        *splice_events.borrow(),
+        vec![(0, 0, 10), (2, 0, 3), (0, 10, 0), (3, 0, 2), (0, 5, 0)]
+    );
+    splice_events.borrow_mut().clear();
+    spliced.replace(0);
+    assert!(splice_events.borrow().is_empty());
+
+    let list = items.upcast::<gio::ListModel>();
+    assert_eq!(list.item_type(), gtk::StringObject::static_type());
+    assert_eq!(list.n_items(), 8);
+
+    // GTK initialization permanently claims GLib's process-wide default
+    // context, so exercise object construction without poisoning other tests.
+    let status = Command::new(std::env::current_exe().expect("test executable should exist"))
+        .args(["--exact", TEST_NAME])
+        .env(GTK_CHILD, "1")
+        .status()
+        .expect("isolated GTK model test should start");
+    assert!(status.success(), "isolated GTK model test failed");
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -11,6 +11,7 @@ mod search;
 mod settings;
 mod theme;
 mod thumbnail;
+mod thumbnail_cache;
 mod window;
 
 pub use window::{present, present_location};

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4,6 +4,7 @@ mod blur;
 mod browser;
 mod browser_modes;
 mod controls;
+mod entry_list_model;
 mod marquee;
 mod motion;
 mod preview;

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -4,8 +4,8 @@ use std::{
     cell::{Cell, RefCell},
     process::{Command, Stdio},
     rc::Rc,
-    sync::mpsc::TryRecvError,
-    time::Duration,
+    sync::{OnceLock, mpsc::TryRecvError},
+    time::{Duration, Instant},
 };
 
 use gtk::{gdk, gio, glib, prelude::*, subclass::prelude::*};
@@ -76,13 +76,129 @@ thread_local! {
 /// deliberately never released: it is one `bool`, and the guard's
 /// correctness should not depend on some window or in-flight install
 /// happening to still hold a strong reference.
-///
-/// This bounds races to *this* process. A second `strata` process can
-/// still install over the same executable, but `update_install` stages
-/// into a unique path and lands it with a single atomic rename, so that
-/// case degrades to last-writer-wins rather than a corrupted binary.
 pub(super) fn install_guard() -> InstallGuard {
-    INSTALL_GUARD.with(Rc::clone)
+    INSTALL_GUARD.with(|guard| guard.clone())
+}
+
+thread_local! {
+    /// When the last automatic update check completed. Consulted by the
+    /// due scheduler so every window shares one TTL instead of each
+    /// window firing its own check.
+    static LAST_COMPLETED_CHECK: Cell<Option<Instant>> = const { Cell::new(None) };
+    static CHECK_IN_FLIGHT: Cell<bool> = const { Cell::new(false) };
+}
+
+/// The detected package-manager method, computed once per process. The
+/// detection spawns a package-manager child, so it never runs during
+/// startup: it resolves asynchronously the first time the Updates page or
+/// a due background check needs it.
+static UPDATE_METHOD_CACHE: OnceLock<UpdateMethod> = OnceLock::new();
+
+/// Resolves the update method, invoking `callback` on the GTK thread. A
+/// cached value answers synchronously; otherwise detection runs on a worker
+/// thread so neither page opens nor background checks stall the main loop.
+/// The callback stays on the main thread (UI closures are `Rc`-bound, not
+/// `Send`): the worker reports through a channel that a main-thread poll
+/// drains, mirroring the existing update-check receivers.
+pub(super) fn resolve_update_method_async(callback: impl FnOnce(UpdateMethod) + 'static) {
+    if let Some(method) = UPDATE_METHOD_CACHE.get().copied() {
+        callback(method);
+        return;
+    }
+    let (sender, receiver) = std::sync::mpsc::channel();
+    let spawned = std::thread::Builder::new()
+        .name("strata-update-method".into())
+        .spawn(move || {
+            let method = *UPDATE_METHOD_CACHE.get_or_init(services::update_method);
+            let _sent = sender.send(method);
+        });
+    if spawned.is_err() {
+        // Thread spawn practically never fails; fall back to a synchronous
+        // detect so the caller never waits on a placeholder forever.
+        let method = *UPDATE_METHOD_CACHE.get_or_init(services::update_method);
+        callback(method);
+        return;
+    }
+    let mut callback = Some(callback);
+    glib::timeout_add_local(Duration::from_millis(50), move || {
+        match receiver.try_recv() {
+            Err(TryRecvError::Empty) => glib::ControlFlow::Continue,
+            resolved => {
+                let method = match resolved {
+                    Ok(method) => method,
+                    // The worker died mid-detect; detect synchronously
+                    // rather than leaving the caller on a placeholder.
+                    Err(TryRecvError::Disconnected) => {
+                        *UPDATE_METHOD_CACHE.get_or_init(services::update_method)
+                    }
+                    Err(TryRecvError::Empty) => return glib::ControlFlow::Continue,
+                };
+                if let Some(callback) = callback.take() {
+                    callback(method);
+                }
+                glib::ControlFlow::Break
+            }
+        }
+    });
+}
+/// Minimum age of the last completed check before another automatic one is
+/// due. Manual checks and channel toggles always run immediately.
+const UPDATE_DUE_INTERVAL: Duration = Duration::from_secs(24 * 3600);
+
+/// Whether an automatic check is due given the last completion time.
+/// Pure so the scheduler policy is unit-testable without clocks or network.
+fn update_check_due(last: Option<Instant>, now: Instant) -> bool {
+    last.is_none_or(|completed| now.duration_since(completed) >= UPDATE_DUE_INTERVAL)
+}
+
+/// Runs the headless due update check when one is actually due: automatic
+/// checks enabled, none in flight, and the TTL expired. Shows the sidebar
+/// notice on new releases; failures stay silent and uncached so the next
+/// launch retries. Every `SortingStarted`... (no sorting here).
+pub(super) fn maybe_run_due_update_check(manager: &Rc<ThemeManager>, notice: &UpdateNoticeHandler) {
+    if !manager.checks_for_updates() || CHECK_IN_FLIGHT.get() {
+        return;
+    }
+    if !update_check_due(LAST_COMPLETED_CHECK.get(), Instant::now()) {
+        return;
+    }
+    CHECK_IN_FLIGHT.set(true);
+    let channel = manager.release_channel();
+    let weak_manager = Rc::downgrade(manager);
+    let notice = notice.clone();
+    resolve_update_method_async(move |method| {
+        let receiver = services::check_for_updates(channel, crate::build_info::installed_version());
+        glib::timeout_add_local(Duration::from_millis(100), move || {
+            match receiver.try_recv() {
+                Err(TryRecvError::Empty) => glib::ControlFlow::Continue,
+                Err(TryRecvError::Disconnected) => {
+                    CHECK_IN_FLIGHT.set(false);
+                    glib::ControlFlow::Break
+                }
+                Ok(UpdateCheck::Available {
+                    release,
+                    download_url,
+                }) => {
+                    CHECK_IN_FLIGHT.set(false);
+                    LAST_COMPLETED_CHECK.set(Some(Instant::now()));
+                    if weak_manager.upgrade().is_some_and(|manager| {
+                        manager.checks_for_updates() && manager.release_channel() == channel
+                    }) {
+                        notice(Some((release, download_url, method)));
+                    }
+                    glib::ControlFlow::Break
+                }
+                Ok(_) => {
+                    // UpToDate caches like a result; Failed stays uncached
+                    // so the next launch retries instead of waiting out the
+                    // TTL on a transient network error.
+                    CHECK_IN_FLIGHT.set(false);
+                    LAST_COMPLETED_CHECK.set(Some(Instant::now()));
+                    glib::ControlFlow::Break
+                }
+            }
+        });
+    });
 }
 
 const DIALOG_WIDTH: i32 = 920;
@@ -237,6 +353,32 @@ impl ResponsiveBin {
         child.set_parent(&bin);
         bin
     }
+
+    /// Registers one navigation entry after construction, for pages that
+    /// build on first selection rather than with the layer.
+    fn add_navigation(&self, label: gtk::Label, content: gtk::Box) {
+        let imp = self.imp();
+        imp.navigation_labels.borrow_mut().push(label);
+        imp.navigation_contents.borrow_mut().push(content);
+    }
+
+    /// Registers one theme flow after construction, for the lazily built
+    /// theme page.
+    fn add_flow(&self, flow: gtk::FlowBox, columns: u32) {
+        self.imp()
+            .responsive_flows
+            .borrow_mut()
+            .push((flow, columns));
+    }
+
+    /// Registers one update row after construction, for the lazily built
+    /// Updates page.
+    fn add_action(&self, row: gtk::Box, button: gtk::Button) {
+        self.imp()
+            .responsive_actions
+            .borrow_mut()
+            .push((row, button));
+    }
 }
 
 fn responsive_dialog_size(width: i32, height: i32) -> (i32, i32) {
@@ -310,17 +452,45 @@ pub fn build_layer(
     let (general, responsive_setting_rows, responsive_activation_rows) =
         general_page(browser, themes.clone());
     stack.add_named(&general, Some("general"));
-    let (updates, responsive_actions) = updates_page(themes.clone(), update_notice, install_guard);
-    stack.add_named(&updates, Some("updates"));
     stack.add_named(&keybindings_page(), Some("keybindings"));
-    let (theme_page, responsive_flows) = theme_page(themes);
-    stack.add_named(&theme_page, Some("theme"));
     stack.add_named(&about_page(), Some("about"));
+    // Heavy pages build on first selection, never during startup: the
+    // Updates page spawns package-manager detection plus release-note
+    // network work, and the theme page builds its swatch flows.
+    let updates_container = gtk::Box::new(gtk::Orientation::Vertical, 0);
+    updates_container.set_hexpand(true);
+    updates_container.set_vexpand(true);
+    let updates_spinner = gtk::Spinner::new();
+    updates_spinner.start();
+    updates_spinner.set_halign(gtk::Align::Center);
+    updates_spinner.set_valign(gtk::Align::Center);
+    updates_spinner.set_vexpand(true);
+    updates_container.append(&updates_spinner);
+    stack.add_named(&updates_container, Some("updates"));
     page.append(&stack);
 
+    // Created before the navigation loop so lazy builders can register
+    // their responsive rows and flows as pages materialize.
+    let responsive_panel = ResponsiveBin::new(
+        &panel,
+        &navigation,
+        &navigation_heading,
+        Vec::new(),
+        Vec::new(),
+        ResponsiveContent {
+            flows: Vec::new(),
+            actions: Vec::new(),
+            setting_rows: responsive_setting_rows,
+            activation_rows: responsive_activation_rows,
+        },
+    );
+    // Navigation entries register as their buttons are created, so the
+    // responsive panel compacts correctly even with lazy pages.
+    let responsive_for_nav = responsive_panel.clone();
+    let built: Rc<RefCell<std::collections::HashSet<&'static str>>> = Rc::new(RefCell::new(
+        ["general", "keybindings", "about"].into_iter().collect(),
+    ));
     let nav_buttons: Rc<RefCell<Vec<gtk::Button>>> = Rc::new(RefCell::new(Vec::new()));
-    let mut navigation_labels = Vec::new();
-    let mut navigation_contents = Vec::new();
     for (label, icon, name) in [
         ("General", icons::SLIDERS, "general"),
         ("Keybindings", icons::KEYBOARD, "keybindings"),
@@ -330,8 +500,7 @@ pub fn build_layer(
     ] {
         let active = name == "general";
         let (button, navigation_label, navigation_content) = navigation_button(icon, label);
-        navigation_labels.push(navigation_label);
-        navigation_contents.push(navigation_content);
+        responsive_for_nav.add_navigation(navigation_label, navigation_content);
         if active {
             button.add_css_class("settings-nav-active");
         }
@@ -340,12 +509,51 @@ pub fn build_layer(
         let stack = stack.clone();
         let title = title.clone();
         let page_title = label.to_owned();
+        let built = built.clone();
+        let themes = themes.clone();
+        let update_notice = update_notice.clone();
+        let install_guard = install_guard.clone();
+        let updates_container = updates_container.clone();
+        let responsive_panel = responsive_panel.clone();
         button.connect_clicked(move |clicked| {
             for candidate in buttons.borrow().iter() {
                 if candidate == clicked {
                     candidate.add_css_class("settings-nav-active");
                 } else {
                     candidate.remove_css_class("settings-nav-active");
+                }
+            }
+            if built.borrow_mut().insert(name) {
+                match name {
+                    "theme" => {
+                        let (theme_widget, flows) = theme_page(themes.clone());
+                        stack.add_named(&theme_widget, Some("theme"));
+                        for (flow, columns) in flows {
+                            responsive_panel.add_flow(flow, columns);
+                        }
+                    }
+                    "updates" => {
+                        // Release notes fetch only when the Updates page is
+                        // opened; detection itself stays off the main thread.
+                        let container = updates_container.clone();
+                        let panel = responsive_panel.clone();
+                        let themes = themes.clone();
+                        let update_notice = update_notice.clone();
+                        let install_guard = install_guard.clone();
+                        let _ = stack;
+                        resolve_update_method_async(move |method| {
+                            let (updates, actions) =
+                                updates_page(themes, update_notice, install_guard, method);
+                            while let Some(child) = container.first_child() {
+                                container.remove(&child);
+                            }
+                            container.append(&updates);
+                            for (row, button) in actions {
+                                panel.add_action(row, button);
+                            }
+                        });
+                    }
+                    _ => {}
                 }
             }
             stack.set_visible_child_name(name);
@@ -356,19 +564,6 @@ pub fn build_layer(
 
     panel.append(&navigation);
     panel.append(&page);
-    let responsive_panel = ResponsiveBin::new(
-        &panel,
-        &navigation,
-        &navigation_heading,
-        navigation_labels,
-        navigation_contents,
-        ResponsiveContent {
-            flows: responsive_flows,
-            actions: responsive_actions,
-            setting_rows: responsive_setting_rows,
-            activation_rows: responsive_activation_rows,
-        },
-    );
     responsive_panel.set_hexpand(false);
     responsive_panel.set_vexpand(false);
     let top = gtk::Box::new(gtk::Orientation::Vertical, 0);
@@ -614,6 +809,7 @@ fn updates_page(
     manager: Rc<ThemeManager>,
     update_notice: UpdateNoticeHandler,
     install_guard: InstallGuard,
+    update_method: UpdateMethod,
 ) -> (gtk::Widget, Vec<(gtk::Box, gtk::Button)>) {
     let preferences = page_content();
     append_heading(&preferences, "UPDATE PREFERENCES");
@@ -626,7 +822,6 @@ fn updates_page(
         "Available release",
         "Check for updates to see the latest release notes.",
     );
-    let update_method = services::update_method();
     let UpdateCheckRow {
         row: update_row,
         run_check,
@@ -686,9 +881,11 @@ fn updates_page(
             update_notice(None);
         }
     });
-    if auto_check_enabled {
-        run_check(false);
-    }
+    // No automatic check here: the due scheduler (see
+    // `maybe_run_due_update_check`) owns background checks process-wide,
+    // starting after the first viewport is ready and the app is idle.
+    // Manual checks, channel toggles, and re-enabling auto-check run
+    // immediately through `run_check`.
 
     let page = scrollable_page(&preferences, None);
     let broadcast_check = run_check.clone();

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -167,7 +167,12 @@ pub(super) fn maybe_run_due_update_check(manager: &Rc<ThemeManager>, notice: &Up
     let weak_manager = Rc::downgrade(manager);
     let notice = notice.clone();
     resolve_update_method_async(move |method| {
-        let receiver = services::check_for_updates(channel, crate::build_info::installed_version());
+        let receiver = services::check_for_updates(
+            channel,
+            crate::build_info::installed_version(),
+            method,
+            false,
+        );
         glib::timeout_add_local(Duration::from_millis(100), move || {
             match receiver.try_recv() {
                 Err(TryRecvError::Empty) => glib::ControlFlow::Continue,

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -81,25 +81,16 @@ pub(super) fn install_guard() -> InstallGuard {
 }
 
 thread_local! {
-    /// When the last automatic update check completed. Consulted by the
-    /// due scheduler so every window shares one TTL instead of each
-    /// window firing its own check.
+    /// Shared by the due scheduler so every window uses one TTL.
     static LAST_COMPLETED_CHECK: Cell<Option<Instant>> = const { Cell::new(None) };
     static CHECK_IN_FLIGHT: Cell<bool> = const { Cell::new(false) };
 }
 
-/// The detected package-manager method, computed once per process. The
-/// detection spawns a package-manager child, so it never runs during
-/// startup: it resolves asynchronously the first time the Updates page or
-/// a due background check needs it.
+/// Detection spawns a package-manager child, so it resolves asynchronously
+/// on first need, never during startup.
 static UPDATE_METHOD_CACHE: OnceLock<UpdateMethod> = OnceLock::new();
 
-/// Resolves the update method, invoking `callback` on the GTK thread. A
-/// cached value answers synchronously; otherwise detection runs on a worker
-/// thread so neither page opens nor background checks stall the main loop.
-/// The callback stays on the main thread (UI closures are `Rc`-bound, not
-/// `Send`): the worker reports through a channel that a main-thread poll
-/// drains, mirroring the existing update-check receivers.
+/// Invokes `callback` on the GTK thread, detecting on a worker thread on a cache miss.
 pub(super) fn resolve_update_method_async(callback: impl FnOnce(UpdateMethod) + 'static) {
     if let Some(method) = UPDATE_METHOD_CACHE.get().copied() {
         callback(method);
@@ -113,8 +104,6 @@ pub(super) fn resolve_update_method_async(callback: impl FnOnce(UpdateMethod) + 
             let _sent = sender.send(method);
         });
     if spawned.is_err() {
-        // Thread spawn practically never fails; fall back to a synchronous
-        // detect so the caller never waits on a placeholder forever.
         let method = *UPDATE_METHOD_CACHE.get_or_init(services::update_method);
         callback(method);
         return;
@@ -126,8 +115,6 @@ pub(super) fn resolve_update_method_async(callback: impl FnOnce(UpdateMethod) + 
             resolved => {
                 let method = match resolved {
                     Ok(method) => method,
-                    // The worker died mid-detect; detect synchronously
-                    // rather than leaving the caller on a placeholder.
                     Err(TryRecvError::Disconnected) => {
                         *UPDATE_METHOD_CACHE.get_or_init(services::update_method)
                     }
@@ -141,20 +128,12 @@ pub(super) fn resolve_update_method_async(callback: impl FnOnce(UpdateMethod) + 
         }
     });
 }
-/// Minimum age of the last completed check before another automatic one is
-/// due. Manual checks and channel toggles always run immediately.
 const UPDATE_DUE_INTERVAL: Duration = Duration::from_secs(24 * 3600);
 
-/// Whether an automatic check is due given the last completion time.
-/// Pure so the scheduler policy is unit-testable without clocks or network.
 fn update_check_due(last: Option<Instant>, now: Instant) -> bool {
     last.is_none_or(|completed| now.duration_since(completed) >= UPDATE_DUE_INTERVAL)
 }
 
-/// Runs the headless due update check when one is actually due: automatic
-/// checks enabled, none in flight, and the TTL expired. Shows the sidebar
-/// notice on new releases; failures stay silent and uncached so the next
-/// launch retries. Every `SortingStarted`... (no sorting here).
 pub(super) fn maybe_run_due_update_check(manager: &Rc<ThemeManager>, notice: &UpdateNoticeHandler) {
     if !manager.checks_for_updates() || CHECK_IN_FLIGHT.get() {
         return;
@@ -194,9 +173,7 @@ pub(super) fn maybe_run_due_update_check(manager: &Rc<ThemeManager>, notice: &Up
                     glib::ControlFlow::Break
                 }
                 Ok(_) => {
-                    // UpToDate caches like a result; Failed stays uncached
-                    // so the next launch retries instead of waiting out the
-                    // TTL on a transient network error.
+                    // Failed stays uncached so the next launch retries on transient errors.
                     CHECK_IN_FLIGHT.set(false);
                     LAST_COMPLETED_CHECK.set(Some(Instant::now()));
                     glib::ControlFlow::Break
@@ -359,16 +336,12 @@ impl ResponsiveBin {
         bin
     }
 
-    /// Registers one navigation entry after construction, for pages that
-    /// build on first selection rather than with the layer.
     fn add_navigation(&self, label: gtk::Label, content: gtk::Box) {
         let imp = self.imp();
         imp.navigation_labels.borrow_mut().push(label);
         imp.navigation_contents.borrow_mut().push(content);
     }
 
-    /// Registers one theme flow after construction, for the lazily built
-    /// theme page.
     fn add_flow(&self, flow: gtk::FlowBox, columns: u32) {
         self.imp()
             .responsive_flows
@@ -376,8 +349,6 @@ impl ResponsiveBin {
             .push((flow, columns));
     }
 
-    /// Registers one update row after construction, for the lazily built
-    /// Updates page.
     fn add_action(&self, row: gtk::Box, button: gtk::Button) {
         self.imp()
             .responsive_actions
@@ -538,8 +509,6 @@ pub fn build_layer(
                         }
                     }
                     "updates" => {
-                        // Release notes fetch only when the Updates page is
-                        // opened; detection itself stays off the main thread.
                         let container = updates_container.clone();
                         let panel = responsive_panel.clone();
                         let themes = themes.clone();
@@ -886,11 +855,7 @@ fn updates_page(
             update_notice(None);
         }
     });
-    // No automatic check here: the due scheduler (see
-    // `maybe_run_due_update_check`) owns background checks process-wide,
-    // starting after the first viewport is ready and the app is idle.
-    // Manual checks, channel toggles, and re-enabling auto-check run
-    // immediately through `run_check`.
+    // No automatic check here: the due scheduler owns background checks process-wide.
 
     let page = scrollable_page(&preferences, None);
     let broadcast_check = run_check.clone();

--- a/src/ui/settings/tests.rs
+++ b/src/ui/settings/tests.rs
@@ -384,13 +384,9 @@ fn due_check_respects_its_ttl() {
     use std::time::{Duration, Instant};
 
     let now = Instant::now();
-    // Never checked: due.
     assert!(update_check_due(None, now));
-    // Just checked: not due.
     assert!(!update_check_due(Some(now), now));
-    // Exactly at the TTL boundary: due.
     assert!(update_check_due(Some(now - UPDATE_DUE_INTERVAL), now));
-    // One second of TTL left: not due.
     assert!(!update_check_due(
         Some(now - UPDATE_DUE_INTERVAL + Duration::from_secs(1)),
         now
@@ -408,8 +404,6 @@ fn update_method_resolves_and_caches() {
         Rc::new(std::cell::RefCell::new(None));
     let second: Rc<std::cell::RefCell<Option<UpdateMethod>>> =
         Rc::new(std::cell::RefCell::new(None));
-    // Detection shells out to the package manager; even so, both resolves
-    // must complete rather than hang on a placeholder.
     let capture = first.clone();
     resolve_update_method_async(move |method| {
         *capture.borrow_mut() = Some(method);
@@ -419,7 +413,6 @@ fn update_method_resolves_and_caches() {
         gtk::glib::MainContext::default().iteration(true);
     }
     let resolved = first.borrow().expect("the update method should resolve");
-    // The second resolve answers from the process-wide cache.
     let capture = second.clone();
     resolve_update_method_async(move |method| {
         *capture.borrow_mut() = Some(method);

--- a/src/ui/settings/tests.rs
+++ b/src/ui/settings/tests.rs
@@ -9,13 +9,14 @@ use crate::services::{
 
 use super::{
     CHANNEL_ORDER, COMPACT_NAVIGATION_BREAKPOINT, DIALOG_HEIGHT, DIALOG_MARGIN, DIALOG_WIDTH,
-    RELEASE_CHANNEL_DESCRIPTION, RELEASE_CHANNEL_TITLE, aur_update_command, channel_index,
-    effective_update_channel, install_guard, installed_version_status, is_stale_check,
-    managed_channel_description, managed_install_summary, offer_still_eligible,
-    omarchy_update_command, responsive_dialog_size, shows_available_release_notes,
-    theme_background_is_light, theme_name_matches, update_check_message, update_dialog_status,
-    update_status_markup, uses_compact_navigation, video_preview_backend_label,
-    video_preview_control_state,
+    RELEASE_CHANNEL_DESCRIPTION, RELEASE_CHANNEL_TITLE, UPDATE_DUE_INTERVAL,
+    aur_update_command, channel_index, effective_update_channel, install_guard,
+    installed_version_status, is_stale_check, managed_channel_description,
+    managed_install_summary, offer_still_eligible, omarchy_update_command,
+    resolve_update_method_async, responsive_dialog_size, shows_available_release_notes,
+    theme_background_is_light, theme_name_matches, update_check_due, update_check_message,
+    update_dialog_status, update_status_markup, uses_compact_navigation,
+    video_preview_backend_label, video_preview_control_state,
 };
 use crate::sandbox::MediaPreviewBackend;
 
@@ -377,4 +378,52 @@ fn the_selector_highlights_the_button_for_the_persisted_channel() {
     for (index, channel) in CHANNEL_ORDER.into_iter().enumerate() {
         assert_eq!(channel_index(channel), index);
     }
+}
+
+#[test]
+fn due_check_respects_its_ttl() {
+    use std::time::{Duration, Instant};
+
+    let now = Instant::now();
+    // Never checked: due.
+    assert!(update_check_due(None, now));
+    // Just checked: not due.
+    assert!(!update_check_due(Some(now), now));
+    // Exactly at the TTL boundary: due.
+    assert!(update_check_due(Some(now - UPDATE_DUE_INTERVAL), now));
+    // One second of TTL left: not due.
+    assert!(!update_check_due(
+        Some(now - UPDATE_DUE_INTERVAL + Duration::from_secs(1)),
+        now
+    ));
+}
+
+#[test]
+fn update_method_resolves_and_caches() {
+    use std::time::{Duration, Instant};
+
+    let _serial = crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
+    let first: Rc<std::cell::RefCell<Option<UpdateMethod>>> =
+        Rc::new(std::cell::RefCell::new(None));
+    let second: Rc<std::cell::RefCell<Option<UpdateMethod>>> =
+        Rc::new(std::cell::RefCell::new(None));
+    // Detection shells out to the package manager; even so, both resolves
+    // must complete rather than hang on a placeholder.
+    let capture = first.clone();
+    resolve_update_method_async(move |method| {
+        *capture.borrow_mut() = Some(method);
+    });
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while first.borrow().is_none() && Instant::now() < deadline {
+        gtk::glib::MainContext::default().iteration(true);
+    }
+    let resolved = first.borrow().expect("the update method should resolve");
+    // The second resolve answers from the process-wide cache.
+    let capture = second.clone();
+    resolve_update_method_async(move |method| {
+        *capture.borrow_mut() = Some(method);
+    });
+    assert_eq!(second.borrow().expect("the cache should answer"), resolved);
 }

--- a/src/ui/settings/tests.rs
+++ b/src/ui/settings/tests.rs
@@ -9,13 +9,12 @@ use crate::services::{
 
 use super::{
     CHANNEL_ORDER, COMPACT_NAVIGATION_BREAKPOINT, DIALOG_HEIGHT, DIALOG_MARGIN, DIALOG_WIDTH,
-    RELEASE_CHANNEL_DESCRIPTION, RELEASE_CHANNEL_TITLE, UPDATE_DUE_INTERVAL,
-    aur_update_command, channel_index, effective_update_channel, install_guard,
-    installed_version_status, is_stale_check, managed_channel_description,
-    managed_install_summary, offer_still_eligible, omarchy_update_command,
-    resolve_update_method_async, responsive_dialog_size, shows_available_release_notes,
-    theme_background_is_light, theme_name_matches, update_check_due, update_check_message,
-    update_dialog_status, update_status_markup, uses_compact_navigation,
+    RELEASE_CHANNEL_DESCRIPTION, RELEASE_CHANNEL_TITLE, UPDATE_DUE_INTERVAL, aur_update_command,
+    channel_index, effective_update_channel, install_guard, installed_version_status,
+    is_stale_check, managed_channel_description, managed_install_summary, offer_still_eligible,
+    omarchy_update_command, resolve_update_method_async, responsive_dialog_size,
+    shows_available_release_notes, theme_background_is_light, theme_name_matches, update_check_due,
+    update_check_message, update_dialog_status, update_status_markup, uses_compact_navigation,
     video_preview_backend_label, video_preview_control_state,
 };
 use crate::sandbox::MediaPreviewBackend;

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -23,6 +23,11 @@ thread_local! {
     static SOURCE_STYLE_PATH_INSTALLED: Cell<bool> = const { Cell::new(false) };
     static SOURCE_BUFFERS: RefCell<Vec<glib::WeakRef<sourceview5::Buffer>>> = const { RefCell::new(Vec::new()) };
     static CHANNEL_LISTENERS: RefCell<Vec<ChannelListener>> = const { RefCell::new(Vec::new()) };
+    /// Latest theme tokens awaiting installation. File generation and the
+    /// style-manager rescan wait for the first source preview buffer, so
+    /// ordinary startup performs no SourceView I/O at all.
+    static PENDING_STYLE_TOKENS: RefCell<Option<ThemeTokens>> = const { RefCell::new(None) };
+    static STYLE_SCHEME_DIRTY: Cell<bool> = const { Cell::new(true) };
 }
 
 struct ChannelListener {
@@ -740,7 +745,7 @@ impl ThemeManager {
             .load_from_string(&tokens_css(tokens, self.text_size().root_font_px()));
         crate::assets::set_primary_icon_color(&tokens.accent);
         crate::assets::set_danger_icon_color(&tokens.danger);
-        install_source_style_scheme(tokens);
+        stage_source_style_scheme(tokens);
     }
 
     fn save_preferences(&self) {
@@ -984,6 +989,7 @@ fn source_style_scheme() -> Option<sourceview5::StyleScheme> {
 }
 
 pub(super) fn register_source_buffer(buffer: &sourceview5::Buffer) {
+    ensure_source_style_scheme_installed();
     buffer.set_style_scheme(source_style_scheme().as_ref());
     SOURCE_BUFFERS.with(|buffers| {
         let mut buffers = buffers.borrow_mut();
@@ -994,10 +1000,37 @@ pub(super) fn register_source_buffer(buffer: &sourceview5::Buffer) {
     });
 }
 
-fn install_source_style_scheme(tokens: &ThemeTokens) {
+/// Stages theme tokens for the source preview style without touching disk:
+/// an explicit theme switch while previews are live reinstalls immediately,
+/// otherwise installation waits for the first source buffer.
+fn stage_source_style_scheme(tokens: &ThemeTokens) {
+    PENDING_STYLE_TOKENS.with(|pending| pending.replace(Some(tokens.clone())));
+    STYLE_SCHEME_DIRTY.with(|dirty| dirty.set(true));
+    let live = SOURCE_BUFFERS.with(|buffers| {
+        buffers
+            .borrow_mut()
+            .retain(|buffer| buffer.upgrade().is_some());
+        !buffers.borrow().is_empty()
+    });
+    if live {
+        ensure_source_style_scheme_installed();
+    }
+}
+
+/// Writes the staged style scheme and rescans the style manager, once per
+/// staged token set. Called on the first source preview buffer (and on
+/// theme switches while buffers are live), never during ordinary startup.
+fn ensure_source_style_scheme_installed() {
+    if !STYLE_SCHEME_DIRTY.with(|dirty| dirty.get()) {
+        return;
+    }
+    let pending = PENDING_STYLE_TOKENS.with(|pending| pending.borrow().clone());
+    let Some(tokens) = pending else {
+        return;
+    };
     let directory = glib::user_cache_dir().join("strata").join("source-styles");
     if let Err(error) = fs::create_dir_all(&directory).and_then(|()| {
-        let value = source_style_scheme_xml(tokens);
+        let value = source_style_scheme_xml(&tokens);
         crate::storage::atomic_write(&directory.join("strata-current.xml"), value.as_bytes())
     }) {
         tracing::warn!(%error, "unable to write preview syntax style");
@@ -1011,6 +1044,7 @@ fn install_source_style_scheme(tokens: &ThemeTokens) {
         }
     });
     manager.force_rescan();
+    STYLE_SCHEME_DIRTY.with(|dirty| dirty.set(false));
     let scheme = manager.scheme("strata-current");
     SOURCE_BUFFERS.with(|buffers| {
         buffers.borrow_mut().retain(|buffer| {

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -23,9 +23,7 @@ thread_local! {
     static SOURCE_STYLE_PATH_INSTALLED: Cell<bool> = const { Cell::new(false) };
     static SOURCE_BUFFERS: RefCell<Vec<glib::WeakRef<sourceview5::Buffer>>> = const { RefCell::new(Vec::new()) };
     static CHANNEL_LISTENERS: RefCell<Vec<ChannelListener>> = const { RefCell::new(Vec::new()) };
-    /// Latest theme tokens awaiting installation. File generation and the
-    /// style-manager rescan wait for the first source preview buffer, so
-    /// ordinary startup performs no SourceView I/O at all.
+    /// Installed on the first source preview buffer, so startup performs no SourceView I/O.
     static PENDING_STYLE_TOKENS: RefCell<Option<ThemeTokens>> = const { RefCell::new(None) };
     static STYLE_SCHEME_DIRTY: Cell<bool> = const { Cell::new(true) };
 }
@@ -1000,9 +998,6 @@ pub(super) fn register_source_buffer(buffer: &sourceview5::Buffer) {
     });
 }
 
-/// Stages theme tokens for the source preview style without touching disk:
-/// an explicit theme switch while previews are live reinstalls immediately,
-/// otherwise installation waits for the first source buffer.
 fn stage_source_style_scheme(tokens: &ThemeTokens) {
     PENDING_STYLE_TOKENS.with(|pending| pending.replace(Some(tokens.clone())));
     STYLE_SCHEME_DIRTY.with(|dirty| dirty.set(true));
@@ -1017,9 +1012,7 @@ fn stage_source_style_scheme(tokens: &ThemeTokens) {
     }
 }
 
-/// Writes the staged style scheme and rescans the style manager, once per
-/// staged token set. Called on the first source preview buffer (and on
-/// theme switches while buffers are live), never during ordinary startup.
+/// Writes the staged scheme and rescans the style manager, once per staged token set.
 fn ensure_source_style_scheme_installed() {
     if !STYLE_SCHEME_DIRTY.with(|dirty| dirty.get()) {
         return;

--- a/src/ui/thumbnail.rs
+++ b/src/ui/thumbnail.rs
@@ -508,7 +508,7 @@ fn park_thumbnail(
     target: PendingTarget,
     wait_for_metadata: bool,
 ) {
-    crate::metrics::mark_thumbnail_requested(&key.path.display().to_string());
+    crate::metrics::mark_thumbnail_requested();
     let viewport = target.image.upgrade().and_then(|image| viewport_of(&image));
     let group = group_address(viewport.as_ref());
     let viewport_ref = glib::WeakRef::new();
@@ -753,15 +753,13 @@ fn push_metadata_waiter(group: usize, park: SettledPark) {
 }
 
 pub(super) fn note_metadata(path: &Path, modified: Option<i64>, file_size: Option<u64>) {
-    let Some(mtime) = modified else {
-        return;
-    };
-    // Metadata may arrive on either side of the settle gate; update both so no thumbnail strands.
+    // A completed metadata attempt releases thumbnail work even when mtime is unavailable.
+    // Such renders remain memory-only because the shared cache cannot validate them.
     SETTLE_VIEWS.with(|views| {
         for settle in views.borrow_mut().values_mut() {
             for park in &mut settle.pending {
                 if park.wait_for_metadata && park.key.path == path {
-                    park.key.modified = Some(mtime);
+                    park.key.modified = modified;
                     park.key.file_size = file_size.or(park.key.file_size);
                     park.wait_for_metadata = false;
                 }
@@ -775,7 +773,7 @@ pub(super) fn note_metadata(path: &Path, modified: Option<i64>, file_size: Optio
             .filter_map(|active| active.deferred.as_mut())
         {
             if deferred.key.path == path {
-                deferred.key.modified = Some(mtime);
+                deferred.key.modified = modified;
                 deferred.key.file_size = file_size.or(deferred.key.file_size);
             }
         }
@@ -789,7 +787,7 @@ pub(super) fn note_metadata(path: &Path, modified: Option<i64>, file_size: Optio
         }
         let key = ThumbnailKey {
             path: path.to_path_buf(),
-            modified: Some(mtime),
+            modified,
             file_size: file_size.or(waiter.file_size),
             thumbnail_size: waiter.thumbnail_size,
         };
@@ -797,13 +795,14 @@ pub(super) fn note_metadata(path: &Path, modified: Option<i64>, file_size: Optio
     }
 }
 pub(super) fn note_metadata_entry(entry: &FileEntry) {
-    let (Some(path), Some(mtime)) = (
-        entry.location.native_path(),
-        known_metadata(&entry.modified_unix_seconds),
-    ) else {
+    let Some(path) = entry.location.native_path() else {
         return;
     };
-    note_metadata(path, Some(mtime), known_metadata(&entry.size));
+    note_metadata(
+        path,
+        known_metadata(&entry.modified_unix_seconds),
+        known_metadata(&entry.size),
+    );
 }
 
 fn park_into_group(
@@ -874,7 +873,7 @@ fn start_thumbnail_jobs() {
             THUMBNAIL_QUEUE.with(|queue| queue.borrow_mut().finish());
             continue;
         };
-        crate::metrics::mark_thumbnail_started(&job.key.path.display().to_string());
+        crate::metrics::mark_thumbnail_started();
         glib::MainContext::default().spawn_local(run_thumbnail_job(job));
     }
 }
@@ -901,24 +900,22 @@ async fn run_thumbnail_job(job: ThumbnailJob) {
     .await;
     let targets = take_pending_targets(&key, job_id);
     THUMBNAIL_QUEUE.with(|queue| queue.borrow_mut().finish());
-    let uri = key.path.display().to_string();
-
     if let Some(targets) = targets {
         match result {
             Ok(Ok((png, rendered))) => {
-                crate::metrics::mark_thumbnail_completed(&uri);
+                crate::metrics::mark_thumbnail_completed();
                 let bytes = glib::Bytes::from_owned(png.clone());
                 THUMBNAIL_CACHE.with(|cache| cache.borrow_mut().insert(key.clone(), bytes.clone()));
-                finish_thumbnail_targets(targets, Some(&bytes), thumbnail_size, &uri);
+                finish_thumbnail_targets(targets, Some(&bytes), thumbnail_size);
                 // Unverifiable keys (unknown mtime) skip persistence: nothing validates them later.
                 if rendered && let Some(mtime) = key.modified {
                     enqueue_persist(key.path.clone(), mtime, png);
                 }
             }
             Ok(Err(_)) | Err(_) => {
-                crate::metrics::mark_thumbnail_cancelled(&uri);
+                crate::metrics::mark_thumbnail_cancelled();
                 THUMBNAIL_CACHE.with(|cache| cache.borrow_mut().insert_failure(key));
-                finish_thumbnail_targets(targets, None, thumbnail_size, &uri);
+                finish_thumbnail_targets(targets, None, thumbnail_size);
             }
         }
     }
@@ -1002,7 +999,6 @@ fn finish_thumbnail_targets(
     targets: Vec<PendingTarget>,
     bytes: Option<&glib::Bytes>,
     thumbnail_size: i32,
-    uri: &str,
 ) {
     for target in targets {
         let is_current = ACTIVE_REQUESTS.with(|requests| {
@@ -1018,18 +1014,18 @@ fn finish_thumbnail_targets(
             }
         });
         if !is_current {
-            crate::metrics::mark_thumbnail_stale(uri);
+            crate::metrics::mark_thumbnail_stale();
             continue;
         }
         let Some(bytes) = bytes else {
             continue;
         };
         let Some(image) = target.image.upgrade() else {
-            crate::metrics::mark_thumbnail_stale(uri);
+            crate::metrics::mark_thumbnail_stale();
             continue;
         };
         apply_thumbnail(&image, bytes, thumbnail_size);
-        crate::metrics::mark_thumbnail_applied(uri);
+        crate::metrics::mark_thumbnail_applied();
     }
 }
 
@@ -1087,6 +1083,12 @@ fn set_fallback_icon(image: &gtk::Image, icon: &str, size: i32) -> (usize, u64) 
 fn cancel_thumbnail(image_id: usize) {
     ACTIVE_REQUESTS.with(|requests| {
         requests.borrow_mut().remove(&image_id);
+    });
+    METADATA_WAITERS.with(|waiters| {
+        waiters.borrow_mut().retain(|_, targets| {
+            targets.retain(|waiter| waiter.target.image_id != image_id);
+            !targets.is_empty()
+        });
     });
     SETTLE_VIEWS.with(|views| {
         views.borrow_mut().retain(|_, settle| {

--- a/src/ui/thumbnail.rs
+++ b/src/ui/thumbnail.rs
@@ -18,9 +18,23 @@ use crate::{
 static NEXT_REQUEST: AtomicU64 = AtomicU64::new(1);
 const MAX_CACHE_ENTRIES: usize = 256;
 const MAX_CACHE_BYTES: usize = 64 * 1024 * 1024;
-const MAX_THUMBNAIL_WORKERS: usize = 1;
+/// Four concurrent sandbox decodes shorten the visible thumbnail drain;
+/// viewport bounding keeps the amount of admitted work fixed.
+const MAX_THUMBNAIL_WORKERS: usize = 4;
 const MAX_QUEUED_THUMBNAILS: usize = 64;
 const FAILED_THUMBNAIL_TTL: Duration = Duration::from_secs(30);
+/// Settles scrolling before decoding: binds during a fling only park their
+/// rows, and one timer fire starts jobs for the rows still on screen. Cache
+/// hits bypass the gate entirely, so revisits never wait on it.
+const THUMBNAIL_SETTLE_DELAY: Duration = Duration::from_millis(120);
+/// Bounds starvation: continuous binds re-arm the settle timer, but the
+/// first park starts the clock and anything parked longer fires anyway. The
+/// fire still intersects the viewport, so a mid-fling fire only spends work
+/// on rows that are actually visible.
+const MAX_SETTLE_WAIT: Duration = Duration::from_millis(400);
+/// Viewport overscan fraction per side: visible rows plus roughly 25%
+/// prefetch start work; anything further out waits for a later settle.
+const VIEWPORT_OVERSCAN: f32 = 0.25;
 
 thread_local! {
     static ACTIVE_REQUESTS: RefCell<HashMap<usize, ActiveRequest>> =
@@ -29,6 +43,17 @@ thread_local! {
         RefCell::new(HashMap::new());
     static THUMBNAIL_QUEUE: RefCell<ThumbnailQueue> = RefCell::new(ThumbnailQueue::default());
     static THUMBNAIL_CACHE: RefCell<ThumbnailCache> = RefCell::new(ThumbnailCache::default());
+    /// Fallback settle group (key zero) for targets with no viewport
+    /// ancestor (popups, tests): fires on the same per-group machinery.
+    /// One settle group per visible scrolled window, keyed by widget
+    /// address. A fling in one view re-arms only its own timer, so windows
+    /// can never postpone each other's thumbnails.
+    static SETTLE_VIEWS: RefCell<HashMap<usize, ViewSettle>> = RefCell::new(HashMap::new());
+    /// Rows parked while their file metadata is still unknown. The next
+    /// metadata fill promotes them through `note_metadata` instead of
+    /// rendering once without an mtime and again after it arrives.
+    static METADATA_WAITERS: RefCell<HashMap<PathBuf, Vec<MetadataWaiter>>> =
+        RefCell::new(HashMap::new());
 }
 
 struct ActiveRequest {
@@ -47,6 +72,120 @@ struct PendingTarget {
     image_id: usize,
     request: u64,
     image: glib::WeakRef<gtk::Image>,
+}
+/// One parked row: the render key, its provider, the target widget, and
+/// whether the row must wait for file metadata before it may start work.
+struct SettledPark {
+    key: ThumbnailKey,
+    kind: ThumbnailKind,
+    target: PendingTarget,
+    wait_for_metadata: bool,
+}
+
+/// Settle state for one visible scrolled window.
+struct ViewSettle {
+    viewport: glib::WeakRef<gtk::ScrolledWindow>,
+    pending: Vec<SettledPark>,
+    timer: Option<glib::SourceId>,
+    first_park: Option<Instant>,
+    hooked: bool,
+}
+
+/// A row parked while its file metadata is unknown. Promoted by
+/// `note_metadata` into its original viewport group once the fill arrives.
+struct MetadataWaiter {
+    group: usize,
+    kind: ThumbnailKind,
+    target: PendingTarget,
+    file_size: Option<u64>,
+    thumbnail_size: i32,
+}
+/// One validated render awaiting disk persistence.
+struct PersistJob {
+    path: PathBuf,
+    mtime: i64,
+    png: Vec<u8>,
+}
+
+/// Bounded persistence queue. Slow or failing disk must never delay display
+/// or hold a render-worker slot, so validated renders land here and a single
+/// background pump stores them. Over capacity the oldest entry drops: its
+/// file simply re-renders on the next cold start.
+const MAX_PERSIST_QUEUE: usize = 32;
+
+struct PersistQueue {
+    queue: VecDeque<PersistJob>,
+}
+
+impl PersistQueue {
+    const fn new() -> Self {
+        Self {
+            queue: VecDeque::new(),
+        }
+    }
+
+    fn push(&mut self, job: PersistJob) {
+        if self.queue.len() >= MAX_PERSIST_QUEUE {
+            self.queue.pop_front();
+        }
+        self.queue.push_back(job);
+    }
+
+    fn pop_front(&mut self) -> Option<PersistJob> {
+        self.queue.pop_front()
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.queue.len()
+    }
+}
+
+// Process-wide: the persistence pump runs on a worker thread, so the queue
+// cannot be a main-thread local like the settle state.
+static PERSIST_QUEUE: std::sync::Mutex<PersistQueue> = std::sync::Mutex::new(PersistQueue::new());
+static PERSIST_RUNNING: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Enqueues a validated render for background persistence and ensures the
+/// pump runs. Display already applied; this never blocks the caller.
+fn enqueue_persist(path: PathBuf, mtime: i64, png: Vec<u8>) {
+    PERSIST_QUEUE
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .push(PersistJob { path, mtime, png });
+    pump_persist_queue();
+}
+
+fn pump_persist_queue() {
+    use std::sync::atomic::Ordering;
+    if PERSIST_RUNNING.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    gio::spawn_blocking(|| {
+        loop {
+            let job = PERSIST_QUEUE
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner())
+                .pop_front();
+            let Some(job) = job else {
+                break;
+            };
+            // Best effort, on no render slot: every store failure is
+            // silently dropped and the in-memory result already applied.
+            super::thumbnail_cache::store(&job.path, job.mtime, &job.png);
+        }
+        PERSIST_RUNNING.store(false, Ordering::SeqCst);
+        // A job enqueued after the drain but before the flag cleared
+        // restarts the pump instead of stranding work.
+        if !PERSIST_QUEUE
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .queue
+            .is_empty()
+        {
+            pump_persist_queue();
+        }
+    });
 }
 
 struct PendingThumbnail {
@@ -199,15 +338,16 @@ pub(super) fn set_thumbnail_or_icon(
         show_fallback_icon(image, fallback_icon, icon_size);
         return;
     };
-    set_thumbnail_for_path(
+    set_thumbnail_for_path(ThumbnailRequest {
         image,
         path,
-        known_metadata(&entry.modified_unix_seconds),
-        known_metadata(&entry.size),
+        modified: known_metadata(&entry.modified_unix_seconds),
+        file_size: known_metadata(&entry.size),
         fallback_icon,
         icon_size,
         thumbnail_size,
-    );
+        wait_for_metadata: true,
+    });
 }
 
 pub(super) fn set_thumbnail_or_icon_for_path(
@@ -217,54 +357,65 @@ pub(super) fn set_thumbnail_or_icon_for_path(
     icon_size: i32,
     thumbnail_size: i32,
 ) {
-    set_thumbnail_for_path(
+    set_thumbnail_for_path(ThumbnailRequest {
         image,
         path,
-        None,
-        None,
+        modified: None,
+        file_size: None,
         fallback_icon,
         icon_size,
         thumbnail_size,
-    );
+        wait_for_metadata: false,
+    });
 }
 
-fn set_thumbnail_for_path(
-    image: &gtk::Image,
-    path: &Path,
+/// One thumbnail scheduling request. Bundled so the scheduler entry point
+/// stays under the argument-count lint as viewport and metadata flags join
+/// the key material.
+struct ThumbnailRequest<'a> {
+    image: &'a gtk::Image,
+    path: &'a Path,
     modified: Option<i64>,
     file_size: Option<u64>,
-    fallback_icon: &str,
+    fallback_icon: &'a str,
     icon_size: i32,
     thumbnail_size: i32,
-) {
-    let (image_id, request) = set_fallback_icon(image, fallback_icon, icon_size);
-    let path = path.to_path_buf();
+    wait_for_metadata: bool,
+}
+
+fn set_thumbnail_for_path(request: ThumbnailRequest<'_>) {
+    let (image_id, request_id) =
+        set_fallback_icon(request.image, request.fallback_icon, request.icon_size);
+    let path = request.path.to_path_buf();
     let Some(kind) = thumbnail_kind(&path) else {
         return;
     };
-    let thumbnail_size = thumbnail_size.clamp(16, 256);
+    let thumbnail_size = request.thumbnail_size.clamp(16, 256);
     let key = ThumbnailKey {
         path: path.clone(),
-        modified,
-        file_size,
+        modified: request.modified,
+        file_size: request.file_size,
         thumbnail_size,
     };
+    // Memory hits apply instantly with no I/O: revisits never wait on the
+    // settle queue. Disk validation moves to fire time, where only rows in
+    // the settled viewport spend the lookup; offscreen rows never touch the
+    // disk merely because GTK retained them.
     match THUMBNAIL_CACHE.with(|cache| cache.borrow_mut().get(&key)) {
         Some(CacheHit::Ready(bytes)) => {
-            apply_thumbnail(image, &bytes, thumbnail_size);
+            apply_thumbnail(request.image, &bytes, thumbnail_size);
             return;
         }
         Some(CacheHit::Failed) => return,
         None => {}
     }
-
     let weak_image = glib::WeakRef::new();
-    weak_image.set(Some(image));
+    weak_image.set(Some(request.image));
     ACTIVE_REQUESTS.with(|requests| {
         requests.borrow_mut().insert(
             image_id,
             ActiveRequest {
-                id: request,
+                id: request_id,
                 image: weak_image.clone(),
                 deferred: None,
             },
@@ -272,28 +423,519 @@ fn set_thumbnail_for_path(
     });
     let target = PendingTarget {
         image_id,
-        request,
+        request: request_id,
         image: weak_image,
     };
-    schedule_or_defer(key, kind, target);
+    // Factory binds run while GTK is mutating the list's widget tree. Wait
+    // until that mutation finishes before walking the image's ancestors and
+    // hooking its viewport; doing either from the bind callback can corrupt
+    // GTK's in-progress layout.
+    glib::idle_add_local_once(move || {
+        if target_live_image(&target).is_some() {
+            park_thumbnail(key, kind, target, request.wait_for_metadata);
+        }
+    });
 }
 
+/// Viewport ancestor of a bound row image, if the row lives inside a
+/// scrolled window. Resolved at park time, when the row is parented, so bind
+/// call sites pass nothing new: every column, grid, explorer, and search row
+/// finds its own viewport automatically. No scrolled ancestor (popups,
+/// tests) lands in the fallback group with the historic behavior.
+fn viewport_of(image: &gtk::Image) -> Option<gtk::ScrolledWindow> {
+    let mut ancestor = image.parent();
+    while let Some(widget) = ancestor {
+        ancestor = widget.parent();
+        if let Ok(viewport) = widget.downcast::<gtk::ScrolledWindow>() {
+            return Some(viewport);
+        }
+    }
+    None
+}
+
+/// Eligibility of an item rect expressed in viewport coordinates against the
+/// viewport size. Visible rows plus `VIEWPORT_OVERSCAN` prefetch on every
+/// side start work; anything further out waits for a later settle. Pure over
+/// floats so the geometry is unit-testable without a display.
+fn rect_eligible(
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
+    viewport_width: f32,
+    viewport_height: f32,
+) -> bool {
+    let overscan = VIEWPORT_OVERSCAN;
+    width > 0.0
+        && height > 0.0
+        && viewport_width > 0.0
+        && viewport_height > 0.0
+        && x < viewport_width * (1.0 + overscan)
+        && x + width > -viewport_width * overscan
+        && y < viewport_height * (1.0 + overscan)
+        && y + height > -viewport_height * overscan
+}
+
+/// The live item rect of a bound row image in viewport coordinates, or
+/// `None` when the row is unmapped or detached. A miss degrades to
+/// ineligible, never to a wrong row.
+fn image_viewport_rect(
+    image: &gtk::Image,
+    viewport: &gtk::ScrolledWindow,
+) -> Option<(f32, f32, f32, f32)> {
+    let bounds = image.compute_bounds(viewport)?;
+    Some((bounds.x(), bounds.y(), bounds.width(), bounds.height()))
+}
+
+fn list_item_owner(widget: &gtk::Widget) -> Option<gtk::Widget> {
+    let mut child = widget.clone();
+    while let Some(parent) = child.parent() {
+        if parent.is::<gtk::ListView>() || parent.is::<gtk::GridView>() {
+            return Some(child);
+        }
+        child = parent;
+    }
+    None
+}
+
+/// GTK keeps the last allocation of rows visited during a fling, so bounds
+/// alone can make every intermediate page look current. Hit-testing the
+/// visible part identifies the row actually displayed at that position.
+fn image_is_currently_picked(
+    image: &gtk::Image,
+    viewport: &gtk::ScrolledWindow,
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
+) -> bool {
+    let left = x.max(0.0);
+    let right = (x + width).min(viewport.width() as f32);
+    let top = y.max(0.0);
+    let bottom = (y + height).min(viewport.height() as f32);
+    if left >= right || top >= bottom {
+        return true;
+    }
+    let Some(picked) = viewport.pick(
+        f64::from((left + right) / 2.0),
+        f64::from((top + bottom) / 2.0),
+        gtk::PickFlags::DEFAULT,
+    ) else {
+        return false;
+    };
+    match (
+        list_item_owner(image.upcast_ref()),
+        list_item_owner(&picked),
+    ) {
+        (Some(image), Some(picked)) => image == picked,
+        _ => false,
+    }
+}
+
+fn image_eligible(image: &gtk::Image, viewport: &gtk::ScrolledWindow) -> bool {
+    let Some((x, y, width, height)) = image_viewport_rect(image, viewport) else {
+        return false;
+    };
+    rect_eligible(
+        x,
+        y,
+        width,
+        height,
+        viewport.width() as f32,
+        viewport.height() as f32,
+    ) && image_is_currently_picked(image, viewport, x, y, width, height)
+}
+
+/// Settle group address for a viewport: its widget address, or zero for the
+/// fallback group. The map holds only weak viewport refs, so dead windows
+/// drop out at the next fire instead of leaking.
+fn group_address(viewport: Option<&gtk::ScrolledWindow>) -> usize {
+    viewport.map_or(0, |viewport| viewport.as_ptr() as usize)
+}
+
+fn park_thumbnail(
+    key: ThumbnailKey,
+    kind: ThumbnailKind,
+    target: PendingTarget,
+    wait_for_metadata: bool,
+) {
+    crate::metrics::mark_thumbnail_requested(&key.path.display().to_string());
+    // Parked until scrolling settles: a fling binds hundreds of rows, and
+    // only the rows still visible at fire time earn a decode.
+    let viewport = target.image.upgrade().and_then(|image| viewport_of(&image));
+    let group = group_address(viewport.as_ref());
+    let viewport_ref = glib::WeakRef::new();
+    if let Some(viewport) = &viewport {
+        viewport_ref.set(Some(viewport));
+    }
+    SETTLE_VIEWS.with(|views| {
+        let mut views = views.borrow_mut();
+        let settle = views.entry(group).or_insert_with(|| ViewSettle {
+            viewport: viewport_ref.clone(),
+            pending: Vec::new(),
+            timer: None,
+            first_park: None,
+            hooked: false,
+        });
+        // A dead viewport's address may be recycled by a new window: never
+        // join its stale hooks and pendings, reset the group instead. The
+        // orphaned timer fires into the fresh group at worst, which only
+        // settles early.
+        if group != 0 && settle.viewport.upgrade().is_none() {
+            if let Some(timer) = settle.timer.take() {
+                timer.remove();
+            }
+            *settle = ViewSettle {
+                viewport: viewport_ref.clone(),
+                pending: Vec::new(),
+                timer: None,
+                first_park: None,
+                hooked: false,
+            };
+        }
+        settle.pending.push(SettledPark {
+            key,
+            kind,
+            target,
+            wait_for_metadata,
+        });
+        if settle.first_park.is_none() {
+            settle.first_park = Some(Instant::now());
+        }
+    });
+    if let Some(viewport) = viewport {
+        hook_viewport(group, &viewport);
+    }
+    request_group_fire(group);
+}
+
+/// Parks into the legacy fallback group. Tests land here with the historic
+/// global behavior.
+#[cfg(test)]
 fn schedule_or_defer(key: ThumbnailKey, kind: ThumbnailKind, target: PendingTarget) {
-    let image_id = target.image_id;
-    let request = target.request;
-    if schedule_thumbnail(key.clone(), kind, target) {
+    park_thumbnail(key, kind, target, false);
+}
+fn mark_deferred(key: ThumbnailKey, kind: ThumbnailKind, image_id: usize, request: u64) {
+    ACTIVE_REQUESTS.with(|requests| {
+        if let Some(active) = requests
+            .borrow_mut()
+            .get_mut(&image_id)
+            .filter(|active| active.id == request)
+        {
+            active.deferred = Some(DeferredThumbnail { key, kind });
+        }
+    });
+}
+
+/// Arms a group's settle timer. Fires happen exclusively on the main loop
+/// through timer callbacks: `request_group_fire` runs inside binds and
+/// adjustment callbacks, and a synchronous fire there would nest thumbnail
+/// application inside GTK layout (reentrant relayout, torn item bounds,
+/// fatal `bounds.y` assertion). An overdue group (continuous binds past
+/// `MAX_SETTLE_WAIT`) arms a zero-delay timer instead of extending the
+/// wait, so the bound holds without ever firing nested.
+fn request_group_fire(group: usize) {
+    SETTLE_VIEWS.with(|views| {
+        let mut views = views.borrow_mut();
+        let Some(settle) = views.get_mut(&group) else {
+            return;
+        };
+        // No pending rows, no timer: adjustment callbacks fire constantly
+        // during layout, and re-arming into an empty queue would turn every
+        // thumbnail application (which relayouts) into another fire, a
+        // self-sustaining apply storm that tears item bounds apart.
+        if settle.pending.is_empty() {
+            return;
+        }
+        let overdue = settle
+            .first_park
+            .is_some_and(|first| first.elapsed() >= MAX_SETTLE_WAIT);
+        if let Some(timer) = settle.timer.take() {
+            timer.remove();
+        }
+        let delay = if overdue {
+            Duration::ZERO
+        } else {
+            THUMBNAIL_SETTLE_DELAY
+        };
+        settle.timer = Some(glib::timeout_add_local_once(delay, move || {
+            fire_view_group(group);
+        }));
+    });
+}
+/// Hooks a viewport's adjustments so scrolling or resizing without fresh
+/// binds still reconciles the parked set. Connected once per viewport; the
+/// closures hold only the group address, so no reference cycle keeps a dead
+/// window alive.
+fn hook_viewport(group: usize, viewport: &gtk::ScrolledWindow) {
+    let hooked = SETTLE_VIEWS.with(|views| {
+        views
+            .borrow_mut()
+            .get_mut(&group)
+            .map(|settle| std::mem::replace(&mut settle.hooked, true))
+            .unwrap_or(true)
+    });
+    if hooked {
+        return;
+    }
+    for adjustment in [viewport.vadjustment(), viewport.hadjustment()] {
+        adjustment.connect_value_changed(move |_| request_group_fire(group));
+        adjustment.connect_changed(move |_| request_group_fire(group));
+    }
+}
+
+/// Fires one viewport group: drops dead windows, intersects the parked rows
+/// with the live viewport, serves memory and disk caches for visible rows,
+/// parks metadata waiters, and queues renders for the visible remainder.
+fn fire_view_group(group: usize) {
+    let (viewport, drained) = SETTLE_VIEWS.with(|views| {
+        let mut views = views.borrow_mut();
+        let Some(settle) = views.get_mut(&group) else {
+            return (None, Vec::new());
+        };
+        if let Some(timer) = settle.timer.take() {
+            timer.remove();
+        }
+        settle.first_park = None;
+        let viewport = settle.viewport.upgrade();
+        if group != 0 && viewport.is_none() {
+            views.remove(&group);
+            return (None, Vec::new());
+        }
+        let drained = std::mem::take(&mut settle.pending);
+        (viewport, drained)
+    });
+    fire_parks(drained, viewport.as_ref());
+}
+
+/// Fires the fallback group. Tests drive this directly.
+#[cfg(test)]
+fn fire_settled_thumbnails() {
+    // fire_view_group takes the group's timer, so no disarm is needed here.
+    fire_view_group(0);
+}
+
+fn target_live_image(target: &PendingTarget) -> Option<gtk::Image> {
+    let live = ACTIVE_REQUESTS.with(|requests| {
+        requests
+            .borrow()
+            .get(&target.image_id)
+            .is_some_and(|active| active.id == target.request)
+    });
+    if !live {
+        return None;
+    }
+    target.image.upgrade()
+}
+
+fn fire_parks(mut drained: Vec<SettledPark>, viewport: Option<&gtk::ScrolledWindow>) {
+    if let Some(viewport) = viewport {
+        // Factory bind order is not a display-order contract. Queue the
+        // settled viewport from top to bottom (and left to right for grids)
+        // so the first visible item cannot be overtaken by a later row.
+        drained.sort_by(|left, right| {
+            let position = |park: &SettledPark| {
+                park.target
+                    .image
+                    .upgrade()
+                    .and_then(|image| image_viewport_rect(&image, viewport))
+                    .map_or((f32::MAX, f32::MAX), |(x, y, _, _)| (y, x))
+            };
+            let left = position(left);
+            let right = position(right);
+            left.0
+                .total_cmp(&right.0)
+                .then_with(|| left.1.total_cmp(&right.1))
+        });
+    }
+    let mut offscreen = Vec::new();
+    let mut eligible = 0;
+    let mut started = false;
+    for park in drained {
+        let image_id = park.target.image_id;
+        let request = park.target.request;
+        // Rows that scrolled away (or were unbound) while settling earn
+        // nothing: their request was superseded or cancelled. Rows outside
+        // the settled viewport wait for a later settle instead of decoding
+        // off-screen: scrolling back re-parks them on rebind.
+        let live = ACTIVE_REQUESTS.with(|requests| {
+            requests
+                .borrow()
+                .get(&image_id)
+                .is_some_and(|active| active.id == request)
+        });
+        if !live {
+            continue;
+        }
+        // The widget may be gone while its request is still current (tests
+        // park imageless targets): viewport, memory, and disk steps need the
+        // live image, but the render queue decision does not. Completion
+        // still drops imageless results as stale.
+        let image = park.target.image.upgrade();
+        if let (Some(image), Some(viewport)) = (image.as_ref(), viewport)
+            && !image_eligible(image, viewport)
+        {
+            // GTK pre-binds rows outside its allocated window. Keep those
+            // requests parked: adjustment changes recheck the same live
+            // widgets, so scrolling into them starts work without a rebind.
+            offscreen.push(park);
+            continue;
+        }
+        eligible += 1;
+        if let Some(image) = image.as_ref()
+            && let Some(hit) = THUMBNAIL_CACHE.with(|cache| cache.borrow_mut().get(&park.key))
+        {
+            match hit {
+                CacheHit::Ready(bytes) => {
+                    apply_thumbnail(image, &bytes, park.key.thumbnail_size);
+                }
+                CacheHit::Failed => {}
+            }
+            continue;
+        }
+        if park.wait_for_metadata && park.key.modified.is_none() {
+            push_metadata_waiter(group_of_viewport(viewport), park);
+            continue;
+        }
+        if schedule_thumbnail(park.key.clone(), park.kind, park.target) {
+            started = true;
+        } else {
+            mark_deferred(park.key, park.kind, image_id, request);
+        }
+    }
+    if started {
         start_thumbnail_jobs();
-    } else {
-        ACTIVE_REQUESTS.with(|requests| {
-            if let Some(active) = requests
-                .borrow_mut()
-                .get_mut(&image_id)
-                .filter(|active| active.id == request)
-            {
-                active.deferred = Some(DeferredThumbnail { key, kind });
+    }
+    crate::metrics::mark_thumbnail_eligible(eligible);
+    if let Some(viewport) = viewport
+        && !offscreen.is_empty()
+    {
+        let group = group_address(Some(viewport));
+        SETTLE_VIEWS.with(|views| {
+            if let Some(settle) = views.borrow_mut().get_mut(&group) {
+                settle.pending.extend(offscreen);
             }
         });
     }
+}
+
+/// Settle group for a fire-time viewport reference.
+fn group_of_viewport(viewport: Option<&gtk::ScrolledWindow>) -> usize {
+    group_address(viewport)
+}
+
+fn push_metadata_waiter(group: usize, park: SettledPark) {
+    METADATA_WAITERS.with(|waiters| {
+        let mut waiters = waiters.borrow_mut();
+        let queue = waiters.entry(park.key.path.clone()).or_default();
+        // One waiter per bound view of the file is plenty; extras re-park
+        // on their next bind.
+        if queue.len() < 8 {
+            queue.push(MetadataWaiter {
+                group,
+                kind: park.kind,
+                target: park.target,
+                file_size: park.key.file_size,
+                thumbnail_size: park.key.thumbnail_size,
+            });
+        }
+    });
+}
+
+/// Promotes rows parked while their file metadata was unknown. Called from
+/// every metadata-fill path with the filled values; unknown mtimes no-op so
+/// call sites stay one-liners. Each promoted waiter re-parks into its
+/// original viewport group with a validated key, so the file renders once
+/// instead of once without an mtime and again after it arrives.
+pub(super) fn note_metadata(path: &Path, modified: Option<i64>, file_size: Option<u64>) {
+    let Some(mtime) = modified else {
+        return;
+    };
+    // Metadata may arrive after a bind parks the row but before the settle
+    // timer moves it into METADATA_WAITERS. Update both sides of that gate so
+    // the ordering cannot strand a live thumbnail indefinitely.
+    SETTLE_VIEWS.with(|views| {
+        for settle in views.borrow_mut().values_mut() {
+            for park in &mut settle.pending {
+                if park.wait_for_metadata && park.key.path == path {
+                    park.key.modified = Some(mtime);
+                    park.key.file_size = file_size.or(park.key.file_size);
+                    park.wait_for_metadata = false;
+                }
+            }
+        }
+    });
+    ACTIVE_REQUESTS.with(|requests| {
+        for deferred in requests
+            .borrow_mut()
+            .values_mut()
+            .filter_map(|active| active.deferred.as_mut())
+        {
+            if deferred.key.path == path {
+                deferred.key.modified = Some(mtime);
+                deferred.key.file_size = file_size.or(deferred.key.file_size);
+            }
+        }
+    });
+    let Some(waiters) = METADATA_WAITERS.with(|waiters| waiters.borrow_mut().remove(path)) else {
+        return;
+    };
+    for waiter in waiters {
+        if target_live_image(&waiter.target).is_none() {
+            continue;
+        }
+        let key = ThumbnailKey {
+            path: path.to_path_buf(),
+            modified: Some(mtime),
+            file_size: file_size.or(waiter.file_size),
+            thumbnail_size: waiter.thumbnail_size,
+        };
+        park_into_group(waiter.group, key, waiter.kind, waiter.target, false);
+    }
+}
+/// Fill-arm entry point: promotes metadata waiters for one filled entry.
+/// Non-native locations and unknown mtimes no-op, so every fill arm calls
+/// this unconditionally per update before touching its own rows.
+pub(super) fn note_metadata_entry(entry: &FileEntry) {
+    let (Some(path), Some(mtime)) = (
+        entry.location.native_path(),
+        known_metadata(&entry.modified_unix_seconds),
+    ) else {
+        return;
+    };
+    note_metadata(path, Some(mtime), known_metadata(&entry.size));
+}
+
+/// Parks into a known group (waiter promotion). A vanished group falls back
+/// to the shared queue instead of dropping the row.
+fn park_into_group(
+    group: usize,
+    key: ThumbnailKey,
+    kind: ThumbnailKind,
+    target: PendingTarget,
+    wait_for_metadata: bool,
+) {
+    let known = SETTLE_VIEWS.with(|views| views.borrow().contains_key(&group));
+    if !known && group != 0 {
+        park_thumbnail(key, kind, target, wait_for_metadata);
+        return;
+    }
+    SETTLE_VIEWS.with(|views| {
+        let mut views = views.borrow_mut();
+        let Some(settle) = views.get_mut(&group) else {
+            return;
+        };
+        settle.pending.push(SettledPark {
+            key,
+            kind,
+            target,
+            wait_for_metadata,
+        });
+        if settle.first_park.is_none() {
+            settle.first_park = Some(Instant::now());
+        }
+    });
+    request_group_fire(group);
 }
 
 fn schedule_thumbnail(key: ThumbnailKey, kind: ThumbnailKind, target: PendingTarget) -> bool {
@@ -334,6 +976,7 @@ fn start_thumbnail_jobs() {
             THUMBNAIL_QUEUE.with(|queue| queue.borrow_mut().finish());
             continue;
         };
+        crate::metrics::mark_thumbnail_started(&job.key.path.display().to_string());
         glib::MainContext::default().spawn_local(run_thumbnail_job(job));
     }
 }
@@ -343,32 +986,55 @@ async fn run_thumbnail_job(job: ThumbnailJob) {
     let key = job.key.clone();
     let thumbnail_size = key.thumbnail_size;
     let result = gio::spawn_blocking(move || {
+        if let Some(mtime) = job.key.modified
+            && let Some(png) = super::thumbnail_cache::lookup(&job.key.path, mtime)
+        {
+            return Ok((png, false));
+        }
+        // Always render the canonical `large` size class: the shared cache
+        // keys one entry per file, so a small view's render must never
+        // poison the bucket. Presentation downscales via `apply_thumbnail`.
+        // Persistence deliberately stays out of this worker: storing beside
+        // rendering holds a render slot behind disk I/O. Validated bytes
+        // apply first and persist through the bounded background queue.
         render_thumbnail(
             &job.key.path,
             job.kind,
-            job.key.thumbnail_size,
+            super::thumbnail_cache::CANONICAL_MAX_EDGE,
             &job.cancellation,
         )
+        .map(|png| (png, true))
     })
     .await;
     let targets = take_pending_targets(&key, job_id);
     THUMBNAIL_QUEUE.with(|queue| queue.borrow_mut().finish());
+    let uri = key.path.display().to_string();
 
     if let Some(targets) = targets {
         match result {
-            Ok(Ok(png)) => {
-                let bytes = glib::Bytes::from_owned(png);
-                THUMBNAIL_CACHE.with(|cache| cache.borrow_mut().insert(key, bytes.clone()));
-                finish_thumbnail_targets(targets, Some(&bytes), thumbnail_size);
+            Ok(Ok((png, rendered))) => {
+                crate::metrics::mark_thumbnail_completed(&uri);
+                let bytes = glib::Bytes::from_owned(png.clone());
+                THUMBNAIL_CACHE.with(|cache| cache.borrow_mut().insert(key.clone(), bytes.clone()));
+                finish_thumbnail_targets(targets, Some(&bytes), thumbnail_size, &uri);
+                // Validated bytes apply first; persistence follows on no
+                // render slot. Unverifiable keys (unknown mtime) skip the
+                // shared cache: nothing validates them later.
+                if rendered && let Some(mtime) = key.modified {
+                    enqueue_persist(key.path.clone(), mtime, png);
+                }
             }
             Ok(Err(_)) | Err(_) => {
+                crate::metrics::mark_thumbnail_cancelled(&uri);
                 THUMBNAIL_CACHE.with(|cache| cache.borrow_mut().insert_failure(key));
-                finish_thumbnail_targets(targets, None, thumbnail_size);
+                finish_thumbnail_targets(targets, None, thumbnail_size, &uri);
             }
         }
     }
     start_thumbnail_jobs();
     retry_deferred_thumbnails();
+    let counts = crate::metrics::thumbnail_counts();
+    tracing::debug!(?counts, "thumbnail pipeline settled");
 }
 
 fn retry_deferred_thumbnails() {
@@ -445,6 +1111,7 @@ fn finish_thumbnail_targets(
     targets: Vec<PendingTarget>,
     bytes: Option<&glib::Bytes>,
     thumbnail_size: i32,
+    uri: &str,
 ) {
     for target in targets {
         let is_current = ACTIVE_REQUESTS.with(|requests| {
@@ -460,15 +1127,18 @@ fn finish_thumbnail_targets(
             }
         });
         if !is_current {
+            crate::metrics::mark_thumbnail_stale(uri);
             continue;
         }
         let Some(bytes) = bytes else {
             continue;
         };
         let Some(image) = target.image.upgrade() else {
+            crate::metrics::mark_thumbnail_stale(uri);
             continue;
         };
         apply_thumbnail(&image, bytes, thumbnail_size);
+        crate::metrics::mark_thumbnail_applied(uri);
     }
 }
 
@@ -526,6 +1196,18 @@ fn set_fallback_icon(image: &gtk::Image, icon: &str, size: i32) -> (usize, u64) 
 fn cancel_thumbnail(image_id: usize) {
     ACTIVE_REQUESTS.with(|requests| {
         requests.borrow_mut().remove(&image_id);
+    });
+    // Departed rows cancel everywhere they can wait: every viewport group
+    // and the metadata-waiter map, so no queued work survives its row.
+    SETTLE_VIEWS.with(|views| {
+        views.borrow_mut().retain(|_, settle| {
+            settle
+                .pending
+                .retain(|park| park.target.image_id != image_id);
+            // Hooked viewports keep their group (and connections) across
+            // empty moments; unhooked groups vanish once drained.
+            !settle.pending.is_empty() || settle.hooked
+        });
     });
     let cancelled = PENDING_THUMBNAILS.with(|pending| {
         let mut pending = pending.borrow_mut();

--- a/src/ui/thumbnail.rs
+++ b/src/ui/thumbnail.rs
@@ -524,7 +524,7 @@ fn park_thumbnail(
             first_park: None,
             hooked: false,
         });
-        // A dead viewport's address may be recycled: reset the group instead of joining its stale hooks and pendings.
+        // A dead viewport's address may be recycled: reset the group instead of joining its stale hooks and pending requests.
         if group != 0 && settle.viewport.upgrade().is_none() {
             if let Some(timer) = settle.timer.take() {
                 timer.remove();

--- a/src/ui/thumbnail.rs
+++ b/src/ui/thumbnail.rs
@@ -18,22 +18,14 @@ use crate::{
 static NEXT_REQUEST: AtomicU64 = AtomicU64::new(1);
 const MAX_CACHE_ENTRIES: usize = 256;
 const MAX_CACHE_BYTES: usize = 64 * 1024 * 1024;
-/// Four concurrent sandbox decodes shorten the visible thumbnail drain;
-/// viewport bounding keeps the amount of admitted work fixed.
+/// Viewport bounding keeps the admitted work fixed.
 const MAX_THUMBNAIL_WORKERS: usize = 4;
 const MAX_QUEUED_THUMBNAILS: usize = 64;
 const FAILED_THUMBNAIL_TTL: Duration = Duration::from_secs(30);
-/// Settles scrolling before decoding: binds during a fling only park their
-/// rows, and one timer fire starts jobs for the rows still on screen. Cache
-/// hits bypass the gate entirely, so revisits never wait on it.
+/// Settles scrolling before decoding; cache hits bypass the gate.
 const THUMBNAIL_SETTLE_DELAY: Duration = Duration::from_millis(120);
-/// Bounds starvation: continuous binds re-arm the settle timer, but the
-/// first park starts the clock and anything parked longer fires anyway. The
-/// fire still intersects the viewport, so a mid-fling fire only spends work
-/// on rows that are actually visible.
+/// Bounds starvation: overlong parks fire anyway, still viewport-intersected.
 const MAX_SETTLE_WAIT: Duration = Duration::from_millis(400);
-/// Viewport overscan fraction per side: visible rows plus roughly 25%
-/// prefetch start work; anything further out waits for a later settle.
 const VIEWPORT_OVERSCAN: f32 = 0.25;
 
 thread_local! {
@@ -43,15 +35,9 @@ thread_local! {
         RefCell::new(HashMap::new());
     static THUMBNAIL_QUEUE: RefCell<ThumbnailQueue> = RefCell::new(ThumbnailQueue::default());
     static THUMBNAIL_CACHE: RefCell<ThumbnailCache> = RefCell::new(ThumbnailCache::default());
-    /// Fallback settle group (key zero) for targets with no viewport
-    /// ancestor (popups, tests): fires on the same per-group machinery.
-    /// One settle group per visible scrolled window, keyed by widget
-    /// address. A fling in one view re-arms only its own timer, so windows
-    /// can never postpone each other's thumbnails.
+    /// Per-viewport settle groups (key zero is the fallback); one view's fling never postpones another's.
     static SETTLE_VIEWS: RefCell<HashMap<usize, ViewSettle>> = RefCell::new(HashMap::new());
-    /// Rows parked while their file metadata is still unknown. The next
-    /// metadata fill promotes them through `note_metadata` instead of
-    /// rendering once without an mtime and again after it arrives.
+    /// Parked while metadata is unknown to avoid rendering twice.
     static METADATA_WAITERS: RefCell<HashMap<PathBuf, Vec<MetadataWaiter>>> =
         RefCell::new(HashMap::new());
 }
@@ -73,8 +59,6 @@ struct PendingTarget {
     request: u64,
     image: glib::WeakRef<gtk::Image>,
 }
-/// One parked row: the render key, its provider, the target widget, and
-/// whether the row must wait for file metadata before it may start work.
 struct SettledPark {
     key: ThumbnailKey,
     kind: ThumbnailKind,
@@ -82,7 +66,6 @@ struct SettledPark {
     wait_for_metadata: bool,
 }
 
-/// Settle state for one visible scrolled window.
 struct ViewSettle {
     viewport: glib::WeakRef<gtk::ScrolledWindow>,
     pending: Vec<SettledPark>,
@@ -91,8 +74,6 @@ struct ViewSettle {
     hooked: bool,
 }
 
-/// A row parked while its file metadata is unknown. Promoted by
-/// `note_metadata` into its original viewport group once the fill arrives.
 struct MetadataWaiter {
     group: usize,
     kind: ThumbnailKind,
@@ -100,17 +81,13 @@ struct MetadataWaiter {
     file_size: Option<u64>,
     thumbnail_size: i32,
 }
-/// One validated render awaiting disk persistence.
 struct PersistJob {
     path: PathBuf,
     mtime: i64,
     png: Vec<u8>,
 }
 
-/// Bounded persistence queue. Slow or failing disk must never delay display
-/// or hold a render-worker slot, so validated renders land here and a single
-/// background pump stores them. Over capacity the oldest entry drops: its
-/// file simply re-renders on the next cold start.
+/// Bounded: slow disk never delays display; over capacity the oldest entry drops.
 const MAX_PERSIST_QUEUE: usize = 32;
 
 struct PersistQueue {
@@ -146,8 +123,6 @@ impl PersistQueue {
 static PERSIST_QUEUE: std::sync::Mutex<PersistQueue> = std::sync::Mutex::new(PersistQueue::new());
 static PERSIST_RUNNING: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
-/// Enqueues a validated render for background persistence and ensures the
-/// pump runs. Display already applied; this never blocks the caller.
 fn enqueue_persist(path: PathBuf, mtime: i64, png: Vec<u8>) {
     PERSIST_QUEUE
         .lock()
@@ -170,8 +145,7 @@ fn pump_persist_queue() {
             let Some(job) = job else {
                 break;
             };
-            // Best effort, on no render slot: every store failure is
-            // silently dropped and the in-memory result already applied.
+            // Best effort: store failures are dropped; the in-memory result already applied.
             super::thumbnail_cache::store(&job.path, job.mtime, &job.png);
         }
         PERSIST_RUNNING.store(false, Ordering::SeqCst);
@@ -369,9 +343,7 @@ pub(super) fn set_thumbnail_or_icon_for_path(
     });
 }
 
-/// One thumbnail scheduling request. Bundled so the scheduler entry point
-/// stays under the argument-count lint as viewport and metadata flags join
-/// the key material.
+/// Bundled to stay under the argument-count lint.
 struct ThumbnailRequest<'a> {
     image: &'a gtk::Image,
     path: &'a Path,
@@ -397,10 +369,7 @@ fn set_thumbnail_for_path(request: ThumbnailRequest<'_>) {
         file_size: request.file_size,
         thumbnail_size,
     };
-    // Memory hits apply instantly with no I/O: revisits never wait on the
-    // settle queue. Disk validation moves to fire time, where only rows in
-    // the settled viewport spend the lookup; offscreen rows never touch the
-    // disk merely because GTK retained them.
+    // Disk validation moves to fire time so offscreen rows never touch the disk.
     match THUMBNAIL_CACHE.with(|cache| cache.borrow_mut().get(&key)) {
         Some(CacheHit::Ready(bytes)) => {
             apply_thumbnail(request.image, &bytes, thumbnail_size);
@@ -426,10 +395,7 @@ fn set_thumbnail_for_path(request: ThumbnailRequest<'_>) {
         request: request_id,
         image: weak_image,
     };
-    // Factory binds run while GTK is mutating the list's widget tree. Wait
-    // until that mutation finishes before walking the image's ancestors and
-    // hooking its viewport; doing either from the bind callback can corrupt
-    // GTK's in-progress layout.
+    // Binds run while GTK mutates the widget tree; walking ancestors or hooking the viewport here can corrupt layout. Defer to idle.
     glib::idle_add_local_once(move || {
         if target_live_image(&target).is_some() {
             park_thumbnail(key, kind, target, request.wait_for_metadata);
@@ -437,11 +403,6 @@ fn set_thumbnail_for_path(request: ThumbnailRequest<'_>) {
     });
 }
 
-/// Viewport ancestor of a bound row image, if the row lives inside a
-/// scrolled window. Resolved at park time, when the row is parented, so bind
-/// call sites pass nothing new: every column, grid, explorer, and search row
-/// finds its own viewport automatically. No scrolled ancestor (popups,
-/// tests) lands in the fallback group with the historic behavior.
 fn viewport_of(image: &gtk::Image) -> Option<gtk::ScrolledWindow> {
     let mut ancestor = image.parent();
     while let Some(widget) = ancestor {
@@ -453,10 +414,6 @@ fn viewport_of(image: &gtk::Image) -> Option<gtk::ScrolledWindow> {
     None
 }
 
-/// Eligibility of an item rect expressed in viewport coordinates against the
-/// viewport size. Visible rows plus `VIEWPORT_OVERSCAN` prefetch on every
-/// side start work; anything further out waits for a later settle. Pure over
-/// floats so the geometry is unit-testable without a display.
 fn rect_eligible(
     x: f32,
     y: f32,
@@ -476,9 +433,6 @@ fn rect_eligible(
         && y + height > -viewport_height * overscan
 }
 
-/// The live item rect of a bound row image in viewport coordinates, or
-/// `None` when the row is unmapped or detached. A miss degrades to
-/// ineligible, never to a wrong row.
 fn image_viewport_rect(
     image: &gtk::Image,
     viewport: &gtk::ScrolledWindow,
@@ -498,9 +452,7 @@ fn list_item_owner(widget: &gtk::Widget) -> Option<gtk::Widget> {
     None
 }
 
-/// GTK keeps the last allocation of rows visited during a fling, so bounds
-/// alone can make every intermediate page look current. Hit-testing the
-/// visible part identifies the row actually displayed at that position.
+/// GTK keeps stale allocations from fling-visited rows; hit-test the visible part to find the row actually displayed.
 fn image_is_currently_picked(
     image: &gtk::Image,
     viewport: &gtk::ScrolledWindow,
@@ -546,9 +498,6 @@ fn image_eligible(image: &gtk::Image, viewport: &gtk::ScrolledWindow) -> bool {
     ) && image_is_currently_picked(image, viewport, x, y, width, height)
 }
 
-/// Settle group address for a viewport: its widget address, or zero for the
-/// fallback group. The map holds only weak viewport refs, so dead windows
-/// drop out at the next fire instead of leaking.
 fn group_address(viewport: Option<&gtk::ScrolledWindow>) -> usize {
     viewport.map_or(0, |viewport| viewport.as_ptr() as usize)
 }
@@ -560,8 +509,6 @@ fn park_thumbnail(
     wait_for_metadata: bool,
 ) {
     crate::metrics::mark_thumbnail_requested(&key.path.display().to_string());
-    // Parked until scrolling settles: a fling binds hundreds of rows, and
-    // only the rows still visible at fire time earn a decode.
     let viewport = target.image.upgrade().and_then(|image| viewport_of(&image));
     let group = group_address(viewport.as_ref());
     let viewport_ref = glib::WeakRef::new();
@@ -577,10 +524,7 @@ fn park_thumbnail(
             first_park: None,
             hooked: false,
         });
-        // A dead viewport's address may be recycled by a new window: never
-        // join its stale hooks and pendings, reset the group instead. The
-        // orphaned timer fires into the fresh group at worst, which only
-        // settles early.
+        // A dead viewport's address may be recycled: reset the group instead of joining its stale hooks and pendings.
         if group != 0 && settle.viewport.upgrade().is_none() {
             if let Some(timer) = settle.timer.take() {
                 timer.remove();
@@ -609,8 +553,6 @@ fn park_thumbnail(
     request_group_fire(group);
 }
 
-/// Parks into the legacy fallback group. Tests land here with the historic
-/// global behavior.
 #[cfg(test)]
 fn schedule_or_defer(key: ThumbnailKey, kind: ThumbnailKind, target: PendingTarget) {
     park_thumbnail(key, kind, target, false);
@@ -627,23 +569,14 @@ fn mark_deferred(key: ThumbnailKey, kind: ThumbnailKind, image_id: usize, reques
     });
 }
 
-/// Arms a group's settle timer. Fires happen exclusively on the main loop
-/// through timer callbacks: `request_group_fire` runs inside binds and
-/// adjustment callbacks, and a synchronous fire there would nest thumbnail
-/// application inside GTK layout (reentrant relayout, torn item bounds,
-/// fatal `bounds.y` assertion). An overdue group (continuous binds past
-/// `MAX_SETTLE_WAIT`) arms a zero-delay timer instead of extending the
-/// wait, so the bound holds without ever firing nested.
+/// Fires happen only on the main loop: firing inside binds or adjustment callbacks would nest thumbnail application inside GTK layout (reentrant relayout, fatal `bounds.y` assertion). Overdue groups arm a zero-delay timer so the bound holds without ever firing nested.
 fn request_group_fire(group: usize) {
     SETTLE_VIEWS.with(|views| {
         let mut views = views.borrow_mut();
         let Some(settle) = views.get_mut(&group) else {
             return;
         };
-        // No pending rows, no timer: adjustment callbacks fire constantly
-        // during layout, and re-arming into an empty queue would turn every
-        // thumbnail application (which relayouts) into another fire, a
-        // self-sustaining apply storm that tears item bounds apart.
+        // No pending rows, no timer: re-arming into an empty queue turns every thumbnail application (which relayouts) into another fire.
         if settle.pending.is_empty() {
             return;
         }
@@ -663,10 +596,6 @@ fn request_group_fire(group: usize) {
         }));
     });
 }
-/// Hooks a viewport's adjustments so scrolling or resizing without fresh
-/// binds still reconciles the parked set. Connected once per viewport; the
-/// closures hold only the group address, so no reference cycle keeps a dead
-/// window alive.
 fn hook_viewport(group: usize, viewport: &gtk::ScrolledWindow) {
     let hooked = SETTLE_VIEWS.with(|views| {
         views
@@ -684,9 +613,6 @@ fn hook_viewport(group: usize, viewport: &gtk::ScrolledWindow) {
     }
 }
 
-/// Fires one viewport group: drops dead windows, intersects the parked rows
-/// with the live viewport, serves memory and disk caches for visible rows,
-/// parks metadata waiters, and queues renders for the visible remainder.
 fn fire_view_group(group: usize) {
     let (viewport, drained) = SETTLE_VIEWS.with(|views| {
         let mut views = views.borrow_mut();
@@ -708,10 +634,8 @@ fn fire_view_group(group: usize) {
     fire_parks(drained, viewport.as_ref());
 }
 
-/// Fires the fallback group. Tests drive this directly.
 #[cfg(test)]
 fn fire_settled_thumbnails() {
-    // fire_view_group takes the group's timer, so no disarm is needed here.
     fire_view_group(0);
 }
 
@@ -730,9 +654,7 @@ fn target_live_image(target: &PendingTarget) -> Option<gtk::Image> {
 
 fn fire_parks(mut drained: Vec<SettledPark>, viewport: Option<&gtk::ScrolledWindow>) {
     if let Some(viewport) = viewport {
-        // Factory bind order is not a display-order contract. Queue the
-        // settled viewport from top to bottom (and left to right for grids)
-        // so the first visible item cannot be overtaken by a later row.
+        // Bind order is not display order; queue top-to-bottom so the first visible item is not overtaken.
         drained.sort_by(|left, right| {
             let position = |park: &SettledPark| {
                 park.target
@@ -754,10 +676,6 @@ fn fire_parks(mut drained: Vec<SettledPark>, viewport: Option<&gtk::ScrolledWind
     for park in drained {
         let image_id = park.target.image_id;
         let request = park.target.request;
-        // Rows that scrolled away (or were unbound) while settling earn
-        // nothing: their request was superseded or cancelled. Rows outside
-        // the settled viewport wait for a later settle instead of decoding
-        // off-screen: scrolling back re-parks them on rebind.
         let live = ACTIVE_REQUESTS.with(|requests| {
             requests
                 .borrow()
@@ -767,17 +685,11 @@ fn fire_parks(mut drained: Vec<SettledPark>, viewport: Option<&gtk::ScrolledWind
         if !live {
             continue;
         }
-        // The widget may be gone while its request is still current (tests
-        // park imageless targets): viewport, memory, and disk steps need the
-        // live image, but the render queue decision does not. Completion
-        // still drops imageless results as stale.
         let image = park.target.image.upgrade();
         if let (Some(image), Some(viewport)) = (image.as_ref(), viewport)
             && !image_eligible(image, viewport)
         {
-            // GTK pre-binds rows outside its allocated window. Keep those
-            // requests parked: adjustment changes recheck the same live
-            // widgets, so scrolling into them starts work without a rebind.
+            // Keep pre-bound offscreen requests parked; scrolling into them starts work without a rebind.
             offscreen.push(park);
             continue;
         }
@@ -819,7 +731,6 @@ fn fire_parks(mut drained: Vec<SettledPark>, viewport: Option<&gtk::ScrolledWind
     }
 }
 
-/// Settle group for a fire-time viewport reference.
 fn group_of_viewport(viewport: Option<&gtk::ScrolledWindow>) -> usize {
     group_address(viewport)
 }
@@ -828,8 +739,7 @@ fn push_metadata_waiter(group: usize, park: SettledPark) {
     METADATA_WAITERS.with(|waiters| {
         let mut waiters = waiters.borrow_mut();
         let queue = waiters.entry(park.key.path.clone()).or_default();
-        // One waiter per bound view of the file is plenty; extras re-park
-        // on their next bind.
+        // Capped per file; extras re-park on their next bind.
         if queue.len() < 8 {
             queue.push(MetadataWaiter {
                 group,
@@ -842,18 +752,11 @@ fn push_metadata_waiter(group: usize, park: SettledPark) {
     });
 }
 
-/// Promotes rows parked while their file metadata was unknown. Called from
-/// every metadata-fill path with the filled values; unknown mtimes no-op so
-/// call sites stay one-liners. Each promoted waiter re-parks into its
-/// original viewport group with a validated key, so the file renders once
-/// instead of once without an mtime and again after it arrives.
 pub(super) fn note_metadata(path: &Path, modified: Option<i64>, file_size: Option<u64>) {
     let Some(mtime) = modified else {
         return;
     };
-    // Metadata may arrive after a bind parks the row but before the settle
-    // timer moves it into METADATA_WAITERS. Update both sides of that gate so
-    // the ordering cannot strand a live thumbnail indefinitely.
+    // Metadata may arrive on either side of the settle gate; update both so no thumbnail strands.
     SETTLE_VIEWS.with(|views| {
         for settle in views.borrow_mut().values_mut() {
             for park in &mut settle.pending {
@@ -893,9 +796,6 @@ pub(super) fn note_metadata(path: &Path, modified: Option<i64>, file_size: Optio
         park_into_group(waiter.group, key, waiter.kind, waiter.target, false);
     }
 }
-/// Fill-arm entry point: promotes metadata waiters for one filled entry.
-/// Non-native locations and unknown mtimes no-op, so every fill arm calls
-/// this unconditionally per update before touching its own rows.
 pub(super) fn note_metadata_entry(entry: &FileEntry) {
     let (Some(path), Some(mtime)) = (
         entry.location.native_path(),
@@ -906,8 +806,6 @@ pub(super) fn note_metadata_entry(entry: &FileEntry) {
     note_metadata(path, Some(mtime), known_metadata(&entry.size));
 }
 
-/// Parks into a known group (waiter promotion). A vanished group falls back
-/// to the shared queue instead of dropping the row.
 fn park_into_group(
     group: usize,
     key: ThumbnailKey,
@@ -991,12 +889,7 @@ async fn run_thumbnail_job(job: ThumbnailJob) {
         {
             return Ok((png, false));
         }
-        // Always render the canonical `large` size class: the shared cache
-        // keys one entry per file, so a small view's render must never
-        // poison the bucket. Presentation downscales via `apply_thumbnail`.
-        // Persistence deliberately stays out of this worker: storing beside
-        // rendering holds a render slot behind disk I/O. Validated bytes
-        // apply first and persist through the bounded background queue.
+        // Render the canonical size class: one entry per file, so a small view must never poison the bucket.
         render_thumbnail(
             &job.key.path,
             job.kind,
@@ -1017,9 +910,7 @@ async fn run_thumbnail_job(job: ThumbnailJob) {
                 let bytes = glib::Bytes::from_owned(png.clone());
                 THUMBNAIL_CACHE.with(|cache| cache.borrow_mut().insert(key.clone(), bytes.clone()));
                 finish_thumbnail_targets(targets, Some(&bytes), thumbnail_size, &uri);
-                // Validated bytes apply first; persistence follows on no
-                // render slot. Unverifiable keys (unknown mtime) skip the
-                // shared cache: nothing validates them later.
+                // Unverifiable keys (unknown mtime) skip persistence: nothing validates them later.
                 if rendered && let Some(mtime) = key.modified {
                     enqueue_persist(key.path.clone(), mtime, png);
                 }
@@ -1197,15 +1088,11 @@ fn cancel_thumbnail(image_id: usize) {
     ACTIVE_REQUESTS.with(|requests| {
         requests.borrow_mut().remove(&image_id);
     });
-    // Departed rows cancel everywhere they can wait: every viewport group
-    // and the metadata-waiter map, so no queued work survives its row.
     SETTLE_VIEWS.with(|views| {
         views.borrow_mut().retain(|_, settle| {
             settle
                 .pending
                 .retain(|park| park.target.image_id != image_id);
-            // Hooked viewports keep their group (and connections) across
-            // empty moments; unhooked groups vanish once drained.
             !settle.pending.is_empty() || settle.hooked
         });
     });

--- a/src/ui/thumbnail/tests.rs
+++ b/src/ui/thumbnail/tests.rs
@@ -9,11 +9,12 @@ use gtk::glib;
 
 use super::{
     ACTIVE_REQUESTS, ActiveRequest, CacheHit, CachedThumbnail, MAX_CACHE_ENTRIES,
-    MAX_PERSIST_QUEUE, MAX_QUEUED_THUMBNAILS, MAX_THUMBNAIL_WORKERS, PENDING_THUMBNAILS,
-    PendingTarget, PendingThumbnail, PersistJob, PersistQueue, SETTLE_VIEWS, SettledPark,
-    THUMBNAIL_QUEUE, ThumbnailCache, ThumbnailKey, ThumbnailKind, ThumbnailQueue, ViewSettle,
-    cancel_thumbnail, finish_thumbnail_targets, fire_settled_thumbnails, note_metadata,
-    retry_deferred_thumbnail, schedule_or_defer, take_pending_targets, thumbnail_kind,
+    MAX_PERSIST_QUEUE, MAX_QUEUED_THUMBNAILS, MAX_THUMBNAIL_WORKERS, METADATA_WAITERS,
+    MetadataWaiter, PENDING_THUMBNAILS, PendingTarget, PendingThumbnail, PersistJob, PersistQueue,
+    SETTLE_VIEWS, SettledPark, THUMBNAIL_QUEUE, ThumbnailCache, ThumbnailKey, ThumbnailKind,
+    ThumbnailQueue, ViewSettle, cancel_thumbnail, finish_thumbnail_targets,
+    fire_settled_thumbnails, note_metadata, retry_deferred_thumbnail, schedule_or_defer,
+    take_pending_targets, thumbnail_kind,
 };
 
 fn key(index: usize) -> ThumbnailKey {
@@ -182,7 +183,6 @@ fn failed_jobs_release_their_active_requests() {
         }],
         None,
         64,
-        "test",
     );
 
     ACTIVE_REQUESTS.with(|requests| assert!(requests.borrow().is_empty()));
@@ -344,6 +344,72 @@ fn metadata_fill_updates_thumbnail_waiting_for_settle() {
         assert!(!park.wait_for_metadata);
         views.clear();
     });
+}
+
+#[test]
+fn unavailable_metadata_releases_settled_thumbnail_work() {
+    let path = PathBuf::from("unavailable.png");
+    SETTLE_VIEWS.with(|views| {
+        views.borrow_mut().insert(
+            0,
+            ViewSettle {
+                viewport: glib::WeakRef::new(),
+                pending: vec![SettledPark {
+                    key: ThumbnailKey {
+                        path: path.clone(),
+                        modified: None,
+                        file_size: None,
+                        thumbnail_size: 64,
+                    },
+                    kind: ThumbnailKind::Image,
+                    target: PendingTarget {
+                        image_id: 1,
+                        request: 1,
+                        image: glib::WeakRef::new(),
+                    },
+                    wait_for_metadata: true,
+                }],
+                timer: None,
+                first_park: None,
+                hooked: false,
+            },
+        );
+    });
+
+    note_metadata(&path, None, None);
+
+    SETTLE_VIEWS.with(|views| {
+        let mut views = views.borrow_mut();
+        let park = &views[&0].pending[0];
+        assert_eq!(park.key.modified, None);
+        assert!(!park.wait_for_metadata);
+        views.clear();
+    });
+}
+
+#[test]
+fn cancellation_removes_metadata_waiters() {
+    let path = PathBuf::from("cancelled.png");
+    METADATA_WAITERS.with(|waiters| {
+        waiters.borrow_mut().insert(
+            path.clone(),
+            vec![MetadataWaiter {
+                group: 0,
+                kind: ThumbnailKind::Image,
+                target: PendingTarget {
+                    image_id: 7,
+                    request: 1,
+                    image: glib::WeakRef::new(),
+                },
+                file_size: None,
+                thumbnail_size: 64,
+            }],
+        );
+    });
+
+    cancel_thumbnail(7);
+
+    METADATA_WAITERS.with(|waiters| assert!(!waiters.borrow().contains_key(&path)));
 }
 
 #[test]

--- a/src/ui/thumbnail/tests.rs
+++ b/src/ui/thumbnail/tests.rs
@@ -9,10 +9,11 @@ use gtk::glib;
 
 use super::{
     ACTIVE_REQUESTS, ActiveRequest, CacheHit, CachedThumbnail, MAX_CACHE_ENTRIES,
-    MAX_QUEUED_THUMBNAILS, MAX_THUMBNAIL_WORKERS, PENDING_THUMBNAILS, PendingTarget,
-    PendingThumbnail, THUMBNAIL_QUEUE, ThumbnailCache, ThumbnailKey, ThumbnailKind, ThumbnailQueue,
-    cancel_thumbnail, finish_thumbnail_targets, retry_deferred_thumbnail, schedule_or_defer,
-    take_pending_targets, thumbnail_kind,
+    MAX_PERSIST_QUEUE, MAX_QUEUED_THUMBNAILS, MAX_THUMBNAIL_WORKERS, PENDING_THUMBNAILS,
+    PendingTarget, PendingThumbnail, PersistJob, PersistQueue, SETTLE_VIEWS, SettledPark,
+    THUMBNAIL_QUEUE, ThumbnailCache, ThumbnailKey, ThumbnailKind, ThumbnailQueue, ViewSettle,
+    cancel_thumbnail, finish_thumbnail_targets, fire_settled_thumbnails, note_metadata,
+    retry_deferred_thumbnail, schedule_or_defer, take_pending_targets, thumbnail_kind,
 };
 
 fn key(index: usize) -> ThumbnailKey {
@@ -76,16 +77,19 @@ fn thumbnail_queue_bounds_waiting_and_running_jobs() {
     }
     assert!(!queue.enqueue(key(MAX_QUEUED_THUMBNAILS)));
 
-    for _ in 0..MAX_THUMBNAIL_WORKERS {
-        assert!(queue.begin_next().is_some());
+    for index in 0..MAX_THUMBNAIL_WORKERS {
+        assert_eq!(queue.begin_next(), Some(key(index)));
     }
     assert!(queue.begin_next().is_none());
     queue.finish();
-    assert!(queue.begin_next().is_some());
+    assert_eq!(queue.begin_next(), Some(key(MAX_THUMBNAIL_WORKERS)));
 }
 
 #[test]
 fn saturated_queue_defers_the_live_request() {
+    let _serial = crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .expect("the async test lock should not be poisoned");
     let image_id = 99;
     let request = 7;
     ACTIVE_REQUESTS.with(|requests| {
@@ -115,7 +119,18 @@ fn saturated_queue_defers_the_live_request() {
             image: glib::WeakRef::new(),
         },
     );
-
+    // Bypass the settle delay: the fire defers the live request against the
+    // saturated render queue.
+    fire_settled_thumbnails();
+    // The fire takes the fallback group's timer, so nothing is left armed:
+    // nothing pumps it in this test, and a later test sharing this thread
+    // must not inherit the fire. The drain is asserted through the per-view
+    // settle map the park resolved (no viewport ancestor: group zero).
+    SETTLE_VIEWS.with(|views| {
+        let settle = &views.borrow()[&0];
+        assert!(settle.timer.is_none());
+        assert!(settle.pending.is_empty());
+    });
     ACTIVE_REQUESTS.with(|requests| {
         let requests = requests.borrow();
         let deferred = requests[&image_id]
@@ -173,6 +188,7 @@ fn failed_jobs_release_their_active_requests() {
         }],
         None,
         64,
+        "test",
     );
 
     ACTIVE_REQUESTS.with(|requests| assert!(requests.borrow().is_empty()));
@@ -259,4 +275,109 @@ fn failed_thumbnails_expire_and_share_the_cache_bound() {
 fn rejects_files_without_a_thumbnail_provider() {
     assert_eq!(thumbnail_kind(Path::new("README.md")), None);
     assert_eq!(thumbnail_kind(Path::new("no-extension")), None);
+}
+
+#[test]
+fn viewport_eligibility_covers_visible_plus_overscan() {
+    use super::rect_eligible;
+    // Fully inside a 1000x760 viewport.
+    assert!(rect_eligible(10.0, 10.0, 100.0, 40.0, 1000.0, 760.0));
+    // Partial boundary rows count: hanging off every edge.
+    assert!(rect_eligible(-20.0, 100.0, 100.0, 40.0, 1000.0, 760.0));
+    assert!(rect_eligible(950.0, 100.0, 100.0, 40.0, 1000.0, 760.0));
+    assert!(rect_eligible(100.0, -20.0, 100.0, 40.0, 1000.0, 760.0));
+    assert!(rect_eligible(100.0, 750.0, 100.0, 40.0, 1000.0, 760.0));
+    // Within the 25% prefetch band but off-screen.
+    assert!(rect_eligible(100.0, -190.0, 100.0, 40.0, 1000.0, 760.0));
+    assert!(rect_eligible(
+        100.0,
+        760.0 + 100.0,
+        100.0,
+        40.0,
+        1000.0,
+        760.0
+    ));
+    // Past the band: a flung row earns nothing until it settles on screen.
+    assert!(!rect_eligible(100.0, -300.0, 100.0, 40.0, 1000.0, 760.0));
+    assert!(!rect_eligible(
+        100.0,
+        760.0 + 500.0,
+        100.0,
+        40.0,
+        1000.0,
+        760.0
+    ));
+    assert!(!rect_eligible(2000.0, 100.0, 100.0, 40.0, 1000.0, 760.0));
+    assert!(!rect_eligible(-500.0, 100.0, 100.0, 40.0, 1000.0, 760.0));
+    // GTK pre-binds offscreen rows with a zero-sized allocation. Neither
+    // those rows nor a degenerate viewport may start thumbnail work.
+    assert!(!rect_eligible(0.0, 4.0, 0.0, 0.0, 1000.0, 760.0));
+    assert!(!rect_eligible(0.0, 4.0, -1.0, 40.0, 1000.0, 760.0));
+    assert!(!rect_eligible(0.0, 0.0, 100.0, 40.0, 0.0, 0.0));
+}
+
+#[test]
+fn metadata_fill_updates_thumbnail_waiting_for_settle() {
+    let path = PathBuf::from("pending.png");
+    SETTLE_VIEWS.with(|views| {
+        views.borrow_mut().insert(
+            0,
+            ViewSettle {
+                viewport: glib::WeakRef::new(),
+                pending: vec![SettledPark {
+                    key: ThumbnailKey {
+                        path: path.clone(),
+                        modified: None,
+                        file_size: None,
+                        thumbnail_size: 64,
+                    },
+                    kind: ThumbnailKind::Image,
+                    target: PendingTarget {
+                        image_id: 1,
+                        request: 1,
+                        image: glib::WeakRef::new(),
+                    },
+                    wait_for_metadata: true,
+                }],
+                timer: None,
+                first_park: None,
+                hooked: false,
+            },
+        );
+    });
+
+    note_metadata(&path, Some(42), Some(99));
+
+    SETTLE_VIEWS.with(|views| {
+        let mut views = views.borrow_mut();
+        let park = &views[&0].pending[0];
+        assert_eq!(park.key.modified, Some(42));
+        assert_eq!(park.key.file_size, Some(99));
+        assert!(!park.wait_for_metadata);
+        views.clear();
+    });
+}
+
+#[test]
+fn persist_queue_bounds_and_drains_oldest_first() {
+    let mut queue = PersistQueue::new();
+    for index in 0..MAX_PERSIST_QUEUE + 5 {
+        queue.push(PersistJob {
+            path: PathBuf::from(index.to_string()),
+            mtime: 1,
+            png: vec![1],
+        });
+    }
+    // Bounded: the five oldest renders dropped instead of growing the queue
+    // behind a slow disk.
+    assert_eq!(queue.len(), MAX_PERSIST_QUEUE);
+    assert_eq!(
+        queue.pop_front().expect("queue should drain").path,
+        PathBuf::from("5")
+    );
+    let mut drained = 1;
+    while queue.pop_front().is_some() {
+        drained += 1;
+    }
+    assert_eq!(drained, MAX_PERSIST_QUEUE);
 }

--- a/src/ui/thumbnail/tests.rs
+++ b/src/ui/thumbnail/tests.rs
@@ -119,13 +119,7 @@ fn saturated_queue_defers_the_live_request() {
             image: glib::WeakRef::new(),
         },
     );
-    // Bypass the settle delay: the fire defers the live request against the
-    // saturated render queue.
     fire_settled_thumbnails();
-    // The fire takes the fallback group's timer, so nothing is left armed:
-    // nothing pumps it in this test, and a later test sharing this thread
-    // must not inherit the fire. The drain is asserted through the per-view
-    // settle map the park resolved (no viewport ancestor: group zero).
     SETTLE_VIEWS.with(|views| {
         let settle = &views.borrow()[&0];
         assert!(settle.timer.is_none());
@@ -280,14 +274,11 @@ fn rejects_files_without_a_thumbnail_provider() {
 #[test]
 fn viewport_eligibility_covers_visible_plus_overscan() {
     use super::rect_eligible;
-    // Fully inside a 1000x760 viewport.
     assert!(rect_eligible(10.0, 10.0, 100.0, 40.0, 1000.0, 760.0));
-    // Partial boundary rows count: hanging off every edge.
     assert!(rect_eligible(-20.0, 100.0, 100.0, 40.0, 1000.0, 760.0));
     assert!(rect_eligible(950.0, 100.0, 100.0, 40.0, 1000.0, 760.0));
     assert!(rect_eligible(100.0, -20.0, 100.0, 40.0, 1000.0, 760.0));
     assert!(rect_eligible(100.0, 750.0, 100.0, 40.0, 1000.0, 760.0));
-    // Within the 25% prefetch band but off-screen.
     assert!(rect_eligible(100.0, -190.0, 100.0, 40.0, 1000.0, 760.0));
     assert!(rect_eligible(
         100.0,
@@ -297,7 +288,6 @@ fn viewport_eligibility_covers_visible_plus_overscan() {
         1000.0,
         760.0
     ));
-    // Past the band: a flung row earns nothing until it settles on screen.
     assert!(!rect_eligible(100.0, -300.0, 100.0, 40.0, 1000.0, 760.0));
     assert!(!rect_eligible(
         100.0,
@@ -309,8 +299,6 @@ fn viewport_eligibility_covers_visible_plus_overscan() {
     ));
     assert!(!rect_eligible(2000.0, 100.0, 100.0, 40.0, 1000.0, 760.0));
     assert!(!rect_eligible(-500.0, 100.0, 100.0, 40.0, 1000.0, 760.0));
-    // GTK pre-binds offscreen rows with a zero-sized allocation. Neither
-    // those rows nor a degenerate viewport may start thumbnail work.
     assert!(!rect_eligible(0.0, 4.0, 0.0, 0.0, 1000.0, 760.0));
     assert!(!rect_eligible(0.0, 4.0, -1.0, 40.0, 1000.0, 760.0));
     assert!(!rect_eligible(0.0, 0.0, 100.0, 40.0, 0.0, 0.0));
@@ -368,8 +356,6 @@ fn persist_queue_bounds_and_drains_oldest_first() {
             png: vec![1],
         });
     }
-    // Bounded: the five oldest renders dropped instead of growing the queue
-    // behind a slow disk.
     assert_eq!(queue.len(), MAX_PERSIST_QUEUE);
     assert_eq!(
         queue.pop_front().expect("queue should drain").path,

--- a/src/ui/thumbnail_cache.rs
+++ b/src/ui/thumbnail_cache.rs
@@ -22,7 +22,7 @@ use std::{
 };
 
 pub const CANONICAL_MAX_EDGE: i32 = 256;
-/// Canonical PNGs are tens of kilobytes; anything past this is hostile or corrupt and is a miss without being read.
+/// Canonical PNG files are tens of kilobytes; anything past this is hostile or corrupt and is a miss without being read.
 const MAX_DISK_THUMBNAIL_BYTES: u64 = 2 * 1024 * 1024;
 /// Foreign spec-following `large` entries peak at 256 px too; anything wider is rejected before allocation.
 const MAX_CACHED_DIMENSION: u32 = 512;

--- a/src/ui/thumbnail_cache.rs
+++ b/src/ui/thumbnail_cache.rs
@@ -1,24 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-//! Freedesktop shared thumbnail cache: reads and writes
-//! `$XDG_CACHE_HOME/thumbnails/large` so thumbnails survive restarts and are
-//! shared with every other spec-following application.
+//! Freedesktop shared thumbnail cache (`$XDG_CACHE_HOME/thumbnails/large`).
 //!
-//! Keys follow the thumbnail managing standard: the MD5 of the file's URI as
-//! the file name. Every hit re-validates the PNG's own `Thumb::URI` and
-//! `Thumb::MTime` text chunks against the requested file, so a stale or
-//! foreign entry can never serve the wrong image; anything unreadable is a
-//! miss. Only entries with a known modification time touch the disk at all,
-//! since there is nothing to validate the cached copy against otherwise.
+//! Keys are the MD5 of the file's URI; every hit re-validates the PNG's
+//! `Thumb::URI`/`Thumb::MTime` tags, so stale or foreign entries miss. Only
+//! known mtimes touch the disk, since there is nothing to validate against
+//! otherwise.
 //!
-//! Cache bytes are untrusted: entries are opened without following symlinks,
-//! size- and dimension-bounded before allocation, structurally validated
-//! before their tags are read, and never decoded outside the platform's
-//! glycin-backed loader path. Raster decoding of source media happens only
-//! inside the sandbox; this module merely persists and re-serves PNG bytes.
-//! Stored entries are always normalized to the canonical `large` size class
-//! (maximum edge of 256 px), so a small view can never poison the shared
-//! bucket for larger views.
+//! Cache bytes are untrusted: opened without following symlinks,
+//! size- and dimension-bounded before allocation, and never decoded outside
+//! the sandbox loader path. Entries are normalized to the canonical `large`
+//! size class so small views cannot poison the shared bucket.
 
 #[cfg(test)]
 mod tests;
@@ -29,26 +21,15 @@ use std::{
     path::{Path, PathBuf},
 };
 
-/// Canonical `large` size class: every stored entry has a maximum edge of
-/// exactly this many pixels, regardless of which view rendered it.
 pub const CANONICAL_MAX_EDGE: i32 = 256;
-/// Upper bound for one cache entry on disk. Canonical PNGs are tens of
-/// kilobytes; anything past this is hostile or corrupt and is a miss without
-/// being read.
+/// Canonical PNGs are tens of kilobytes; anything past this is hostile or corrupt and is a miss without being read.
 const MAX_DISK_THUMBNAIL_BYTES: u64 = 2 * 1024 * 1024;
-/// Upper bound for decoded cache dimensions. Canonical entries peak at 256
-/// px; foreign spec-following `large` entries peak there too. Anything wider
-/// is rejected before allocation.
+/// Foreign spec-following `large` entries peak at 256 px too; anything wider is rejected before allocation.
 const MAX_CACHED_DIMENSION: u32 = 512;
-/// Upper bound for decoded cache pixels, bounding `width * height` before
-/// any pixel buffer exists.
 const MAX_CACHED_PIXELS: u64 = 512 * 512;
-/// Upper bound for renders handed to `store`. Sandbox outputs are small; this
-/// only guards the normalization decode against absurd inputs.
+/// Only guards the normalization decode against absurd inputs.
 const MAX_RENDER_BYTES: usize = 32 * 1024 * 1024;
 
-/// Reads a cached thumbnail for `path` validated at `mtime`, or `None` on any
-/// miss, mismatch, or I/O failure. Callers fall back to rendering.
 pub fn lookup(path: &Path, mtime: i64) -> Option<Vec<u8>> {
     let (uri, name) = cache_key(path)?;
     let bytes = read_bounded(&shared_cache_dir()?.join(name))?;
@@ -59,8 +40,6 @@ pub fn lookup(path: &Path, mtime: i64) -> Option<Vec<u8>> {
     if u64::from(width) * u64::from(height) > MAX_CACHED_PIXELS {
         return None;
     }
-    // Tags validate only after the structure passed the bounded checks:
-    // corrupt ancillary data is a miss, never a crash.
     let (stored_uri, stored_mtime) = read_thumb_tags(&bytes)?;
     if stored_uri != uri || stored_mtime != mtime.to_string() {
         return None;
@@ -68,11 +47,7 @@ pub fn lookup(path: &Path, mtime: i64) -> Option<Vec<u8>> {
     Some(bytes)
 }
 
-/// Stores freshly rendered PNG bytes under the file's cache key, tagged with
-/// its URI and mtime and normalized to the canonical size class. Best
-/// effort: every failure is silently dropped and the in-memory result still
-/// applies. Cancellation, vanished sources, and renderer failures never reach
-/// here with bytes to persist, so nothing writes negative-cache files.
+/// Best effort: failures are silently dropped. Only rendered bytes reach here, so nothing writes negative-cache files.
 pub fn store(path: &Path, mtime: i64, png: &[u8]) {
     if png.is_empty() || png.len() > MAX_RENDER_BYTES {
         return;
@@ -92,10 +67,7 @@ pub fn store(path: &Path, mtime: i64, png: &[u8]) {
     let _ignored = crate::storage::atomic_write(&dir.join(name), &tagged);
 }
 
-/// `(uri, "<md5>.png")` for `path`, or `None` when the path has no URI form.
-/// The digest is only a file name, where MD5's collision weakness is
-/// irrelevant; it comes from GLib's checksum support rather than a bespoke
-/// implementation so keys match every other spec-following application.
+/// The digest is only a file name, where MD5's weakness is irrelevant; GLib keeps keys matching other spec-following applications.
 fn cache_key(path: &Path) -> Option<(String, String)> {
     let uri = gtk_glib_filename_to_uri(path)?;
     Some((
@@ -119,10 +91,7 @@ fn gtk_glib_filename_to_uri(path: &Path) -> Option<String> {
 #[cfg(test)]
 static CACHE_DIR_OVERRIDE: std::sync::Mutex<Option<PathBuf>> = std::sync::Mutex::new(None);
 
-/// Test-only bucket override. Production always resolves through the
-/// environment; mutating process-global environment in tests is both unsafe
-/// (edition 2024) and racy, so tests serialize on a lock and swap this cell
-/// instead.
+/// Test-only bucket override: mutating process-global environment in tests is unsafe and racy, so tests swap this cell instead.
 #[cfg(test)]
 fn set_cache_dir_override(dir: Option<PathBuf>) {
     match CACHE_DIR_OVERRIDE.lock() {
@@ -161,24 +130,16 @@ fn shared_cache_dir() -> Option<PathBuf> {
     Some(base.join("thumbnails").join("large"))
 }
 
-/// Creates the cache directory with 0700 permissions even under a permissive
-/// umask or XDG parent, and repairs the mode when the directory already
-/// exists. Same-user applications are unaffected by the mode; other users
-/// lose the ability to plant symlinks or FIFOs in the bucket.
+/// 0700 so other users cannot plant symlinks or FIFOs in the bucket; repairs the mode when the directory already exists.
 fn ensure_cache_dir(dir: &Path) -> std::io::Result<()> {
     std::fs::create_dir_all(dir)?;
     std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))?;
     Ok(())
 }
 
-/// Opens `path` without following symlinks, verifies it is a regular file,
-/// and reads at most the entry bound. Symlinks, FIFOs, oversized entries,
-/// and sparse files with huge claimed lengths are misses that never allocate
-/// past the bound.
+/// Symlinks, FIFOs, oversized, and sparse entries are misses that never allocate past the bound.
 fn read_bounded(path: &Path) -> Option<Vec<u8>> {
-    // `NONBLOCK`: opening a FIFO without it would wait for a writer
-    // forever. The type check below rejects everything but regular files
-    // before any byte is read.
+    // `NONBLOCK`: opening a FIFO without it would wait for a writer forever.
     let fd = rustix::fs::open(
         path,
         rustix::fs::OFlags::RDONLY
@@ -203,11 +164,7 @@ fn read_bounded(path: &Path) -> Option<Vec<u8>> {
     Some(bytes)
 }
 
-/// Decodes rendered PNG bytes and re-saves them at the canonical size class,
-/// tagged with the file's URI and mtime, so later lookups can validate the
-/// entry. The output always has a maximum edge of 256 px: larger renders
-/// scale down and smaller renders scale up, so a tiny view can never poison
-/// the shared bucket with an upscaled-after-the-fact entry.
+/// The output always has a maximum edge of 256 px, so a tiny view can never poison the shared bucket.
 fn normalize_to_canonical(png: &[u8], uri: &str, mtime: i64) -> Result<Vec<u8>, String> {
     use gtk::gdk_pixbuf::prelude::PixbufLoaderExt;
     let loader = gtk::gdk_pixbuf::PixbufLoader::new();
@@ -247,8 +204,6 @@ fn normalize_to_canonical(png: &[u8], uri: &str, mtime: i64) -> Result<Vec<u8>, 
         .map(|bytes| bytes.to_vec())
 }
 
-/// Reads `(width, height)` out of a PNG's IHDR without decoding anything.
-/// Returns `None` for anything that is not a PNG with a well-formed IHDR.
 fn png_dimensions(png: &[u8]) -> Option<(u32, u32)> {
     const SIGNATURE: &[u8] = b"\x89PNG\r\n\x1a\n";
     if png.get(..SIGNATURE.len())? != SIGNATURE {
@@ -273,9 +228,7 @@ fn png_dimensions(png: &[u8]) -> Option<(u32, u32)> {
     Some((width, height))
 }
 
-/// Reads the `Thumb::URI` / `Thumb::MTime` text tags out of PNG bytes.
-/// Returns `None` for anything that is not a PNG or carries no tags, without
-/// ever panicking on hostile input: the shared cache is world-writable data.
+/// Never panics on hostile input: the shared cache is world-writable data.
 fn read_thumb_tags(png: &[u8]) -> Option<(String, String)> {
     const SIGNATURE: &[u8] = b"\x89PNG\r\n\x1a\n";
     if png.get(..SIGNATURE.len())? != SIGNATURE {
@@ -288,7 +241,6 @@ fn read_thumb_tags(png: &[u8]) -> Option<(String, String)> {
         let length = u32::from_be_bytes(png.get(position..position + 4)?.try_into().ok()?) as usize;
         let kind = png.get(position + 4..position + 8)?;
         let data_end = position.checked_add(8)?.checked_add(length)?;
-        // Trailing CRC included: a truncated chunk ends the walk, never the process.
         if data_end.checked_add(4)? > png.len() {
             return None;
         }

--- a/src/ui/thumbnail_cache.rs
+++ b/src/ui/thumbnail_cache.rs
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Freedesktop shared thumbnail cache: reads and writes
+//! `$XDG_CACHE_HOME/thumbnails/large` so thumbnails survive restarts and are
+//! shared with every other spec-following application.
+//!
+//! Keys follow the thumbnail managing standard: the MD5 of the file's URI as
+//! the file name. Every hit re-validates the PNG's own `Thumb::URI` and
+//! `Thumb::MTime` text chunks against the requested file, so a stale or
+//! foreign entry can never serve the wrong image; anything unreadable is a
+//! miss. Only entries with a known modification time touch the disk at all,
+//! since there is nothing to validate the cached copy against otherwise.
+//!
+//! Cache bytes are untrusted: entries are opened without following symlinks,
+//! size- and dimension-bounded before allocation, structurally validated
+//! before their tags are read, and never decoded outside the platform's
+//! glycin-backed loader path. Raster decoding of source media happens only
+//! inside the sandbox; this module merely persists and re-serves PNG bytes.
+//! Stored entries are always normalized to the canonical `large` size class
+//! (maximum edge of 256 px), so a small view can never poison the shared
+//! bucket for larger views.
+
+#[cfg(test)]
+mod tests;
+
+use std::{
+    io::Read,
+    os::unix::fs::PermissionsExt,
+    path::{Path, PathBuf},
+};
+
+/// Canonical `large` size class: every stored entry has a maximum edge of
+/// exactly this many pixels, regardless of which view rendered it.
+pub const CANONICAL_MAX_EDGE: i32 = 256;
+/// Upper bound for one cache entry on disk. Canonical PNGs are tens of
+/// kilobytes; anything past this is hostile or corrupt and is a miss without
+/// being read.
+const MAX_DISK_THUMBNAIL_BYTES: u64 = 2 * 1024 * 1024;
+/// Upper bound for decoded cache dimensions. Canonical entries peak at 256
+/// px; foreign spec-following `large` entries peak there too. Anything wider
+/// is rejected before allocation.
+const MAX_CACHED_DIMENSION: u32 = 512;
+/// Upper bound for decoded cache pixels, bounding `width * height` before
+/// any pixel buffer exists.
+const MAX_CACHED_PIXELS: u64 = 512 * 512;
+/// Upper bound for renders handed to `store`. Sandbox outputs are small; this
+/// only guards the normalization decode against absurd inputs.
+const MAX_RENDER_BYTES: usize = 32 * 1024 * 1024;
+
+/// Reads a cached thumbnail for `path` validated at `mtime`, or `None` on any
+/// miss, mismatch, or I/O failure. Callers fall back to rendering.
+pub fn lookup(path: &Path, mtime: i64) -> Option<Vec<u8>> {
+    let (uri, name) = cache_key(path)?;
+    let bytes = read_bounded(&shared_cache_dir()?.join(name))?;
+    let (width, height) = png_dimensions(&bytes)?;
+    if width == 0 || height == 0 || width > MAX_CACHED_DIMENSION || height > MAX_CACHED_DIMENSION {
+        return None;
+    }
+    if u64::from(width) * u64::from(height) > MAX_CACHED_PIXELS {
+        return None;
+    }
+    // Tags validate only after the structure passed the bounded checks:
+    // corrupt ancillary data is a miss, never a crash.
+    let (stored_uri, stored_mtime) = read_thumb_tags(&bytes)?;
+    if stored_uri != uri || stored_mtime != mtime.to_string() {
+        return None;
+    }
+    Some(bytes)
+}
+
+/// Stores freshly rendered PNG bytes under the file's cache key, tagged with
+/// its URI and mtime and normalized to the canonical size class. Best
+/// effort: every failure is silently dropped and the in-memory result still
+/// applies. Cancellation, vanished sources, and renderer failures never reach
+/// here with bytes to persist, so nothing writes negative-cache files.
+pub fn store(path: &Path, mtime: i64, png: &[u8]) {
+    if png.is_empty() || png.len() > MAX_RENDER_BYTES {
+        return;
+    }
+    let Some((uri, name)) = cache_key(path) else {
+        return;
+    };
+    let Some(dir) = shared_cache_dir() else {
+        return;
+    };
+    if ensure_cache_dir(&dir).is_err() {
+        return;
+    }
+    let Ok(tagged) = normalize_to_canonical(png, &uri, mtime) else {
+        return;
+    };
+    let _ignored = crate::storage::atomic_write(&dir.join(name), &tagged);
+}
+
+/// `(uri, "<md5>.png")` for `path`, or `None` when the path has no URI form.
+/// The digest is only a file name, where MD5's collision weakness is
+/// irrelevant; it comes from GLib's checksum support rather than a bespoke
+/// implementation so keys match every other spec-following application.
+fn cache_key(path: &Path) -> Option<(String, String)> {
+    let uri = gtk_glib_filename_to_uri(path)?;
+    Some((
+        uri.clone(),
+        format!("{}.png", glib_md5_hex(uri.as_bytes())?),
+    ))
+}
+
+fn glib_md5_hex(data: &[u8]) -> Option<String> {
+    let mut checksum = gtk::glib::Checksum::new(gtk::glib::ChecksumType::Md5)?;
+    checksum.update(data);
+    checksum.string()
+}
+
+fn gtk_glib_filename_to_uri(path: &Path) -> Option<String> {
+    gtk::glib::filename_to_uri(path, None)
+        .ok()
+        .map(|uri| uri.to_string())
+}
+
+#[cfg(test)]
+static CACHE_DIR_OVERRIDE: std::sync::Mutex<Option<PathBuf>> = std::sync::Mutex::new(None);
+
+/// Test-only bucket override. Production always resolves through the
+/// environment; mutating process-global environment in tests is both unsafe
+/// (edition 2024) and racy, so tests serialize on a lock and swap this cell
+/// instead.
+#[cfg(test)]
+fn set_cache_dir_override(dir: Option<PathBuf>) {
+    match CACHE_DIR_OVERRIDE.lock() {
+        Ok(mut slot) => *slot = dir,
+        Err(poison) => {
+            CACHE_DIR_OVERRIDE.clear_poison();
+            *poison.into_inner() = dir;
+        }
+    }
+}
+
+#[cfg(test)]
+fn cache_dir_override() -> Option<PathBuf> {
+    match CACHE_DIR_OVERRIDE.lock() {
+        Ok(slot) => slot.clone(),
+        Err(poison) => {
+            CACHE_DIR_OVERRIDE.clear_poison();
+            poison.into_inner().clone()
+        }
+    }
+}
+
+fn shared_cache_dir() -> Option<PathBuf> {
+    #[cfg(test)]
+    if let Some(dir) = cache_dir_override() {
+        return Some(dir);
+    }
+    let base = std::env::var_os("XDG_CACHE_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .filter(|value| !value.is_empty())
+                .map(|home| PathBuf::from(home).join(".cache"))
+        })?;
+    Some(base.join("thumbnails").join("large"))
+}
+
+/// Creates the cache directory with 0700 permissions even under a permissive
+/// umask or XDG parent, and repairs the mode when the directory already
+/// exists. Same-user applications are unaffected by the mode; other users
+/// lose the ability to plant symlinks or FIFOs in the bucket.
+fn ensure_cache_dir(dir: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dir)?;
+    std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))?;
+    Ok(())
+}
+
+/// Opens `path` without following symlinks, verifies it is a regular file,
+/// and reads at most the entry bound. Symlinks, FIFOs, oversized entries,
+/// and sparse files with huge claimed lengths are misses that never allocate
+/// past the bound.
+fn read_bounded(path: &Path) -> Option<Vec<u8>> {
+    // `NONBLOCK`: opening a FIFO without it would wait for a writer
+    // forever. The type check below rejects everything but regular files
+    // before any byte is read.
+    let fd = rustix::fs::open(
+        path,
+        rustix::fs::OFlags::RDONLY
+            | rustix::fs::OFlags::NOFOLLOW
+            | rustix::fs::OFlags::CLOEXEC
+            | rustix::fs::OFlags::NONBLOCK,
+        rustix::fs::Mode::empty(),
+    )
+    .ok()?;
+    let stat = rustix::fs::fstat(&fd).ok()?;
+    if rustix::fs::FileType::from_raw_mode(stat.st_mode) != rustix::fs::FileType::RegularFile {
+        return None;
+    }
+    let file = std::fs::File::from(fd);
+    let mut bytes = Vec::new();
+    file.take(MAX_DISK_THUMBNAIL_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .ok()?;
+    if bytes.len() as u64 > MAX_DISK_THUMBNAIL_BYTES {
+        return None;
+    }
+    Some(bytes)
+}
+
+/// Decodes rendered PNG bytes and re-saves them at the canonical size class,
+/// tagged with the file's URI and mtime, so later lookups can validate the
+/// entry. The output always has a maximum edge of 256 px: larger renders
+/// scale down and smaller renders scale up, so a tiny view can never poison
+/// the shared bucket with an upscaled-after-the-fact entry.
+fn normalize_to_canonical(png: &[u8], uri: &str, mtime: i64) -> Result<Vec<u8>, String> {
+    use gtk::gdk_pixbuf::prelude::PixbufLoaderExt;
+    let loader = gtk::gdk_pixbuf::PixbufLoader::new();
+    loader.write(png).map_err(|error| error.to_string())?;
+    loader.close().map_err(|error| error.to_string())?;
+    let pixbuf = loader
+        .pixbuf()
+        .ok_or_else(|| "thumbnail decoded to no image".to_owned())?;
+    let (width, height) = (pixbuf.width(), pixbuf.height());
+    if width <= 0 || height <= 0 {
+        return Err("thumbnail decoded to empty dimensions".to_owned());
+    }
+    let long_edge = width.max(height);
+    let pixbuf = if long_edge == CANONICAL_MAX_EDGE {
+        pixbuf
+    } else {
+        let scale = f64::from(CANONICAL_MAX_EDGE) / f64::from(long_edge);
+        let scaled_width = ((f64::from(width) * scale).round() as i32).max(1);
+        let scaled_height = ((f64::from(height) * scale).round() as i32).max(1);
+        pixbuf
+            .scale_simple(
+                scaled_width,
+                scaled_height,
+                gtk::gdk_pixbuf::InterpType::Bilinear,
+            )
+            .ok_or_else(|| "thumbnail scaling failed".to_owned())?
+    };
+    pixbuf
+        .save_to_bufferv(
+            "png",
+            &[
+                ("tEXt::Thumb::URI", uri),
+                ("tEXt::Thumb::MTime", &mtime.to_string()),
+            ],
+        )
+        .map_err(|error| error.to_string())
+        .map(|bytes| bytes.to_vec())
+}
+
+/// Reads `(width, height)` out of a PNG's IHDR without decoding anything.
+/// Returns `None` for anything that is not a PNG with a well-formed IHDR.
+fn png_dimensions(png: &[u8]) -> Option<(u32, u32)> {
+    const SIGNATURE: &[u8] = b"\x89PNG\r\n\x1a\n";
+    if png.get(..SIGNATURE.len())? != SIGNATURE {
+        return None;
+    }
+    let mut position = SIGNATURE.len();
+    let length = u32::from_be_bytes(png.get(position..position + 4)?.try_into().ok()?) as usize;
+    let kind = png.get(position + 4..position + 8)?;
+    if kind != b"IHDR" || length < 13 {
+        return None;
+    }
+    let data = png.get(position + 8..position + 8 + 13)?;
+    let width = u32::from_be_bytes(data[0..4].try_into().ok()?);
+    let height = u32::from_be_bytes(data[4..8].try_into().ok()?);
+    position = position
+        .checked_add(8)?
+        .checked_add(length)?
+        .checked_add(4)?;
+    if position > png.len() {
+        return None;
+    }
+    Some((width, height))
+}
+
+/// Reads the `Thumb::URI` / `Thumb::MTime` text tags out of PNG bytes.
+/// Returns `None` for anything that is not a PNG or carries no tags, without
+/// ever panicking on hostile input: the shared cache is world-writable data.
+fn read_thumb_tags(png: &[u8]) -> Option<(String, String)> {
+    const SIGNATURE: &[u8] = b"\x89PNG\r\n\x1a\n";
+    if png.get(..SIGNATURE.len())? != SIGNATURE {
+        return None;
+    }
+    let mut uri = None;
+    let mut mtime = None;
+    let mut position = SIGNATURE.len();
+    while position.checked_add(8)? <= png.len() {
+        let length = u32::from_be_bytes(png.get(position..position + 4)?.try_into().ok()?) as usize;
+        let kind = png.get(position + 4..position + 8)?;
+        let data_end = position.checked_add(8)?.checked_add(length)?;
+        // Trailing CRC included: a truncated chunk ends the walk, never the process.
+        if data_end.checked_add(4)? > png.len() {
+            return None;
+        }
+        if kind == b"tEXt" {
+            let data = &png[position + 8..data_end];
+            if let Some(nul) = data.iter().position(|byte| *byte == 0) {
+                let (keyword, value) = (&data[..nul], &data[nul + 1..]);
+                if keyword == b"Thumb::URI" {
+                    uri = std::str::from_utf8(value).ok().map(str::to_owned);
+                } else if keyword == b"Thumb::MTime" {
+                    mtime = std::str::from_utf8(value).ok().map(str::to_owned);
+                }
+            }
+        }
+        if kind == b"IEND" {
+            break;
+        }
+        position = data_end + 4;
+    }
+    Some((uri?, mtime?))
+}

--- a/src/ui/thumbnail_cache/tests.rs
+++ b/src/ui/thumbnail_cache/tests.rs
@@ -17,10 +17,6 @@ use crate::test_support::TestMutex;
 
 static CACHE_TEST_LOCK: TestMutex = TestMutex::new();
 
-/// Serializes cache tests around a unique bucket override: the override cell
-/// is process-global, and mutating the umask is too, so concurrent tests
-/// must never interleave. Production resolution always goes through the
-/// environment; tests never touch it (mutating it is unsafe in edition 2024).
 struct BucketGuard {
     _lock: std::sync::MutexGuard<'static, ()>,
     previous_umask: Option<u32>,
@@ -78,8 +74,6 @@ fn unique_source(label: &str) -> PathBuf {
     dir
 }
 
-/// A solid-color PNG of the requested size, standing in for a sandbox
-/// render without needing media fixtures.
 fn solid_png(width: i32, height: i32) -> Vec<u8> {
     let pixbuf =
         gtk::gdk_pixbuf::Pixbuf::new(gtk::gdk_pixbuf::Colorspace::Rgb, false, 8, width, height)
@@ -103,9 +97,6 @@ fn glib_md5(input: &str) -> String {
 
 #[test]
 fn md5_matches_reference_vectors() {
-    // Verified against the system's md5sum, not copied from anywhere. The
-    // digest is only the cache file name; it comes from GLib so keys match
-    // every other spec-following application.
     let vectors = [
         ("", "d41d8cd98f00b204e9800998ecf8427e"),
         ("a", "0cc175b9c0f1b6a831c399e269772661"),
@@ -129,15 +120,12 @@ fn md5_matches_reference_vectors() {
 fn tag_reader_rejects_non_png_and_truncation() {
     assert_eq!(read_thumb_tags(b"definitely not a png"), None);
     assert_eq!(read_thumb_tags(b"\x89PNG\r\n\x1a\n"), None);
-    // Signature plus a truncated chunk header: ends the walk, never panics.
     assert_eq!(read_thumb_tags(b"\x89PNG\r\n\x1a\n\x00\x00"), None);
 }
 
 #[test]
 fn tag_reader_reads_a_minimal_tagged_png() {
     let mut png = b"\x89PNG\r\n\x1a\n".to_vec();
-    // IHDR with a zero length and no CRC: the reader skips structure, it
-    // does not validate it.
     png.extend_from_slice(&[0, 0, 0, 0]);
     png.extend_from_slice(b"IHDR");
     png.extend_from_slice(&[0, 0, 0, 0]);
@@ -168,12 +156,9 @@ fn stored_entries_are_canonical_large() {
     let path = source.join("photo.jpg");
     std::fs::write(&path, b"source").expect("the fixture should be written");
 
-    // A 300 px render scales down to the canonical maximum edge.
     store(&path, 111, &solid_png(300, 200));
     assert_eq!(stored_dimensions(&bucket, &path), Some((256, 171)));
 
-    // A tiny view's render scales up instead of poisoning the bucket: a
-    // later large view reads a valid large entry, not a 17 px one.
     store(&path, 111, &solid_png(20, 10));
     assert_eq!(stored_dimensions(&bucket, &path), Some((256, 128)));
     assert!(lookup(&path, 111).is_some());
@@ -187,10 +172,8 @@ fn stale_entries_are_misses() {
     std::fs::write(&path, b"source").expect("the fixture should be written");
     store(&path, 111, &solid_png(64, 64));
     assert!(lookup(&path, 111).is_some());
-    // Wrong mtime: the file changed since the entry was stored.
     assert_eq!(lookup(&path, 222), None);
 
-    // Foreign bytes under another file's key: URI tags mismatch.
     let other = source.join("other.jpg");
     std::fs::write(&other, b"source").expect("the fixture should be written");
     let (_, name) = cache_key(&other).expect("the other path should key");
@@ -210,7 +193,6 @@ fn oversized_and_sparse_entries_are_misses_without_huge_reads() {
     std::fs::create_dir_all(&bucket).expect("the bucket should exist");
     let source = unique_source("oversized");
 
-    // A multi-megabyte blob under a valid key name is a miss.
     let path = source.join("huge.jpg");
     std::fs::write(&path, b"source").expect("the fixture should be written");
     let (_, name) = cache_key(&path).expect("the path should key");
@@ -218,8 +200,6 @@ fn oversized_and_sparse_entries_are_misses_without_huge_reads() {
         .expect("the oversized entry should be written");
     assert_eq!(lookup(&path, 111), None);
 
-    // A sparse 100 MB file reports a huge length but holds no blocks: the
-    // size bound rejects it before any allocation.
     let sparse = source.join("sparse.jpg");
     std::fs::write(&sparse, b"source").expect("the fixture should be written");
     let (_, sparse_name) = cache_key(&sparse).expect("the sparse path should key");
@@ -237,7 +217,6 @@ fn fifo_symlink_and_malformed_entries_are_safe_misses() {
     std::fs::create_dir_all(&bucket).expect("the bucket should exist");
     let source = unique_source("hostile");
 
-    // FIFO under a key name: not a regular file, never opened for parsing.
     let fifo_path = source.join("fifo.jpg");
     std::fs::write(&fifo_path, b"source").expect("the fixture should be written");
     let (_, fifo_name) = cache_key(&fifo_path).expect("the fifo path should key");
@@ -249,8 +228,6 @@ fn fifo_symlink_and_malformed_entries_are_safe_misses() {
     .expect("the fifo should be created");
     assert_eq!(lookup(&fifo_path, 111), None);
 
-    // Symlink under a key name: never followed, and the link target that a
-    // successful write would have clobbered stays intact.
     let canary = source.join("canary.txt");
     std::fs::write(&canary, b"canary").expect("the canary should be written");
     let link_path = source.join("linked.jpg");
@@ -262,15 +239,12 @@ fn fifo_symlink_and_malformed_entries_are_safe_misses() {
         std::fs::read(&canary).expect("the canary should survive"),
         b"canary"
     );
-    // A symlink at the destination also blocks stores: the atomic write
-    // refuses non-regular destinations instead of following the link.
     store(&link_path, 111, &solid_png(64, 64));
     assert_eq!(
         std::fs::read(&canary).expect("the canary should survive the store"),
         b"canary"
     );
 
-    // Random bytes, truncated PNGs, and absurd dimensions: misses, no panic.
     let bad_path = source.join("bad.jpg");
     std::fs::write(&bad_path, b"source").expect("the fixture should be written");
     let (_, bad_name) = cache_key(&bad_path).expect("the bad path should key");
@@ -288,8 +262,6 @@ fn fifo_symlink_and_malformed_entries_are_safe_misses() {
     extreme.extend_from_slice(&[8, 2, 0, 0, 0]);
     extreme.extend_from_slice(&[0, 0, 0, 0]);
     std::fs::write(bucket.join(&bad_name), &extreme).expect("the extreme entry is written");
-    // 100000 px dwarfs the cache bound, so the pre-decode dimension check
-    // rejects it without allocating a pixel buffer.
     assert_eq!(lookup(&bad_path, 111), None);
 }
 
@@ -321,8 +293,6 @@ fn bucket_and_entries_keep_strict_modes_under_a_permissive_umask() {
 fn uri_keys_cover_tricky_names() {
     let (_guard, _bucket) = BucketGuard::unique("urikeys");
     let source = unique_source("urikeys");
-    // Spaces, fragments, queries, at-signs, and Unicode round-trip through
-    // GLib URI forms with matching keys.
     let tricky = [
         "sp ace.jpg",
         "hash#tag.jpg",
@@ -343,8 +313,6 @@ fn uri_keys_cover_tricky_names() {
         assert_eq!(lookup(&path, 222), None);
     }
 
-    // Non-UTF-8 native names must never panic: they round-trip where GLib
-    // can represent them, and miss otherwise.
     let raw_path = source.join(OsString::from_vec(b"raw-\xff.jpg".to_vec()));
     std::fs::write(&raw_path, b"source").expect("the raw fixture should be written");
     store(&raw_path, 111, &solid_png(64, 64));

--- a/src/ui/thumbnail_cache/tests.rs
+++ b/src/ui/thumbnail_cache/tests.rs
@@ -1,0 +1,360 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::{
+    ffi::OsString,
+    os::unix::{
+        ffi::OsStringExt,
+        fs::{PermissionsExt, symlink},
+    },
+    path::{Path, PathBuf},
+};
+
+use super::{
+    cache_key, ensure_cache_dir, glib_md5_hex, lookup, normalize_to_canonical, png_dimensions,
+    read_thumb_tags, set_cache_dir_override, shared_cache_dir, store,
+};
+use crate::test_support::TestMutex;
+
+static CACHE_TEST_LOCK: TestMutex = TestMutex::new();
+
+/// Serializes cache tests around a unique bucket override: the override cell
+/// is process-global, and mutating the umask is too, so concurrent tests
+/// must never interleave. Production resolution always goes through the
+/// environment; tests never touch it (mutating it is unsafe in edition 2024).
+struct BucketGuard {
+    _lock: std::sync::MutexGuard<'static, ()>,
+    previous_umask: Option<u32>,
+}
+
+impl BucketGuard {
+    fn unique(label: &str) -> (Self, PathBuf) {
+        let lock = CACHE_TEST_LOCK
+            .lock()
+            .expect("the cache test lock should not be poisoned");
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("the system clock should be after the Unix epoch")
+            .as_nanos();
+        let bucket = std::env::temp_dir().join(format!(
+            "strata-thumb-cache-{label}-{unique}-{}",
+            std::process::id()
+        ));
+        let bucket = bucket.join("thumbnails").join("large");
+        set_cache_dir_override(Some(bucket.clone()));
+        (
+            Self {
+                _lock: lock,
+                previous_umask: None,
+            },
+            bucket,
+        )
+    }
+
+    fn permissive_umask(&mut self) {
+        let previous = rustix::process::umask(rustix::fs::Mode::from_bits_truncate(0o022));
+        self.previous_umask = Some(previous.bits());
+    }
+}
+
+impl Drop for BucketGuard {
+    fn drop(&mut self) {
+        set_cache_dir_override(None);
+        if let Some(mask) = self.previous_umask.take() {
+            rustix::process::umask(rustix::fs::Mode::from_bits_truncate(mask));
+        }
+    }
+}
+
+fn unique_source(label: &str) -> PathBuf {
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("the system clock should be after the Unix epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!(
+        "strata-thumb-source-{label}-{unique}-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).expect("the source dir should exist");
+    dir
+}
+
+/// A solid-color PNG of the requested size, standing in for a sandbox
+/// render without needing media fixtures.
+fn solid_png(width: i32, height: i32) -> Vec<u8> {
+    let pixbuf =
+        gtk::gdk_pixbuf::Pixbuf::new(gtk::gdk_pixbuf::Colorspace::Rgb, false, 8, width, height)
+            .expect("a solid test pixbuf should allocate");
+    pixbuf.fill(0x80402000);
+    pixbuf
+        .save_to_bufferv("png", &[])
+        .expect("a solid test pixbuf should encode")
+        .to_vec()
+}
+
+fn stored_dimensions(bucket: &Path, path: &Path) -> Option<(u32, u32)> {
+    let (_, name) = cache_key(path)?;
+    let bytes = std::fs::read(bucket.join(name)).ok()?;
+    png_dimensions(&bytes)
+}
+
+fn glib_md5(input: &str) -> String {
+    glib_md5_hex(input.as_bytes()).expect("GLib should hash the vector")
+}
+
+#[test]
+fn md5_matches_reference_vectors() {
+    // Verified against the system's md5sum, not copied from anywhere. The
+    // digest is only the cache file name; it comes from GLib so keys match
+    // every other spec-following application.
+    let vectors = [
+        ("", "d41d8cd98f00b204e9800998ecf8427e"),
+        ("a", "0cc175b9c0f1b6a831c399e269772661"),
+        ("abc", "900150983cd24fb0d6963f7d28e17f72"),
+        ("message digest", "f96b697d7cb7938d525a2f31aaf161d0"),
+        (
+            "abcdefghijklmnopqrstuvwxyz",
+            "c3fcd3d76192e4007dfb496cca67e13b",
+        ),
+        (
+            "file:///home/kaperala/picture.jpg",
+            "aca2162ac461307f56a89d41dccb4fde",
+        ),
+    ];
+    for (input, expected) in vectors {
+        assert_eq!(glib_md5(input), expected, "input {input:?}");
+    }
+}
+
+#[test]
+fn tag_reader_rejects_non_png_and_truncation() {
+    assert_eq!(read_thumb_tags(b"definitely not a png"), None);
+    assert_eq!(read_thumb_tags(b"\x89PNG\r\n\x1a\n"), None);
+    // Signature plus a truncated chunk header: ends the walk, never panics.
+    assert_eq!(read_thumb_tags(b"\x89PNG\r\n\x1a\n\x00\x00"), None);
+}
+
+#[test]
+fn tag_reader_reads_a_minimal_tagged_png() {
+    let mut png = b"\x89PNG\r\n\x1a\n".to_vec();
+    // IHDR with a zero length and no CRC: the reader skips structure, it
+    // does not validate it.
+    png.extend_from_slice(&[0, 0, 0, 0]);
+    png.extend_from_slice(b"IHDR");
+    png.extend_from_slice(&[0, 0, 0, 0]);
+    let text = b"Thumb::URI\0file:///x/y.png";
+    png.extend_from_slice(&(text.len() as u32).to_be_bytes());
+    png.extend_from_slice(b"tEXt");
+    png.extend_from_slice(text);
+    png.extend_from_slice(&[0, 0, 0, 0]);
+    let mut mtime = b"Thumb::MTime\0".to_vec();
+    mtime.extend_from_slice(b"12345678");
+    png.extend_from_slice(&(mtime.len() as u32).to_be_bytes());
+    png.extend_from_slice(b"tEXt");
+    png.extend_from_slice(&mtime);
+    png.extend_from_slice(&[0, 0, 0, 0]);
+    png.extend_from_slice(&[0, 0, 0, 0]);
+    png.extend_from_slice(b"IEND");
+    png.extend_from_slice(&[0, 0, 0, 0]);
+    assert_eq!(
+        read_thumb_tags(&png),
+        Some(("file:///x/y.png".to_owned(), "12345678".to_owned()))
+    );
+}
+
+#[test]
+fn stored_entries_are_canonical_large() {
+    let (_guard, bucket) = BucketGuard::unique("canonical");
+    let source = unique_source("canonical");
+    let path = source.join("photo.jpg");
+    std::fs::write(&path, b"source").expect("the fixture should be written");
+
+    // A 300 px render scales down to the canonical maximum edge.
+    store(&path, 111, &solid_png(300, 200));
+    assert_eq!(stored_dimensions(&bucket, &path), Some((256, 171)));
+
+    // A tiny view's render scales up instead of poisoning the bucket: a
+    // later large view reads a valid large entry, not a 17 px one.
+    store(&path, 111, &solid_png(20, 10));
+    assert_eq!(stored_dimensions(&bucket, &path), Some((256, 128)));
+    assert!(lookup(&path, 111).is_some());
+}
+
+#[test]
+fn stale_entries_are_misses() {
+    let (_guard, _bucket) = BucketGuard::unique("stale");
+    let source = unique_source("stale");
+    let path = source.join("photo.jpg");
+    std::fs::write(&path, b"source").expect("the fixture should be written");
+    store(&path, 111, &solid_png(64, 64));
+    assert!(lookup(&path, 111).is_some());
+    // Wrong mtime: the file changed since the entry was stored.
+    assert_eq!(lookup(&path, 222), None);
+
+    // Foreign bytes under another file's key: URI tags mismatch.
+    let other = source.join("other.jpg");
+    std::fs::write(&other, b"source").expect("the fixture should be written");
+    let (_, name) = cache_key(&other).expect("the other path should key");
+    let dir = shared_cache_dir().expect("the cache dir should resolve");
+    let ours = {
+        let (_, name) = cache_key(&path).expect("the path should key");
+        std::fs::read(dir.join(name)).expect("our entry should exist")
+    };
+    std::fs::create_dir_all(&dir).expect("the cache dir should exist");
+    std::fs::write(dir.join(name), ours).expect("the foreign copy should be written");
+    assert_eq!(lookup(&other, 111), None);
+}
+
+#[test]
+fn oversized_and_sparse_entries_are_misses_without_huge_reads() {
+    let (_guard, bucket) = BucketGuard::unique("oversized");
+    std::fs::create_dir_all(&bucket).expect("the bucket should exist");
+    let source = unique_source("oversized");
+
+    // A multi-megabyte blob under a valid key name is a miss.
+    let path = source.join("huge.jpg");
+    std::fs::write(&path, b"source").expect("the fixture should be written");
+    let (_, name) = cache_key(&path).expect("the path should key");
+    std::fs::write(bucket.join(&name), vec![0x41u8; 3 * 1024 * 1024])
+        .expect("the oversized entry should be written");
+    assert_eq!(lookup(&path, 111), None);
+
+    // A sparse 100 MB file reports a huge length but holds no blocks: the
+    // size bound rejects it before any allocation.
+    let sparse = source.join("sparse.jpg");
+    std::fs::write(&sparse, b"source").expect("the fixture should be written");
+    let (_, sparse_name) = cache_key(&sparse).expect("the sparse path should key");
+    let file =
+        std::fs::File::create(bucket.join(&sparse_name)).expect("the sparse entry is created");
+    file.set_len(100 * 1024 * 1024)
+        .expect("the sparse entry should be sized");
+    drop(file);
+    assert_eq!(lookup(&sparse, 111), None);
+}
+
+#[test]
+fn fifo_symlink_and_malformed_entries_are_safe_misses() {
+    let (_guard, bucket) = BucketGuard::unique("hostile");
+    std::fs::create_dir_all(&bucket).expect("the bucket should exist");
+    let source = unique_source("hostile");
+
+    // FIFO under a key name: not a regular file, never opened for parsing.
+    let fifo_path = source.join("fifo.jpg");
+    std::fs::write(&fifo_path, b"source").expect("the fixture should be written");
+    let (_, fifo_name) = cache_key(&fifo_path).expect("the fifo path should key");
+    rustix::fs::mkfifoat(
+        rustix::fs::CWD,
+        bucket.join(&fifo_name),
+        rustix::fs::Mode::from_bits_truncate(0o600),
+    )
+    .expect("the fifo should be created");
+    assert_eq!(lookup(&fifo_path, 111), None);
+
+    // Symlink under a key name: never followed, and the link target that a
+    // successful write would have clobbered stays intact.
+    let canary = source.join("canary.txt");
+    std::fs::write(&canary, b"canary").expect("the canary should be written");
+    let link_path = source.join("linked.jpg");
+    std::fs::write(&link_path, b"source").expect("the fixture should be written");
+    let (_, link_name) = cache_key(&link_path).expect("the link path should key");
+    symlink(&canary, bucket.join(&link_name)).expect("the symlink should be created");
+    assert_eq!(lookup(&link_path, 111), None);
+    assert_eq!(
+        std::fs::read(&canary).expect("the canary should survive"),
+        b"canary"
+    );
+    // A symlink at the destination also blocks stores: the atomic write
+    // refuses non-regular destinations instead of following the link.
+    store(&link_path, 111, &solid_png(64, 64));
+    assert_eq!(
+        std::fs::read(&canary).expect("the canary should survive the store"),
+        b"canary"
+    );
+
+    // Random bytes, truncated PNGs, and absurd dimensions: misses, no panic.
+    let bad_path = source.join("bad.jpg");
+    std::fs::write(&bad_path, b"source").expect("the fixture should be written");
+    let (_, bad_name) = cache_key(&bad_path).expect("the bad path should key");
+    std::fs::write(bucket.join(&bad_name), b"definitely not a png")
+        .expect("the garbage should be written");
+    assert_eq!(lookup(&bad_path, 111), None);
+    std::fs::write(bucket.join(&bad_name), b"\x89PNG\r\n\x1a\n\x00\x00")
+        .expect("the truncation should be written");
+    assert_eq!(lookup(&bad_path, 111), None);
+    let mut extreme = b"\x89PNG\r\n\x1a\n".to_vec();
+    extreme.extend_from_slice(&13u32.to_be_bytes());
+    extreme.extend_from_slice(b"IHDR");
+    extreme.extend_from_slice(&100_000u32.to_be_bytes());
+    extreme.extend_from_slice(&100_000u32.to_be_bytes());
+    extreme.extend_from_slice(&[8, 2, 0, 0, 0]);
+    extreme.extend_from_slice(&[0, 0, 0, 0]);
+    std::fs::write(bucket.join(&bad_name), &extreme).expect("the extreme entry is written");
+    // 100000 px dwarfs the cache bound, so the pre-decode dimension check
+    // rejects it without allocating a pixel buffer.
+    assert_eq!(lookup(&bad_path, 111), None);
+}
+
+#[test]
+fn bucket_and_entries_keep_strict_modes_under_a_permissive_umask() {
+    let (mut guard, bucket) = BucketGuard::unique("modes");
+    guard.permissive_umask();
+    let source = unique_source("modes");
+    let path = source.join("photo.jpg");
+    std::fs::write(&path, b"source").expect("the fixture should be written");
+    store(&path, 111, &solid_png(64, 64));
+
+    let dir_mode = std::fs::metadata(&bucket)
+        .expect("the bucket should exist")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(dir_mode, 0o700);
+    let (_, name) = cache_key(&path).expect("the path should key");
+    let file_mode = std::fs::metadata(bucket.join(name))
+        .expect("the entry should exist")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(file_mode, 0o600);
+}
+
+#[test]
+fn uri_keys_cover_tricky_names() {
+    let (_guard, _bucket) = BucketGuard::unique("urikeys");
+    let source = unique_source("urikeys");
+    // Spaces, fragments, queries, at-signs, and Unicode round-trip through
+    // GLib URI forms with matching keys.
+    let tricky = [
+        "sp ace.jpg",
+        "hash#tag.jpg",
+        "what?.jpg",
+        "at@home.jpg",
+        "ünïcödé.jpg",
+    ];
+    for name in tricky {
+        let path = source.join(name);
+        std::fs::write(&path, b"source").expect("the fixture should be written");
+        let (uri, key_name) = cache_key(&path).expect("the tricky name should key");
+        assert_eq!(format!("{}.png", glib_md5(&uri)), key_name);
+        store(&path, 111, &solid_png(64, 64));
+        assert!(
+            lookup(&path, 111).is_some(),
+            "name {name:?} should round-trip"
+        );
+        assert_eq!(lookup(&path, 222), None);
+    }
+
+    // Non-UTF-8 native names must never panic: they round-trip where GLib
+    // can represent them, and miss otherwise.
+    let raw_path = source.join(OsString::from_vec(b"raw-\xff.jpg".to_vec()));
+    std::fs::write(&raw_path, b"source").expect("the raw fixture should be written");
+    store(&raw_path, 111, &solid_png(64, 64));
+    let hit = lookup(&raw_path, 111);
+    assert!(hit.is_some() || cache_key(&raw_path).is_none());
+}
+
+#[test]
+fn normalizer_rejects_degenerate_renders() {
+    assert!(normalize_to_canonical(b"", "file:///x.jpg", 1).is_err());
+    assert!(normalize_to_canonical(b"not a png", "file:///x.jpg", 1).is_err());
+    assert!(ensure_cache_dir(&PathBuf::from("/proc/strata-nope/thumbnails")).is_err());
+}

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -24,6 +24,7 @@ use super::{
     motion::{animations_enabled, emphasized_deceleration},
     preview::PreviewDrawer,
     search::SearchDialog,
+    theme::ThemeManager,
 };
 
 const SIDEBAR_WIDTH: i32 = 208;
@@ -51,9 +52,14 @@ pub fn present(application: &gtk::Application) {
 }
 
 pub fn present_location(application: &gtk::Application, location: Option<PathBuf>) {
+    let present_started = std::time::Instant::now();
     crate::assets::register_icon_theme();
     let theme_manager = super::theme::ThemeManager::shared();
     load_styles();
+    tracing::debug!(
+        elapsed_ms = present_started.elapsed().as_millis() as u64,
+        "present theme and styles ready"
+    );
 
     let window = gtk::ApplicationWindow::builder()
         .application(application)
@@ -77,14 +83,14 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
     let preview_for_selection = preview.clone();
     let weak_controller = Rc::downgrade(&controller);
     controller.observe(move |event| match event {
-        BrowserEvent::PreviewRequested { entry } => preview_for_selection.show(entry),
+        BrowserEvent::PreviewRequested { entry } => preview_for_selection.show(entry.clone()),
         BrowserEvent::FocusChanged {
             depth,
             position: Some(position),
         } if preview_for_selection.is_open() => {
             if let Some(entry) = weak_controller
                 .upgrade()
-                .and_then(|browser| browser.entry_at(depth, position))
+                .and_then(|browser| browser.entry_at(*depth, *position))
             {
                 if entry.is_directory() {
                     preview_for_selection.close();
@@ -383,23 +389,46 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
             update_area.set_visible(false);
         }
     });
-    let settings_layer = super::settings::build_layer(
-        &browser,
-        &settings,
-        &blurred_root,
-        theme_manager,
-        update_notice,
-        install_guard,
-    );
-    window_overlay.add_overlay(&settings_layer);
-    let shown_settings = settings_layer.clone();
+    // The settings shell builds on first open, never during startup: even
+    // the cheap pages are widgets the user may never need, and the heavy
+    // pages (Updates detection, release notes, theme swatches) build on
+    // first selection from there.
+    let settings_layer: Rc<RefCell<Option<gtk::Box>>> = Rc::new(RefCell::new(None));
+    let ensure_settings_layer = {
+        let browser = browser.clone();
+        let settings_button = settings.clone();
+        let blurred = blurred_root.clone();
+        let themes = theme_manager.clone();
+        let notice = update_notice.clone();
+        let guard = install_guard.clone();
+        let overlay = window_overlay.clone();
+        let layers = settings_layer.clone();
+        Rc::new(move || {
+            if let Some(layer) = layers.borrow().clone() {
+                return layer;
+            }
+            let layer = super::settings::build_layer(
+                &browser,
+                &settings_button,
+                &blurred,
+                themes.clone(),
+                notice.clone(),
+                guard.clone(),
+            );
+            overlay.add_overlay(&layer);
+            layers.borrow_mut().replace(layer.clone());
+            layer
+        })
+    };
+    let shown_settings = ensure_settings_layer.clone();
     let settings_button = settings.clone();
     let settings_blurred_root = blurred_root.clone();
     settings.connect_clicked(move |_| {
-        show_settings(&shown_settings, &settings_button, &settings_blurred_root);
+        let layer = shown_settings();
+        show_settings(&layer, &settings_button, &settings_blurred_root);
     });
     let settings_shortcut = gtk::EventControllerKey::new();
-    let shown_settings = settings_layer.clone();
+    let shown_settings = ensure_settings_layer.clone();
     let settings_button = settings.clone();
     let shortcut_blurred_root = blurred_root.clone();
     settings_shortcut.connect_key_pressed(move |_, key, _, modifiers| {
@@ -407,7 +436,8 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
         {
             return glib::Propagation::Proceed;
         }
-        show_settings(&shown_settings, &settings_button, &shortcut_blurred_root);
+        let layer = shown_settings();
+        show_settings(&layer, &settings_button, &shortcut_blurred_root);
         glib::Propagation::Stop
     });
     window.add_controller(settings_shortcut);
@@ -433,17 +463,58 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
     window.add_controller(rename_cancel);
     install_modal_focus_trap(&window);
     install_keyboard_navigation(&window, &browser, &sidebar, &sidebar_toggle, &preview);
-    browser.navigate(location.unwrap_or_else(home_directory));
-
     let browser_controller = browser.browser();
+    schedule_sidebar_devices(&sidebar);
     window.connect_destroy(move |_| {
         browser_controller.clear_observer();
         sidebar.disconnect();
     });
+    // Present before navigating: the window maps while the directory streams
+    // in behind the loading state, instead of holding first paint for
+    // validation and enumeration. Navigation runs from idle so mapping and
+    // the first frame are never queued behind enumeration setup.
     window.present();
     crate::metrics::mark_window_presented();
+    crate::metrics::mark_first_themed_frame();
+    let pending_location = location.unwrap_or_else(home_directory);
+    let idle_browser = browser.clone();
+    glib::idle_add_local_once(move || {
+        let started = std::time::Instant::now();
+        idle_browser.navigate(pending_location);
+        tracing::debug!(
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "present navigation started"
+        );
+    });
+    schedule_due_update_check(&theme_manager, &update_notice);
 }
 
+/// Populates dynamic sidebar volumes and mounts after the first painted
+/// frame, on idle. Static places render synchronously with the shell;
+/// devices append at the end later, so focus and layout never jump.
+fn schedule_sidebar_devices(sidebar: &SidebarView) {
+    let state = sidebar.state.clone();
+    glib::idle_add_local_once(move || {
+        state.rebuild();
+    });
+}
+
+/// Schedules the process-wide due update check: eight seconds after mapping
+/// so it never competes with first paint, then on idle so it never steals
+/// input. A due online notice normally lands within about ten seconds after
+/// initial load. See `settings::maybe_run_due_update_check`.
+fn schedule_due_update_check(
+    manager: &Rc<ThemeManager>,
+    notice: &super::settings::UpdateNoticeHandler,
+) {
+    let manager = manager.clone();
+    let notice = notice.clone();
+    glib::timeout_add_local_once(std::time::Duration::from_secs(8), move || {
+        glib::idle_add_local_once(move || {
+            super::settings::maybe_run_due_update_check(&manager, &notice);
+        });
+    });
+}
 fn animate_sidebar(
     paned: &gtk::Paned,
     sidebar: &gtk::Widget,
@@ -1172,6 +1243,14 @@ impl SidebarState {
         }
         self.place_rows.borrow_mut().clear();
 
+        self.append_static_places();
+        self.append_devices();
+        self.sync_active_place();
+    }
+
+    /// Renders every static place without touching the volume monitor:
+    /// safe to run synchronously with the shell during startup.
+    fn append_static_places(self: &Rc<Self>) {
         self.append_place(
             crate::assets::icons::HOME,
             "Home",
@@ -1209,7 +1288,13 @@ impl SidebarState {
                 self.append_pinned_place(index, &name, location);
             }
         }
+    }
 
+    /// Enumerates volumes and mounts. Deferred past the first painted frame
+    /// on idle: volume enumeration can block on remote backends, and the
+    /// DEVICES section appends at the end, so late population never moves
+    /// focus or existing rows.
+    fn append_devices(self: &Rc<Self>) {
         let volumes = self.volume_monitor.volumes();
         let mounts: Vec<_> = self
             .volume_monitor
@@ -1236,7 +1321,6 @@ impl SidebarState {
                 }
             }
         }
-        self.sync_active_place();
     }
 
     fn pin_location(self: &Rc<Self>, location: Location, name: String) {
@@ -1253,6 +1337,17 @@ impl SidebarState {
             save_pinned_places(&self.pinned_places.borrow());
             self.rebuild();
         }
+    }
+    /// Whether a browser event can change the active location or place.
+    /// Pure so the fan-out gate stays unit-testable without widgets.
+    fn event_changes_active_place(event: &BrowserEvent) -> bool {
+        matches!(
+            event,
+            BrowserEvent::Reset
+                | BrowserEvent::ColumnAdded { .. }
+                | BrowserEvent::ColumnsTruncated { .. }
+                | BrowserEvent::FocusChanged { .. }
+        )
     }
 
     fn sync_active_place(&self) {
@@ -1942,7 +2037,13 @@ fn build_sidebar(view: BrowserView, theme_manager: Rc<super::theme::ThemeManager
     });
 
     let weak = Rc::downgrade(&state);
-    state.browser.observe(move |_| {
+    state.browser.observe(move |event| {
+        // The active place follows the active location only: batch,
+        // metadata, sort-progress, and operation traffic never moves it,
+        // so syncing on every event is pure overhead per listing batch.
+        if !SidebarState::event_changes_active_place(event) {
+            return;
+        }
         if let Some(state) = weak.upgrade() {
             state.sync_active_place();
         }
@@ -1985,8 +2086,11 @@ fn build_sidebar(view: BrowserView, theme_manager: Rc<super::theme::ThemeManager
             state.rebuild();
         }
     }));
-    state.rebuild();
-
+    // Static places render with the shell; dynamic volumes arrive on idle
+    // after the first frame (see `schedule_sidebar_devices`), so volume
+    // enumeration never blocks first paint.
+    state.append_static_places();
+    state.sync_active_place();
     SidebarView {
         widget: shell.upcast(),
         state,

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -83,14 +83,14 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
     let preview_for_selection = preview.clone();
     let weak_controller = Rc::downgrade(&controller);
     controller.observe(move |event| match event {
-        BrowserEvent::PreviewRequested { entry } => preview_for_selection.show(entry),
+        BrowserEvent::PreviewRequested { entry } => preview_for_selection.show(entry.clone()),
         BrowserEvent::FocusChanged {
             depth,
             position: Some(position),
         } if preview_for_selection.is_open() => {
             if let Some(entry) = weak_controller
                 .upgrade()
-                .and_then(|browser| browser.entry_at(depth, position))
+                .and_then(|browser| browser.entry_at(*depth, *position))
             {
                 if entry.is_directory() {
                     preview_for_selection.close();
@@ -2041,7 +2041,7 @@ fn build_sidebar(view: BrowserView, theme_manager: Rc<super::theme::ThemeManager
         // The active place follows the active location only: batch,
         // metadata, sort-progress, and operation traffic never moves it,
         // so syncing on every event is pure overhead per listing batch.
-        if !SidebarState::event_changes_active_place(&event) {
+        if !SidebarState::event_changes_active_place(event) {
             return;
         }
         if let Some(state) = weak.upgrade() {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -389,10 +389,6 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
             update_area.set_visible(false);
         }
     });
-    // The settings shell builds on first open, never during startup: even
-    // the cheap pages are widgets the user may never need, and the heavy
-    // pages (Updates detection, release notes, theme swatches) build on
-    // first selection from there.
     let settings_layer: Rc<RefCell<Option<gtk::Box>>> = Rc::new(RefCell::new(None));
     let ensure_settings_layer = {
         let browser = browser.clone();
@@ -464,18 +460,13 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
     install_modal_focus_trap(&window);
     install_keyboard_navigation(&window, &browser, &sidebar, &sidebar_toggle, &preview);
     let browser_controller = browser.browser();
-    schedule_sidebar_devices(&sidebar);
+    schedule_after_first_paint(&window, &sidebar);
     window.connect_destroy(move |_| {
         browser_controller.clear_observer();
         sidebar.disconnect();
     });
-    // Present before navigating: the window maps while the directory streams
-    // in behind the loading state, instead of holding first paint for
-    // validation and enumeration. Navigation runs from idle so mapping and
-    // the first frame are never queued behind enumeration setup.
     window.present();
     crate::metrics::mark_window_presented();
-    crate::metrics::mark_first_themed_frame();
     let pending_location = location.unwrap_or_else(home_directory);
     let idle_browser = browser.clone();
     glib::idle_add_local_once(move || {
@@ -489,20 +480,32 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
     schedule_due_update_check(&theme_manager, &update_notice);
 }
 
-/// Populates dynamic sidebar volumes and mounts after the first painted
-/// frame, on idle. Static places render synchronously with the shell;
-/// devices append at the end later, so focus and layout never jump.
-fn schedule_sidebar_devices(sidebar: &SidebarView) {
+fn schedule_after_first_paint(window: &gtk::ApplicationWindow, sidebar: &SidebarView) {
     let state = sidebar.state.clone();
-    glib::idle_add_local_once(move || {
-        state.rebuild();
+    let armed = Cell::new(false);
+    window.connect_map(move |window| {
+        if armed.get() {
+            return;
+        }
+        let Some(clock) = window.frame_clock() else {
+            return;
+        };
+        armed.set(true);
+        let handler = Rc::new(RefCell::new(None));
+        let handler_for_paint = handler.clone();
+        let state = state.clone();
+        let id = clock.connect_after_paint(move |clock| {
+            if let Some(id) = handler_for_paint.borrow_mut().take() {
+                clock.disconnect(id);
+            }
+            crate::metrics::mark_first_themed_frame();
+            let state = state.clone();
+            glib::idle_add_local_once(move || state.rebuild());
+        });
+        handler.replace(Some(id));
     });
 }
 
-/// Schedules the process-wide due update check: eight seconds after mapping
-/// so it never competes with first paint, then on idle so it never steals
-/// input. A due online notice normally lands within about ten seconds after
-/// initial load. See `settings::maybe_run_due_update_check`.
 fn schedule_due_update_check(
     manager: &Rc<ThemeManager>,
     notice: &super::settings::UpdateNoticeHandler,
@@ -1248,8 +1251,6 @@ impl SidebarState {
         self.sync_active_place();
     }
 
-    /// Renders every static place without touching the volume monitor:
-    /// safe to run synchronously with the shell during startup.
     fn append_static_places(self: &Rc<Self>) {
         self.append_place(
             crate::assets::icons::HOME,
@@ -1290,10 +1291,6 @@ impl SidebarState {
         }
     }
 
-    /// Enumerates volumes and mounts. Deferred past the first painted frame
-    /// on idle: volume enumeration can block on remote backends, and the
-    /// DEVICES section appends at the end, so late population never moves
-    /// focus or existing rows.
     fn append_devices(self: &Rc<Self>) {
         let volumes = self.volume_monitor.volumes();
         let mounts: Vec<_> = self
@@ -1338,8 +1335,6 @@ impl SidebarState {
             self.rebuild();
         }
     }
-    /// Whether a browser event can change the active location or place.
-    /// Pure so the fan-out gate stays unit-testable without widgets.
     fn event_changes_active_place(event: &BrowserEvent) -> bool {
         matches!(
             event,
@@ -2038,9 +2033,6 @@ fn build_sidebar(view: BrowserView, theme_manager: Rc<super::theme::ThemeManager
 
     let weak = Rc::downgrade(&state);
     state.browser.observe(move |event| {
-        // The active place follows the active location only: batch,
-        // metadata, sort-progress, and operation traffic never moves it,
-        // so syncing on every event is pure overhead per listing batch.
         if !SidebarState::event_changes_active_place(event) {
             return;
         }
@@ -2086,9 +2078,6 @@ fn build_sidebar(view: BrowserView, theme_manager: Rc<super::theme::ThemeManager
             state.rebuild();
         }
     }));
-    // Static places render with the shell; dynamic volumes arrive on idle
-    // after the first frame (see `schedule_sidebar_devices`), so volume
-    // enumeration never blocks first paint.
     state.append_static_places();
     state.sync_active_place();
     SidebarView {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -83,14 +83,14 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
     let preview_for_selection = preview.clone();
     let weak_controller = Rc::downgrade(&controller);
     controller.observe(move |event| match event {
-        BrowserEvent::PreviewRequested { entry } => preview_for_selection.show(entry.clone()),
+        BrowserEvent::PreviewRequested { entry } => preview_for_selection.show(entry),
         BrowserEvent::FocusChanged {
             depth,
             position: Some(position),
         } if preview_for_selection.is_open() => {
             if let Some(entry) = weak_controller
                 .upgrade()
-                .and_then(|browser| browser.entry_at(*depth, *position))
+                .and_then(|browser| browser.entry_at(depth, position))
             {
                 if entry.is_directory() {
                     preview_for_selection.close();
@@ -2041,7 +2041,7 @@ fn build_sidebar(view: BrowserView, theme_manager: Rc<super::theme::ThemeManager
         // The active place follows the active location only: batch,
         // metadata, sort-progress, and operation traffic never moves it,
         // so syncing on every event is pure overhead per listing batch.
-        if !SidebarState::event_changes_active_place(event) {
+        if !SidebarState::event_changes_active_place(&event) {
             return;
         }
         if let Some(state) = weak.upgrade() {

--- a/src/ui/window/tests.rs
+++ b/src/ui/window/tests.rs
@@ -442,3 +442,58 @@ fn desktop_is_hidden_when_it_points_to_home() {
     ));
     assert!(should_show_standard_place("documents", home, home));
 }
+
+#[test]
+fn sidebar_sync_runs_only_for_location_changes() {
+    use super::SidebarState;
+    use crate::app::BrowserEvent;
+    use crate::model::Location;
+
+    assert!(SidebarState::event_changes_active_place(
+        &BrowserEvent::Reset
+    ));
+    assert!(SidebarState::event_changes_active_place(
+        &BrowserEvent::ColumnAdded {
+            depth: 1,
+            location: Location::local("/fixture/sub"),
+        }
+    ));
+    assert!(SidebarState::event_changes_active_place(
+        &BrowserEvent::ColumnsTruncated { len: 1 }
+    ));
+    assert!(SidebarState::event_changes_active_place(
+        &BrowserEvent::FocusChanged {
+            depth: 0,
+            position: Some(2),
+        }
+    ));
+    // Batch, metadata, sort-progress, and operation traffic never moves the
+    // active location.
+    assert!(!SidebarState::event_changes_active_place(
+        &BrowserEvent::EntriesInserted {
+            depth: 0,
+            insertions: Vec::new(),
+        }
+    ));
+    assert!(!SidebarState::event_changes_active_place(
+        &BrowserEvent::MetadataFilled {
+            depth: 0,
+            updates: Vec::new(),
+        }
+    ));
+    assert!(!SidebarState::event_changes_active_place(
+        &BrowserEvent::SortingStarted { depth: 0 }
+    ));
+    assert!(!SidebarState::event_changes_active_place(
+        &BrowserEvent::SortingFinished { depth: 0 }
+    ));
+    assert!(!SidebarState::event_changes_active_place(
+        &BrowserEvent::LoadFinished {
+            depth: 0,
+            truncated: false,
+        }
+    ));
+    assert!(!SidebarState::event_changes_active_place(
+        &BrowserEvent::TransferCompleted
+    ));
+}

--- a/src/ui/window/tests.rs
+++ b/src/ui/window/tests.rs
@@ -467,8 +467,6 @@ fn sidebar_sync_runs_only_for_location_changes() {
             position: Some(2),
         }
     ));
-    // Batch, metadata, sort-progress, and operation traffic never moves the
-    // active location.
     assert!(!SidebarState::event_changes_active_place(
         &BrowserEvent::EntriesInserted {
             depth: 0,


### PR DESCRIPTION
## Description

This reduces the work Strata performs before large native and media-heavy directories become usable and quiet:

- enumerate native directories off the GTK thread with `std::fs::read_dir`, while preserving GIO for remote and GVfs locations;
- split identity listing from viewport metadata fills and full metadata sorts;
- isolate viewport and sort metadata generations, preserve correct ordering after incomplete fills, and drain remote rows before terminal events;
- reduce staging clones, selection scans, sort overhead, and main-loop publication callbacks;
- publish Columns-mode GTK rows through a count-backed lazy `gio::ListModel` instead of retaining one `StringObject` payload per entry;
- schedule thumbnails from the visible viewport plus bounded overscan, preserve top-to-bottom priority, persist the freedesktop shared cache, and cap queues and workers;
- keep video thumbnails inside the existing bounded Bubblewrap sandbox while avoiding an extra helper process;
- harden `.hidden` reads and bound each remote metadata request by its remaining deadline;
- defer update checks, package-manager detection, heavy settings pages, source-style generation, and sidebar work off the critical startup path;
- cache healthy GVfs probes per daemon generation and force both `GIO_USE_VFS=local` and `GIO_USE_VOLUME_MONITOR=unix` after a confirmed timeout;
- record first paint from GTK's after-paint signal and publish large model tails after redraw in bounded slices;
- add startup, state-install, UI-publication, and thumbnail stage and counter probes.

There are no intended visual design changes. Filtering, selection restoration, filesystem monitoring, cancellation, sorting, accessibility, all three browser modes, and remote and GVfs paths remain supported.

### Benchmark method

Base is clean `main` at `298043f`, the benchmark baseline used when measurements began. Candidate is the reviewed performance branch at `681cc10`, configured with four thumbnail workers. Both were built with `cargo build --release` before measurement.

Each result is the median of three cold runs on the same machine. The harness waits for one-minute load average at or below 0.50, drops page cache before every run, drops the shared thumbnail cache for media runs, samples peak proportional set size for the Strata window process, and totals CPU across the process tree. Settled means the complete process tree records no CPU-tick movement for 500 ms.

The scale fixture contains 100,000 non-thumbnailable text files and was tested under both name and modified-time sorting. The media fixture contains 2,000 mixed JPG, PNG, WebP, HEIC, MP4, MKV, WebM, and TXT files. It used the normal 2560x1440 DP-1 viewport with no resize, forced thumbnail count, or work matching. Thumbnail counts remain beside media timings because the Candidate intentionally avoids Base's offscreen work.

Peak PSS covers the Strata window process. Transient thumbnail processes are included in process-tree CPU but not in the PSS column.

### Performance impact against benchmark baseline

| Fixture | Metric | Base, main at `298043f` | Candidate, 4 workers | Change |
|---|---|---:|---:|---:|
| 100,000 files, name sort | First window | 1,221 ms | 688 ms | **-533 ms (-43.7%)** |
| 100,000 files, name sort | Settled | 11,092 ms | 1,111 ms | **-9,981 ms (-90.0%, 9.98x faster)** |
| 100,000 files, name sort | Peak window PSS | 197,939 KiB (193.3 MiB) | 210,450 KiB (205.5 MiB) | **+12,511 KiB (+6.3%)** |
| 100,000 files, name sort | Process-tree CPU | 10.27 s | 0.72 s | **-9.55 s (-93.0%)** |
| 100,000 files, name sort | Entries | 100,000 | 100,000 | equal work |
| 100,000 files, modified sort | First window | 1,195 ms | 687 ms | **-508 ms (-42.5%)** |
| 100,000 files, modified sort | Settled | 8,278 ms | 1,083 ms | **-7,195 ms (-86.9%, 7.64x faster)** |
| 100,000 files, modified sort | Peak window PSS | 203,619 KiB (198.8 MiB) | 191,669 KiB (187.2 MiB) | **-11,950 KiB (-5.9%)** |
| 100,000 files, modified sort | Process-tree CPU | 7.45 s | 1.12 s | **-6.33 s (-85.0%)** |
| 100,000 files, modified sort | Entries | 100,000 | 100,000 | equal work |
| 2,000 media files | First window | 1,199 ms | 682 ms | **-517 ms (-43.1%)** |
| 2,000 media files | Settled | 16,393 ms | 1,654 ms | **-14,739 ms (-89.9%, 9.91x faster)** |
| 2,000 media files | Peak window PSS | 158,633 KiB (154.9 MiB) | 171,781 KiB (167.8 MiB) | **+13,148 KiB (+8.3%)** |
| 2,000 media files | Process-tree CPU | 1.01 s | 0.66 s | **-0.35 s (-34.7%)** |
| 2,000 media files | Thumbnails | 183 | 40 | viewport-bounded; intentionally different work |

### 100,000-file scale benchmark

| Build | Sort | First window | Settled | Peak window PSS | Process-tree CPU | Entries |
|---|---|---:|---:|---:|---:|---:|
| Base, main at `298043f` | Name | 1,221 ms | 11,092 ms | 197,939 KiB (193.3 MiB) | 10.27 s | 100,000 |
| Candidate, `681cc10` | Name | 688 ms | 1,111 ms | 210,450 KiB (205.5 MiB) | 0.72 s | 100,000 |
| Base, main at `298043f` | Modified | 1,195 ms | 8,278 ms | 203,619 KiB (198.8 MiB) | 7.45 s | 100,000 |
| Candidate, `681cc10` | Modified | 687 ms | 1,083 ms | 191,669 KiB (187.2 MiB) | 1.12 s | 100,000 |

With name sorting, the Candidate reaches the first window 43.7% sooner, settles 90.0% sooner or 9.98x faster, and uses 93.0% less process-tree CPU. Peak window PSS rises by 12.2 MiB or 6.3% in this leg.

With modified-time sorting, the Candidate reaches the first window 42.5% sooner, settles 86.9% sooner or 7.64x faster, uses 11.7 MiB less peak PSS, and uses 85.0% less process-tree CPU.

### Media benchmark

| Build | First window | Settled | Peak window PSS | Process-tree CPU | Thumbnails |
|---|---:|---:|---:|---:|---:|
| Base, main at `298043f` | 1,199 ms | 16,393 ms | 158,633 KiB (154.9 MiB) | 1.01 s | 183 |
| Candidate, `681cc10`, 4 workers | 682 ms | 1,654 ms | 171,781 KiB (167.8 MiB) | 0.66 s | 40 |

The Candidate reaches the first window 43.1% sooner and settles 89.9% sooner or 9.91x faster. Process-tree CPU falls 34.7%. Peak window PSS rises by 12.8 MiB or 8.3% during this media workload.

The thumbnail counts are intentionally different. Base renders 183 rows, while the Candidate bounds work to the normal viewport plus overscan and rendered 40 thumbnails in every run. This is the intended user-visible workload, not a matched or artificially capped experiment.

## Visual evidence

N/A: this is a performance and internal-model change with no intended visual design change.

## How to test

1. Build with `cargo build --release` and open a native directory containing 100,000 files under name and modified-time sorting.
2. While it loads, scroll, filter, change selection, change sort direction, navigate away and back, and verify no stale rows or blocked input.
3. Repeat in Columns, Grid, and Explorer modes; verify filtering with duplicate display names and selection restoration after sorting.
4. Open a mixed image and video directory with an empty shared thumbnail cache; verify the top visible row starts first, only the viewport plus overscan renders, rapid scrolling cancels or deprioritizes stale work, and thumbnails persist safely.
5. Exercise an SMB or GVfs location to confirm remote enumeration remains on GIO. To test the failure path, make the GVfs probe time out and confirm the session selects local VFS and Unix volume-monitor backends.

**Expected result:** The window maps promptly, large native folders remain interactive and settle faster, thumbnail work stays bounded to visible content, every mode preserves correct order, selection, and filtering, remote locations behave as before, and no GTK warnings or crashes occur.

### Verification completed

- `scripts/check.sh`: **593 passed, 0 failed, 0 ignored**.
- All six reported benchmark legs contain three valid cold runs with matching fixture assertions and recorded source provenance.
- `cargo-deny` and `typos` were not installed, so the check script skipped those optional tools.

## Related issue

Closes #273

