### PR TITLE
fix(navigation): keep the address-bar scrollbar from expanding

### DIFF
--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -409,6 +409,7 @@ impl BrowserView {
             .vscrollbar_policy(gtk::PolicyType::Never)
             .hexpand(true)
             .build();
+        breadcrumb_scroller.add_css_class("fixed-scrollbar");
         let location_stack = gtk::Stack::builder()
             .hhomogeneous(false)
             .vhomogeneous(false)


### PR DESCRIPTION
## Description

The breadcrumb `ScrolledWindow` was the only scroller in the interface without the shared
`fixed-scrollbar` class, so its horizontal scrollbar grew on hover and while dragging and shifted
the address-bar layout. Adding the class reuses the treatment the browser panes already have and
keeps the scrollbar at a constant size in every state.

## Visual evidence

Verified on Hyprland with a temporary probe build that forced the breadcrumb scrollbar to stay
visible, so the hover geometry could be compared directly:

- Before: hovering the address-bar scrollbar drew a full-height trough with a fat slider
  (~13 px tall), pushing the breadcrumb row.
- After: the same hover keeps a 5 px scrollbar with a 3 px slider and no trough, identical to the
  pane scrollers, and the address-bar height does not change.

Screenshots could not be attached from the CLI; the comparison above is what the probe build showed.

## How to test

1. Open a path deep enough that the address-bar breadcrumbs overflow horizontally.
2. Hover the pointer over the breadcrumb scrollbar and drag it.

**Expected result:** the scrollbar stays the same narrow size while hovering and dragging, remains
usable for scrolling the breadcrumbs, and the address bar and toolbar do not change height.

## Related issue

Closes #297