### PR TITLE
feat(filter): search subfolders from Ctrl+F inline filter

### DIFF
--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -4606,6 +4606,7 @@ impl ViewState {
             None,
         );
         let selection = gtk::MultiSelection::new(Some(filtered_model.clone()));
+        let recursive_search_active = Rc::new(Cell::new(false));
         let syncing_selection = Rc::new(Cell::new(false));
         let modified_selection = Rc::new(Cell::new(false));
         let focused_filtered = Rc::new(Cell::new(None::<u32>));
@@ -4614,8 +4615,9 @@ impl ViewState {
         let syncing_selection_changed = syncing_selection.clone();
         let focused_filtered_changed = focused_filtered.clone();
         let filter_for_column = filter.clone();
+        let search_active_for_selection = recursive_search_active.clone();
         selection.connect_selection_changed(move |selection, position, count| {
-            if syncing_selection_changed.get() {
+            if syncing_selection_changed.get() || search_active_for_selection.get() {
                 return;
             }
             let filtered_positions = bitset_positions(&selection.selection());
@@ -4661,6 +4663,7 @@ impl ViewState {
         let search_results_for_changed = search_results.clone();
         let search_handle_for_changed = search_handle.clone();
         let search_gen_for_changed = search_generation.clone();
+        let search_active_for_changed = recursive_search_active.clone();
         let weak_filter_entry = filter_entry.downgrade();
         debounce_filter_entry(&filter_entry, move |text| {
             let query = text.trim().to_string();
@@ -4680,9 +4683,11 @@ impl ViewState {
                     &filter_query,
                     text.to_lowercase(),
                 );
+                search_active_for_changed.set(false);
                 return;
             }
             *filter_query.borrow_mut() = text.to_lowercase();
+            search_active_for_changed.set(true);
             let weak_entry = weak_filter_entry.clone();
             let weak_state = weak_state_for_search.clone();
             let filtered = filtered_model_for_search.clone();
@@ -5024,7 +5029,7 @@ impl ViewState {
         });
         let map_for_bind = map.clone();
         let weak_state_for_bind = Rc::downgrade(self);
-        let search_handle_for_bind = search_handle.clone();
+        let search_active_for_bind = recursive_search_active.clone();
         let search_results_for_bind = search_results.clone();
         factory.connect_bind(move |_, item| {
             let Some(item) = item.downcast_ref::<gtk::ListItem>() else {
@@ -5064,7 +5069,7 @@ impl ViewState {
             rename.set_visible(false);
             label.set_visible(true);
             spacer.set_visible(true);
-            let searching = search_handle_for_bind.borrow().is_some();
+            let searching = search_active_for_bind.get();
             let source_position = (!searching)
                 .then(|| map_for_bind.source_position(item.position()))
                 .flatten();
@@ -5150,6 +5155,46 @@ impl ViewState {
         list.set_enable_rubberband(false);
         list.set_single_click_activate(false);
         list.set_vexpand(true);
+
+        let search_navigation = gtk::EventControllerKey::new();
+        search_navigation.set_propagation_phase(gtk::PropagationPhase::Capture);
+        let search_active_for_navigation = recursive_search_active.clone();
+        let selection_for_navigation = selection.clone();
+        let syncing_for_navigation = syncing_selection.clone();
+        let list_for_navigation = list.clone();
+        search_navigation.connect_key_pressed(move |_, key, _, modifiers| {
+            if !search_active_for_navigation.get()
+                || modifiers.intersects(
+                    gtk::gdk::ModifierType::CONTROL_MASK
+                        | gtk::gdk::ModifierType::ALT_MASK
+                        | gtk::gdk::ModifierType::SUPER_MASK
+                        | gtk::gdk::ModifierType::SHIFT_MASK,
+                )
+            {
+                return glib::Propagation::Proceed;
+            }
+            let direction = match key {
+                gtk::gdk::Key::Down => 1,
+                gtk::gdk::Key::Up => -1,
+                _ => return glib::Propagation::Proceed,
+            };
+            let current = bitset_positions(&selection_for_navigation.selection())
+                .last()
+                .copied();
+            let Some(next) = search_result_navigation_position(
+                current,
+                selection_for_navigation.n_items(),
+                direction,
+            ) else {
+                return glib::Propagation::Stop;
+            };
+            syncing_for_navigation.set(true);
+            selection_for_navigation.select_item(next, true);
+            syncing_for_navigation.set(false);
+            list_for_navigation.scroll_to(next, gtk::ListScrollFlags::empty(), None);
+            glib::Propagation::Stop
+        });
+        filter_entry.add_controller(search_navigation);
 
         let clear_selection = gtk::GestureClick::new();
         clear_selection.set_button(1);
@@ -5983,6 +6028,20 @@ impl ViewMap {
             })
             .collect()
     }
+}
+
+pub(crate) fn search_result_navigation_position(
+    current: Option<u32>,
+    count: u32,
+    direction: i32,
+) -> Option<u32> {
+    if count == 0 {
+        return None;
+    }
+    let Some(current) = current else {
+        return Some(if direction < 0 { count - 1 } else { 0 });
+    };
+    Some((i64::from(current) + i64::from(direction)).clamp(0, i64::from(count - 1)) as u32)
 }
 
 pub(crate) enum SelectionPlan<'a> {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -5162,6 +5162,8 @@ impl ViewState {
         let selection_for_navigation = selection.clone();
         let syncing_for_navigation = syncing_selection.clone();
         let list_for_navigation = list.clone();
+        let browser_for_navigation = Rc::downgrade(&self.browser);
+        let results_for_navigation = search_results.clone();
         search_navigation.connect_key_pressed(move |_, key, _, modifiers| {
             if !search_active_for_navigation.get()
                 || modifiers.intersects(
@@ -5173,14 +5175,27 @@ impl ViewState {
             {
                 return glib::Propagation::Proceed;
             }
+            let current = bitset_positions(&selection_for_navigation.selection())
+                .last()
+                .copied();
+            if recursive_search_activation_key(key) {
+                return if current.is_some_and(|position| {
+                    activate_recursive_search_result(
+                        &browser_for_navigation,
+                        &results_for_navigation,
+                        position,
+                    )
+                }) {
+                    glib::Propagation::Stop
+                } else {
+                    glib::Propagation::Proceed
+                };
+            }
             let direction = match key {
                 gtk::gdk::Key::Down => 1,
                 gtk::gdk::Key::Up => -1,
                 _ => return glib::Propagation::Proceed,
             };
-            let current = bitset_positions(&selection_for_navigation.selection())
-                .last()
-                .copied();
             let Some(next) = search_result_navigation_position(
                 current,
                 selection_for_navigation.n_items(),
@@ -5238,16 +5253,11 @@ impl ViewState {
         let search_results_for_activate = search_results.clone();
         list.connect_activate(move |_, position| {
             if search_handle_for_activate.borrow().is_some() {
-                if let Some(item) = search_results_for_activate.borrow().get(position as usize) {
-                    let location = Location::local(item.path.clone());
-                    if let Some(browser) = weak_browser.upgrade() {
-                        if item.is_directory {
-                            browser.navigate(location);
-                        } else if let Some(parent) = item.path.parent() {
-                            browser.navigate(Location::local(parent));
-                        }
-                    }
-                }
+                activate_recursive_search_result(
+                    &weak_browser,
+                    &search_results_for_activate,
+                    position,
+                );
                 return;
             }
             let source_position = map_for_activation.source_position(position);
@@ -6028,6 +6038,34 @@ impl ViewMap {
             })
             .collect()
     }
+}
+
+pub(crate) fn recursive_search_activation_key(key: gtk::gdk::Key) -> bool {
+    matches!(
+        key,
+        gtk::gdk::Key::Return | gtk::gdk::Key::KP_Enter | gtk::gdk::Key::Right
+    )
+}
+
+fn activate_recursive_search_result(
+    browser: &Weak<Browser>,
+    results: &RefCell<Vec<crate::services::SearchItem>>,
+    position: u32,
+) -> bool {
+    let Some(item) = results.borrow().get(position as usize).cloned() else {
+        return false;
+    };
+    let Some(browser) = browser.upgrade() else {
+        return false;
+    };
+    if item.is_directory {
+        browser.navigate(Location::local(item.path));
+    } else if let Some(parent) = item.path.parent() {
+        browser.navigate(Location::local(parent));
+    } else {
+        return false;
+    }
+    true
 }
 
 pub(crate) fn search_result_navigation_position(

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -4513,9 +4513,11 @@ impl ViewState {
                             let Some(sm) = weak_sm.upgrade() else {
                                 return glib::ControlFlow::Break;
                             };
-                            let labels: Vec<_> = items.iter().map(|i| i.name.as_str()).collect();
-                            sm.splice(0, sm.n_items(), &labels);
+                            let labels: Vec<_> =
+                                items.iter().map(|item| item.name.clone()).collect();
                             results.replace(items);
+                            let labels: Vec<_> = labels.iter().map(String::as_str).collect();
+                            sm.splice(0, sm.n_items(), &labels);
                             if let Some(fm) = weak_filtered.upgrade() {
                                 fm.items_changed(0, sm.n_items(), sm.n_items());
                             }
@@ -4867,7 +4869,17 @@ impl ViewState {
             set_active_path_style(&row, active);
             set_cut_path_style(&row, false);
             if let Some(entry) = entry.as_ref() {
-                super::thumbnail::set_thumbnail_or_icon(&icon, entry, entry_icon(entry), 17, 17);
+                if entry.is_directory() {
+                    super::thumbnail::show_fallback_icon(&icon, crate::assets::icons::FOLDER, 17);
+                } else {
+                    super::thumbnail::set_thumbnail_or_icon(
+                        &icon,
+                        entry,
+                        entry_icon(entry),
+                        17,
+                        17,
+                    );
+                }
                 icon.set_opacity(if entry.is_directory() { 1.0 } else { 0.72 });
                 chevron.set_visible(entry.is_directory());
             } else {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -81,6 +81,10 @@ struct ColumnView {
     new_entry_entry: gtk::Entry,
     show_hidden: Rc<Cell<bool>>,
     filter: gtk::CustomFilter,
+    search_results: Rc<RefCell<Vec<crate::services::SearchItem>>>,
+    search_handle: Rc<RefCell<Option<crate::services::SearchHandle>>>,
+    search_generation: Rc<Cell<u64>>,
+    search_model: gtk::StringList,
 }
 
 struct ActiveRename {
@@ -3827,6 +3831,15 @@ impl ViewState {
             }
             BrowserEvent::ColumnReloaded { depth } => {
                 if let Some(column) = self.columns.borrow().get(depth) {
+                    column.search_handle.borrow_mut().take();
+                    column
+                        .search_generation
+                        .set(column.search_generation.get().saturating_add(1));
+                    column.search_results.borrow_mut().clear();
+                    column
+                        .search_model
+                        .splice(0, column.search_model.n_items(), &[]);
+                    column.filter_entry.set_text("");
                     column.syncing_selection.set(true);
                     column.selection.set_model(None::<&gio::ListModel>);
                     column.filtered_model.set_model(None::<&gio::ListModel>);
@@ -4410,9 +4423,111 @@ impl ViewState {
                 browser.set_selection(depth, &source_positions, focused_source);
             }
         });
+        let search_results: Rc<RefCell<Vec<crate::services::SearchItem>>> =
+            Rc::new(RefCell::new(Vec::new()));
+        let search_handle: Rc<RefCell<Option<crate::services::SearchHandle>>> =
+            Rc::new(RefCell::new(None));
+        let search_generation: Rc<Cell<u64>> = Rc::new(Cell::new(0));
+        let search_model = gtk::StringList::new(&[]);
+
+        let weak_state_for_search = Rc::downgrade(self);
+        let depth_for_search = depth;
+        let filtered_model_for_search = filtered_model.clone();
+        let model_for_search = model.clone();
+        let search_model_for_changed = search_model.clone();
+        let search_results_for_changed = search_results.clone();
+        let search_handle_for_changed = search_handle.clone();
+        let search_gen_for_changed = search_generation.clone();
         filter_entry.connect_changed(move |entry| {
+            let query = entry.text().trim().to_string();
             *filter_query.borrow_mut() = entry.text().to_lowercase();
-            filter.changed(gtk::FilterChange::Different);
+            search_gen_for_changed.set(search_gen_for_changed.get().saturating_add(1));
+            if query.is_empty() {
+                search_handle_for_changed.borrow_mut().take();
+                search_results_for_changed.borrow_mut().clear();
+                search_model_for_changed.splice(0, search_model_for_changed.n_items(), &[]);
+                if filtered_model_for_search.model().as_ref()
+                    != Some(model_for_search.upcast_ref::<gio::ListModel>())
+                {
+                    filtered_model_for_search.set_filter(Some(&filter));
+                    filtered_model_for_search.set_model(Some(&model_for_search));
+                }
+                filter.changed(gtk::FilterChange::Different);
+                return;
+            }
+            let weak_entry = entry.downgrade();
+            let weak_state = weak_state_for_search.clone();
+            let filtered = filtered_model_for_search.clone();
+            let sm = search_model_for_changed.clone();
+            let results = search_results_for_changed.clone();
+            let handle = search_handle_for_changed.clone();
+            let search_gen = search_gen_for_changed.clone();
+            let my_gen = search_gen_for_changed.get();
+            let query = query.clone();
+            glib::timeout_add_local(Duration::from_millis(200), move || {
+                if search_gen.get() != my_gen {
+                    return glib::ControlFlow::Break;
+                }
+                if handle.borrow().is_none() {
+                    let Some(state) = weak_state.upgrade() else {
+                        return glib::ControlFlow::Break;
+                    };
+                    let Some(path) = state
+                        .browser
+                        .location_at(depth_for_search)
+                        .and_then(|loc| loc.native_path().map(Path::to_path_buf))
+                    else {
+                        return glib::ControlFlow::Break;
+                    };
+                    search_gen.set(search_gen.get().saturating_add(1));
+                    let poll_gen = search_gen.get();
+                    let (h, receiver) = crate::services::index_tree(path);
+                    handle.replace(Some(h));
+                    filtered.set_filter(None::<&gtk::CustomFilter>);
+                    filtered.set_model(Some(&sm));
+                    let weak_entry = weak_entry.clone();
+                    let weak_sm = sm.downgrade();
+                    let weak_filtered = filtered.downgrade();
+                    let results = results.clone();
+                    let gen_check = search_gen.clone();
+                    let _poll = glib::timeout_add_local(Duration::from_millis(16), move || {
+                        if gen_check.get() != poll_gen {
+                            return glib::ControlFlow::Break;
+                        }
+                        let mut latest = None;
+                        for _ in 0..8 {
+                            match receiver.try_recv() {
+                                Ok(event) => latest = Some(event),
+                                Err(std::sync::mpsc::TryRecvError::Empty) => break,
+                                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                                    return glib::ControlFlow::Break;
+                                }
+                            }
+                        }
+                        if let Some(crate::services::SearchEvent::Results { query, items, .. }) =
+                            latest
+                            && let Some(entry) = weak_entry.upgrade()
+                            && !query.is_empty()
+                            && query == entry.text().trim()
+                        {
+                            let Some(sm) = weak_sm.upgrade() else {
+                                return glib::ControlFlow::Break;
+                            };
+                            let labels: Vec<_> = items.iter().map(|i| i.name.as_str()).collect();
+                            sm.splice(0, sm.n_items(), &labels);
+                            results.replace(items);
+                            if let Some(fm) = weak_filtered.upgrade() {
+                                fm.items_changed(0, sm.n_items(), sm.n_items());
+                            }
+                        }
+                        glib::ControlFlow::Continue
+                    });
+                }
+                if let Some(h) = handle.borrow().as_ref() {
+                    h.query(&query);
+                }
+                glib::ControlFlow::Break
+            });
         });
 
         let factory = gtk::SignalListItemFactory::new();
@@ -4681,6 +4796,8 @@ impl ViewState {
         let source_for_bind = model.clone();
         let filtered_for_bind = filtered_model.clone();
         let weak_state_for_bind = Rc::downgrade(self);
+        let search_handle_for_bind = search_handle.clone();
+        let search_results_for_bind = search_results.clone();
         factory.connect_bind(move |_, item| {
             let Some(item) = item.downcast_ref::<gtk::ListItem>() else {
                 return;
@@ -4719,26 +4836,36 @@ impl ViewState {
             rename.set_visible(false);
             label.set_visible(true);
             spacer.set_visible(true);
-            let source_position =
-                source_position_for_filtered(&source_for_bind, &filtered_for_bind, item.position());
             let state = weak_state_for_bind.upgrade();
             let browser = state.as_ref().map(|state| &state.browser);
-            let entry = source_position.and_then(|position| browser?.entry_at(depth, position));
-            let active = source_position.is_some_and(|position| {
-                browser
-                    .as_ref()
-                    .and_then(|browser| browser.active_child_position(depth))
-                    == Some(position)
-            });
+            let entry = if search_handle_for_bind.borrow().is_some() {
+                search_results_for_bind
+                    .borrow()
+                    .get(item.position() as usize)
+                    .map(|item| FileEntry {
+                        location: Location::local(item.path.clone()),
+                        native_name: item.path.file_name().unwrap_or_default().to_os_string(),
+                        display_name: item.name.clone(),
+                        kind: if item.is_directory {
+                            EntryKind::Directory
+                        } else {
+                            EntryKind::File
+                        },
+                        size: crate::model::MetadataValue::Unknown,
+                        modified_unix_seconds: crate::model::MetadataValue::Unknown,
+                        is_hidden: false,
+                    })
+            } else {
+                let source_position = source_position_for_filtered(
+                    &source_for_bind,
+                    &filtered_for_bind,
+                    item.position(),
+                );
+                source_position.and_then(|position| browser?.entry_at(depth, position))
+            };
+            let active = false;
             set_active_path_style(&row, active);
-            set_cut_path_style(
-                &row,
-                entry.as_ref().is_some_and(|entry| {
-                    state
-                        .as_ref()
-                        .is_some_and(|state| state.cut_locations.borrow().contains(&entry.location))
-                }),
-            );
+            set_cut_path_style(&row, false);
             if let Some(entry) = entry.as_ref() {
                 super::thumbnail::set_thumbnail_or_icon(&icon, entry, entry_icon(entry), 17, 17);
                 icon.set_opacity(if entry.is_directory() { 1.0 } else { 0.72 });
@@ -4806,7 +4933,22 @@ impl ViewState {
         let weak_browser = Rc::downgrade(&self.browser);
         let source_for_activation = model.clone();
         let filtered_for_activation = filtered_model.clone();
+        let search_handle_for_activate = search_handle.clone();
+        let search_results_for_activate = search_results.clone();
         list.connect_activate(move |_, position| {
+            if search_handle_for_activate.borrow().is_some() {
+                if let Some(item) = search_results_for_activate.borrow().get(position as usize) {
+                    let location = Location::local(item.path.clone());
+                    if let Some(browser) = weak_browser.upgrade() {
+                        if item.is_directory {
+                            browser.navigate(location);
+                        } else if let Some(parent) = item.path.parent() {
+                            browser.navigate(Location::local(parent));
+                        }
+                    }
+                }
+                return;
+            }
             let source_position = source_position_for_filtered(
                 &source_for_activation,
                 &filtered_for_activation,
@@ -5013,6 +5155,10 @@ impl ViewState {
             new_entry_entry,
             show_hidden,
             filter: filter_for_column,
+            search_results,
+            search_handle,
+            search_generation,
+            search_model,
         });
 
         self.refresh_active_path_rows();

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -13,6 +13,15 @@ fn recursive_search_arrows_select_and_clamp_results() {
 }
 
 #[test]
+fn recursive_search_activation_accepts_enter_and_right_arrow() {
+    assert!(recursive_search_activation_key(gtk::gdk::Key::Return));
+    assert!(recursive_search_activation_key(gtk::gdk::Key::KP_Enter));
+    assert!(recursive_search_activation_key(gtk::gdk::Key::Right));
+    assert!(!recursive_search_activation_key(gtk::gdk::Key::Left));
+    assert!(!recursive_search_activation_key(gtk::gdk::Key::Down));
+}
+
+#[test]
 fn terminal_shortcut_prefers_one_selected_directory() {
     let entry = |name: &str, kind| FileEntry {
         location: Location::local(format!("/fixture/{name}")),

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -3,6 +3,16 @@
 use super::*;
 
 #[test]
+fn recursive_search_arrows_select_and_clamp_results() {
+    assert_eq!(search_result_navigation_position(None, 3, 1), Some(0));
+    assert_eq!(search_result_navigation_position(None, 3, -1), Some(2));
+    assert_eq!(search_result_navigation_position(Some(0), 3, -1), Some(0));
+    assert_eq!(search_result_navigation_position(Some(1), 3, 1), Some(2));
+    assert_eq!(search_result_navigation_position(Some(2), 3, 1), Some(2));
+    assert_eq!(search_result_navigation_position(None, 0, 1), None);
+}
+
+#[test]
 fn terminal_shortcut_prefers_one_selected_directory() {
     let entry = |name: &str, kind| FileEntry {
         location: Location::local(format!("/fixture/{name}")),


### PR DESCRIPTION
## Summary
- Ctrl+F inline filter now searches the current folder and all descendant subfolders, not just immediate children
- Reuses `index_tree` from `services::search` (same logic as global search) scoped to the current folder
- 200ms debounce avoids starting a search on every keystroke
- Clearing the query restores the normal folder view

#### Test plan
- [x] Open a folder with nested subfolders, press Ctrl+F, type a query matching a file inside a subfolder — result appears
- [x] Clear the filter — normal folder list restores
- [x] No crash on rapid typing
<img width="960" height="518" alt="screenrecording-2026-09-04_18-24-15" src="https://github.com/user-attachments/assets/70209d00-42f5-4ce6-9a02-61036529ac81" />

Closes #277 
