### PR TITLE
feat(preview): allow dragging files directly from the preview pane

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1383,8 +1383,10 @@ switch:checked slider {
   box-shadow: none;
   color: @theme_text;
   min-height: 30px;
+  outline: 1px solid transparent;
+  outline-offset: -1px;
   padding: 3px 8px;
-  transition: background 160ms ease-out, transform 160ms ease-out;
+  transition: background 220ms ease-out, outline-color 220ms ease-out, transform 200ms cubic-bezier(0.2, 0.9, 0.3, 1.2);
 }
 
 .sidebar-row:hover {
@@ -1409,10 +1411,11 @@ switch:checked slider {
   opacity: 0.52;
 }
 
-.sidebar-row.reorderable:drop(active) {
+.sidebar-row.reorderable:drop(active),
+.sidebar-row:drop(active) {
   background: alpha(@theme_highlight, 0.46);
-  outline: 1px solid alpha(@theme_accent, 0.72);
-  outline-offset: -1px;
+  outline-color: alpha(@theme_accent, 0.72);
+  transform: scale(1.02);
 }
 
 .sidebar-row:focus {
@@ -1463,7 +1466,7 @@ paned > separator {
 }
 
 .preview-title {
-  color: @theme_accent;
+  color: @theme_text;
   font-weight: 700;
 }
 
@@ -1524,6 +1527,15 @@ paned > separator {
 .preview-content scrolledwindow,
 .preview-content viewport {
   background: @theme_surface;
+  transition: opacity 200ms ease-out, transform 200ms cubic-bezier(0.2, 0.9, 0.3, 1.2);
+}
+
+.preview-content.dragging {
+  opacity: 0.48;
+}
+
+.preview-content.slide-out {
+  animation: slide-out-up 240ms ease-out;
 }
 
 .preview-text,
@@ -1542,7 +1554,14 @@ paned > separator {
 .preview-image,
 .preview-media {
   background: alpha(@theme_bg, 0.55);
+  border-radius: 8px;
   margin: 12px;
+  transition: transform 240ms cubic-bezier(0.2, 0.9, 0.3, 1.2), opacity 200ms ease-out, box-shadow 200ms ease-out;
+}
+
+.preview-image:hover,
+.preview-media:hover {
+  box-shadow: 0 4px 16px alpha(@theme_bg, 0.45);
 }
 
 .preview-note {
@@ -2391,6 +2410,14 @@ menubutton.column-header-action > button:active {
   transition: background 160ms ease-out, color 160ms ease-out;
 }
 
+.file-row,
+.grid-card,
+.explorer-row {
+  outline: 1px solid transparent;
+  outline-offset: -1px;
+  transition: background 220ms ease-out, color 180ms ease-out, outline-color 220ms ease-out, transform 200ms cubic-bezier(0.2, 0.9, 0.3, 1.2), opacity 200ms ease-out;
+}
+
 .file-row {
   border-radius: 6px;
   color: @theme_text;
@@ -2405,11 +2432,38 @@ menubutton.column-header-action > button:active {
   opacity: 0.48;
 }
 
-.file-row:drop(active) {
+@keyframes slide-in-down {
+  from { transform: translate(0, -10px); }
+  to { transform: translate(0, 0); }
+}
+
+@keyframes slide-out-up {
+  from { transform: translate(0, 0); opacity: 1; }
+  to { transform: translate(0, -14px); opacity: 0; }
+}
+
+.file-row.just-dropped {
+  animation: slide-in-down 200ms cubic-bezier(0.2, 0.9, 0.3, 1.2);
+}
+
+.file-row.slide-out {
+  animation: slide-out-up 240ms ease-out;
+}
+
+.file-appear {
+  opacity: 0;
+  transform: translate(0, 6px);
+}
+
+.file-row:drop(active),
+.file-row.drop-destination {
   background: alpha(@theme_highlight, 0.72);
   color: @theme_accent;
-  outline: 1px solid @theme_accent;
-  outline-offset: -1px;
+  outline-color: @theme_accent;
+}
+
+.file-drop-zone {
+  transition: box-shadow 220ms ease-out;
 }
 
 .file-drop-zone:drop(active) {
@@ -2980,11 +3034,11 @@ menubutton.grid-thumbnail-menu > button:focus-visible {
   color: @theme_text;
 }
 
-.grid-card.drop-destination {
+.grid-card.drop-destination,
+.grid-card:drop(active) {
   background: alpha(@theme_highlight, 0.82);
   color: @theme_accent;
-  outline: 1px solid @theme_accent;
-  outline-offset: -1px;
+  outline-color: @theme_accent;
 }
 
 .grid-card.dragging {
@@ -3148,11 +3202,11 @@ menubutton.grid-thumbnail-menu > button:focus-visible {
   color: @theme_text;
 }
 
-.explorer-row.drop-destination {
+.explorer-row.drop-destination,
+.explorer-row:drop(active) {
   background: alpha(@theme_highlight, 0.82);
   color: @theme_accent;
-  outline: 1px solid @theme_accent;
-  outline-offset: -1px;
+  outline-color: @theme_accent;
 }
 
 .explorer-row.dragging {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -4431,6 +4431,13 @@ impl ViewState {
             };
             let row = gtk::Box::new(gtk::Orientation::Horizontal, 8);
             row.add_css_class("file-row");
+            row.add_css_class("file-appear");
+            let weak_row = row.downgrade();
+            glib::idle_add_local_once(move || {
+                if let Some(row) = weak_row.upgrade() {
+                    row.remove_css_class("file-appear");
+                }
+            });
             let icon = gtk::Image::new();
             icon.add_css_class("file-icon");
             icon.set_pixel_size(17);
@@ -4513,7 +4520,9 @@ impl ViewState {
             let dragged_item = item.clone();
             let source_for_drag = source_for_hover.clone();
             let filtered_for_drag = filtered_for_hover.clone();
+            let prepare_row = row.clone();
             drag.connect_prepare(move |source, x, y| {
+                prepare_row.remove_css_class("slide-out");
                 let state = weak_state_for_drag.upgrade()?;
                 let source_position = source_position_for_filtered(
                     &source_for_drag,
@@ -4537,15 +4546,25 @@ impl ViewState {
             let dragged_row = row.clone();
             drag.connect_drag_begin(move |_, _| dragged_row.add_css_class("dragging"));
             let dragged_row = row.clone();
-            drag.connect_drag_end(move |_, _, _| dragged_row.remove_css_class("dragging"));
+            drag.connect_drag_end(move |_, _, _| {
+                dragged_row.remove_css_class("dragging");
+                slide_out(&dragged_row);
+            });
             row.add_controller(drag);
 
             let drop = gtk::DropTarget::new(
                 gtk::gdk::FileList::static_type(),
                 gtk::gdk::DragAction::COPY | gtk::gdk::DragAction::MOVE,
             );
-            drop.connect_enter(|target, _, _| file_drop_action(target));
-            drop.connect_motion(|target, _, _| file_drop_action(target));
+            let highlighted_row = row.clone();
+            let highlight = move |target: &gtk::DropTarget, _, _| {
+                highlighted_row.add_css_class("drop-destination");
+                file_drop_action(target)
+            };
+            drop.connect_enter(highlight.clone());
+            drop.connect_motion(highlight);
+            let highlighted_row = row.clone();
+            drop.connect_leave(move |_| highlighted_row.remove_css_class("drop-destination"));
             let weak_state_for_accept = weak_state.clone();
             let accepted_item = item.clone();
             let source_for_accept = source_for_hover.clone();
@@ -4571,7 +4590,9 @@ impl ViewState {
             let dropped_item = item.clone();
             let source_for_drop = source_for_hover.clone();
             let filtered_for_drop = filtered_for_hover.clone();
+            let dropped_row = row.clone();
             drop.connect_drop(move |target, value, _, _| {
+                dropped_row.remove_css_class("drop-destination");
                 let Some(state) = weak_state_for_drop.upgrade() else {
                     return false;
                 };
@@ -4585,7 +4606,13 @@ impl ViewState {
                 .map(|entry| entry.location) else {
                     return false;
                 };
-                transfer_dropped_files(&state, target, value, destination)
+                slide_in_down(&dropped_row);
+                let target = target.clone();
+                let value = value.clone();
+                glib::timeout_add_local_once(Duration::from_millis(300), move || {
+                    transfer_dropped_files(&state, &target, &value, destination);
+                });
+                true
             });
             row.add_controller(drop);
 
@@ -7811,6 +7838,30 @@ pub(super) fn animate_in(layer: &gtk::Box) {
 pub(super) fn animate_out(layer: &gtk::Box, on_done: impl FnOnce() + 'static) {
     layer.add_css_class("modal-hidden");
     glib::timeout_add_local_once(Duration::from_millis(200), on_done);
+}
+
+pub(super) fn slide_out(widget: &impl IsA<gtk::Widget>) {
+    let w = widget.as_ref();
+    w.remove_css_class("slide-out");
+    w.add_css_class("slide-out");
+    let weak = w.downgrade();
+    glib::timeout_add_local_once(Duration::from_millis(240), move || {
+        if let Some(w) = weak.upgrade() {
+            w.remove_css_class("slide-out");
+        }
+    });
+}
+
+pub(super) fn slide_in_down(widget: &impl IsA<gtk::Widget>) {
+    let w = widget.as_ref();
+    w.remove_css_class("just-dropped");
+    w.add_css_class("just-dropped");
+    let weak = w.downgrade();
+    glib::timeout_add_local_once(Duration::from_millis(200), move || {
+        if let Some(w) = weak.upgrade() {
+            w.remove_css_class("just-dropped");
+        }
+    });
 }
 
 pub(super) fn dismiss_modal_layer(

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -4735,11 +4735,13 @@ impl ViewState {
                 else {
                     return false;
                 };
+                let Some(sources) = locations_from_file_list_value(value) else {
+                    return false;
+                };
+                let move_sources = file_drop_action(target) == gtk::gdk::DragAction::MOVE;
                 slide_in_down(&dropped_row);
-                let target = target.clone();
-                let value = value.clone();
                 glib::timeout_add_local_once(Duration::from_millis(300), move || {
-                    transfer_dropped_files(&state, &target, &value, destination);
+                    state.start_transfer(destination, sources, move_sources);
                 });
                 true
             });

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -1425,6 +1425,13 @@ fn build_grid_view(
         };
         let card = gtk::Box::new(gtk::Orientation::Vertical, 0);
         card.add_css_class("grid-card");
+        card.add_css_class("file-appear");
+        let weak_card = card.downgrade();
+        glib::idle_add_local_once(move || {
+            if let Some(card) = weak_card.upgrade() {
+                card.remove_css_class("file-appear");
+            }
+        });
         card.set_halign(gtk::Align::Center);
         card.set_valign(gtk::Align::Center);
         let centered = gtk::CenterBox::new();
@@ -2139,6 +2146,13 @@ fn build_explorer_pane(
         };
         let row = gtk::Box::new(gtk::Orientation::Horizontal, 0);
         row.add_css_class("explorer-row");
+        row.add_css_class("file-appear");
+        let weak_row = row.downgrade();
+        glib::idle_add_local_once(move || {
+            if let Some(row) = weak_row.upgrade() {
+                row.remove_css_class("file-appear");
+            }
+        });
         let name_cell = gtk::Box::new(gtk::Orientation::Horizontal, 12);
         name_cell.add_css_class("explorer-name-cell");
         let icon = gtk::Image::new();

--- a/src/ui/preview.rs
+++ b/src/ui/preview.rs
@@ -32,6 +32,8 @@ struct PreviewState {
     provider: Rc<dyn PreviewProvider>,
     revealer: gtk::Revealer,
     pane: gtk::Box,
+    header_handle: gtk::Box,
+    icon: gtk::Image,
     title: gtk::Label,
     size: gtk::Label,
     modified: gtk::Label,
@@ -96,8 +98,13 @@ impl PreviewDrawer {
         )));
         close.add_css_class("preview-close");
         close.add_css_class("preview-header-action");
-        header.append(&icon);
-        header.append(&title);
+        let header_handle = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+        header_handle.add_css_class("preview-header-handle");
+        header_handle.set_hexpand(true);
+        header_handle.set_cursor_from_name(Some("grab"));
+        header_handle.append(&icon);
+        header_handle.append(&title);
+        header.append(&header_handle);
         header.append(&open);
         header.append(&close);
         pane.append(&header);
@@ -128,6 +135,8 @@ impl PreviewDrawer {
             provider,
             revealer,
             pane,
+            header_handle: header_handle.clone(),
+            icon,
             title,
             size,
             modified,
@@ -151,6 +160,7 @@ impl PreviewDrawer {
             animating: Cell::new(false),
             animation_generation: Rc::new(Cell::new(0)),
         });
+        install_preview_drag(&header_handle, &state);
         let weak = Rc::downgrade(&state);
         open.connect_clicked(move |_| {
             let Some(state) = weak.upgrade() else {
@@ -384,6 +394,7 @@ impl PreviewState {
 
     fn load(self: &Rc<Self>, entry: FileEntry, pdf_page: i32) {
         self.current.replace(Some(entry.clone()));
+        crate::assets::set_primary_icon(&self.icon, super::browser::entry_icon(&entry));
         self.title.set_text(&entry.display_name);
         self.title
             .set_tooltip_text(Some(&entry.location.display_path()));
@@ -494,6 +505,8 @@ impl PreviewState {
                         picture.set_content_fit(gtk::ContentFit::Contain);
                         picture.set_hexpand(true);
                         picture.set_vexpand(true);
+                        picture.set_cursor_from_name(Some("grab"));
+                        install_preview_drag(&picture, self);
                         self.content.append(&picture);
                     }
                     Err(error) => self.show_message("Preview unavailable", &error.to_string()),
@@ -520,6 +533,8 @@ impl PreviewState {
                 picture.set_content_fit(gtk::ContentFit::Contain);
                 picture.set_hexpand(true);
                 picture.set_vexpand(true);
+                picture.set_cursor_from_name(Some("grab"));
+                install_preview_drag(&picture, self);
 
                 let overlay = gtk::Overlay::new();
                 overlay.set_child(Some(&picture));
@@ -1452,6 +1467,39 @@ fn fmt_time(microseconds: i64) -> String {
     let minutes = total_seconds / 60;
     let seconds = total_seconds % 60;
     format!("{minutes}:{seconds:02}")
+}
+
+fn preview_drag_entries(entry: Option<&FileEntry>) -> Option<Vec<FileEntry>> {
+    entry.cloned().map(|entry| vec![entry])
+}
+
+fn install_preview_drag(widget: &impl IsA<gtk::Widget>, state: &Rc<PreviewState>) {
+    let drag = gtk::DragSource::builder()
+        .actions(gtk::gdk::DragAction::COPY | gtk::gdk::DragAction::MOVE)
+        .build();
+    drag.set_propagation_phase(gtk::PropagationPhase::Capture);
+    let weak = Rc::downgrade(state);
+    drag.connect_prepare(move |source, x, y| {
+        let state = weak.upgrade()?;
+        let entries = preview_drag_entries(state.current.borrow().as_ref())?;
+        let paintable = gtk::WidgetPaintable::new(Some(&state.header_handle));
+        source.set_icon(Some(&paintable), x.round() as i32, y.round() as i32);
+        super::browser::file_drag_content(&entries)
+    });
+    let weak = Rc::downgrade(state);
+    drag.connect_drag_begin(move |_, _| {
+        if let Some(state) = weak.upgrade() {
+            state.content.add_css_class("dragging");
+        }
+    });
+    let weak = Rc::downgrade(state);
+    drag.connect_drag_end(move |_, _, _| {
+        if let Some(state) = weak.upgrade() {
+            state.content.remove_css_class("dragging");
+            super::browser::slide_out(&state.content);
+        }
+    });
+    widget.add_controller(drag);
 }
 
 #[cfg(test)]

--- a/src/ui/preview/tests.rs
+++ b/src/ui/preview/tests.rs
@@ -2,7 +2,8 @@
 
 use super::{
     MEDIA_PLUGIN_INSTALL_COMMAND, PDF_MAX_ZOOM, PDF_MIN_ZOOM, format_file_size, format_media_time,
-    media_error_feedback, pdf_zoom_after_scroll, preview_width_for_empty_space,
+    media_error_feedback, pdf_zoom_after_scroll, preview_drag_entries,
+    preview_width_for_empty_space,
 };
 
 #[test]
@@ -54,4 +55,24 @@ fn media_time_formats_minutes_and_seconds() {
 #[test]
 fn media_time_clamps_negative_timestamps_to_zero() {
     assert_eq!(format_media_time(-500_000, 10_000_000), "0:00/0:10");
+}
+
+#[test]
+fn preview_drag_entries_returns_none_when_no_entry_loaded() {
+    assert_eq!(preview_drag_entries(None), None);
+}
+
+#[test]
+fn preview_drag_entries_wraps_loaded_file_entry() {
+    let entry = crate::model::FileEntry {
+        location: crate::model::Location::local("/tmp/test.png"),
+        native_name: std::ffi::OsString::from("test.png"),
+        display_name: "test.png".to_owned(),
+        kind: crate::model::EntryKind::File,
+        size: crate::model::MetadataValue::Known(100),
+        modified_unix_seconds: crate::model::MetadataValue::Known(1),
+        is_hidden: false,
+    };
+    let dragged = preview_drag_entries(Some(&entry));
+    assert_eq!(dragged, Some(vec![entry]));
 }


### PR DESCRIPTION
## Description

Add a drag handle controller to the preview drawer header and image preview widgets, allowing users to drag previewed files directly to folders, sidebar destinations, or external applications.

## Visual evidence

N/A (drag-and-drop gesture interaction)

## How to test

1. Select any file in the browser to open the preview drawer.
2. Click and drag either the preview header handle (the file icon/title area) or an image preview.
3. Drop the dragged file into another folder, a sidebar location, or an external window.

**Expected result:**

The previewed file is transferred to the destination folder or application as a standard drag-and-drop operation.

## Related issue

Closes #269
<img width="960" height="540" alt="screenrecording-2026-09-04_23-27-01" src="https://github.com/user-attachments/assets/3ebe6506-dfc4-45bd-b610-f03d23ed89c8" />