### PR TITLE
fix(browser): keep cut intent across windows and mount representations

### DIFF
--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -8,7 +8,7 @@ use std::{
     path::Path,
     pin::Pin,
     process::{Command, Stdio},
-    rc::Rc,
+    rc::{Rc, Weak},
     time::{Duration, Instant},
 };
 
@@ -293,7 +293,6 @@ pub(super) struct ViewState {
     mode_views: RefCell<ModeViews>,
     columns: RefCell<Vec<ColumnView>>,
     hovered_column: Cell<Option<usize>>,
-    cut_locations: RefCell<Vec<Location>>,
     horizontal_scroll_generation: Rc<Cell<u64>>,
     peek: RefCell<Option<PeekView>>,
     pending_peek: RefCell<Option<glib::SourceId>>,
@@ -449,7 +448,6 @@ impl BrowserView {
             mode_views: RefCell::new(mode_views),
             columns: RefCell::new(Vec::new()),
             hovered_column: Cell::new(None),
-            cut_locations: RefCell::new(Vec::new()),
             horizontal_scroll_generation: Rc::new(Cell::new(0)),
             peek: RefCell::new(None),
             pending_peek: RefCell::new(None),
@@ -480,6 +478,8 @@ impl BrowserView {
 
         // Columns are laid out from the start edge, so the blank strip beside the last
         // one is the natural place to begin a marquee that runs into it.
+        register_cut_view(&state);
+
         let weak_state = Rc::downgrade(&state);
         super::marquee::install_shared_origin_surface(&state.scroller, move |surface, _, x, _| {
             let state = weak_state.upgrade()?;
@@ -1413,34 +1413,24 @@ impl ViewState {
     }
 
     fn copy_entries(&self, entries: &[FileEntry]) {
-        self.sync_mode_selection();
         if set_files_clipboard(entries) {
             self.clear_cut();
         }
     }
 
     fn cut_entries(&self, entries: &[FileEntry]) {
-        self.sync_mode_selection();
         if set_files_clipboard(entries) {
             let locations: Vec<Location> =
                 entries.iter().map(|entry| entry.location.clone()).collect();
-            self.cut_locations.replace(locations.clone());
             set_shared_cut(&locations);
-            self.refresh_cut_rows();
         }
     }
 
     fn clear_cut(&self) {
         clear_shared_cut();
-        if self.cut_locations.borrow().is_empty() {
-            return;
-        }
-        self.cut_locations.borrow_mut().clear();
-        self.refresh_cut_rows();
     }
 
     fn complete_cut_transfer(&self, transferred: &[Location]) {
-        retain_untransferred(&mut self.cut_locations.borrow_mut(), transferred);
         retain_shared_untransferred(transferred);
         let remaining = shared_cut_locations();
         if remaining.is_empty() {
@@ -1452,11 +1442,10 @@ impl ViewState {
         } else {
             let _set = set_location_files_clipboard(&remaining);
         }
-        self.refresh_cut_rows();
     }
 
     fn refresh_cut_rows(&self) {
-        let cut = self.cut_locations.borrow();
+        let cut = shared_cut_locations();
         self.mode_views.borrow().set_cut_locations(&cut);
         let cut_lookup: HashSet<_> = cut.iter().collect();
         for (depth, column) in self.columns.borrow().iter().enumerate() {
@@ -1499,7 +1488,7 @@ impl ViewState {
                 .filter_map(|file| location_for_file(&file))
                 .collect::<Vec<_>>();
             if let Some(state) = weak.upgrade() {
-                let move_sources = is_cut_match(&sources, &state.cut_locations.borrow());
+                let move_sources = is_cut_match(&sources);
                 state.start_transfer(destination, sources, move_sources);
             }
         });
@@ -4760,9 +4749,9 @@ impl ViewState {
             set_cut_path_style(
                 &row,
                 entry.as_ref().is_some_and(|entry| {
-                    state
-                        .as_ref()
-                        .is_some_and(|state| state.cut_locations.borrow().contains(&entry.location))
+                    shared_cut_locations()
+                        .iter()
+                        .any(|cut| locations_equal(cut, &entry.location))
                 }),
             );
             if let Some(entry) = entry.as_ref() {
@@ -6318,6 +6307,7 @@ fn context_entries(
     state: &ViewState,
     target: &RefCell<Option<(usize, FileEntry)>>,
 ) -> Vec<FileEntry> {
+    state.sync_mode_selection();
     let entries = state.browser.selected_entries();
     if entries.is_empty() {
         target
@@ -6876,12 +6866,28 @@ fn needs_shell_escape(c: char) -> bool {
 }
 
 // Process-wide cut intent shared by every window. The GDK clipboard only
-// carries a `FileList` with no cut marker, and each `ViewState` keeps its own
-// `cut_locations` for dimming, so a cut in one window always pasted as a copy
-// in another. This thread-local (GTK stays on the main thread) is the source
-// of truth for "was this a cut", while the per-view list stays for styling.
+// carries a `FileList` with no cut marker, so this thread-local (GTK stays on
+// the main thread) is the source of truth for both paste behavior and styling.
 thread_local! {
     static SHARED_CUT_LOCATIONS: RefCell<Vec<Location>> = const { RefCell::new(Vec::new()) };
+    static CUT_VIEWS: RefCell<Vec<Weak<ViewState>>> = const { RefCell::new(Vec::new()) };
+}
+
+fn register_cut_view(state: &Rc<ViewState>) {
+    CUT_VIEWS.with(|views| views.borrow_mut().push(Rc::downgrade(state)));
+    state.refresh_cut_rows();
+}
+
+fn refresh_cut_views() {
+    let views = CUT_VIEWS.with(|views| {
+        let mut views = views.borrow_mut();
+        let live = views.iter().filter_map(Weak::upgrade).collect::<Vec<_>>();
+        views.retain(|view| view.strong_count() > 0);
+        live
+    });
+    for view in views {
+        view.refresh_cut_rows();
+    }
 }
 
 fn shared_cut_locations() -> Vec<Location> {
@@ -6890,21 +6896,21 @@ fn shared_cut_locations() -> Vec<Location> {
 
 fn set_shared_cut(locations: &[Location]) {
     SHARED_CUT_LOCATIONS.with(|cut| cut.replace(locations.to_vec()));
+    refresh_cut_views();
 }
 
 fn clear_shared_cut() {
     SHARED_CUT_LOCATIONS.with(|cut| cut.borrow_mut().clear());
+    refresh_cut_views();
 }
 
 fn retain_shared_untransferred(transferred: &[Location]) {
     SHARED_CUT_LOCATIONS.with(|cut| retain_untransferred(&mut cut.borrow_mut(), transferred));
+    refresh_cut_views();
 }
 
-/// True when the clipboard sources match a pending cut, checking the local
-/// view first and falling back to the process-wide cut list so cross-window
-/// paste still moves.
-fn is_cut_match(sources: &[Location], local_cut: &[Location]) -> bool {
-    same_locations(sources, local_cut) || same_locations(sources, &shared_cut_locations())
+fn is_cut_match(sources: &[Location]) -> bool {
+    same_locations(sources, &shared_cut_locations())
 }
 
 fn set_files_clipboard(entries: &[FileEntry]) -> bool {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -1413,20 +1413,25 @@ impl ViewState {
     }
 
     fn copy_entries(&self, entries: &[FileEntry]) {
+        self.sync_mode_selection();
         if set_files_clipboard(entries) {
             self.clear_cut();
         }
     }
 
     fn cut_entries(&self, entries: &[FileEntry]) {
+        self.sync_mode_selection();
         if set_files_clipboard(entries) {
-            self.cut_locations
-                .replace(entries.iter().map(|entry| entry.location.clone()).collect());
+            let locations: Vec<Location> =
+                entries.iter().map(|entry| entry.location.clone()).collect();
+            self.cut_locations.replace(locations.clone());
+            set_shared_cut(&locations);
             self.refresh_cut_rows();
         }
     }
 
     fn clear_cut(&self) {
+        clear_shared_cut();
         if self.cut_locations.borrow().is_empty() {
             return;
         }
@@ -1436,7 +1441,8 @@ impl ViewState {
 
     fn complete_cut_transfer(&self, transferred: &[Location]) {
         retain_untransferred(&mut self.cut_locations.borrow_mut(), transferred);
-        let remaining = self.cut_locations.borrow().clone();
+        retain_shared_untransferred(transferred);
+        let remaining = shared_cut_locations();
         if remaining.is_empty() {
             if let Some(display) = gtk::gdk::Display::default() {
                 let _result = display
@@ -1493,7 +1499,7 @@ impl ViewState {
                 .filter_map(|file| location_for_file(&file))
                 .collect::<Vec<_>>();
             if let Some(state) = weak.upgrade() {
-                let move_sources = same_locations(&sources, &state.cut_locations.borrow());
+                let move_sources = is_cut_match(&sources, &state.cut_locations.borrow());
                 state.start_transfer(destination, sources, move_sources);
             }
         });
@@ -6869,6 +6875,38 @@ fn needs_shell_escape(c: char) -> bool {
         )
 }
 
+// Process-wide cut intent shared by every window. The GDK clipboard only
+// carries a `FileList` with no cut marker, and each `ViewState` keeps its own
+// `cut_locations` for dimming, so a cut in one window always pasted as a copy
+// in another. This thread-local (GTK stays on the main thread) is the source
+// of truth for "was this a cut", while the per-view list stays for styling.
+thread_local! {
+    static SHARED_CUT_LOCATIONS: RefCell<Vec<Location>> = const { RefCell::new(Vec::new()) };
+}
+
+fn shared_cut_locations() -> Vec<Location> {
+    SHARED_CUT_LOCATIONS.with(|cut| cut.borrow().clone())
+}
+
+fn set_shared_cut(locations: &[Location]) {
+    SHARED_CUT_LOCATIONS.with(|cut| cut.replace(locations.to_vec()));
+}
+
+fn clear_shared_cut() {
+    SHARED_CUT_LOCATIONS.with(|cut| cut.borrow_mut().clear());
+}
+
+fn retain_shared_untransferred(transferred: &[Location]) {
+    SHARED_CUT_LOCATIONS.with(|cut| retain_untransferred(&mut cut.borrow_mut(), transferred));
+}
+
+/// True when the clipboard sources match a pending cut, checking the local
+/// view first and falling back to the process-wide cut list so cross-window
+/// paste still moves.
+fn is_cut_match(sources: &[Location], local_cut: &[Location]) -> bool {
+    same_locations(sources, local_cut) || same_locations(sources, &shared_cut_locations())
+}
+
 fn set_files_clipboard(entries: &[FileEntry]) -> bool {
     set_location_files_clipboard(
         &entries
@@ -6975,18 +7013,44 @@ fn duplicate_transfer(entries: &[FileEntry]) -> Option<(Location, Vec<Location>)
     Some((destination, sources))
 }
 
+/// Location equality that also accepts GIO-level equivalence (URI
+/// normalization, `file://` vs native path for the same file). Mounts such as
+/// NFS can round-trip through the clipboard with a different but equivalent
+/// representation, and strict `PathBuf` equality alone would degrade a cut to
+/// a copy.
+fn locations_equal(left: &Location, right: &Location) -> bool {
+    left == right || gio_file_for_location(left).equal(&gio_file_for_location(right))
+}
+
 fn same_locations(left: &[Location], right: &[Location]) -> bool {
     if left.is_empty() || left.len() != right.len() {
         return false;
     }
-    let left: HashSet<_> = left.iter().collect();
-    let right: HashSet<_> = right.iter().collect();
-    left.len() == right.len() && left == right
+    let left_set: HashSet<_> = left.iter().collect();
+    let right_set: HashSet<_> = right.iter().collect();
+    if left_set.len() == right_set.len() && left_set == right_set {
+        return true;
+    }
+    let mut used = vec![false; right.len()];
+    left.iter().all(|location| {
+        let Some((index, _)) = right
+            .iter()
+            .enumerate()
+            .find(|(index, candidate)| !used[*index] && locations_equal(location, candidate))
+        else {
+            return false;
+        };
+        used[index] = true;
+        true
+    })
 }
 
 fn retain_untransferred(cut: &mut Vec<Location>, transferred: &[Location]) {
-    let transferred: HashSet<_> = transferred.iter().collect();
-    cut.retain(|location| !transferred.contains(location));
+    cut.retain(|location| {
+        !transferred
+            .iter()
+            .any(|moved| locations_equal(location, moved))
+    });
 }
 
 fn item_context_option(icon: &str, label: &str, accelerator: &str) -> gtk::Button {

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -809,6 +809,18 @@ fn cut_matches_gio_equivalent_representations() {
 }
 
 #[test]
+fn cleared_shared_cut_is_not_revived_by_stale_view_state() {
+    let native = Location::local("/fixture/first");
+    let uri = Location::uri("file:///fixture/first");
+
+    set_shared_cut(std::slice::from_ref(&native));
+    assert!(is_cut_match(std::slice::from_ref(&uri)));
+
+    clear_shared_cut();
+    assert!(!is_cut_match(std::slice::from_ref(&native)));
+}
+
+#[test]
 fn completed_moves_match_gio_equivalent_cut_entries() {
     let mut cut = vec![Location::local("/fixture/first")];
 

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -793,6 +793,31 @@ fn cut_clipboard_locations_match_regardless_of_order() {
 }
 
 #[test]
+fn cut_matches_gio_equivalent_representations() {
+    let native = Location::local("/fixture/first");
+    let uri = Location::uri("file:///fixture/first");
+
+    assert!(locations_equal(&native, &uri));
+    assert!(same_locations(
+        std::slice::from_ref(&native),
+        std::slice::from_ref(&uri)
+    ));
+    assert!(!same_locations(
+        std::slice::from_ref(&native),
+        std::slice::from_ref(&Location::uri("file:///fixture/other"))
+    ));
+}
+
+#[test]
+fn completed_moves_match_gio_equivalent_cut_entries() {
+    let mut cut = vec![Location::local("/fixture/first")];
+
+    retain_untransferred(&mut cut, &[Location::uri("file:///fixture/first")]);
+
+    assert!(cut.is_empty());
+}
+
+#[test]
 fn completed_moves_are_removed_from_the_cut_list() {
     let first = Location::local("/fixture/first");
     let second = Location::local("/fixture/second");


### PR DESCRIPTION
## Description

Fixes Cut via right-click context menu pasting as Copy (source left behind, duplicate created). Three defects combined to cause the silent degradation:

- Cut intent lived only in per-`ViewState` `cut_locations`, while the GDK clipboard carries just a `FileList` with no cut marker. A cut in one window always pasted as a copy in another. Added a process-wide thread-local cut list as the source of truth for "was this a cut" (per-view list retained for dimming).
- `same_locations` used strict `Location ==` (`PathBuf`) equality. Clipboard round-trips through `location_for_file` can yield an equivalent but non-identical representation (native path vs `file://` URI, normalization on mounts such as NFS), failing the match and degrading to copy. Matching now also accepts GIO-level `equal`, with multiset semantics preserved for duplicates; `retain_untransferred` uses the same comparison.
- Context-menu Cut/Copy never called `sync_mode_selection` (keyboard Ctrl+X/C does), so Grid/Explorer right-click could operate on a stale selection. Sync moved inside `cut_entries`/`copy_entries` so both paths match.

No new dependencies. Full `x-special/gnome-copied-files` interop with external file managers is intentionally left as a follow-up.

## Visual evidence

N/A - no visual changes. Cut-row dimming behavior unchanged.

## How to test

1. Same window, local dir: Cut a file via right-click -> row dims -> Paste into another folder -> progress shows "Moving items", source removed.
2. Cross-window: Cut in window A -> Paste in window B -> moves, not copies.
3. Mount-equivalent: Cut `/mnt/share/file` (or any native path) -> Paste elsewhere -> moves; clipboard `file://` URI form still matches.
4. Grid/Explorer: multi-select files -> right-click Cut -> Paste -> all move, no stale selection.
5. Copy still copies: Copy -> Paste leaves source; follow-up Cut in another window cancels the first cut (paste copies).

**Expected result:** Cut+Paste always moves (with existing confirmation/collision flow); only Copy duplicates.

## Related issue

Closes #287
