### PR TITLE
feat(sidebar): add eject and unmount for removable media

### DIFF
--- a/data/icons/scalable/actions/strata-eject.svg
+++ b/data/icons/scalable/actions/strata-eject.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#8bc9eb" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 13a1 1 0 0 1-.72-1.695l7.257-7.668a2 2 0 0 1 2.926 0l7.256 7.668A1 1 0 0 1 20 13z"/><rect x="3" y="17" width="18" height="4" rx="1"/></svg>

--- a/data/strata.gresource.xml
+++ b/data/strata.gresource.xml
@@ -14,6 +14,7 @@
     <file>icons/scalable/actions/strata-copy.svg</file>
     <file>icons/scalable/actions/strata-corner-down-left.svg</file>
     <file>icons/scalable/actions/strata-download.svg</file>
+    <file>icons/scalable/actions/strata-eject.svg</file>
     <file>icons/scalable/actions/strata-eye-off.svg</file>
     <file>icons/scalable/actions/strata-eye.svg</file>
     <file>icons/scalable/actions/strata-external-link.svg</file>

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -27,6 +27,7 @@ pub mod icons {
     pub const CORNER_DOWN_LEFT: &str = "strata-corner-down-left";
     pub const DOCUMENTS: &str = "strata-file-text";
     pub const DOWNLOADS: &str = "strata-download";
+    pub const EJECT: &str = "strata-eject";
     pub const EYE: &str = "strata-eye";
     pub const EYE_OFF: &str = "strata-eye-off";
     pub const EXTERNAL_LINK: &str = "strata-external-link";

--- a/src/style.css
+++ b/src/style.css
@@ -1425,6 +1425,33 @@ switch:checked slider {
   color: @theme_border;
 }
 
+.sidebar-device {
+  padding-right: 2px;
+}
+
+.sidebar-eject {
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  box-shadow: none;
+  margin: 3px 0;
+  min-height: 24px;
+  min-width: 24px;
+  opacity: 0.75;
+  padding: 2px;
+}
+
+.sidebar-eject:hover {
+  background: alpha(@theme_accent, 0.15);
+  opacity: 1;
+}
+
+.sidebar-eject:focus {
+  opacity: 1;
+  outline: 1px solid @theme_accent;
+  outline-offset: -1px;
+}
+
 .sidebar-separator {
   background: alpha(@theme_border, 0.24);
   margin: 6px 4px;

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -1314,7 +1314,27 @@ impl SidebarState {
                 if is_smb_location(&location) {
                     self.append_smb_mount(&name, location, mount);
                 } else {
-                    self.append_place(crate::assets::icons::HARD_DRIVE, &name, location);
+                    let action = mount_release_action(mount.can_eject(), mount.can_unmount());
+                    let release = action.map(|action| {
+                        let release_mount = mount.clone();
+                        let release_browser = self.browser.clone();
+                        let release_parent = self.view.widget();
+                        let on_release: Rc<dyn Fn()> = Rc::new(move || {
+                            release_device_mount(
+                                &release_mount,
+                                action,
+                                &release_parent,
+                                &release_browser,
+                            );
+                        });
+                        (action, on_release)
+                    });
+                    self.append_device_place(
+                        crate::assets::icons::HARD_DRIVE,
+                        &name,
+                        location,
+                        release,
+                    );
                 }
             }
         }
@@ -1571,7 +1591,9 @@ impl SidebarState {
         let weak_browser = Rc::downgrade(&self.browser);
         let sidebar = self.widget.clone();
         let selected_row = row.clone();
+        let clicked_volume = volume.clone();
         row.connect_clicked(move |button| {
+            let volume = clicked_volume.clone();
             select_sidebar_row(&sidebar, &selected_row);
             let Some(browser) = weak_browser.upgrade() else {
                 return;
@@ -1583,7 +1605,6 @@ impl SidebarState {
 
             let window = button.root().and_downcast::<gtk::Window>();
             let operation = gtk::MountOperation::new(window.as_ref());
-            let volume = volume.clone();
             glib::MainContext::default().spawn_local(async move {
                 match volume
                     .mount_future(gio::MountMountFlags::NONE, Some(&operation))
@@ -1605,7 +1626,34 @@ impl SidebarState {
                 }
             });
         });
-        self.widget.append(&row);
+        let (mount_can_eject, mount_can_unmount) = volume
+            .get_mount()
+            .map(|mount| (mount.can_eject(), mount.can_unmount()))
+            .unwrap_or((false, false));
+        match volume_release_action(volume.can_eject(), mount_can_eject, mount_can_unmount) {
+            Some(action) => {
+                let release_volume = volume.clone();
+                let release_browser = self.browser.clone();
+                let release_parent = self.view.widget();
+                let on_release: Rc<dyn Fn()> = Rc::new(move || {
+                    release_device_volume(
+                        &release_volume,
+                        action,
+                        &release_parent,
+                        &release_browser,
+                    );
+                });
+                let eject = sidebar_eject_button(action, {
+                    let on_release = on_release.clone();
+                    move || on_release()
+                });
+                attach_device_release_menu(&row, action, on_release);
+                self.widget.append(&sidebar_device_row(&row, &eject));
+            }
+            None => {
+                self.widget.append(&row);
+            }
+        }
     }
 
     fn append_smb_mount(self: &Rc<Self>, name: &str, location: Location, mount: gio::Mount) {
@@ -1747,6 +1795,16 @@ impl SidebarState {
     }
 
     fn append_place(&self, icon: &str, name: &str, location: Location) -> gtk::Button {
+        self.append_device_place(icon, name, location, None)
+    }
+
+    fn append_device_place(
+        &self,
+        icon: &str,
+        name: &str,
+        location: Location,
+        release: Option<(MediaRelease, Rc<dyn Fn()>)>,
+    ) -> gtk::Button {
         let row = sidebar_button(icon, name);
         row.set_tooltip_text(Some(&location.display_path()));
         self.place_rows
@@ -1761,7 +1819,19 @@ impl SidebarState {
                 browser.navigate_location(location.clone());
             }
         });
-        self.widget.append(&row);
+        match release {
+            Some((action, on_release)) => {
+                let eject = sidebar_eject_button(action, {
+                    let on_release = on_release.clone();
+                    move || on_release()
+                });
+                attach_device_release_menu(&row, action, on_release);
+                self.widget.append(&sidebar_device_row(&row, &eject));
+            }
+            None => {
+                self.widget.append(&row);
+            }
+        }
         row
     }
 }
@@ -1769,12 +1839,23 @@ impl SidebarState {
 fn select_sidebar_row(sidebar: &gtk::Box, selected: &gtk::Button) {
     let mut child = sidebar.first_child();
     while let Some(widget) = child {
-        if let Ok(row) = widget.clone().downcast::<gtk::Button>() {
+        if let Some(row) = sidebar_row_button(&widget) {
             row.remove_css_class("active");
         }
         child = widget.next_sibling();
     }
     selected.add_css_class("active");
+}
+
+/// Resolves the navigable row button for a sidebar child. Device rows wrap
+/// their button with an eject sibling, so look one level down when the child
+/// itself is a container.
+fn sidebar_row_button(widget: &gtk::Widget) -> Option<gtk::Button> {
+    widget.clone().downcast::<gtk::Button>().ok().or_else(|| {
+        widget
+            .first_child()
+            .and_then(|child| child.downcast::<gtk::Button>().ok())
+    })
 }
 
 fn reorder_places(order: &mut Vec<&'static str>, source: &str, target: &str, after: bool) -> bool {
@@ -1842,6 +1923,145 @@ fn is_smb_location(location: &Location) -> bool {
         uri.get(..4)
             .is_some_and(|scheme| scheme.eq_ignore_ascii_case("smb:"))
     })
+}
+
+/// Safe-removal action for a sidebar device row. Eject is preferred whenever
+/// the drive reports it (USB sticks, optical discs); plain unmount covers
+/// mounts without ejectable media. `None` means fixed internal storage with
+/// no actionable release.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MediaRelease {
+    EjectVolume,
+    EjectMount,
+    UnmountMount,
+}
+
+fn volume_release_action(
+    can_eject_volume: bool,
+    mount_can_eject: bool,
+    mount_can_unmount: bool,
+) -> Option<MediaRelease> {
+    if can_eject_volume {
+        Some(MediaRelease::EjectVolume)
+    } else if mount_can_eject {
+        Some(MediaRelease::EjectMount)
+    } else if mount_can_unmount {
+        Some(MediaRelease::UnmountMount)
+    } else {
+        None
+    }
+}
+
+fn mount_release_action(can_eject: bool, can_unmount: bool) -> Option<MediaRelease> {
+    if can_eject {
+        Some(MediaRelease::EjectMount)
+    } else if can_unmount {
+        Some(MediaRelease::UnmountMount)
+    } else {
+        None
+    }
+}
+
+fn media_release_label(action: MediaRelease) -> &'static str {
+    match action {
+        MediaRelease::EjectVolume | MediaRelease::EjectMount => "Eject",
+        MediaRelease::UnmountMount => "Unmount",
+    }
+}
+
+fn media_release_error_title(action: MediaRelease) -> &'static str {
+    match action {
+        MediaRelease::EjectVolume | MediaRelease::EjectMount => "Unable to eject device",
+        MediaRelease::UnmountMount => "Unable to unmount device",
+    }
+}
+
+fn navigate_home_if_within(browser: &Rc<Browser>, root: &gio::File) {
+    let Some(device) = location_for_file(root) else {
+        return;
+    };
+    let active = browser.active_location();
+    if active
+        .as_ref()
+        .is_some_and(|active| active == &device || active.is_within(&device))
+    {
+        browser.navigate(Location::local(home_directory()));
+    }
+}
+
+fn release_device_volume(
+    volume: &gio::Volume,
+    action: MediaRelease,
+    parent: &gtk::Widget,
+    browser: &Rc<Browser>,
+) {
+    let away_root = volume.get_mount().map(|mount| mount.root());
+    let window = parent.root().and_downcast::<gtk::Window>();
+    let operation = gtk::MountOperation::new(window.as_ref());
+    let error_parent = parent.clone();
+    let browser = browser.clone();
+    let volume = volume.clone();
+    let title = media_release_error_title(action);
+    glib::MainContext::default().spawn_local(async move {
+        let result = match action {
+            MediaRelease::EjectVolume | MediaRelease::EjectMount => {
+                volume
+                    .eject_with_operation_future(gio::MountUnmountFlags::NONE, Some(&operation))
+                    .await
+            }
+            MediaRelease::UnmountMount => {
+                let Some(mount) = volume.get_mount() else {
+                    return;
+                };
+                mount
+                    .unmount_with_operation_future(gio::MountUnmountFlags::NONE, Some(&operation))
+                    .await
+            }
+        };
+        match result {
+            Ok(()) => {
+                if let Some(root) = away_root {
+                    navigate_home_if_within(&browser, &root);
+                }
+            }
+            Err(error) if error.matches(gio::IOErrorEnum::Cancelled) => {}
+            Err(error) => show_error_dialog(&error_parent, title, &error.to_string()),
+        }
+    });
+}
+
+fn release_device_mount(
+    mount: &gio::Mount,
+    action: MediaRelease,
+    parent: &gtk::Widget,
+    browser: &Rc<Browser>,
+) {
+    let away_root = mount.root();
+    let window = parent.root().and_downcast::<gtk::Window>();
+    let operation = gtk::MountOperation::new(window.as_ref());
+    let error_parent = parent.clone();
+    let browser = browser.clone();
+    let mount = mount.clone();
+    let title = media_release_error_title(action);
+    glib::MainContext::default().spawn_local(async move {
+        let result = match action {
+            MediaRelease::EjectVolume | MediaRelease::EjectMount => {
+                mount
+                    .eject_with_operation_future(gio::MountUnmountFlags::NONE, Some(&operation))
+                    .await
+            }
+            MediaRelease::UnmountMount => {
+                mount
+                    .unmount_with_operation_future(gio::MountUnmountFlags::NONE, Some(&operation))
+                    .await
+            }
+        };
+        match result {
+            Ok(()) => navigate_home_if_within(&browser, &away_root),
+            Err(error) if error.matches(gio::IOErrorEnum::Cancelled) => {}
+            Err(error) => show_error_dialog(&error_parent, title, &error.to_string()),
+        }
+    });
 }
 
 fn is_standard_place_location(location: &Location) -> bool {
@@ -1953,6 +2173,72 @@ fn sidebar_button(icon: &str, name: &str) -> gtk::Button {
     row.add_css_class("sidebar-row");
     row.set_has_frame(false);
     row
+}
+
+fn sidebar_eject_button(action: MediaRelease, on_release: impl Fn() + 'static) -> gtk::Button {
+    let button = gtk::Button::builder()
+        .tooltip_text(media_release_label(action))
+        .build();
+    button.set_child(Some(&crate::assets::primary_icon(
+        crate::assets::icons::EJECT,
+        14,
+    )));
+    button.add_css_class("sidebar-eject");
+    button.set_has_frame(false);
+    button.set_valign(gtk::Align::Center);
+    button.connect_clicked(move |_| on_release());
+    button
+}
+
+fn sidebar_device_row(row: &gtk::Button, eject: &gtk::Button) -> gtk::Box {
+    let shell = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    shell.add_css_class("sidebar-device");
+    row.set_hexpand(true);
+    shell.append(row);
+    shell.append(eject);
+    shell
+}
+
+fn attach_device_release_menu(row: &gtk::Button, action: MediaRelease, on_release: Rc<dyn Fn()>) {
+    let menu = gtk::Box::new(gtk::Orientation::Vertical, 0);
+    menu.add_css_class("folder-context-menu");
+    let release = sidebar_context_option(
+        crate::assets::icons::EJECT,
+        media_release_label(action),
+        false,
+    );
+    menu.append(&release);
+    let popover = gtk::Popover::builder()
+        .child(&menu)
+        .autohide(true)
+        .has_arrow(false)
+        .build();
+    popover.add_css_class("folder-context-popover");
+    popover.set_parent(row);
+    let release_popover = popover.downgrade();
+    release.connect_clicked(move |_| {
+        if let Some(popover) = release_popover.upgrade() {
+            popover.popdown();
+        }
+        on_release();
+    });
+    let context = gtk::GestureClick::new();
+    context.set_button(3);
+    let weak_popover = popover.downgrade();
+    context.connect_pressed(move |gesture, _, x, y| {
+        gesture.set_state(gtk::EventSequenceState::Claimed);
+        let Some(popover) = weak_popover.upgrade() else {
+            return;
+        };
+        popover.set_pointing_to(Some(&gtk::gdk::Rectangle::new(
+            x.round() as i32,
+            y.round() as i32,
+            1,
+            1,
+        )));
+        popover.popup();
+    });
+    row.add_controller(context);
 }
 
 fn navigate_to_gio_file(browser: &Rc<Browser>, file: &gio::File) {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -1319,12 +1319,14 @@ impl SidebarState {
                         let release_mount = mount.clone();
                         let release_browser = self.browser.clone();
                         let release_parent = self.view.widget();
+                        let release_in_flight = Rc::new(Cell::new(false));
                         let on_release: Rc<dyn Fn()> = Rc::new(move || {
                             release_device_mount(
                                 &release_mount,
                                 action,
                                 &release_parent,
                                 &release_browser,
+                                &release_in_flight,
                             );
                         });
                         (action, on_release)
@@ -1635,12 +1637,14 @@ impl SidebarState {
                 let release_volume = volume.clone();
                 let release_browser = self.browser.clone();
                 let release_parent = self.view.widget();
+                let release_in_flight = Rc::new(Cell::new(false));
                 let on_release: Rc<dyn Fn()> = Rc::new(move || {
                     release_device_volume(
                         &release_volume,
                         action,
                         &release_parent,
                         &release_browser,
+                        &release_in_flight,
                     );
                 });
                 let eject = sidebar_eject_button(action, {
@@ -1989,35 +1993,63 @@ fn navigate_home_if_within(browser: &Rc<Browser>, root: &gio::File) {
     }
 }
 
+fn begin_media_release(in_flight: &Cell<bool>) -> bool {
+    !in_flight.replace(true)
+}
+
 fn release_device_volume(
     volume: &gio::Volume,
     action: MediaRelease,
     parent: &gtk::Widget,
     browser: &Rc<Browser>,
+    in_flight: &Rc<Cell<bool>>,
 ) {
-    let away_root = volume.get_mount().map(|mount| mount.root());
+    if !begin_media_release(in_flight) {
+        return;
+    }
+    let mount = volume.get_mount();
+    let away_root = mount.as_ref().map(gio::Mount::root);
     let window = parent.root().and_downcast::<gtk::Window>();
     let operation = gtk::MountOperation::new(window.as_ref());
     let error_parent = parent.clone();
     let browser = browser.clone();
     let volume = volume.clone();
+    let in_flight = in_flight.clone();
     let title = media_release_error_title(action);
     glib::MainContext::default().spawn_local(async move {
         let result = match action {
-            MediaRelease::EjectVolume | MediaRelease::EjectMount => {
+            MediaRelease::EjectVolume => {
                 volume
                     .eject_with_operation_future(gio::MountUnmountFlags::NONE, Some(&operation))
                     .await
             }
-            MediaRelease::UnmountMount => {
-                let Some(mount) = volume.get_mount() else {
+            MediaRelease::EjectMount => match mount {
+                Some(mount) => {
+                    mount
+                        .eject_with_operation_future(gio::MountUnmountFlags::NONE, Some(&operation))
+                        .await
+                }
+                None => {
+                    in_flight.set(false);
                     return;
-                };
-                mount
-                    .unmount_with_operation_future(gio::MountUnmountFlags::NONE, Some(&operation))
-                    .await
-            }
+                }
+            },
+            MediaRelease::UnmountMount => match mount {
+                Some(mount) => {
+                    mount
+                        .unmount_with_operation_future(
+                            gio::MountUnmountFlags::NONE,
+                            Some(&operation),
+                        )
+                        .await
+                }
+                None => {
+                    in_flight.set(false);
+                    return;
+                }
+            },
         };
+        in_flight.set(false);
         match result {
             Ok(()) => {
                 if let Some(root) = away_root {
@@ -2035,13 +2067,18 @@ fn release_device_mount(
     action: MediaRelease,
     parent: &gtk::Widget,
     browser: &Rc<Browser>,
+    in_flight: &Rc<Cell<bool>>,
 ) {
+    if !begin_media_release(in_flight) {
+        return;
+    }
     let away_root = mount.root();
     let window = parent.root().and_downcast::<gtk::Window>();
     let operation = gtk::MountOperation::new(window.as_ref());
     let error_parent = parent.clone();
     let browser = browser.clone();
     let mount = mount.clone();
+    let in_flight = in_flight.clone();
     let title = media_release_error_title(action);
     glib::MainContext::default().spawn_local(async move {
         let result = match action {
@@ -2056,6 +2093,7 @@ fn release_device_mount(
                     .await
             }
         };
+        in_flight.set(false);
         match result {
             Ok(()) => navigate_home_if_within(&browser, &away_root),
             Err(error) if error.matches(gio::IOErrorEnum::Cancelled) => {}

--- a/src/ui/window/tests.rs
+++ b/src/ui/window/tests.rs
@@ -5,12 +5,13 @@ use std::path::Path;
 use crate::services::{BuildKind, ReleaseMetadata};
 
 use super::{
-    MouseHistoryAction, PinStatus, STANDARD_PLACE_IDS, is_open_terminal_shortcut,
+    MediaRelease, MouseHistoryAction, PinStatus, STANDARD_PLACE_IDS, is_open_terminal_shortcut,
     is_sidebar_focus_shortcut, is_smb_location, is_standard_place_location,
-    is_toggle_hidden_shortcut, is_undo_trash_shortcut, mouse_history_action,
-    parse_pinned_drag_source, parse_pinned_places, pin_status, remove_pinned_place,
-    reorder_pinned_places, reorder_places, resolve_place_order, serialize_pinned_places,
-    should_show_standard_place, sidebar_update_label, standard_place, vim_focus_direction,
+    is_toggle_hidden_shortcut, is_undo_trash_shortcut, media_release_label, mount_release_action,
+    mouse_history_action, parse_pinned_drag_source, parse_pinned_places, pin_status,
+    remove_pinned_place, reorder_pinned_places, reorder_places, resolve_place_order,
+    serialize_pinned_places, should_show_standard_place, sidebar_update_label, standard_place,
+    vim_focus_direction, volume_release_action,
 };
 
 fn release(version: &str, kind: BuildKind) -> ReleaseMetadata {
@@ -494,4 +495,53 @@ fn sidebar_sync_runs_only_for_location_changes() {
     assert!(!SidebarState::event_changes_active_place(
         &BrowserEvent::TransferCompleted
     ));
+}
+
+#[test]
+fn volume_release_prefers_eject_and_hides_fixed_disks() {
+    assert_eq!(
+        volume_release_action(true, false, false),
+        Some(MediaRelease::EjectVolume)
+    );
+    assert_eq!(
+        volume_release_action(true, true, true),
+        Some(MediaRelease::EjectVolume)
+    );
+    assert_eq!(
+        volume_release_action(false, true, false),
+        Some(MediaRelease::EjectMount)
+    );
+    assert_eq!(
+        volume_release_action(false, true, true),
+        Some(MediaRelease::EjectMount)
+    );
+    assert_eq!(
+        volume_release_action(false, false, true),
+        Some(MediaRelease::UnmountMount)
+    );
+    assert_eq!(volume_release_action(false, false, false), None);
+}
+
+#[test]
+fn mount_release_prefers_eject_and_hides_fixed_disks() {
+    assert_eq!(
+        mount_release_action(true, false),
+        Some(MediaRelease::EjectMount)
+    );
+    assert_eq!(
+        mount_release_action(true, true),
+        Some(MediaRelease::EjectMount)
+    );
+    assert_eq!(
+        mount_release_action(false, true),
+        Some(MediaRelease::UnmountMount)
+    );
+    assert_eq!(mount_release_action(false, false), None);
+}
+
+#[test]
+fn media_release_labels_match_nautilus_wording() {
+    assert_eq!(media_release_label(MediaRelease::EjectVolume), "Eject");
+    assert_eq!(media_release_label(MediaRelease::EjectMount), "Eject");
+    assert_eq!(media_release_label(MediaRelease::UnmountMount), "Unmount");
 }

--- a/src/ui/window/tests.rs
+++ b/src/ui/window/tests.rs
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use std::path::Path;
+use std::{cell::Cell, path::Path};
 
 use crate::services::{BuildKind, ReleaseMetadata};
 
 use super::{
-    MediaRelease, MouseHistoryAction, PinStatus, STANDARD_PLACE_IDS, is_open_terminal_shortcut,
-    is_sidebar_focus_shortcut, is_smb_location, is_standard_place_location,
-    is_toggle_hidden_shortcut, is_undo_trash_shortcut, media_release_label, mount_release_action,
-    mouse_history_action, parse_pinned_drag_source, parse_pinned_places, pin_status,
-    remove_pinned_place, reorder_pinned_places, reorder_places, resolve_place_order,
-    serialize_pinned_places, should_show_standard_place, sidebar_update_label, standard_place,
-    vim_focus_direction, volume_release_action,
+    MediaRelease, MouseHistoryAction, PinStatus, STANDARD_PLACE_IDS, begin_media_release,
+    is_open_terminal_shortcut, is_sidebar_focus_shortcut, is_smb_location,
+    is_standard_place_location, is_toggle_hidden_shortcut, is_undo_trash_shortcut,
+    media_release_label, mount_release_action, mouse_history_action, parse_pinned_drag_source,
+    parse_pinned_places, pin_status, remove_pinned_place, reorder_pinned_places, reorder_places,
+    resolve_place_order, serialize_pinned_places, should_show_standard_place, sidebar_update_label,
+    standard_place, vim_focus_direction, volume_release_action,
 };
 
 fn release(version: &str, kind: BuildKind) -> ReleaseMetadata {
@@ -544,4 +544,15 @@ fn media_release_labels_match_nautilus_wording() {
     assert_eq!(media_release_label(MediaRelease::EjectVolume), "Eject");
     assert_eq!(media_release_label(MediaRelease::EjectMount), "Eject");
     assert_eq!(media_release_label(MediaRelease::UnmountMount), "Unmount");
+}
+
+#[test]
+fn media_release_guard_rejects_repeated_actions_until_completion() {
+    let in_flight = Cell::new(false);
+
+    assert!(begin_media_release(&in_flight));
+    assert!(!begin_media_release(&in_flight));
+
+    in_flight.set(false);
+    assert!(begin_media_release(&in_flight));
 }


### PR DESCRIPTION
## Description

Removable media (USB sticks, second hard drives, optical discs) and plain disk mounts appear under DEVICES with no safe-removal path — only SMB shares have Disconnect. Adds Nautilus-style ejection: an inline ⏏ button on sidebar device rows plus a right-click Eject/Unmount entry, shown only when GIO reports the action (`can_eject` preferred, else `can_unmount`; hidden on fixed internal disks).

Details: new `strata-eject` icon from Lucide (geometry intact, theme-recolored like other `strata-*` icons); volume eject uses `Volume::eject`, mount release uses mount eject/unmount; after success navigates home if the active location was inside the device; failures other than user-cancel show the standard error dialog. Device rows wrap the row button + eject sibling so row clicks never misfire, and active-row highlighting accounts for the wrapper.

## Visual evidence

- Sidebar DEVICES rows for USB/HDD/optical now show ⏏ at the row end; right-click offers Eject/Unmount with the eject icon. (Screenshot to be attached after a device-present run.)

## How to test

1. `cargo run`, plug in a USB stick -> DEVICES shows it with an ⏏ button.
2. Click ⏏ (or right-click -> Eject) -> device ejects; if browsing inside it, view returns home.
3. Right-click a fixed internal disk row -> no Eject/Unmount entry.
4. Unmountable plain mount (non-SMB) -> Unmount entry; cancel in the auth dialog -> no error shown; real failure -> "Unable to unmount device" dialog.
5. `cargo test --all-targets --all-features` (618 passed incl. 3 new release-matrix tests).

**Expected result:** Ejectable media can be safely removed from the sidebar; internal disks unchanged.

## Related issue

Closes #295
