### PR TITLE
feat(explorer): add Mode column showing file permissions

### DIFF
--- a/src/adapters/local_files.rs
+++ b/src/adapters/local_files.rs
@@ -25,8 +25,8 @@ use crate::{
 
 const LIST_ATTRIBUTES: &str =
     "standard::display-name,standard::name,standard::type,standard::is-hidden,standard::is-symlink";
-const FULL_ATTRIBUTES: &str = "standard::display-name,standard::name,standard::type,standard::is-hidden,standard::is-symlink,standard::size,time::modified";
-const METADATA_ATTRIBUTES: &str = "standard::type,standard::size,time::modified";
+const FULL_ATTRIBUTES: &str = "standard::display-name,standard::name,standard::type,standard::is-hidden,standard::is-symlink,standard::size,time::modified,unix::mode";
+const METADATA_ATTRIBUTES: &str = "standard::type,standard::size,time::modified,unix::mode";
 const MAX_PENDING_MONITOR_CHANGES: usize = 256;
 const MAX_HIDDEN_FILE_BYTES: u64 = 1024 * 1024;
 
@@ -147,6 +147,10 @@ fn entry_from_info(location: Location, info: gio::FileInfo) -> FileEntry {
         kind,
         size,
         modified_unix_seconds,
+        mode: match info.attribute_uint32("unix::mode") {
+            0 => MetadataValue::Unknown,
+            m => MetadataValue::Known(m),
+        },
         is_hidden: info_is_hidden(&info),
     }
 }

--- a/src/adapters/local_files.rs
+++ b/src/adapters/local_files.rs
@@ -291,6 +291,7 @@ fn scan_native_directory(
             kind,
             size: MetadataValue::Unknown,
             modified_unix_seconds: MetadataValue::Unknown,
+            mode: MetadataValue::Unknown,
             is_hidden,
         });
     }

--- a/src/adapters/local_files.rs
+++ b/src/adapters/local_files.rs
@@ -6,7 +6,7 @@ use std::{
     ffi::OsString,
     fs,
     io::{ErrorKind, Read},
-    os::unix::ffi::OsStringExt,
+    os::unix::{ffi::OsStringExt, fs::MetadataExt},
     path::{Path, PathBuf},
     rc::Rc,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
@@ -106,6 +106,14 @@ fn info_is_symlink(info: &gio::FileInfo) -> bool {
     info.has_attribute(gio::FILE_ATTRIBUTE_STANDARD_IS_SYMLINK) && info.is_symlink()
 }
 
+fn info_mode(info: &gio::FileInfo) -> MetadataValue<u32> {
+    if info.has_attribute(gio::FILE_ATTRIBUTE_UNIX_MODE) {
+        MetadataValue::Known(info.attribute_uint32(gio::FILE_ATTRIBUTE_UNIX_MODE))
+    } else {
+        MetadataValue::Unavailable
+    }
+}
+
 fn entry_from_info(location: Location, info: gio::FileInfo) -> FileEntry {
     let native_name = info.name().into_os_string();
     let kind = match (info.file_type(), info_is_symlink(&info)) {
@@ -147,10 +155,7 @@ fn entry_from_info(location: Location, info: gio::FileInfo) -> FileEntry {
         kind,
         size,
         modified_unix_seconds,
-        mode: match info.attribute_uint32("unix::mode") {
-            0 => MetadataValue::Unknown,
-            m => MetadataValue::Known(m),
-        },
+        mode: info_mode(&info),
         is_hidden: info_is_hidden(&info),
     }
 }
@@ -193,6 +198,7 @@ fn fill_native_entry_metadata(entry: &mut FileEntry) {
     let Ok(metadata) = fs::metadata(path) else {
         entry.size = MetadataValue::Unknown;
         entry.modified_unix_seconds = MetadataValue::Unknown;
+        entry.mode = MetadataValue::Unknown;
         return;
     };
     entry.size = if metadata.is_dir() {
@@ -206,6 +212,7 @@ fn fill_native_entry_metadata(entry: &mut FileEntry) {
         .and_then(unix_seconds)
         .map(MetadataValue::Known)
         .unwrap_or(MetadataValue::Unavailable);
+    entry.mode = MetadataValue::Known(metadata.mode());
 }
 
 fn native_hidden_names(path: &Path) -> HashSet<OsString> {
@@ -684,6 +691,7 @@ impl FileSource for LocalFileSource {
                             location: location.clone(),
                             size: MetadataValue::Unknown,
                             modified_unix_seconds: MetadataValue::Unknown,
+                            mode: MetadataValue::Unknown,
                         },
                         false,
                     ),
@@ -872,6 +880,7 @@ fn fill_parallel_with(
                                         location: location.clone(),
                                         size: MetadataValue::Unknown,
                                         modified_unix_seconds: MetadataValue::Unknown,
+                                        mode: MetadataValue::Unknown,
                                     },
                                     false,
                                 ),
@@ -945,12 +954,16 @@ fn update_from_info(info: &gio::FileInfo, location: &Location) -> (MetadataUpdat
         .modification_date_time()
         .map(|modified| MetadataValue::Known(modified.to_unix()))
         .unwrap_or(MetadataValue::Unavailable);
-    let ok = size != MetadataValue::Unknown || modified_unix_seconds != MetadataValue::Unknown;
+    let mode = info_mode(info);
+    let ok = size != MetadataValue::Unknown
+        || modified_unix_seconds != MetadataValue::Unknown
+        || mode != MetadataValue::Unknown;
     (
         MetadataUpdate {
             location: location.clone(),
             size,
             modified_unix_seconds,
+            mode,
         },
         ok,
     )

--- a/src/adapters/local_files/tests.rs
+++ b/src/adapters/local_files/tests.rs
@@ -5,7 +5,10 @@ use std::{
     ffi::OsString,
     fs,
     io::{ErrorKind, Write},
-    os::unix::ffi::{OsStrExt, OsStringExt},
+    os::unix::{
+        ffi::{OsStrExt, OsStringExt},
+        fs::PermissionsExt,
+    },
     sync::{Arc, Mutex, MutexGuard},
     time::{Instant, SystemTime},
 };
@@ -179,12 +182,16 @@ fn missing_optional_attributes_use_safe_defaults() {
 
     assert!(!info_is_hidden(&info));
     assert!(!info_is_symlink(&info));
+    assert_eq!(info_mode(&info), MetadataValue::Unavailable);
 
     info.set_is_hidden(true);
     info.set_is_symlink(true);
 
     assert!(info_is_hidden(&info));
     assert!(info_is_symlink(&info));
+
+    info.set_attribute_uint32(gio::FILE_ATTRIBUTE_UNIX_MODE, 0);
+    assert_eq!(info_mode(&info), MetadataValue::Known(0));
 }
 
 #[test]
@@ -646,7 +653,10 @@ fn cancelled_native_scan_returns_no_partial_result() {
 fn enumerate_with_metadata_fills_sizes_up_front() -> Result<(), Box<dyn Error>> {
     let root = unique_fixture_root("with-metadata");
     fs::create_dir_all(&root).expect("the fixture directory should be created");
-    fs::write(root.join("file-0.txt"), b"content").expect("the fixture file should be written");
+    let path = root.join("file-0.txt");
+    fs::write(&path, b"content").expect("the fixture file should be written");
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o640))
+        .expect("the fixture permissions should be set");
 
     let with_metadata = run_enumerate(DirectoryRequest {
         id: RequestId(1),
@@ -666,14 +676,14 @@ fn enumerate_with_metadata_fills_sizes_up_front() -> Result<(), Box<dyn Error>> 
     });
     fs::remove_dir_all(&root).expect("the fixture directory should be removed");
 
-    let sizes = |events: &[DirectoryEvent]| {
+    let metadata = |events: &[DirectoryEvent]| {
         events
             .iter()
             .filter_map(|event| match event {
                 DirectoryEvent::Batch { entries, .. } => Some(
                     entries
                         .iter()
-                        .map(|entry| entry.size.clone())
+                        .map(|entry| (entry.size.clone(), entry.mode.clone()))
                         .collect::<Vec<_>>(),
                 ),
                 _ => None,
@@ -682,13 +692,13 @@ fn enumerate_with_metadata_fills_sizes_up_front() -> Result<(), Box<dyn Error>> 
             .collect::<Vec<_>>()
     };
     assert_eq!(
-        sizes(&with_metadata),
-        vec![MetadataValue::Known(7)],
+        metadata(&with_metadata),
+        vec![(MetadataValue::Known(7), MetadataValue::Known(0o100640))],
         "a metadata load should stat every entry up front"
     );
     assert_eq!(
-        sizes(&streaming),
-        vec![MetadataValue::Unknown],
+        metadata(&streaming),
+        vec![(MetadataValue::Unknown, MetadataValue::Unknown)],
         "a streaming load should leave sizes for the window fill"
     );
     Ok(())
@@ -840,23 +850,29 @@ fn fill_file_uri_stats_through_the_uri_form() -> Result<(), Box<dyn Error>> {
 fn fill_live_file_completes_with_a_chunk() -> Result<(), Box<dyn Error>> {
     let root = unique_fixture_root("fill-live");
     fs::create_dir_all(&root).expect("the fixture directory should be created");
-    fs::write(root.join("photo.jpg"), b"content").expect("the fixture file should be written");
+    let path = root.join("photo.jpg");
+    fs::write(&path, b"content").expect("the fixture file should be written");
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o640))
+        .expect("the fixture permissions should be set");
 
     let events = run_fill(MetadataRequest {
         id: RequestId(1),
-        entries: vec![Location::local(root.join("photo.jpg"))],
+        entries: vec![Location::local(&path)],
         full: false,
         time_budget: Duration::from_secs(10),
     });
     assert_eq!(fill_outcome(&events), Some(MetadataOutcome::Complete));
     assert_eq!(fill_chunk_count(&events), 1);
-    let size = events.iter().find_map(|event| match event {
-        DirectoryEvent::MetadataFilled { updates, .. } => {
-            updates.first().map(|update| update.size.clone())
-        }
+    let metadata = events.iter().find_map(|event| match event {
+        DirectoryEvent::MetadataFilled { updates, .. } => updates
+            .first()
+            .map(|update| (update.size.clone(), update.mode.clone())),
         _ => None,
     });
-    assert_eq!(size, Some(MetadataValue::Known(7)));
+    assert_eq!(
+        metadata,
+        Some((MetadataValue::Known(7), MetadataValue::Known(0o100640)))
+    );
     Ok(())
 }
 

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -51,6 +51,7 @@ fn file_entry(path: &std::path::Path) -> FileEntry {
         size: MetadataValue::Unknown,
         modified_unix_seconds: MetadataValue::Unknown,
         is_hidden: false,
+        mode: MetadataValue::Unknown,
     }
 }
 
@@ -858,6 +859,7 @@ fn test_file_entry(path: &Path) -> FileEntry {
         size: MetadataValue::Unknown,
         modified_unix_seconds: MetadataValue::Unknown,
         is_hidden: false,
+        mode: MetadataValue::Unknown,
     }
 }
 

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -1732,6 +1732,7 @@ impl FileSource for SortFillSource {
                         location: location.clone(),
                         size: MetadataValue::Known(size),
                         modified_unix_seconds: MetadataValue::Unknown,
+                        mode: MetadataValue::Unknown,
                     }
                 })
                 .collect(),
@@ -2064,6 +2065,7 @@ impl ScriptedSource {
                     location: locate(name),
                     size: MetadataValue::Known(*size),
                     modified_unix_seconds: MetadataValue::Known(7),
+                    mode: MetadataValue::Unknown,
                 })
                 .collect(),
         };
@@ -2363,6 +2365,7 @@ fn navigation_cancels_an_awaiting_sort_without_stale_commit() {
             location: Location::local("/fixture/alpha"),
             size: MetadataValue::Known(1),
             modified_unix_seconds: MetadataValue::Known(7),
+            mode: MetadataValue::Unknown,
         }],
     });
     old_emit(DirectoryEvent::MetadataFinished {
@@ -2452,6 +2455,7 @@ fn viewport_flush_never_disturbs_an_active_sort() {
             location: Location::local("/fixture/alpha"),
             size: MetadataValue::Known(30),
             modified_unix_seconds: MetadataValue::Known(7),
+            mode: MetadataValue::Unknown,
         }],
     });
     viewport_emit(DirectoryEvent::MetadataFinished {
@@ -2469,11 +2473,13 @@ fn viewport_flush_never_disturbs_an_active_sort() {
                 location: Location::local("/fixture/alpha"),
                 size: MetadataValue::Known(30),
                 modified_unix_seconds: MetadataValue::Known(7),
+                mode: MetadataValue::Unknown,
             },
             MetadataUpdate {
                 location: Location::local("/fixture/beta"),
                 size: MetadataValue::Known(10),
                 modified_unix_seconds: MetadataValue::Known(7),
+                mode: MetadataValue::Unknown,
             },
         ],
     });
@@ -2662,6 +2668,7 @@ fn shifted_viewport_rows_go_stale_without_repaint() {
             location: Location::local("/fixture/beta"),
             size: MetadataValue::Known(10),
             modified_unix_seconds: MetadataValue::Known(7),
+            mode: MetadataValue::Unknown,
         }],
     });
     assert_eq!(replaced_count(&events), 1);
@@ -2748,11 +2755,13 @@ fn modified_sort_fills_directory_mtimes() {
                 location: Location::local("/fixture/sub"),
                 size: MetadataValue::Unknown,
                 modified_unix_seconds: MetadataValue::Known(200),
+                mode: MetadataValue::Unknown,
             },
             MetadataUpdate {
                 location: Location::local("/fixture/b.txt"),
                 size: MetadataValue::Known(10),
                 modified_unix_seconds: MetadataValue::Known(100),
+                mode: MetadataValue::Unknown,
             },
         ],
     });

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -1642,6 +1642,7 @@ fn batch_entry(name: &str) -> FileEntry {
         kind: EntryKind::File,
         size: MetadataValue::Unknown,
         modified_unix_seconds: MetadataValue::Unknown,
+        mode: MetadataValue::Unknown,
         is_hidden: false,
     }
 }
@@ -2041,6 +2042,7 @@ impl ScriptedSource {
             },
             size: MetadataValue::Unknown,
             modified_unix_seconds: MetadataValue::Unknown,
+            mode: MetadataValue::Unknown,
             is_hidden: false,
         }
     }
@@ -2859,6 +2861,7 @@ fn staged_entry(name: &str, kind: EntryKind, size: MetadataValue<u64>, modified:
         kind,
         size,
         modified_unix_seconds: MetadataValue::Known(modified),
+        mode: MetadataValue::Unknown,
         is_hidden: false,
     }
 }

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -21,6 +21,7 @@ fn deleted_trash_entries_refresh_the_trash_root() {
         size: MetadataValue::Known(10),
         modified_unix_seconds: MetadataValue::Unknown,
         is_hidden: false,
+        mode: MetadataValue::Unknown,
     };
 
     assert_eq!(
@@ -103,6 +104,7 @@ impl FileSource for WatchingFileSource {
                 size: MetadataValue::Unknown,
                 modified_unix_seconds: MetadataValue::Unknown,
                 is_hidden: false,
+                mode: MetadataValue::Unknown,
             }],
         });
         emit(DirectoryEvent::Finished {
@@ -177,6 +179,7 @@ impl FileSource for RetryFileSource {
                     size: MetadataValue::Unknown,
                     modified_unix_seconds: MetadataValue::Unknown,
                     is_hidden: false,
+                    mode: MetadataValue::Unknown,
                 }],
             });
             emit(DirectoryEvent::Finished {
@@ -232,6 +235,7 @@ impl FileSource for FilePreviewSource {
                 size: MetadataValue::Known(12),
                 modified_unix_seconds: MetadataValue::Known(1),
                 is_hidden: false,
+                mode: MetadataValue::Unknown,
             }],
         });
         emit(DirectoryEvent::Finished {
@@ -256,6 +260,7 @@ impl FileSource for RestoredSortingSource {
             size: MetadataValue::Known(size),
             modified_unix_seconds: MetadataValue::Unknown,
             is_hidden: false,
+            mode: MetadataValue::Unknown,
         };
         emit(DirectoryEvent::Batch {
             request_id: request.id,
@@ -285,6 +290,7 @@ impl FileSource for FakeFileSource {
                 size: MetadataValue::Unknown,
                 modified_unix_seconds: MetadataValue::Unknown,
                 is_hidden: false,
+                mode: MetadataValue::Unknown,
             }],
         });
         emit(DirectoryEvent::Finished {
@@ -313,6 +319,7 @@ impl FileSource for TrashFileSource {
                 size: MetadataValue::Unknown,
                 modified_unix_seconds: MetadataValue::Unknown,
                 is_hidden: false,
+                mode: MetadataValue::Unknown,
             }],
         });
         emit(DirectoryEvent::Finished {
@@ -570,6 +577,7 @@ fn a_completed_trash_operation_can_be_undone_once() {
         size: MetadataValue::Unknown,
         modified_unix_seconds: MetadataValue::Unknown,
         is_hidden: false,
+        mode: MetadataValue::Unknown,
     };
 
     browser.delete(vec![entry], false);
@@ -596,6 +604,7 @@ fn another_browser_can_undo_the_latest_trash_operation() {
         size: MetadataValue::Unknown,
         modified_unix_seconds: MetadataValue::Unknown,
         is_hidden: false,
+        mode: MetadataValue::Unknown,
     };
 
     deleting_browser.delete(vec![entry], false);
@@ -616,6 +625,7 @@ fn permanent_delete_preserves_the_previous_trash_undo() {
         size: MetadataValue::Unknown,
         modified_unix_seconds: MetadataValue::Unknown,
         is_hidden: false,
+        mode: MetadataValue::Unknown,
     };
     let permanently_deleted = FileEntry {
         location: Location::local("/fixture/draft.txt"),
@@ -685,6 +695,7 @@ fn renaming_on_a_remote_location_refreshes_the_open_column() {
             size: MetadataValue::Known(1),
             modified_unix_seconds: MetadataValue::Unknown,
             is_hidden: false,
+            mode: MetadataValue::Unknown,
         },
         "new-name.txt".to_owned(),
     );
@@ -811,6 +822,7 @@ fn filesystem_notifications_update_the_affected_column_incrementally() {
         size: MetadataValue::Known(4),
         modified_unix_seconds: MetadataValue::Known(1),
         is_hidden: false,
+        mode: MetadataValue::Unknown,
     }));
 
     assert!(events.borrow().iter().any(|event| matches!(
@@ -3316,6 +3328,7 @@ impl FileSource for MixedPeekFileSource {
                     size: MetadataValue::Unknown,
                     modified_unix_seconds: MetadataValue::Unknown,
                     is_hidden: true,
+                    mode: MetadataValue::Unknown,
                 },
                 FileEntry {
                     location: Location::local("/fixture/normal.txt"),
@@ -3325,6 +3338,7 @@ impl FileSource for MixedPeekFileSource {
                     size: MetadataValue::Unknown,
                     modified_unix_seconds: MetadataValue::Unknown,
                     is_hidden: false,
+                    mode: MetadataValue::Unknown,
                 },
             ],
         });

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -981,6 +981,10 @@ fn apply_metadata_update(entry: &mut FileEntry, update: &MetadataUpdate) -> bool
         entry.modified_unix_seconds = update.modified_unix_seconds.clone();
         changed = true;
     }
+    if update.mode != MetadataValue::Unknown && entry.mode != update.mode {
+        entry.mode = update.mode.clone();
+        changed = true;
+    }
     changed
 }
 

--- a/src/app/navigation/tests.rs
+++ b/src/app/navigation/tests.rs
@@ -25,6 +25,7 @@ fn named_entry(path: &str, name: &str) -> FileEntry {
         size: MetadataValue::Unknown,
         modified_unix_seconds: MetadataValue::Unknown,
         is_hidden: false,
+        mode: MetadataValue::Unknown,
     }
 }
 
@@ -395,6 +396,7 @@ fn hidden_entry(path: &str, name: &str) -> FileEntry {
         size: MetadataValue::Unknown,
         modified_unix_seconds: MetadataValue::Unknown,
         is_hidden: true,
+        mode: MetadataValue::Unknown,
     }
 }
 

--- a/src/app/navigation/tests.rs
+++ b/src/app/navigation/tests.rs
@@ -676,6 +676,7 @@ fn file_entry(path: &str, name: &str) -> FileEntry {
         kind: EntryKind::File,
         size: MetadataValue::Unknown,
         modified_unix_seconds: MetadataValue::Unknown,
+        mode: MetadataValue::Unknown,
         is_hidden: false,
     }
 }

--- a/src/app/navigation/tests.rs
+++ b/src/app/navigation/tests.rs
@@ -686,6 +686,7 @@ fn metadata_update(path: &str, size: u64, modified: i64) -> MetadataUpdate {
         location: location(path),
         size: MetadataValue::Known(size),
         modified_unix_seconds: MetadataValue::Known(modified),
+        mode: MetadataValue::Unknown,
     }
 }
 
@@ -816,6 +817,7 @@ fn fill_updates_never_clobber_known_fields() {
             location: location("/fixture/half"),
             size: MetadataValue::Unknown,
             modified_unix_seconds: MetadataValue::Known(300),
+            mode: MetadataValue::Known(0o100640),
         }],
     );
     assert!(matches!(applied, Some((0, ref positions)) if positions == &[0]));
@@ -824,6 +826,10 @@ fn fill_updates_never_clobber_known_fields() {
         state.columns[0].entries[0].modified_unix_seconds,
         MetadataValue::Known(300)
     );
+    assert_eq!(
+        state.columns[0].entries[0].mode,
+        MetadataValue::Known(0o100640)
+    );
 
     let applied = state.apply_metadata(
         RequestId(1),
@@ -831,6 +837,7 @@ fn fill_updates_never_clobber_known_fields() {
             location: location("/fixture/half"),
             size: MetadataValue::Unknown,
             modified_unix_seconds: MetadataValue::Unknown,
+            mode: MetadataValue::Unknown,
         }],
     );
     assert_eq!(applied, None);

--- a/src/app/peek/tests.rs
+++ b/src/app/peek/tests.rs
@@ -14,6 +14,7 @@ fn entry() -> FileEntry {
         size: MetadataValue::Unknown,
         modified_unix_seconds: MetadataValue::Unknown,
         is_hidden: false,
+        mode: MetadataValue::Unknown,
     }
 }
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -237,6 +237,7 @@ pub struct FileEntry {
     pub kind: EntryKind,
     pub size: MetadataValue<u64>,
     pub modified_unix_seconds: MetadataValue<i64>,
+    pub mode: MetadataValue<u32>,
     pub is_hidden: bool,
 }
 

--- a/src/services/file_source.rs
+++ b/src/services/file_source.rs
@@ -223,13 +223,14 @@ pub enum MetadataOutcome {
     Cancelled,
 }
 
-/// Fresh size/mtime for one listed entry. Either field may stay `Unknown`/`Unavailable`
+/// Fresh metadata for one listed entry. Fields may stay `Unknown`/`Unavailable`
 /// when the stat failed; the row keeps its placeholder for a later retry.
 #[derive(Clone, Debug)]
 pub struct MetadataUpdate {
     pub location: Location,
     pub size: MetadataValue<u64>,
     pub modified_unix_seconds: MetadataValue<i64>,
+    pub mode: MetadataValue<u32>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -8940,7 +8940,7 @@ fn with_execute_permissions(mode: u32, executable: bool) -> u32 {
     }
 }
 
-fn format_permissions(mode: u32) -> String {
+pub fn format_permissions(mode: u32) -> String {
     let kind = if mode & 0o170000 == 0o040000 {
         'd'
     } else {

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -429,6 +429,7 @@ fn printing_is_offered_for_text_code_images_and_pdfs() {
         kind,
         size: crate::model::MetadataValue::Unknown,
         modified_unix_seconds: crate::model::MetadataValue::Unknown,
+        mode: crate::model::MetadataValue::Unknown,
         is_hidden: false,
     };
 

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -35,6 +35,7 @@ fn duplicate_transfer_uses_the_selected_entries_parent() {
         kind: crate::model::EntryKind::File,
         size: crate::model::MetadataValue::Unknown,
         modified_unix_seconds: crate::model::MetadataValue::Unknown,
+        mode: crate::model::MetadataValue::Unknown,
         is_hidden: false,
     };
     let first = entry("/fixture/selected/first.txt");

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -12,6 +12,7 @@ fn terminal_shortcut_prefers_one_selected_directory() {
         size: crate::model::MetadataValue::Unknown,
         modified_unix_seconds: crate::model::MetadataValue::Unknown,
         is_hidden: false,
+        mode: crate::model::MetadataValue::Unknown,
     };
     let directory = entry("selected", crate::model::EntryKind::Directory);
     let file = entry("notes.txt", crate::model::EntryKind::File);
@@ -213,6 +214,7 @@ fn delete_confirmation_labels_distinguish_files_and_folders() {
         size: crate::model::MetadataValue::Known(10),
         modified_unix_seconds: crate::model::MetadataValue::Unknown,
         is_hidden: false,
+        mode: crate::model::MetadataValue::Unknown,
     };
     let mut folder = file.clone();
     folder.kind = crate::model::EntryKind::Directory;
@@ -384,6 +386,7 @@ fn quick_preview_is_offered_only_for_supported_files() {
         size: crate::model::MetadataValue::Unknown,
         modified_unix_seconds: crate::model::MetadataValue::Unknown,
         is_hidden: false,
+        mode: crate::model::MetadataValue::Unknown,
     };
 
     assert!(entry_supports_quick_preview(&entry(
@@ -490,6 +493,7 @@ fn multi_selection_summary_lists_at_most_three_names() {
         size: crate::model::MetadataValue::Unknown,
         modified_unix_seconds: crate::model::MetadataValue::Unknown,
         is_hidden: false,
+        mode: crate::model::MetadataValue::Unknown,
     };
 
     assert_eq!(
@@ -1286,6 +1290,7 @@ fn entry_model_value_encodes_hidden_state_and_preserves_display_name() {
         size: crate::model::MetadataValue::Unknown,
         modified_unix_seconds: crate::model::MetadataValue::Unknown,
         is_hidden: false,
+        mode: crate::model::MetadataValue::Unknown,
     };
     let hidden = FileEntry {
         location: Location::local("/fixture/.config"),
@@ -1295,6 +1300,7 @@ fn entry_model_value_encodes_hidden_state_and_preserves_display_name() {
         size: crate::model::MetadataValue::Unknown,
         modified_unix_seconds: crate::model::MetadataValue::Unknown,
         is_hidden: true,
+        mode: crate::model::MetadataValue::Unknown,
     };
 
     let encoded_visible = entry_model_value(&visible);
@@ -1363,6 +1369,7 @@ fn pinning_requires_an_available_non_trash_directory() {
         size: crate::model::MetadataValue::Unknown,
         modified_unix_seconds: crate::model::MetadataValue::Unknown,
         is_hidden: false,
+        mode: crate::model::MetadataValue::Unknown,
     };
     let directory = entry(
         Location::local("/fixture/folder"),
@@ -1425,6 +1432,7 @@ fn retryable_delete_entries_keeps_only_the_named_locations() {
         size: crate::model::MetadataValue::Unknown,
         modified_unix_seconds: crate::model::MetadataValue::Unknown,
         is_hidden: false,
+        mode: crate::model::MetadataValue::Unknown,
     };
     let retryable = entry("share-file.txt");
     let denied = entry("locked-file.txt");
@@ -1445,6 +1453,7 @@ fn retryable_delete_entries_is_empty_when_nothing_matches() {
         size: crate::model::MetadataValue::Unknown,
         modified_unix_seconds: crate::model::MetadataValue::Unknown,
         is_hidden: false,
+        mode: crate::model::MetadataValue::Unknown,
     };
 
     let kept = retryable_delete_entries(vec![entry], &[]);

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -1608,7 +1608,7 @@ fn build_grid_view(
                 26,
                 thumbnail_size_for_bind.get(),
             );
-            if let Some(position) = metadata_fill_position(source_position, &entry)
+            if let Some(position) = metadata_fill_position(source_position, &entry, false)
                 && let Some(browser) = browser.as_ref()
             {
                 browser.request_metadata_fill(depth, position, entry.location.clone());
@@ -2353,7 +2353,7 @@ fn build_explorer_pane(
                 18,
                 18,
             );
-            if let Some(position) = metadata_fill_position(source_position, &entry)
+            if let Some(position) = metadata_fill_position(source_position, &entry, true)
                 && let Some(browser) = browser.as_ref()
             {
                 browser.request_metadata_fill(depth, position, entry.location.clone());
@@ -2867,8 +2867,15 @@ fn source_position_for_view(
         .map(|position| position as usize)
 }
 
-fn metadata_fill_position(position: Option<usize>, entry: &FileEntry) -> Option<usize> {
-    position.filter(|_| super::browser::metadata_needs_fill(entry))
+fn metadata_fill_position(
+    position: Option<usize>,
+    entry: &FileEntry,
+    include_mode: bool,
+) -> Option<usize> {
+    position.filter(|_| {
+        super::browser::metadata_needs_fill(entry)
+            || (include_mode && entry.mode == MetadataValue::Unknown)
+    })
 }
 
 fn view_position_for_source(

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -19,8 +19,8 @@ use crate::{
     model::{FileEntry, Location, MetadataValue, SortDirection, SortKey},
 };
 
-const EXPLORER_COLUMN_WIDTHS: [i32; 4] = [160, 90, 120, 150];
-const EXPLORER_COLUMN_MIN_WIDTHS: [i32; 4] = [160, 70, 80, 110];
+const EXPLORER_COLUMN_WIDTHS: [i32; 5] = [160, 110, 90, 120, 150];
+const EXPLORER_COLUMN_MIN_WIDTHS: [i32; 5] = [160, 80, 70, 80, 110];
 const DEFAULT_GRID_THUMBNAIL_SIZE: i32 = 64;
 /// Margin and padding a grid card adds around its own width.
 const GRID_CARD_SPACING: i32 = 4;
@@ -39,7 +39,7 @@ impl ExplorerColumnLayout {
     fn new() -> Self {
         Self {
             widths: Rc::new(EXPLORER_COLUMN_WIDTHS.into_iter().map(Cell::new).collect()),
-            cells: Rc::new((0..4).map(|_| RefCell::new(Vec::new())).collect()),
+            cells: Rc::new((0..5).map(|_| RefCell::new(Vec::new())).collect()),
             name_manually_resized: Rc::new(Cell::new(false)),
         }
     }
@@ -1883,10 +1883,15 @@ fn explorer_headings(
     let arrows: Rc<RefCell<Vec<(SortKey, gtk::Image)>>> = Rc::new(RefCell::new(Vec::new()));
 
     for (index, (text, key, width)) in [
-        ("Name", SortKey::Name, EXPLORER_COLUMN_WIDTHS[0]),
-        ("Size", SortKey::Size, EXPLORER_COLUMN_WIDTHS[1]),
-        ("Type", SortKey::Type, EXPLORER_COLUMN_WIDTHS[2]),
-        ("Modified", SortKey::Modified, EXPLORER_COLUMN_WIDTHS[3]),
+        ("Name", Some(SortKey::Name), EXPLORER_COLUMN_WIDTHS[0]),
+        ("Mode", None, EXPLORER_COLUMN_WIDTHS[1]),
+        ("Size", Some(SortKey::Size), EXPLORER_COLUMN_WIDTHS[2]),
+        ("Type", Some(SortKey::Type), EXPLORER_COLUMN_WIDTHS[3]),
+        (
+            "Modified",
+            Some(SortKey::Modified),
+            EXPLORER_COLUMN_WIDTHS[4],
+        ),
     ]
     .into_iter()
     .enumerate()
@@ -1907,50 +1912,52 @@ fn explorer_headings(
             },
             12,
         );
-        arrow.set_visible(preferences.sort_key == key);
+        arrow.set_visible(key.is_some_and(|k| preferences.sort_key == k));
         row.append(&label);
         row.append(&arrow);
         let button = gtk::Button::builder().child(&row).build();
         button.add_css_class("explorer-heading-button");
         button.set_hexpand(true);
-        let weak_browser = Rc::downgrade(browser);
-        let sorting_for_click = sorting.clone();
-        let arrows_for_click = arrows.clone();
-        button.connect_clicked(move |_| {
-            let (current_key, current_direction) = sorting_for_click.get();
-            let direction = if current_key == key {
-                match current_direction {
-                    SortDirection::Ascending => SortDirection::Descending,
-                    SortDirection::Descending => SortDirection::Ascending,
+        if let Some(key) = key {
+            let weak_browser = Rc::downgrade(browser);
+            let sorting_for_click = sorting.clone();
+            let arrows_for_click = arrows.clone();
+            button.connect_clicked(move |_| {
+                let (current_key, current_direction) = sorting_for_click.get();
+                let direction = if current_key == key {
+                    match current_direction {
+                        SortDirection::Ascending => SortDirection::Descending,
+                        SortDirection::Descending => SortDirection::Ascending,
+                    }
+                } else {
+                    SortDirection::Ascending
+                };
+                sorting_for_click.set((key, direction));
+                for (arrow_key, arrow) in arrows_for_click.borrow().iter() {
+                    arrow.set_visible(*arrow_key == key);
+                    if *arrow_key == key {
+                        crate::assets::set_primary_icon(
+                            arrow,
+                            if direction == SortDirection::Ascending {
+                                crate::assets::icons::ARROW_UP
+                            } else {
+                                crate::assets::icons::ARROW_DOWN
+                            },
+                        );
+                    }
                 }
-            } else {
-                SortDirection::Ascending
-            };
-            sorting_for_click.set((key, direction));
-            for (arrow_key, arrow) in arrows_for_click.borrow().iter() {
-                arrow.set_visible(*arrow_key == key);
-                if *arrow_key == key {
-                    crate::assets::set_primary_icon(
-                        arrow,
-                        if direction == SortDirection::Ascending {
-                            crate::assets::icons::ARROW_UP
-                        } else {
-                            crate::assets::icons::ARROW_DOWN
-                        },
-                    );
+                if let Some(browser) = weak_browser.upgrade() {
+                    browser.set_sort(depth, key, direction);
                 }
-            }
-            if let Some(browser) = weak_browser.upgrade() {
-                browser.set_sort(depth, key, direction);
-            }
-        });
+            });
+            arrows.borrow_mut().push((key, arrow));
+        }
         let button_overlay = gtk::Overlay::new();
         button_overlay.set_child(Some(&button));
         button_overlay.set_hexpand(true);
         button_overlay.add_overlay(&column_resize_handle(columns.clone(), index, width));
         cell.append(&button_overlay);
         headings.append(&cell);
-        arrows.borrow_mut().push((key, arrow));
     }
     headings
 }
@@ -2243,11 +2250,13 @@ fn build_explorer_pane(
         name_cell.append(&icon);
         name_cell.append(&name);
         name_cell.append(&field);
+        let mode = explorer_metadata_label();
         let size = explorer_metadata_label();
         let kind = explorer_metadata_label();
         let modified = explorer_metadata_label();
         for (index, widget) in [
             name_cell.clone().upcast::<gtk::Widget>(),
+            mode.clone().upcast(),
             size.clone().upcast(),
             kind.clone().upcast(),
             modified.clone().upcast(),
@@ -2258,6 +2267,7 @@ fn build_explorer_pane(
             register_explorer_column_cell(&columns, index, &widget);
         }
         row.append(&name_cell);
+        row.append(&mode);
         row.append(&size);
         row.append(&kind);
         row.append(&modified);
@@ -2311,7 +2321,10 @@ fn build_explorer_pane(
         let Some(field) = name.next_sibling().and_downcast::<gtk::Entry>() else {
             return;
         };
-        let Some(size) = name_cell.next_sibling().and_downcast::<gtk::Label>() else {
+        let Some(mode) = name_cell.next_sibling().and_downcast::<gtk::Label>() else {
+            return;
+        };
+        let Some(size) = mode.next_sibling().and_downcast::<gtk::Label>() else {
             return;
         };
         let Some(kind) = size.next_sibling().and_downcast::<gtk::Label>() else {
@@ -2346,6 +2359,7 @@ fn build_explorer_pane(
                 browser.request_metadata_fill(depth, position, entry.location.clone());
             }
             name.set_label(&entry.display_name);
+            mode.set_label(&entry_mode(&entry));
             size.set_label(&entry_size(&entry));
             kind.set_label(entry_type(&entry));
             crate::util::set_modified_date(&modified, Some(&entry), "—");
@@ -2359,6 +2373,7 @@ fn build_explorer_pane(
             crate::assets::set_primary_icon(&icon, icon_name);
             name.set_visible(false);
             field.set_visible(true);
+            mode.set_label("");
             size.set_label("");
             kind.set_label("");
             crate::util::set_modified_date(&modified, None, "");
@@ -3095,6 +3110,13 @@ fn entry_type(entry: &FileEntry) -> &'static str {
         EntryKind::FileSymbolicLink => "File link",
         EntryKind::SymbolicLink => "Broken link",
         EntryKind::Other => "Other",
+    }
+}
+
+fn entry_mode(entry: &FileEntry) -> String {
+    match entry.mode {
+        MetadataValue::Known(mode) => super::browser::format_permissions(mode),
+        MetadataValue::Unknown | MetadataValue::Unavailable => String::new(),
     }
 }
 

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -8,7 +8,7 @@
 
 use std::{
     cell::{Cell, RefCell},
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     rc::{Rc, Weak},
 };
 
@@ -723,6 +723,13 @@ impl ModeViews {
                     sync_grid_groups(pane);
                     if !pane.spinner.is_spinning() {
                         show_count(pane);
+                    }
+                }
+            }
+            BrowserEvent::MetadataFilled { depth, updates } => {
+                if self.mode == BrowserMode::Explorer {
+                    for pane in self.panes_at(*depth) {
+                        update_bound_explorer_metadata(pane, updates);
                     }
                 }
             }
@@ -3124,6 +3131,47 @@ fn entry_mode(entry: &FileEntry) -> String {
     match entry.mode {
         MetadataValue::Known(mode) => super::browser::format_permissions(mode),
         MetadataValue::Unknown | MetadataValue::Unavailable => String::new(),
+    }
+}
+
+fn update_bound_explorer_metadata(pane: &Pane, updates: &[(usize, FileEntry)]) {
+    let updates: HashMap<usize, &FileEntry> = updates
+        .iter()
+        .map(|(position, entry)| (*position, entry))
+        .collect();
+    for section in pane.item_sections() {
+        section.bound_items.borrow_mut().retain(|bound| {
+            let (Some(item), Some(row)) = (bound.item.upgrade(), bound.widget.upgrade()) else {
+                return false;
+            };
+            let Some(position) =
+                source_position_for_view(&pane.model, Some(&section.view_model), item.position())
+            else {
+                return true;
+            };
+            let Some(entry) = updates.get(&position) else {
+                return true;
+            };
+            let Some(name_cell) = row.first_child().and_downcast::<gtk::Box>() else {
+                return true;
+            };
+            let Some(mode) = name_cell.next_sibling().and_downcast::<gtk::Label>() else {
+                return true;
+            };
+            let Some(size) = mode.next_sibling().and_downcast::<gtk::Label>() else {
+                return true;
+            };
+            let Some(kind) = size.next_sibling().and_downcast::<gtk::Label>() else {
+                return true;
+            };
+            let Some(modified) = kind.next_sibling().and_downcast::<gtk::Label>() else {
+                return true;
+            };
+            mode.set_label(&entry_mode(entry));
+            size.set_label(&entry_size(entry));
+            crate::util::set_modified_date(&modified, Some(entry), "—");
+            true
+        });
     }
 }
 

--- a/src/ui/browser_modes/tests.rs
+++ b/src/ui/browser_modes/tests.rs
@@ -83,13 +83,16 @@ fn alternate_modes_request_missing_metadata_for_bound_entries() {
         is_hidden: false,
     };
 
-    assert_eq!(metadata_fill_position(Some(7), &entry), Some(7));
-    assert_eq!(metadata_fill_position(None, &entry), None);
+    assert_eq!(metadata_fill_position(Some(7), &entry, false), Some(7));
+    assert_eq!(metadata_fill_position(None, &entry, false), None);
 
     entry.size = MetadataValue::Known(100);
-    assert_eq!(metadata_fill_position(Some(7), &entry), Some(7));
+    assert_eq!(metadata_fill_position(Some(7), &entry, false), Some(7));
     entry.modified_unix_seconds = MetadataValue::Known(1);
-    assert_eq!(metadata_fill_position(Some(7), &entry), None);
+    assert_eq!(metadata_fill_position(Some(7), &entry, false), None);
+    assert_eq!(metadata_fill_position(Some(7), &entry, true), Some(7));
+    entry.mode = MetadataValue::Known(0o100644);
+    assert_eq!(metadata_fill_position(Some(7), &entry, true), None);
 }
 
 #[test]

--- a/src/ui/browser_modes/tests.rs
+++ b/src/ui/browser_modes/tests.rs
@@ -79,6 +79,7 @@ fn alternate_modes_request_missing_metadata_for_bound_entries() {
         kind: EntryKind::File,
         size: MetadataValue::Unknown,
         modified_unix_seconds: MetadataValue::Unknown,
+        mode: MetadataValue::Unknown,
         is_hidden: false,
     };
 

--- a/src/ui/preview/tests.rs
+++ b/src/ui/preview/tests.rs
@@ -71,6 +71,7 @@ fn preview_drag_entries_wraps_loaded_file_entry() {
         kind: crate::model::EntryKind::File,
         size: crate::model::MetadataValue::Known(100),
         modified_unix_seconds: crate::model::MetadataValue::Known(1),
+        mode: crate::model::MetadataValue::Unknown,
         is_hidden: false,
     };
     let dragged = preview_drag_entries(Some(&entry));

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -266,6 +266,7 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
                 size: MetadataValue::Unknown,
                 modified_unix_seconds: MetadataValue::Unknown,
                 is_hidden: false,
+                mode: MetadataValue::Unknown,
             });
         }
     });


### PR DESCRIPTION
## Summary
- Adds a **Mode** column to the Explorer view, placed between Name and Size
- Displays the symbolic unix permission string (e.g. `rw-r--r--  644`) using the existing `format_permissions` helper from the properties dialog
- The column is non-sortable (no sort arrow or click handler)
- Queries `unix::mode` via GIO alongside the existing directory attributes
- Adds `mode: MetadataValue<u32>` to `FileEntry`

#### Test plan
- [x] Switch to Explorer view — Mode column appears after Name, before Size
- [x] Permission strings display correctly for files and folders
- [x] Column is resizable like the others
- [x] Clicking the Mode header does not trigger sorting
- [x] Other columns still sort correctly
<img width="1616" height="840" alt="image" src="https://github.com/user-attachments/assets/fe2a93a9-c139-4ceb-bc76-507d317f81a7" />