### PR TITLE
feat(operations): undo completed moves with Ctrl+Z

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ strata                 # home directory
 strata ~/Documents     # a specific directory
 ```
 
-Useful shortcuts include <kbd>Ctrl</kbd>+<kbd>K</kbd> for recursive search, <kbd>Ctrl</kbd>+<kbd>L</kbd> for a path or URI, <kbd>Ctrl</kbd>+<kbd>F</kbd> to filter the current pane, <kbd>Ctrl</kbd>+<kbd>Z</kbd> to undo the latest move to Trash, <kbd>Space</kbd> for preview, <kbd>F2</kbd> to rename, and <kbd>Alt</kbd>+arrow keys for history and parent navigation.
+Useful shortcuts include <kbd>Ctrl</kbd>+<kbd>K</kbd> for recursive search, <kbd>Ctrl</kbd>+<kbd>L</kbd> for a path or URI, <kbd>Ctrl</kbd>+<kbd>F</kbd> to filter the current pane, <kbd>Ctrl</kbd>+<kbd>Z</kbd> to undo the latest move or move to Trash, <kbd>Space</kbd> for preview, <kbd>F2</kbd> to rename, and <kbd>Alt</kbd>+arrow keys for history and parent navigation.
 
 ### Desktop entry
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -162,6 +162,7 @@ Legend: **P0** blocks the milestone, **P1** is required for its exit criteria, *
 - [ ] **P1** Cross-device move behavior
 - [ ] **P1** Disk-full, permissions, disappearing source, and read-only tests
 - [x] **P2** Limited undo for the latest move to Trash
+- [x] **P2** Limited undo for the latest completed move
 - [ ] **P2** Future Undo/Redo operation history with toolbar buttons and configurable keyboard shortcuts
 - [ ] **P2** Bind Undo to `Ctrl+Z` and Redo to both `Ctrl+Shift+Z` and `Ctrl+Y`
 

--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -34,7 +34,7 @@ use crate::{
         ArchiveFormat, CancelledOperation, CompressRequest, CreateDirectoryRequest,
         CreateFileRequest, DeleteRequest, ExtractRequest, LoadHandle, OperationEvent,
         OperationProvider, OperationRequestId, PasteRequest, RenameRequest, RestoreRequest,
-        RestoreSource, TransferConflict, validate_basename,
+        RestoreSource, TransferConflict, UndoMoveRequest, validate_basename,
     },
 };
 
@@ -1724,6 +1724,88 @@ impl OperationProvider for LocalOperationProvider {
                     return;
                 }
                 completed.push(item.source.clone());
+                emit(OperationEvent::TransferProgress {
+                    request_id: request.id,
+                    completed: completed.len(),
+                    total,
+                });
+            }
+            emit(OperationEvent::Pasted {
+                request_id: request.id,
+                locations: completed,
+            });
+        });
+        cancellation_handle(cancellable)
+    }
+
+    fn undo_move(&self, request: UndoMoveRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle {
+        let cancellable = gio::Cancellable::new();
+        let operation_cancellable = cancellable.clone();
+        let _task = glib::MainContext::default().spawn_local(async move {
+            let total = request.items.len();
+            let mut affected_locations = HashSet::new();
+            for item in &request.items {
+                for location in [&item.record.current, &item.record.original] {
+                    affected_locations.insert(location.clone());
+                    if let Some(parent) = location.parent() {
+                        affected_locations.insert(parent);
+                    }
+                }
+            }
+            let mut completed = Vec::new();
+            for (index, item) in request.items.iter().enumerate() {
+                let remaining = || {
+                    request.items[index..]
+                        .iter()
+                        .map(|item| item.record.current.clone())
+                        .collect::<Vec<_>>()
+                };
+                if operation_cancellable.is_cancelled() {
+                    emit(cancelled_event(
+                        request.id,
+                        completed,
+                        Vec::new(),
+                        remaining(),
+                        affected_locations,
+                    ));
+                    return;
+                }
+                let source = gio_file(&item.record.current);
+                let target = gio_file(&item.record.original);
+                let result = if item.conflict == TransferConflict::ReplaceExisting {
+                    replace_local(
+                        source,
+                        target,
+                        true,
+                        operation_cancellable.clone(),
+                        Some(&mut affected_locations),
+                    )
+                    .await
+                } else {
+                    move_local(source, target, operation_cancellable.clone()).await
+                };
+                if let Err(error) = result {
+                    if was_cancelled(&error) {
+                        emit(cancelled_event(
+                            request.id,
+                            completed,
+                            vec![item.record.current.clone()],
+                            request.items[index + 1..]
+                                .iter()
+                                .map(|item| item.record.current.clone())
+                                .collect(),
+                            affected_locations,
+                        ));
+                        return;
+                    }
+                    emit(OperationEvent::TransferFailed {
+                        request_id: request.id,
+                        completed_locations: completed,
+                        message: error.to_string(),
+                    });
+                    return;
+                }
+                completed.push(item.record.current.clone());
                 emit(OperationEvent::TransferProgress {
                     request_id: request.id,
                     completed: completed.len(),

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -32,9 +32,9 @@ use super::{
 use crate::{
     model::{EntryKind, FileEntry, Location, MetadataValue},
     services::{
-        ArchiveFormat, CompressRequest, DeleteRequest, LoadHandle, OperationEvent,
+        ArchiveFormat, CompressRequest, DeleteRequest, LoadHandle, MoveRecord, OperationEvent,
         OperationProvider, OperationRequestId, PasteItem, PasteRequest, RestoreRequest,
-        RestoreSource, TransferConflict,
+        RestoreSource, TransferConflict, UndoMoveItem, UndoMoveRequest,
     },
 };
 
@@ -1989,5 +1989,158 @@ fn cutting_in_the_same_folder_remains_a_noop() -> Result<(), Box<dyn Error>> {
     assert!(directory.is_dir());
     assert!(!destination.join("document (1).txt").exists());
     assert!(!destination.join("folder (1)").exists());
+    Ok(())
+}
+
+fn drive_until_transfer_settles(events: &Rc<RefCell<Vec<OperationEvent>>>) {
+    while !events.borrow().iter().any(|event| {
+        matches!(
+            event,
+            OperationEvent::Pasted { .. }
+                | OperationEvent::TransferFailed { .. }
+                | OperationEvent::Cancelled { .. }
+        )
+    }) {
+        glib::MainContext::default().iteration(true);
+    }
+}
+
+#[test]
+fn undoing_a_move_returns_each_item_to_its_original_directory() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let root = tempfile::tempdir()?;
+    let origin = root.path().join("origin");
+    let archive = root.path().join("archive");
+    fs::create_dir_all(&origin)?;
+    fs::create_dir_all(&archive)?;
+    let moved = archive.join("report.txt");
+    fs::write(&moved, b"contents")?;
+
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let emitted = events.clone();
+    let _operation = LocalOperationProvider.undo_move(
+        UndoMoveRequest {
+            id: OperationRequestId(40),
+            items: vec![UndoMoveItem {
+                record: MoveRecord {
+                    original: Location::local(origin.join("report.txt")),
+                    current: Location::local(&moved),
+                },
+                conflict: TransferConflict::FailIfExists,
+            }],
+        },
+        Rc::new(move |event| emitted.borrow_mut().push(event)),
+    );
+
+    drive_until_transfer_settles(&events);
+
+    assert!(matches!(
+        events.borrow().last(),
+        Some(OperationEvent::Pasted { .. })
+    ));
+    assert!(!moved.exists());
+    assert_eq!(fs::read(origin.join("report.txt"))?, b"contents");
+    Ok(())
+}
+
+#[test]
+fn undoing_a_move_stops_at_an_unconfirmed_conflict() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let root = tempfile::tempdir()?;
+    let origin = root.path().join("origin");
+    let archive = root.path().join("archive");
+    fs::create_dir_all(&origin)?;
+    fs::create_dir_all(&archive)?;
+    let blocked = origin.join("report.txt");
+    fs::write(&blocked, b"newer")?;
+    let first = archive.join("notes.txt");
+    let second = archive.join("report.txt");
+    fs::write(&first, b"first")?;
+    fs::write(&second, b"second")?;
+
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let emitted = events.clone();
+    let _operation = LocalOperationProvider.undo_move(
+        UndoMoveRequest {
+            id: OperationRequestId(41),
+            items: vec![
+                UndoMoveItem {
+                    record: MoveRecord {
+                        original: Location::local(origin.join("notes.txt")),
+                        current: Location::local(&first),
+                    },
+                    conflict: TransferConflict::FailIfExists,
+                },
+                UndoMoveItem {
+                    record: MoveRecord {
+                        original: Location::local(&blocked),
+                        current: Location::local(&second),
+                    },
+                    conflict: TransferConflict::FailIfExists,
+                },
+            ],
+        },
+        Rc::new(move |event| emitted.borrow_mut().push(event)),
+    );
+
+    drive_until_transfer_settles(&events);
+
+    let completed = match events.borrow().last() {
+        Some(OperationEvent::TransferFailed {
+            completed_locations,
+            ..
+        }) => completed_locations.clone(),
+        other => panic!("expected a transfer failure, got {other:?}"),
+    };
+    assert_eq!(completed, vec![Location::local(&first)]);
+    assert_eq!(fs::read(&blocked)?, b"newer");
+    assert_eq!(fs::read(&second)?, b"second");
+    assert_eq!(fs::read(origin.join("notes.txt"))?, b"first");
+    Ok(())
+}
+
+#[test]
+fn a_confirmed_undo_conflict_replaces_the_newer_item() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let root = tempfile::tempdir()?;
+    let origin = root.path().join("origin");
+    let archive = root.path().join("archive");
+    fs::create_dir_all(&origin)?;
+    fs::create_dir_all(&archive)?;
+    let original = origin.join("report.txt");
+    let moved = archive.join("report.txt");
+    fs::write(&original, b"newer")?;
+    fs::write(&moved, b"moved")?;
+
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let emitted = events.clone();
+    let _operation = LocalOperationProvider.undo_move(
+        UndoMoveRequest {
+            id: OperationRequestId(42),
+            items: vec![UndoMoveItem {
+                record: MoveRecord {
+                    original: Location::local(&original),
+                    current: Location::local(&moved),
+                },
+                conflict: TransferConflict::ReplaceExisting,
+            }],
+        },
+        Rc::new(move |event| emitted.borrow_mut().push(event)),
+    );
+
+    drive_until_transfer_settles(&events);
+
+    assert!(matches!(
+        events.borrow().last(),
+        Some(OperationEvent::Pasted { .. })
+    ));
+    assert!(!moved.exists());
+    assert_eq!(fs::read(&original)?, b"moved");
     Ok(())
 }

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -307,6 +307,17 @@ fn finish_undo(generation: u64, completed: bool) {
     });
 }
 
+fn retain_pending_move_items(generation: u64, items: &[UndoMoveItem]) {
+    PENDING_UNDO.with(|pending| {
+        let mut pending = pending.borrow_mut();
+        if pending.generation == generation
+            && let Some(UndoEntry::Move(records)) = pending.entry.as_mut()
+        {
+            records.retain(|record| items.iter().any(|item| &item.record == record));
+        }
+    });
+}
+
 /// Pairs each moved source with where the transfer left it. Items that never
 /// left their own directory carry no undo.
 fn move_records(sources: &[Location], destination: &Location) -> Vec<MoveRecord> {
@@ -1355,13 +1366,18 @@ impl Browser {
         if items.is_empty() || self.current_operation.get().is_some() {
             return false;
         }
-        let Some((generation, _)) = claim_pending_undo(Some(generation)) else {
+        let Some((generation, entry)) = claim_pending_undo(Some(generation)) else {
+            return false;
+        };
+        let UndoEntry::Move(_) = entry else {
+            finish_undo(generation, false);
             return false;
         };
         let Some(provider) = self.operation_provider.borrow().clone() else {
             finish_undo(generation, false);
             return false;
         };
+        retain_pending_move_items(generation, &items);
         let total = items.len();
         let mut refresh_locations = HashSet::new();
         for item in &items {

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -14,10 +14,10 @@ use crate::{
     services::{
         ArchiveFormat, CompressRequest, CreateDirectoryRequest, CreateFileRequest, DeleteRequest,
         DirectoryChange, DirectoryEvent, DirectoryRequest, ExtractRequest, FileSource, LoadHandle,
-        LocationValidationError, MetadataOutcome, MetadataRequest, OperationEvent,
+        LocationValidationError, MetadataOutcome, MetadataRequest, MoveRecord, OperationEvent,
         OperationProvider, OperationRequestId, PasteItem, PasteRequest, RenameRequest, RequestId,
-        RestoreRequest, RestoreSource, TransferConflict, validate_basename,
-        validate_uri_credentials,
+        RestoreRequest, RestoreSource, TransferConflict, UndoMoveItem, UndoMoveRequest,
+        validate_basename, validate_uri_credentials,
     },
 };
 
@@ -208,64 +208,123 @@ type PreferencesObserver = Rc<dyn Fn(ViewPreferences)>;
 
 const MAX_INCREMENTAL_OPERATION_UPDATES: usize = 64;
 
+/// The latest reversible operation. Trash entries restore from Trash; moved
+/// entries transfer back to the location they started from.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum UndoEntry {
+    Trash(Vec<Location>),
+    Move(Vec<MoveRecord>),
+}
+
+impl UndoEntry {
+    fn is_empty(&self) -> bool {
+        match self {
+            Self::Trash(locations) => locations.is_empty(),
+            Self::Move(records) => records.is_empty(),
+        }
+    }
+}
+
 #[derive(Default)]
-struct TrashUndoState {
+struct UndoState {
     generation: u64,
-    locations: Vec<Location>,
+    entry: Option<UndoEntry>,
     claimed: bool,
 }
 
 // Undo follows the latest operation across every Strata window on the GTK main thread.
 thread_local! {
-    static PENDING_TRASH_UNDO: RefCell<TrashUndoState> = RefCell::new(TrashUndoState::default());
+    static PENDING_UNDO: RefCell<UndoState> = RefCell::new(UndoState::default());
 }
 
-fn replace_pending_trash_undo(locations: Vec<Location>) {
-    PENDING_TRASH_UNDO.with(|pending| {
+fn replace_pending_undo(entry: UndoEntry) {
+    if entry.is_empty() {
+        return;
+    }
+    PENDING_UNDO.with(|pending| {
         let generation = pending.borrow().generation.saturating_add(1);
-        pending.replace(TrashUndoState {
+        pending.replace(UndoState {
             generation,
-            locations,
+            entry: Some(entry),
             claimed: false,
         });
     });
 }
 
-fn claim_pending_trash_undo() -> Option<(u64, Vec<Location>)> {
-    PENDING_TRASH_UNDO.with(|pending| {
-        let mut pending = pending.borrow_mut();
-        if pending.claimed || pending.locations.is_empty() {
+fn peek_pending_undo() -> Option<(u64, UndoEntry)> {
+    PENDING_UNDO.with(|pending| {
+        let pending = pending.borrow();
+        if pending.claimed {
             return None;
         }
-        pending.claimed = true;
-        Some((pending.generation, pending.locations.clone()))
+        Some((pending.generation, pending.entry.clone()?))
     })
 }
 
-fn mark_trash_undo_restored(generation: u64, location: &Location) {
-    PENDING_TRASH_UNDO.with(|pending| {
+/// Claims the pending entry so a second undo cannot run the same work twice.
+/// `expected` pins the claim to the entry a caller already inspected.
+fn claim_pending_undo(expected: Option<u64>) -> Option<(u64, UndoEntry)> {
+    PENDING_UNDO.with(|pending| {
         let mut pending = pending.borrow_mut();
-        if pending.generation == generation {
-            pending.locations.retain(|candidate| candidate != location);
+        if pending.claimed || expected.is_some_and(|generation| generation != pending.generation) {
+            return None;
+        }
+        let entry = pending.entry.clone()?;
+        pending.claimed = true;
+        Some((pending.generation, entry))
+    })
+}
+
+/// Drops one still-pending item so a partial undo leaves only the remainder
+/// for the next attempt.
+fn mark_undo_item_completed(generation: u64, location: &Location) {
+    PENDING_UNDO.with(|pending| {
+        let mut pending = pending.borrow_mut();
+        if pending.generation != generation {
+            return;
+        }
+        match pending.entry.as_mut() {
+            Some(UndoEntry::Trash(locations)) => {
+                locations.retain(|candidate| candidate != location);
+            }
+            Some(UndoEntry::Move(records)) => {
+                records.retain(|record| &record.current != location);
+            }
+            None => {}
         }
     });
 }
 
-fn finish_trash_undo(generation: u64, completed: bool) {
-    PENDING_TRASH_UNDO.with(|pending| {
+fn finish_undo(generation: u64, completed: bool) {
+    PENDING_UNDO.with(|pending| {
         let mut pending = pending.borrow_mut();
         if pending.generation == generation {
             if completed {
-                pending.locations.clear();
+                pending.entry = None;
             }
             pending.claimed = false;
         }
     });
 }
 
+/// Pairs each moved source with where the transfer left it. Items that never
+/// left their own directory carry no undo.
+fn move_records(sources: &[Location], destination: &Location) -> Vec<MoveRecord> {
+    sources
+        .iter()
+        .filter_map(|source| {
+            let current = source.transfer_target(destination)?;
+            (&current != source).then(|| MoveRecord {
+                original: source.clone(),
+                current,
+            })
+        })
+        .collect()
+}
+
 #[cfg(test)]
-fn pending_trash_undo() -> Vec<Location> {
-    PENDING_TRASH_UNDO.with(|pending| pending.borrow().locations.clone())
+fn pending_undo_entry() -> Option<UndoEntry> {
+    PENDING_UNDO.with(|pending| pending.borrow().entry.clone())
 }
 
 /// Settles scrolling before asking for viewport metadata, so a fling never
@@ -410,7 +469,8 @@ pub struct Browser {
     deletion_operation: Cell<bool>,
     deletion_permanent: Cell<bool>,
     restoration_operation: Cell<bool>,
-    undo_restoration: RefCell<Option<(u64, Vec<Location>)>>,
+    transfer_destination: RefCell<Option<Location>>,
+    undo_claim: RefCell<Option<(u64, UndoEntry)>>,
     next_request: Cell<u64>,
     pending_sort: Cell<Option<(u64, usize)>>,
     preferences: Cell<ViewPreferences>,
@@ -454,7 +514,8 @@ impl Browser {
             deletion_operation: Cell::new(false),
             deletion_permanent: Cell::new(false),
             restoration_operation: Cell::new(false),
-            undo_restoration: RefCell::new(None),
+            transfer_destination: RefCell::new(None),
+            undo_claim: RefCell::new(None),
             next_request: Cell::new(1),
             pending_sort: Cell::new(None),
             preferences: Cell::new(preferences),
@@ -1164,6 +1225,7 @@ impl Browser {
         };
         let request_id = self.begin_operation();
         self.transfer_operation.set(Some(move_sources));
+        self.transfer_destination.replace(Some(destination.clone()));
         self.emit(BrowserEvent::TransferStarted {
             total: items.len(),
             moving: move_sources,
@@ -1236,22 +1298,44 @@ impl Browser {
         self.operation_load.replace(Some(load));
     }
 
+    /// The pending move undo, if the latest reversible operation was a move.
+    pub fn pending_undo_move(&self) -> Option<(u64, Vec<MoveRecord>)> {
+        if self.current_operation.get().is_some() {
+            return None;
+        }
+        match peek_pending_undo()? {
+            (generation, UndoEntry::Move(records)) => Some((generation, records)),
+            (_, UndoEntry::Trash(_)) => None,
+        }
+    }
+
+    /// Drops a pending undo whose items are no longer where it recorded them.
+    pub fn discard_pending_undo(&self, generation: u64) {
+        if claim_pending_undo(Some(generation)).is_some() {
+            finish_undo(generation, true);
+        }
+    }
+
     pub fn undo_last_trash(self: &Rc<Self>) -> bool {
         if self.current_operation.get().is_some() {
             return false;
         }
-        let Some((generation, locations)) = claim_pending_trash_undo() else {
+        let Some((generation, entry)) = claim_pending_undo(None) else {
+            return false;
+        };
+        let UndoEntry::Trash(locations) = entry else {
+            finish_undo(generation, false);
             return false;
         };
         let Some(provider) = self.operation_provider.borrow().clone() else {
-            finish_trash_undo(generation, false);
+            finish_undo(generation, false);
             return false;
         };
         let total = locations.len();
         let request_id = self.begin_operation();
         self.restoration_operation.set(true);
-        self.undo_restoration
-            .replace(Some((generation, locations.clone())));
+        self.undo_claim
+            .replace(Some((generation, UndoEntry::Trash(locations.clone()))));
         self.emit(BrowserEvent::RestorationStarted { total });
         let load = provider.restore(
             RestoreRequest {
@@ -1259,6 +1343,50 @@ impl Browser {
                 source: RestoreSource::OriginalLocations(locations),
             },
             self.operation_callback(request_id, false, HashSet::new()),
+        );
+        self.operation_load.replace(Some(load));
+        true
+    }
+
+    /// Moves completed transfers back. `generation` pins the undo the caller
+    /// inspected, so an operation started while conflicts were being confirmed
+    /// wins instead of being reverted.
+    pub fn undo_move(self: &Rc<Self>, generation: u64, items: Vec<UndoMoveItem>) -> bool {
+        if items.is_empty() || self.current_operation.get().is_some() {
+            return false;
+        }
+        let Some((generation, _)) = claim_pending_undo(Some(generation)) else {
+            return false;
+        };
+        let Some(provider) = self.operation_provider.borrow().clone() else {
+            finish_undo(generation, false);
+            return false;
+        };
+        let total = items.len();
+        let mut refresh_locations = HashSet::new();
+        for item in &items {
+            for location in [&item.record.current, &item.record.original] {
+                if let Some(parent) = location.parent() {
+                    refresh_locations.insert(parent);
+                }
+            }
+        }
+        let request_id = self.begin_operation();
+        self.transfer_operation.set(Some(true));
+        self.undo_claim.replace(Some((
+            generation,
+            UndoEntry::Move(items.iter().map(|item| item.record.clone()).collect()),
+        )));
+        self.emit(BrowserEvent::TransferStarted {
+            total,
+            moving: true,
+        });
+        let load = provider.undo_move(
+            UndoMoveRequest {
+                id: request_id,
+                items,
+            },
+            self.operation_callback(request_id, false, refresh_locations),
         );
         self.operation_load.replace(Some(load));
         true
@@ -1342,10 +1470,11 @@ impl Browser {
 
     fn begin_operation(&self) -> OperationRequestId {
         self.operation_load.borrow_mut().take();
-        if let Some((generation, _)) = self.undo_restoration.take() {
-            finish_trash_undo(generation, false);
+        if let Some((generation, _)) = self.undo_claim.take() {
+            finish_undo(generation, false);
         }
         self.transfer_operation.set(None);
+        self.transfer_destination.replace(None);
         self.deletion_operation.set(false);
         self.deletion_permanent.set(false);
         self.restoration_operation.set(false);
@@ -1425,13 +1554,13 @@ impl Browser {
             } = &event
             {
                 if restored_location.is_some()
-                    && let Some((generation, locations)) =
-                        browser.undo_restoration.borrow().as_ref()
+                    && let Some((generation, UndoEntry::Trash(locations))) =
+                        browser.undo_claim.borrow().as_ref()
                     && let Some(location) = completed
                         .checked_sub(1)
                         .and_then(|index| locations.get(index))
                 {
-                    mark_trash_undo_restored(*generation, location);
+                    mark_undo_item_completed(*generation, location);
                 }
                 if *total <= MAX_INCREMENTAL_OPERATION_UPDATES
                     && let Some(location) = restored_location
@@ -1463,10 +1592,37 @@ impl Browser {
             let deleting = browser.deletion_operation.replace(false);
             let deletion_permanent = browser.deletion_permanent.replace(false);
             let restoring = browser.restoration_operation.replace(false);
-            if restoring && let Some((generation, _)) = browser.undo_restoration.take() {
-                finish_trash_undo(
-                    generation,
-                    matches!(&event, OperationEvent::Restored { .. }),
+            let destination = browser.transfer_destination.replace(None);
+            let undoing = browser.undo_claim.take();
+            if let Some((generation, entry)) = &undoing {
+                let completed = match (entry, &event) {
+                    (UndoEntry::Trash(_), _) => Vec::new(),
+                    (UndoEntry::Move(_), OperationEvent::Pasted { locations, .. }) => {
+                        locations.clone()
+                    }
+                    (
+                        UndoEntry::Move(_),
+                        OperationEvent::TransferFailed {
+                            completed_locations,
+                            ..
+                        },
+                    ) => completed_locations.clone(),
+                    (UndoEntry::Move(_), OperationEvent::Cancelled { result, .. }) => {
+                        result.completed.clone()
+                    }
+                    (UndoEntry::Move(_), _) => Vec::new(),
+                };
+                for location in &completed {
+                    mark_undo_item_completed(*generation, location);
+                }
+                finish_undo(
+                    *generation,
+                    match entry {
+                        UndoEntry::Trash(_) => {
+                            matches!(&event, OperationEvent::Restored { .. })
+                        }
+                        UndoEntry::Move(_) => matches!(&event, OperationEvent::Pasted { .. }),
+                    },
                 );
             }
             if deleting && !deletion_permanent {
@@ -1478,9 +1634,7 @@ impl Browser {
                     OperationEvent::Cancelled { result, .. } => result.completed.clone(),
                     _ => Vec::new(),
                 };
-                if !locations.is_empty() {
-                    replace_pending_trash_undo(locations);
-                }
+                replace_pending_undo(UndoEntry::Trash(locations));
             }
             if moving.is_some() {
                 let moved_locations = match &event {
@@ -1496,7 +1650,21 @@ impl Browser {
                     } if moving == Some(true) => completed_locations.clone(),
                     _ => Vec::new(),
                 };
-                browser.emit(BrowserEvent::TransferFinished { moved_locations });
+                if undoing.is_none()
+                    && let Some(destination) = destination.as_ref()
+                {
+                    replace_pending_undo(UndoEntry::Move(move_records(
+                        &moved_locations,
+                        destination,
+                    )));
+                }
+                browser.emit(BrowserEvent::TransferFinished {
+                    moved_locations: if undoing.is_some() {
+                        Vec::new()
+                    } else {
+                        moved_locations
+                    },
+                });
             }
             if deleting {
                 browser.emit(BrowserEvent::DeletionFinished);

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -783,6 +783,38 @@ fn a_partial_move_undo_keeps_the_items_still_to_move_back() {
 }
 
 #[test]
+fn a_partial_move_undo_does_not_retry_items_excluded_before_transfer() {
+    let skipped = MoveRecord {
+        original: Location::local("/fixture/skipped.txt"),
+        current: Location::local("/fixture/archive/skipped.txt"),
+    };
+    let completed = MoveRecord {
+        original: Location::local("/fixture/completed.txt"),
+        current: Location::local("/fixture/archive/completed.txt"),
+    };
+    let retryable = MoveRecord {
+        original: Location::local("/fixture/retryable.txt"),
+        current: Location::local("/fixture/archive/retryable.txt"),
+    };
+    replace_pending_undo(UndoEntry::Move(vec![
+        skipped,
+        completed.clone(),
+        retryable.clone(),
+    ]));
+    let (generation, _) = claim_pending_undo(None).expect("undo claim");
+    let submitted = [completed.clone(), retryable.clone()].map(|record| UndoMoveItem {
+        record,
+        conflict: TransferConflict::FailIfExists,
+    });
+
+    retain_pending_move_items(generation, &submitted);
+    mark_undo_item_completed(generation, &completed.current);
+    finish_undo(generation, false);
+
+    assert_eq!(pending_undo_entry(), Some(UndoEntry::Move(vec![retryable])));
+}
+
+#[test]
 fn undoing_a_move_leaves_a_pending_cut_untouched() {
     let browser = Browser::new(Rc::new(FakeFileSource));
     let events = Rc::new(RefCell::new(Vec::new()));

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -7,7 +7,7 @@ use crate::{
     model::{EntryKind, MetadataValue},
     services::{
         CancelledOperation, CompressRequest, ExtractRequest, LoadHandle, MetadataOutcome,
-        MetadataRequest, MetadataUpdate,
+        MetadataRequest, MetadataUpdate, UndoMoveRequest,
     },
 };
 
@@ -480,6 +480,10 @@ fn transfer_failure_reports_moves_completed_before_the_error() {
     )));
 }
 
+thread_local! {
+    static UNDO_MOVE_REQUESTS: RefCell<Vec<Vec<MoveRecord>>> = const { RefCell::new(Vec::new()) };
+}
+
 struct ImmediateOperationProvider;
 
 impl OperationProvider for ImmediateOperationProvider {
@@ -516,6 +520,27 @@ impl OperationProvider for ImmediateOperationProvider {
         emit(OperationEvent::Pasted {
             request_id: request.id,
             locations: request.items.into_iter().map(|item| item.source).collect(),
+        });
+        LoadHandle::new(|| {})
+    }
+
+    fn undo_move(&self, request: UndoMoveRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle {
+        UNDO_MOVE_REQUESTS.with(|requests| {
+            requests.borrow_mut().push(
+                request
+                    .items
+                    .iter()
+                    .map(|item| item.record.clone())
+                    .collect(),
+            )
+        });
+        emit(OperationEvent::Pasted {
+            request_id: request.id,
+            locations: request
+                .items
+                .into_iter()
+                .map(|item| item.record.current)
+                .collect(),
         });
         LoadHandle::new(|| {})
     }
@@ -575,8 +600,8 @@ fn a_completed_trash_operation_can_be_undone_once() {
     browser.delete(vec![entry], false);
 
     assert_eq!(
-        pending_trash_undo().as_slice(),
-        std::slice::from_ref(&location)
+        pending_undo_entry(),
+        Some(UndoEntry::Trash(vec![location.clone()]))
     );
     assert!(browser.undo_last_trash());
     assert!(!browser.undo_last_trash());
@@ -602,6 +627,178 @@ fn another_browser_can_undo_the_latest_trash_operation() {
 
     assert!(undoing_browser.undo_last_trash());
     assert!(!deleting_browser.undo_last_trash());
+}
+
+#[test]
+fn a_completed_move_records_where_each_item_landed() {
+    let browser = Browser::new(Rc::new(FakeFileSource));
+    browser.set_operation_provider(Rc::new(ImmediateOperationProvider));
+
+    browser.transfer(
+        Location::local("/fixture/archive"),
+        vec![PasteItem {
+            source: Location::local("/fixture/report.txt"),
+            conflict: TransferConflict::FailIfExists,
+        }],
+        true,
+    );
+
+    assert_eq!(
+        pending_undo_entry(),
+        Some(UndoEntry::Move(vec![MoveRecord {
+            original: Location::local("/fixture/report.txt"),
+            current: Location::local("/fixture/archive/report.txt"),
+        }]))
+    );
+}
+
+#[test]
+fn a_copy_records_no_undo() {
+    let browser = Browser::new(Rc::new(FakeFileSource));
+    browser.set_operation_provider(Rc::new(ImmediateOperationProvider));
+
+    browser.transfer(
+        Location::local("/fixture/archive"),
+        vec![PasteItem {
+            source: Location::local("/fixture/report.txt"),
+            conflict: TransferConflict::FailIfExists,
+        }],
+        false,
+    );
+
+    assert_eq!(pending_undo_entry(), None);
+}
+
+#[test]
+fn a_move_into_the_items_own_directory_records_no_undo() {
+    let browser = Browser::new(Rc::new(FakeFileSource));
+    browser.set_operation_provider(Rc::new(ImmediateOperationProvider));
+
+    browser.transfer(
+        Location::local("/fixture"),
+        vec![PasteItem {
+            source: Location::local("/fixture/report.txt"),
+            conflict: TransferConflict::FailIfExists,
+        }],
+        true,
+    );
+
+    assert_eq!(pending_undo_entry(), None);
+}
+
+#[test]
+fn undoing_a_move_transfers_items_back_once() {
+    let browser = Browser::new(Rc::new(FakeFileSource));
+    browser.set_operation_provider(Rc::new(ImmediateOperationProvider));
+    UNDO_MOVE_REQUESTS.with(|requests| requests.borrow_mut().clear());
+    browser.transfer(
+        Location::local("/fixture/archive"),
+        vec![PasteItem {
+            source: Location::local("/fixture/report.txt"),
+            conflict: TransferConflict::FailIfExists,
+        }],
+        true,
+    );
+    let (generation, records) = browser.pending_undo_move().expect("pending move undo");
+
+    assert!(
+        browser.undo_move(
+            generation,
+            records
+                .iter()
+                .cloned()
+                .map(|record| UndoMoveItem {
+                    record,
+                    conflict: TransferConflict::FailIfExists,
+                })
+                .collect(),
+        )
+    );
+
+    assert_eq!(
+        UNDO_MOVE_REQUESTS.with(|requests| requests.borrow().clone()),
+        vec![records]
+    );
+    assert_eq!(pending_undo_entry(), None);
+    assert!(browser.pending_undo_move().is_none());
+    assert!(!browser.undo_last_trash());
+}
+
+#[test]
+fn an_undo_claim_from_an_earlier_operation_is_rejected() {
+    let browser = Browser::new(Rc::new(FakeFileSource));
+    browser.set_operation_provider(Rc::new(ImmediateOperationProvider));
+    let record = MoveRecord {
+        original: Location::local("/fixture/report.txt"),
+        current: Location::local("/fixture/archive/report.txt"),
+    };
+    replace_pending_undo(UndoEntry::Move(vec![record.clone()]));
+    let (stale_generation, _) = peek_pending_undo().expect("pending undo");
+    replace_pending_undo(UndoEntry::Trash(vec![Location::local("/fixture/note.txt")]));
+
+    assert!(!browser.undo_move(
+        stale_generation,
+        vec![UndoMoveItem {
+            record,
+            conflict: TransferConflict::FailIfExists,
+        }],
+    ));
+    assert!(browser.undo_last_trash());
+}
+
+#[test]
+fn a_partial_move_undo_keeps_the_items_still_to_move_back() {
+    let browser = Browser::new(Rc::new(FakeFileSource));
+    let first = MoveRecord {
+        original: Location::local("/fixture/first.txt"),
+        current: Location::local("/fixture/archive/first.txt"),
+    };
+    let second = MoveRecord {
+        original: Location::local("/fixture/second.txt"),
+        current: Location::local("/fixture/archive/second.txt"),
+    };
+    replace_pending_undo(UndoEntry::Move(vec![first.clone(), second.clone()]));
+    let (generation, entry) = claim_pending_undo(None).expect("undo claim");
+    let request_id = browser.begin_operation();
+    browser.transfer_operation.set(Some(true));
+    browser.undo_claim.replace(Some((generation, entry)));
+    let emit = browser.operation_callback(request_id, false, HashSet::new());
+
+    emit(OperationEvent::TransferFailed {
+        request_id,
+        completed_locations: vec![first.current.clone()],
+        message: "injected failure".to_owned(),
+    });
+
+    assert_eq!(pending_undo_entry(), Some(UndoEntry::Move(vec![second])));
+}
+
+#[test]
+fn undoing_a_move_leaves_a_pending_cut_untouched() {
+    let browser = Browser::new(Rc::new(FakeFileSource));
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let observed = events.clone();
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
+    let record = MoveRecord {
+        original: Location::local("/fixture/report.txt"),
+        current: Location::local("/fixture/archive/report.txt"),
+    };
+    replace_pending_undo(UndoEntry::Move(vec![record.clone()]));
+    let (generation, entry) = claim_pending_undo(None).expect("undo claim");
+    let request_id = browser.begin_operation();
+    browser.transfer_operation.set(Some(true));
+    browser.undo_claim.replace(Some((generation, entry)));
+    let emit = browser.operation_callback(request_id, false, HashSet::new());
+
+    emit(OperationEvent::Pasted {
+        request_id,
+        locations: vec![record.current.clone()],
+    });
+
+    assert!(events.borrow().iter().any(|event| matches!(
+        event,
+        BrowserEvent::TransferFinished { moved_locations } if moved_locations.is_empty()
+    )));
 }
 
 #[test]
@@ -634,16 +831,20 @@ fn permanent_delete_preserves_the_previous_trash_undo() {
 fn failed_and_partial_undo_operations_can_be_retried() {
     let first = Location::local("/fixture/first.txt");
     let second = Location::local("/fixture/second.txt");
-    replace_pending_trash_undo(vec![first.clone(), second.clone()]);
-    let (generation, _) = claim_pending_trash_undo().expect("undo claim");
+    replace_pending_undo(UndoEntry::Trash(vec![first.clone(), second.clone()]));
+    let (generation, _) = claim_pending_undo(None).expect("undo claim");
 
-    mark_trash_undo_restored(generation, &first);
-    finish_trash_undo(generation, false);
+    mark_undo_item_completed(generation, &first);
+    finish_undo(generation, false);
 
-    assert_eq!(pending_trash_undo(), vec![second.clone()]);
-    let (retry_generation, retry) = claim_pending_trash_undo().expect("retry claim");
-    assert_eq!(retry, vec![second]);
-    finish_trash_undo(retry_generation, true);
+    assert_eq!(
+        pending_undo_entry(),
+        Some(UndoEntry::Trash(vec![second.clone()]))
+    );
+    let (retry_generation, retry) = claim_pending_undo(None).expect("retry claim");
+    assert_eq!(retry, UndoEntry::Trash(vec![second]));
+    finish_undo(retry_generation, true);
+    assert_eq!(pending_undo_entry(), None);
 }
 
 #[test]

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -75,6 +75,39 @@ impl Location {
         self.native_path().is_some_and(std::path::Path::is_absolute)
     }
 
+    /// Byte-safe file name for native paths, and the decoded final segment for URIs.
+    pub fn file_name(&self) -> Option<OsString> {
+        match &self.kind {
+            LocationKind::Native(path) => path.file_name().map(OsString::from),
+            LocationKind::Uri(uri) => gio::File::for_uri(uri)
+                .basename()?
+                .file_name()
+                .map(OsString::from),
+        }
+    }
+
+    /// Resolves a direct child by name, rejecting names that would escape `self`.
+    pub fn child(&self, name: &std::ffi::OsStr) -> Option<Self> {
+        if name.is_empty() || matches!(name.as_encoded_bytes(), b"." | b"..") {
+            return None;
+        }
+        if name.as_encoded_bytes().contains(&b'/') {
+            return None;
+        }
+        match &self.kind {
+            LocationKind::Native(path) => Some(Self::local(path.join(name))),
+            LocationKind::Uri(uri) => {
+                let child = gio::File::for_uri(uri).child(name.to_str()?);
+                Some(Self::uri(child.uri().to_string()))
+            }
+        }
+    }
+
+    /// Where an item lands when transferred into `destination` without renaming.
+    pub fn transfer_target(&self, destination: &Self) -> Option<Self> {
+        destination.child(&self.file_name()?)
+    }
+
     pub fn rebase(&self, from: &Self, to: &Self) -> Option<Self> {
         let suffix = self.native_path()?.strip_prefix(from.native_path()?).ok()?;
         Some(Self::local(to.native_path()?.join(suffix)))

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -97,7 +97,7 @@ impl Location {
         match &self.kind {
             LocationKind::Native(path) => Some(Self::local(path.join(name))),
             LocationKind::Uri(uri) => {
-                let child = gio::File::for_uri(uri).child(name.to_str()?);
+                let child = gio::File::for_uri(uri).child(name);
                 Some(Self::uri(child.uri().to_string()))
             }
         }

--- a/src/model/tests.rs
+++ b/src/model/tests.rs
@@ -105,3 +105,35 @@ fn root_has_one_breadcrumb() {
         vec![Location::local("/")]
     );
 }
+
+#[test]
+fn transfer_targets_keep_the_item_name_under_the_destination() {
+    assert_eq!(
+        Location::local("/home/user/report.txt")
+            .transfer_target(&Location::local("/home/user/archive")),
+        Some(Location::local("/home/user/archive/report.txt"))
+    );
+    assert_eq!(
+        Location::uri("smb://host/share/notes/report.txt")
+            .transfer_target(&Location::uri("smb://host/share/archive")),
+        Some(Location::uri("smb://host/share/archive/report.txt"))
+    );
+    assert_eq!(
+        Location::local("/home/user/a b.txt").transfer_target(&Location::uri("smb://host/share")),
+        Some(Location::uri("smb://host/share/a%20b.txt"))
+    );
+}
+
+#[test]
+fn children_reject_names_that_would_escape_the_parent() {
+    let parent = Location::local("/home/user");
+
+    for name in ["", ".", "..", "nested/child"] {
+        assert_eq!(parent.child(std::ffi::OsStr::new(name)), None);
+    }
+    assert_eq!(
+        Location::local("/").transfer_target(&parent),
+        None,
+        "a root has no name to carry into a destination"
+    );
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -19,9 +19,9 @@ pub(crate) use install_source::ensure_self_managed;
 pub use install_source::{InstallSource, ManagedInstall};
 pub use operations::{
     ArchiveFormat, CancelledOperation, CompressRequest, CreateDirectoryRequest, CreateFileRequest,
-    DeleteRequest, ExtractRequest, OperationEvent, OperationProvider, OperationRequestId,
-    PasteItem, PasteRequest, RenameRequest, RestoreRequest, RestoreSource, TransferConflict,
-    validate_basename,
+    DeleteRequest, ExtractRequest, MoveRecord, OperationEvent, OperationProvider,
+    OperationRequestId, PasteItem, PasteRequest, RenameRequest, RestoreRequest, RestoreSource,
+    TransferConflict, UndoMoveItem, UndoMoveRequest, validate_basename,
 };
 pub use preview::{
     Preview, PreviewContent, PreviewEvent, PreviewProvider, PreviewRequest, PreviewRequestId,

--- a/src/services/operations.rs
+++ b/src/services/operations.rs
@@ -52,6 +52,25 @@ pub struct PasteItem {
     pub conflict: TransferConflict,
 }
 
+/// A completed move: where an item started and where it ended up.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MoveRecord {
+    pub original: Location,
+    pub current: Location,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UndoMoveItem {
+    pub record: MoveRecord,
+    pub conflict: TransferConflict,
+}
+
+#[derive(Clone, Debug)]
+pub struct UndoMoveRequest {
+    pub id: OperationRequestId,
+    pub items: Vec<UndoMoveItem>,
+}
+
 #[derive(Clone, Debug)]
 pub struct CreateFileRequest {
     pub id: OperationRequestId,
@@ -248,6 +267,8 @@ pub trait OperationProvider {
         emit: Rc<dyn Fn(OperationEvent)>,
     ) -> LoadHandle;
     fn paste(&self, request: PasteRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle;
+    /// Moves completed transfers back to their original locations.
+    fn undo_move(&self, request: UndoMoveRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle;
     fn delete(&self, request: DeleteRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle;
     fn restore(&self, request: RestoreRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle;
     fn compress(&self, request: CompressRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle;

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -19,10 +19,10 @@ use crate::{
     app::{Browser, BrowserEvent},
     model::{EntryKind, FileEntry, Location, SortDirection, SortKey},
     services::{
-        ArchiveFormat, FileSource, LoadHandle, LocationValidationError, OperationProvider,
-        PasteItem, PreviewContent, SearchEvent, TransferConflict, UriCredentials,
-        backend_unavailable_message, content_family, has_plain_text_extension, index_tree,
-        is_extensionless_dotfile, sanitize_uri_credentials, validate_basename,
+        ArchiveFormat, FileSource, LoadHandle, LocationValidationError, MoveRecord,
+        OperationProvider, PasteItem, PreviewContent, SearchEvent, TransferConflict, UndoMoveItem,
+        UriCredentials, backend_unavailable_message, content_family, has_plain_text_extension,
+        index_tree, is_extensionless_dotfile, sanitize_uri_credentials, validate_basename,
     },
 };
 
@@ -1033,7 +1033,10 @@ impl BrowserView {
         true
     }
 
-    pub fn undo_last_trash(&self) -> bool {
+    pub fn undo_last_operation(&self) -> bool {
+        if let Some((generation, records)) = self.state.browser.pending_undo_move() {
+            return self.state.undo_move(generation, records);
+        }
         self.state.browser.undo_last_trash()
     }
 
@@ -1299,6 +1302,133 @@ impl ViewState {
             return;
         }
         let source = collisions.remove(0);
+        let name = source.display_name();
+        let explanation = format!(
+            "An item named \u{201c}{name}\u{201d} already exists in {}. Replacing it will overwrite its contents.",
+            compact_display_path(&destination)
+        );
+        let state = self.clone();
+        self.confirm_replace_conflict(
+            &name,
+            &explanation,
+            !collisions.is_empty(),
+            Rc::new(move |choice, apply_to_all| {
+                let mut accepted = accepted.clone();
+                let mut remaining = collisions.clone();
+                match choice {
+                    ConflictChoice::Replace => {
+                        accepted.push(PasteItem {
+                            source: source.clone(),
+                            conflict: TransferConflict::ReplaceExisting,
+                        });
+                        if apply_to_all {
+                            accepted.extend(remaining.drain(..).map(|source| PasteItem {
+                                source,
+                                conflict: TransferConflict::ReplaceExisting,
+                            }));
+                        }
+                    }
+                    ConflictChoice::Skip if apply_to_all => remaining.clear(),
+                    ConflictChoice::Skip => {}
+                }
+                state.resolve_transfer_collisions(
+                    destination.clone(),
+                    remaining,
+                    accepted,
+                    move_sources,
+                );
+            }),
+        );
+    }
+
+    /// Moves the latest completed transfer back, confirming any item that would
+    /// overwrite something created since the move.
+    fn undo_move(self: &Rc<Self>, generation: u64, records: Vec<MoveRecord>) -> bool {
+        let mut accepted = Vec::new();
+        let mut collisions = Vec::new();
+        for record in records {
+            if !location_exists(&record.current) {
+                continue;
+            }
+            if location_exists(&record.original) {
+                collisions.push(record);
+            } else {
+                accepted.push(UndoMoveItem {
+                    record,
+                    conflict: TransferConflict::FailIfExists,
+                });
+            }
+        }
+        if accepted.is_empty() && collisions.is_empty() {
+            self.browser.discard_pending_undo(generation);
+            return false;
+        }
+        self.resolve_undo_collisions(generation, collisions, accepted);
+        true
+    }
+
+    fn resolve_undo_collisions(
+        self: &Rc<Self>,
+        generation: u64,
+        mut collisions: Vec<MoveRecord>,
+        accepted: Vec<UndoMoveItem>,
+    ) {
+        if collisions.is_empty() {
+            if accepted.is_empty() {
+                self.browser.discard_pending_undo(generation);
+            } else {
+                self.browser.undo_move(generation, accepted);
+            }
+            return;
+        }
+        let record = collisions.remove(0);
+        let name = record.original.display_name();
+        let parent = record
+            .original
+            .parent()
+            .unwrap_or_else(|| record.original.clone());
+        let explanation = format!(
+            "An item named \u{201c}{name}\u{201d} already exists in {}. Undoing the move will overwrite its contents.",
+            compact_display_path(&parent)
+        );
+        let state = self.clone();
+        self.confirm_replace_conflict(
+            &name,
+            &explanation,
+            !collisions.is_empty(),
+            Rc::new(move |choice, apply_to_all| {
+                let mut accepted = accepted.clone();
+                let mut remaining = collisions.clone();
+                match choice {
+                    ConflictChoice::Replace => {
+                        accepted.push(UndoMoveItem {
+                            record: record.clone(),
+                            conflict: TransferConflict::ReplaceExisting,
+                        });
+                        if apply_to_all {
+                            accepted.extend(remaining.drain(..).map(|record| UndoMoveItem {
+                                record,
+                                conflict: TransferConflict::ReplaceExisting,
+                            }));
+                        }
+                    }
+                    ConflictChoice::Skip if apply_to_all => remaining.clear(),
+                    ConflictChoice::Skip => {}
+                }
+                state.resolve_undo_collisions(generation, remaining, accepted);
+            }),
+        );
+    }
+
+    /// Asks whether one conflicting item should be replaced or skipped.
+    /// Cancelling abandons the whole operation, so `on_choice` never runs.
+    fn confirm_replace_conflict(
+        &self,
+        name: &str,
+        explanation: &str,
+        has_more_conflicts: bool,
+        on_choice: Rc<dyn Fn(ConflictChoice, bool)>,
+    ) {
         let Some(window_overlay) = self
             .overlay
             .root()
@@ -1313,21 +1443,16 @@ impl ViewState {
             root.set_blurred(true);
         }
 
-        let name = source.display_name();
         let layout = message_dialog_layout(
             crate::assets::icons::COPY,
             "File already exists",
-            &name,
+            name,
             "Replace",
             ModalTone::Danger,
         );
-        let explanation = message_dialog_description(&format!(
-            "An item named “{name}” already exists in {}. Replacing it will overwrite its contents.",
-            compact_display_path(&destination)
-        ));
-        layout.body.append(&explanation);
+        layout.body.append(&message_dialog_description(explanation));
         let apply_all = form_check_button("Apply this choice to all remaining conflicts");
-        apply_all.set_visible(!collisions.is_empty());
+        apply_all.set_visible(has_more_conflicts);
         layout.body.append(&apply_all);
         let skip = gtk::Button::with_label("Skip");
         skip.add_css_class("action-dialog-cancel");
@@ -1347,56 +1472,20 @@ impl ViewState {
             dismiss_modal_layer(&cancel_layer, &cancel_overlay, cancel_root.as_ref());
         });
 
-        let skipped_layer = layer.clone();
-        let skipped_overlay = window_overlay.clone();
-        let skipped_root = blurred_root.clone();
-        let skipped_state = self.clone();
-        let skipped_destination = destination.clone();
-        let skipped_collisions = collisions.clone();
-        let skipped_accepted = accepted.clone();
-        let skip_all = apply_all.clone();
-        skip.connect_clicked(move |_| {
-            dismiss_modal_layer(&skipped_layer, &skipped_overlay, skipped_root.as_ref());
-            skipped_state.resolve_transfer_collisions(
-                skipped_destination.clone(),
-                if skip_all.is_active() {
-                    Vec::new()
-                } else {
-                    skipped_collisions.clone()
-                },
-                skipped_accepted.clone(),
-                move_sources,
-            );
-        });
-
-        let replaced_layer = layer.clone();
-        let replaced_overlay = window_overlay.clone();
-        let replaced_root = blurred_root.clone();
-        let replaced_state = self.clone();
-        let replace_all = apply_all;
-        replace.connect_clicked(move |_| {
-            dismiss_modal_layer(&replaced_layer, &replaced_overlay, replaced_root.as_ref());
-            let mut accepted = accepted.clone();
-            accepted.push(PasteItem {
-                source: source.clone(),
-                conflict: TransferConflict::ReplaceExisting,
+        for (button, choice) in [
+            (skip.clone(), ConflictChoice::Skip),
+            (replace.clone(), ConflictChoice::Replace),
+        ] {
+            let chosen_layer = layer.clone();
+            let chosen_overlay = window_overlay.clone();
+            let chosen_root = blurred_root.clone();
+            let chosen_apply_all = apply_all.clone();
+            let chosen = on_choice.clone();
+            button.connect_clicked(move |_| {
+                dismiss_modal_layer(&chosen_layer, &chosen_overlay, chosen_root.as_ref());
+                chosen(choice, chosen_apply_all.is_active());
             });
-            let remaining = if replace_all.is_active() {
-                accepted.extend(collisions.iter().cloned().map(|source| PasteItem {
-                    source,
-                    conflict: TransferConflict::ReplaceExisting,
-                }));
-                Vec::new()
-            } else {
-                collisions.clone()
-            };
-            replaced_state.resolve_transfer_collisions(
-                destination.clone(),
-                remaining,
-                accepted,
-                move_sources,
-            );
-        });
+        }
 
         let escape = gtk::EventControllerKey::new();
         escape.set_propagation_phase(gtk::PropagationPhase::Capture);
@@ -7038,6 +7127,16 @@ fn install_directory_drop_target(
         transfer_dropped_files(&state, target, value, destination.clone())
     });
     widget.add_controller(drop);
+}
+
+#[derive(Clone, Copy)]
+enum ConflictChoice {
+    Replace,
+    Skip,
+}
+
+fn location_exists(location: &Location) -> bool {
+    gio_file_for_location(location).query_exists(None::<&gio::Cancellable>)
 }
 
 fn transfer_has_collision(source: &Location, destination: &Location) -> bool {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -699,7 +699,7 @@ fn install_keyboard_navigation(
             }
             return glib::Propagation::Proceed;
         }
-        if !text_has_focus && is_undo_trash_shortcut(key, modifiers) && view.undo_last_trash() {
+        if !text_has_focus && is_undo_shortcut(key, modifiers) && view.undo_last_operation() {
             return glib::Propagation::Stop;
         }
         if alt
@@ -889,7 +889,7 @@ fn install_keyboard_navigation(
     window.add_controller(keys);
 }
 
-fn is_undo_trash_shortcut(key: gtk::gdk::Key, modifiers: gtk::gdk::ModifierType) -> bool {
+fn is_undo_shortcut(key: gtk::gdk::Key, modifiers: gtk::gdk::ModifierType) -> bool {
     modifiers.contains(gtk::gdk::ModifierType::CONTROL_MASK)
         && !modifiers
             .intersects(gtk::gdk::ModifierType::SHIFT_MASK | gtk::gdk::ModifierType::ALT_MASK)

--- a/src/ui/window/tests.rs
+++ b/src/ui/window/tests.rs
@@ -7,10 +7,10 @@ use crate::services::{BuildKind, ReleaseMetadata};
 use super::{
     MouseHistoryAction, PinStatus, STANDARD_PLACE_IDS, is_open_terminal_shortcut,
     is_sidebar_focus_shortcut, is_smb_location, is_standard_place_location,
-    is_toggle_hidden_shortcut, is_undo_trash_shortcut, mouse_history_action,
-    parse_pinned_drag_source, parse_pinned_places, pin_status, remove_pinned_place,
-    reorder_pinned_places, reorder_places, resolve_place_order, serialize_pinned_places,
-    should_show_standard_place, sidebar_update_label, standard_place, vim_focus_direction,
+    is_toggle_hidden_shortcut, is_undo_shortcut, mouse_history_action, parse_pinned_drag_source,
+    parse_pinned_places, pin_status, remove_pinned_place, reorder_pinned_places, reorder_places,
+    resolve_place_order, serialize_pinned_places, should_show_standard_place, sidebar_update_label,
+    standard_place, vim_focus_direction,
 };
 
 fn release(version: &str, kind: BuildKind) -> ReleaseMetadata {
@@ -76,19 +76,19 @@ fn open_terminal_shortcut_requires_only_control() {
 }
 
 #[test]
-fn undo_trash_shortcut_requires_control_without_shift_or_alt() {
+fn undo_shortcut_requires_control_without_shift_or_alt() {
     let control = gtk::gdk::ModifierType::CONTROL_MASK;
     let shift = gtk::gdk::ModifierType::SHIFT_MASK;
     let alt = gtk::gdk::ModifierType::ALT_MASK;
 
-    assert!(is_undo_trash_shortcut(gtk::gdk::Key::z, control));
-    assert!(is_undo_trash_shortcut(gtk::gdk::Key::Z, control));
-    assert!(!is_undo_trash_shortcut(
+    assert!(is_undo_shortcut(gtk::gdk::Key::z, control));
+    assert!(is_undo_shortcut(gtk::gdk::Key::Z, control));
+    assert!(!is_undo_shortcut(
         gtk::gdk::Key::z,
         gtk::gdk::ModifierType::empty()
     ));
-    assert!(!is_undo_trash_shortcut(gtk::gdk::Key::z, control | shift));
-    assert!(!is_undo_trash_shortcut(gtk::gdk::Key::z, control | alt));
+    assert!(!is_undo_shortcut(gtk::gdk::Key::z, control | shift));
+    assert!(!is_undo_shortcut(gtk::gdk::Key::z, control | alt));
 }
 
 #[test]


### PR DESCRIPTION
## Description

`Ctrl+Z` previously only restored the latest move to Trash, so a completed Cut and Paste could not be reversed. Each completed move now records where its items started and where they landed, and `Ctrl+Z` undoes whichever reversible operation happened last — a move or a move to Trash — process-wide across windows.

- Partial, failed, and cancelled moves record the items that actually transferred, and an undo that only partly succeeds leaves the remainder pending so the next `Ctrl+Z` retries it.
- An item whose original location is occupied again asks for confirmation before overwriting, reusing the existing transfer conflict dialog (Replace / Skip / apply to all); items that no longer exist where the move left them are dropped.
- An undo does not itself register a new undo, so `Ctrl+Z` never toggles an item back and forth, and it leaves any pending Cut untouched.

## Visual evidence

N/A — behavior-only change. The undo reuses the existing move progress overlay and the existing "File already exists" conflict dialog, so there is nothing new to show.

## How to test

1. Create two folders, put a file in the first one, and open the first folder in Strata.
2. Select the file, press `Ctrl+X`, navigate to the second folder, and press `Ctrl+V`.
3. Once the move finishes, press `Ctrl+Z`.
4. Repeat steps 1–2, then recreate a file with the same name in the original folder before pressing `Ctrl+Z`.
5. Move a file to Trash and press `Ctrl+Z`.

**Expected result:** step 3 moves the file back to the folder it was cut from, and a second `Ctrl+Z` does nothing. Step 4 asks whether to replace the newer file, and skipping it leaves both files where they are. Step 5 still restores from Trash.

## Related issue

Closes #298