### PR TITLE
chore(release): exclude dependency updates from notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - dependencies


### PR DESCRIPTION
## Description

Configure GitHub-generated release notes to omit pull requests carrying the existing `dependencies` label, keeping routine Dependabot updates out of the user-facing changelog.

## Visual evidence

N/A — this changes release-note configuration only.

## How to test

1. Generate release notes for a range containing a pull request labeled `dependencies`.
2. Confirm the labeled pull request is absent while unlabeled product changes remain.

**Expected result:** Generated release notes exclude dependency updates.

## Related issue

Closes #278