### PR TITLE
perf(browser): keep large listings scrolling after mode and filter ch…

### DIFF
--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -4439,14 +4439,11 @@ impl ViewState {
             scroll_column_to(column, position);
         }
         column.list.grab_focus();
-        let list = column.list.clone();
+        let list = column.list.downgrade();
         glib::idle_add_local_once(move || {
-            if let Some(position) = position
-                && position < list.model().map_or(0, |model| model.n_items())
-            {
-                list.scroll_to(position, gtk::ListScrollFlags::FOCUS, None);
+            if let Some(list) = list.upgrade() {
+                list.grab_focus();
             }
-            list.grab_focus();
         });
     }
 
@@ -4905,15 +4902,26 @@ impl ViewState {
                 gtk::gdk::FileList::static_type(),
                 gtk::gdk::DragAction::COPY | gtk::gdk::DragAction::MOVE,
             );
-            let highlighted_row = row.clone();
-            let highlight = move |target: &gtk::DropTarget, _, _| {
-                highlighted_row.add_css_class("drop-destination");
+            let highlighted_row = row.downgrade();
+            drop.connect_enter(move |target, _, _| {
+                if let Some(row) = highlighted_row.upgrade() {
+                    row.add_css_class("drop-destination");
+                }
                 file_drop_action(target)
-            };
-            drop.connect_enter(highlight.clone());
-            drop.connect_motion(highlight);
-            let highlighted_row = row.clone();
-            drop.connect_leave(move |_| highlighted_row.remove_css_class("drop-destination"));
+            });
+            let highlighted_row = row.downgrade();
+            drop.connect_motion(move |target, _, _| {
+                if let Some(row) = highlighted_row.upgrade() {
+                    row.add_css_class("drop-destination");
+                }
+                file_drop_action(target)
+            });
+            let highlighted_row = row.downgrade();
+            drop.connect_leave(move |_| {
+                if let Some(row) = highlighted_row.upgrade() {
+                    row.remove_css_class("drop-destination");
+                }
+            });
             let weak_state_for_accept = weak_state.clone();
             let accepted_item = item.downgrade();
             let map_for_accept = map_for_hover.clone();
@@ -4937,8 +4945,11 @@ impl ViewState {
             let weak_state_for_drop = weak_state.clone();
             let dropped_item = item.downgrade();
             let map_for_drop = map_for_hover.clone();
-            let dropped_row = row.clone();
+            let dropped_row = row.downgrade();
             drop.connect_drop(move |target, value, _, _| {
+                let Some(dropped_row) = dropped_row.upgrade() else {
+                    return false;
+                };
                 dropped_row.remove_css_class("drop-destination");
                 let Some(state) = weak_state_for_drop.upgrade() else {
                     return false;
@@ -5368,8 +5379,12 @@ impl ViewState {
             self,
             presentation.stack.upcast_ref(),
             {
-                let entries = selection.clone();
-                Rc::new(move || entries.n_items() > 0)
+                let entries = selection.downgrade();
+                Rc::new(move || {
+                    entries
+                        .upgrade()
+                        .is_some_and(|entries| entries.n_items() > 0)
+                })
             },
             Rc::new(|picked| is_file_row_target(picked.clone())),
             depth,
@@ -5922,6 +5937,45 @@ fn set_filter_placeholder(column: &ColumnView, count: usize) {
 
 pub(crate) const FILTER_DEBOUNCE_DELAY: Duration = Duration::from_millis(200);
 
+/// `scroll_to` before the view has a real height leaves ListView/GridView with a
+/// one-row widget pool, so scrolling after a mode switch stays janky.
+pub(crate) fn scroll_collection_when_allocated(view: &gtk::Widget, position: u32) {
+    if view.height() > 1 {
+        apply_collection_scroll(view, position);
+        return;
+    }
+    // ponytail: a few frames is enough for the first layout. Upgrade: a real
+    // allocate listener if GTK grows one that is safe to scroll from.
+    let frames = Cell::new(0u8);
+    view.add_tick_callback(move |view, _| {
+        if view.height() > 1 {
+            apply_collection_scroll(view, position);
+            return glib::ControlFlow::Break;
+        }
+        let waited = frames.get().saturating_add(1);
+        frames.set(waited);
+        if waited >= 8 {
+            glib::ControlFlow::Break
+        } else {
+            glib::ControlFlow::Continue
+        }
+    });
+}
+
+fn apply_collection_scroll(view: &gtk::Widget, position: u32) {
+    if let Ok(list) = view.clone().downcast::<gtk::ListView>() {
+        if position < list.model().map_or(0, |model| model.n_items()) {
+            list.scroll_to(position, gtk::ListScrollFlags::FOCUS, None);
+        }
+        return;
+    }
+    if let Ok(grid) = view.clone().downcast::<gtk::GridView>()
+        && position < grid.model().map_or(0, |model| model.n_items())
+    {
+        grid.scroll_to(position, gtk::ListScrollFlags::FOCUS, None);
+    }
+}
+
 pub(crate) fn detach_collection_view(view: &impl IsA<gtk::Widget>) {
     let view = view.as_ref();
     if let Ok(list) = view.clone().downcast::<gtk::ListView>() {
@@ -6205,18 +6259,7 @@ fn scroll_column_to(column: &ColumnView, position: u32) {
     if position >= column.selection.n_items() {
         return;
     }
-    column
-        .list
-        .scroll_to(position, gtk::ListScrollFlags::FOCUS, None);
-    if column.list.is_mapped() && column.list.height() > 1 {
-        return;
-    }
-    let list = column.list.clone();
-    glib::idle_add_local_once(move || {
-        if position < list.model().map_or(0, |model| model.n_items()) {
-            list.scroll_to(position, gtk::ListScrollFlags::FOCUS, None);
-        }
-    });
+    scroll_collection_when_allocated(column.list.upcast_ref(), position);
 }
 
 fn set_column_selection(column: &ColumnView, position: u32) {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -650,11 +650,13 @@ impl BrowserView {
         if mode == previous {
             return;
         }
+        self.state.mode_views.borrow().show_mode(mode);
         self.state.mode_views.borrow_mut().prepare_mode(mode);
         if mode == BrowserMode::Columns {
             self.state.rebuild_columns();
+        } else if let Some(depth) = self.state.browser.active_depth() {
+            self.state.mode_views.borrow().focus_visible_pane(depth);
         }
-        self.state.mode_views.borrow().show_mode(mode);
         match previous {
             BrowserMode::Columns => self.state.truncate(0),
             BrowserMode::Grid | BrowserMode::Explorer => self
@@ -4150,9 +4152,7 @@ impl ViewState {
                         && self.active_new_entry.borrow().is_none()
                     {
                         if let Some(focused) = column.map.view_position(*focused) {
-                            column
-                                .list
-                                .scroll_to(focused, gtk::ListScrollFlags::FOCUS, None);
+                            scroll_column_to(column, focused);
                         }
                         if *take_focus && self.mode_views.borrow().mode() == BrowserMode::Columns {
                             column.list.grab_focus();
@@ -4169,11 +4169,7 @@ impl ViewState {
                     {
                         set_column_selection(column, filtered_position);
                         if !editing {
-                            column.list.scroll_to(
-                                filtered_position,
-                                gtk::ListScrollFlags::FOCUS,
-                                None,
-                            );
+                            scroll_column_to(column, filtered_position);
                         }
                     }
                     if !editing && self.mode_views.borrow().mode() == BrowserMode::Columns {
@@ -4431,15 +4427,27 @@ impl ViewState {
         let Some(column) = columns.get(depth) else {
             return;
         };
-        if let Some((focused_depth, position, _)) = self.browser.focused_item()
-            && focused_depth == depth
-            && let Some(position) = column.map.view_position(position)
-        {
-            column
-                .list
-                .scroll_to(position, gtk::ListScrollFlags::FOCUS, None);
+        let position = self
+            .browser
+            .focused_item()
+            .and_then(|(focused_depth, position, _)| {
+                (focused_depth == depth)
+                    .then(|| column.map.view_position(position))
+                    .flatten()
+            });
+        if let Some(position) = position {
+            scroll_column_to(column, position);
         }
         column.list.grab_focus();
+        let list = column.list.clone();
+        glib::idle_add_local_once(move || {
+            if let Some(position) = position
+                && position < list.model().map_or(0, |model| model.n_items())
+            {
+                list.scroll_to(position, gtk::ListScrollFlags::FOCUS, None);
+            }
+            list.grab_focus();
+        });
     }
 
     fn event_refreshes_active_path(event: &BrowserEvent) -> bool {
@@ -4820,18 +4828,22 @@ impl ViewState {
             row.append(&middle);
             row.append(&chevron);
             let motion = gtk::EventControllerMotion::new();
-            let list_item = item.clone();
-            let anchor: gtk::Widget = row.clone().upcast();
+            let list_item = item.downgrade();
             let weak_state_for_enter = weak_state.clone();
             let map_for_enter = map_for_hover.clone();
-            motion.connect_enter(move |_, _, _| {
+            motion.connect_enter(move |controller, _, _| {
+                let Some(item) = list_item.upgrade() else {
+                    return;
+                };
                 if let Some(state) = weak_state_for_enter.upgrade() {
-                    let source_position = map_for_enter.source_position(list_item.position());
+                    let source_position = map_for_enter.source_position(item.position());
                     let entry = source_position
                         .and_then(|position| state.browser.entry_at(depth, position));
                     if let Some(entry) = entry {
                         if entry.is_directory() {
-                            state.schedule_peek(depth, entry.location, anchor.clone());
+                            if let Some(anchor) = controller.widget() {
+                                state.schedule_peek(depth, entry.location, anchor);
+                            }
                         } else {
                             cancel_source(&state.pending_peek);
                             state.browser.close_peek();
@@ -4851,12 +4863,14 @@ impl ViewState {
                 .actions(gtk::gdk::DragAction::COPY | gtk::gdk::DragAction::MOVE)
                 .build();
             let weak_state_for_drag = weak_state.clone();
-            let dragged_item = item.clone();
+            let dragged_item = item.downgrade();
             let map_for_drag = map_for_hover.clone();
-            let prepare_row = row.clone();
+            let prepare_row = row.downgrade();
             drag.connect_prepare(move |source, x, y| {
+                let prepare_row = prepare_row.upgrade()?;
                 prepare_row.remove_css_class("slide-out");
                 let state = weak_state_for_drag.upgrade()?;
+                let dragged_item = dragged_item.upgrade()?;
                 let source_position = map_for_drag.source_position(dragged_item.position())?;
                 let entry = state.browser.entry_at(depth, source_position)?;
                 let selected = state.browser.selected_entries();
@@ -4872,12 +4886,18 @@ impl ViewState {
                 source.set_icon(Some(&paintable), x.round() as i32, y.round() as i32);
                 file_drag_content(&entries)
             });
-            let dragged_row = row.clone();
-            drag.connect_drag_begin(move |_, _| dragged_row.add_css_class("dragging"));
-            let dragged_row = row.clone();
+            let dragged_row = row.downgrade();
+            drag.connect_drag_begin(move |_, _| {
+                if let Some(row) = dragged_row.upgrade() {
+                    row.add_css_class("dragging");
+                }
+            });
+            let dragged_row = row.downgrade();
             drag.connect_drag_end(move |_, _, _| {
-                dragged_row.remove_css_class("dragging");
-                slide_out(&dragged_row);
+                if let Some(row) = dragged_row.upgrade() {
+                    row.remove_css_class("dragging");
+                    slide_out(&row);
+                }
             });
             row.add_controller(drag);
 
@@ -4895,10 +4915,13 @@ impl ViewState {
             let highlighted_row = row.clone();
             drop.connect_leave(move |_| highlighted_row.remove_css_class("drop-destination"));
             let weak_state_for_accept = weak_state.clone();
-            let accepted_item = item.clone();
+            let accepted_item = item.downgrade();
             let map_for_accept = map_for_hover.clone();
             drop.connect_accept(move |_, offered| {
                 let Some(state) = weak_state_for_accept.upgrade() else {
+                    return false;
+                };
+                let Some(accepted_item) = accepted_item.upgrade() else {
                     return false;
                 };
                 let entry = map_for_accept
@@ -4912,12 +4935,15 @@ impl ViewState {
                 })
             });
             let weak_state_for_drop = weak_state.clone();
-            let dropped_item = item.clone();
+            let dropped_item = item.downgrade();
             let map_for_drop = map_for_hover.clone();
             let dropped_row = row.clone();
             drop.connect_drop(move |target, value, _, _| {
                 dropped_row.remove_css_class("drop-destination");
                 let Some(state) = weak_state_for_drop.upgrade() else {
+                    return false;
+                };
+                let Some(dropped_item) = dropped_item.upgrade() else {
                     return false;
                 };
                 let Some(destination) = map_for_drop
@@ -4944,12 +4970,15 @@ impl ViewState {
             let weak_state_for_click = weak_state.clone();
             selection_click.set_button(1);
             selection_click.set_propagation_phase(gtk::PropagationPhase::Capture);
-            let clicked_item = item.clone();
+            let clicked_item = item.downgrade();
             let selection_for_click = selection_for_rows.clone();
             let selection_anchor_for_click = mouse_selection_anchor.clone();
             let modified_for_click = modified_selection_for_rows.clone();
             let map_for_click = map_for_hover.clone();
             selection_click.connect_pressed(move |gesture, press_count, _, _| {
+                let Some(clicked_item) = clicked_item.upgrade() else {
+                    return;
+                };
                 let position = clicked_item.position();
                 if position == gtk::INVALID_LIST_POSITION {
                     return;
@@ -5096,11 +5125,10 @@ impl ViewState {
             } else {
                 source_position.and_then(|position| browser?.entry_at(depth, position))
             };
-            let active = source_position.is_some_and(|position| {
+            let active = entry.as_ref().is_some_and(|entry| {
                 browser
                     .as_ref()
-                    .and_then(|browser| browser.active_child_position(depth))
-                    == Some(position)
+                    .is_some_and(|browser| browser.is_open_child(depth, &entry.location))
             });
             set_active_path_style(&row, active);
             set_cut_path_style(
@@ -5388,9 +5416,9 @@ impl ViewState {
         let resize_start = Rc::new(Cell::new(COLUMN_WIDTH));
         let pointer_start = Rc::new(Cell::new(None));
         let last_press = Rc::new(Cell::new(0u64));
-        let shell_for_resize_start = shell.clone();
-        let shell_for_autofit = shell.clone();
-        let column_for_autofit = column.clone();
+        let shell_for_resize_start = shell.downgrade();
+        let shell_for_autofit = shell.downgrade();
+        let column_for_autofit = column.downgrade();
         let resize_start_for_begin = resize_start.clone();
         let pointer_start_for_begin = pointer_start.clone();
         let last_press_for_begin = last_press.clone();
@@ -5398,9 +5426,17 @@ impl ViewState {
             let now = glib::monotonic_time() as u64;
             let prev = last_press_for_begin.get();
             last_press_for_begin.set(now);
+            let Some(shell_for_autofit) = shell_for_autofit.upgrade() else {
+                return;
+            };
+            let Some(shell_for_resize_start) = shell_for_resize_start.upgrade() else {
+                return;
+            };
             if now.wrapping_sub(prev) <= 400_000 {
-                let max_natural =
-                    max_child_natural_width(column_for_autofit.upcast_ref::<gtk::Widget>());
+                let max_natural = column_for_autofit
+                    .upgrade()
+                    .map(|column| max_child_natural_width(column.upcast_ref::<gtk::Widget>()))
+                    .unwrap_or(COLUMN_WIDTH);
                 shell_for_autofit.set_size_request(max_natural.max(COLUMN_WIDTH), -1);
                 gesture.set_state(gtk::EventSequenceState::Denied);
                 return;
@@ -5412,8 +5448,11 @@ impl ViewState {
             }
             gesture.set_state(gtk::EventSequenceState::Claimed);
         });
-        let shell_for_resize = shell.clone();
+        let shell_for_resize = shell.downgrade();
         resize.connect_drag_update(move |gesture, fallback_offset_x, _| {
+            let Some(shell_for_resize) = shell_for_resize.upgrade() else {
+                return;
+            };
             let pointer_x = gesture
                 .current_event()
                 .and_then(|event| event.position())
@@ -5480,9 +5519,12 @@ impl ViewState {
         let animation_id = self.horizontal_scroll_generation.get().saturating_add(1);
         self.horizontal_scroll_generation.set(animation_id);
         let weak = Rc::downgrade(self);
-        let measured_shell = shell;
+        let measured_shell = shell.downgrade();
         let _tick = self.scroller.add_tick_callback(move |_, _| {
             let Some(state) = weak.upgrade() else {
+                return glib::ControlFlow::Break;
+            };
+            let Some(measured_shell) = measured_shell.upgrade() else {
                 return glib::ControlFlow::Break;
             };
             if state.horizontal_scroll_generation.get() != animation_id
@@ -5729,6 +5771,10 @@ impl ViewState {
             column
                 .animation_generation
                 .set(column.animation_generation.get().saturating_add(1));
+            column.syncing_selection.set(true);
+            column.selection.set_model(None::<&gio::ListModel>);
+            column.filtered_model.set_model(None::<&gio::ListModel>);
+            detach_collection_view(&column.list);
             self.columns_widget.remove(&column.shell);
             self.overlay.remove_overlay(&column.marquee.band());
         }
@@ -5876,6 +5922,17 @@ fn set_filter_placeholder(column: &ColumnView, count: usize) {
 
 pub(crate) const FILTER_DEBOUNCE_DELAY: Duration = Duration::from_millis(200);
 
+pub(crate) fn detach_collection_view(view: &impl IsA<gtk::Widget>) {
+    let view = view.as_ref();
+    if let Ok(list) = view.clone().downcast::<gtk::ListView>() {
+        list.set_factory(None::<&gtk::ListItemFactory>);
+        list.set_model(None::<&gtk::SelectionModel>);
+    } else if let Ok(grid) = view.clone().downcast::<gtk::GridView>() {
+        grid.set_factory(None::<&gtk::ListItemFactory>);
+        grid.set_model(None::<&gtk::SelectionModel>);
+    }
+}
+
 pub(crate) fn debounce_filter_entry(entry: &gtk::Entry, on_settled: impl Fn(String) + 'static) {
     let pending: Rc<RefCell<Option<glib::SourceId>>> = Rc::new(RefCell::new(None));
     let on_settled = Rc::new(on_settled);
@@ -5901,6 +5958,21 @@ pub(crate) fn filter_change_for(previous: &str, settled: &str) -> gtk::FilterCha
     } else {
         gtk::FilterChange::Different
     }
+}
+
+pub(crate) fn notify_filter_query(
+    filter: &gtk::CustomFilter,
+    query: &RefCell<String>,
+    text: String,
+) {
+    let settled = text.to_lowercase();
+    let previous = query.borrow().clone();
+    if previous == settled {
+        return;
+    }
+    let change = filter_change_for(&previous, &settled);
+    *query.borrow_mut() = settled;
+    filter.changed(change);
 }
 
 pub(crate) fn apply_filter_query(
@@ -6127,6 +6199,24 @@ fn touch_source_model(column: &ColumnView) {
     column
         .model_generation
         .set(column.model_generation.get().saturating_add(1));
+}
+
+fn scroll_column_to(column: &ColumnView, position: u32) {
+    if position >= column.selection.n_items() {
+        return;
+    }
+    column
+        .list
+        .scroll_to(position, gtk::ListScrollFlags::FOCUS, None);
+    if column.list.is_mapped() && column.list.height() > 1 {
+        return;
+    }
+    let list = column.list.clone();
+    glib::idle_add_local_once(move || {
+        if position < list.model().map_or(0, |model| model.n_items()) {
+            list.scroll_to(position, gtk::ListScrollFlags::FOCUS, None);
+        }
+    });
 }
 
 fn set_column_selection(column: &ColumnView, position: u32) {

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1540,3 +1540,93 @@ fn move_to_trash_stays_visible_inside_trash_regardless_of_can_trash() {
     assert!(move_to_trash_is_visible(true, Some(false)));
     assert!(move_to_trash_is_visible(true, None));
 }
+
+fn mapped_source(values: &[&str]) -> EntryListModel {
+    let owned: Vec<String> = values.iter().map(|value| (*value).to_owned()).collect();
+    let model = EntryListModel::new(std::rc::Rc::new(move |position| {
+        owned.get(position as usize).cloned()
+    }));
+    model.replace(values.len() as u32);
+    model
+}
+
+#[test]
+fn unfiltered_visible_listings_keep_source_order() {
+    let source = mapped_source(&["fv\ta", "fv\tb", "fv\tc"]);
+    let map = rebuild_position_map(&source, "", true, 1);
+    assert_eq!(map.forward, vec![0, 1, 2]);
+    assert_eq!(map.reverse, vec![0, 1, 2]);
+}
+
+#[test]
+fn hidden_entries_are_omitted_from_the_position_map() {
+    let source = mapped_source(&["fv\talpha", "dh\t.secret", "fv\tzulu"]);
+    let map = rebuild_position_map(&source, "", false, 1);
+    assert_eq!(map.forward, vec![0, 2]);
+    assert_eq!(map.reverse[0], 0);
+    assert_eq!(map.reverse[1], NO_FILTERED_POSITION);
+    assert_eq!(map.reverse[2], 1);
+}
+
+#[test]
+fn filter_queries_keep_matches_near_the_end() {
+    let source = mapped_source(&["fv\talpha", "fv\tbeta", "fv\tzulu"]);
+    let map = rebuild_position_map(&source, "zu", true, 4);
+    assert_eq!(map.forward, vec![2]);
+    assert_eq!(map.query, "zu");
+    assert_eq!(map.generation, 4);
+}
+
+#[test]
+fn filter_change_for_classifies_tightening_and_loosening() {
+    assert_eq!(filter_change_for("", "a"), gtk::FilterChange::MoreStrict);
+    assert_eq!(filter_change_for("a", "ab"), gtk::FilterChange::MoreStrict);
+    assert_eq!(filter_change_for("ab", "a"), gtk::FilterChange::LessStrict);
+    assert_eq!(filter_change_for("a", ""), gtk::FilterChange::LessStrict);
+    assert_eq!(filter_change_for("a", "b"), gtk::FilterChange::Different);
+    assert_eq!(filter_change_for("ab", "ac"), gtk::FilterChange::Different);
+}
+
+const FILTER_QUERY_GTK_CHILD: &str = "STRATA_FILTER_QUERY_GTK_CHILD";
+const FILTER_QUERY_TEST: &str =
+    "ui::browser::tests::notify_filter_query_skips_unchanged_folded_text";
+
+fn assert_notify_filter_query_skips_unchanged_folded_text() {
+    use gtk::prelude::*;
+    use std::{cell::Cell, rc::Rc};
+
+    let filter = gtk::CustomFilter::new(|_| true);
+    let emissions = Rc::new(Cell::new(0u32));
+    let emissions_for_signal = emissions.clone();
+    filter.connect_changed(move |_, _| {
+        emissions_for_signal.set(emissions_for_signal.get() + 1);
+    });
+    let query = std::cell::RefCell::new(String::new());
+
+    notify_filter_query(&filter, &query, "Abc".into());
+    assert_eq!(query.borrow().as_str(), "abc");
+    assert_eq!(emissions.get(), 1);
+
+    notify_filter_query(&filter, &query, "ABC".into());
+    assert_eq!(query.borrow().as_str(), "abc");
+    assert_eq!(emissions.get(), 1);
+}
+
+#[test]
+fn notify_filter_query_skips_unchanged_folded_text() {
+    if std::env::var_os(FILTER_QUERY_GTK_CHILD).is_some() {
+        if gtk::init().is_err() {
+            return;
+        }
+        assert_notify_filter_query_skips_unchanged_folded_text();
+        return;
+    }
+
+    let status =
+        std::process::Command::new(std::env::current_exe().expect("test executable should exist"))
+            .args(["--exact", FILTER_QUERY_TEST])
+            .env(FILTER_QUERY_GTK_CHILD, "1")
+            .status()
+            .expect("isolated GTK filter-query test should start");
+    assert!(status.success(), "isolated GTK filter-query test failed");
+}

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1630,3 +1630,40 @@ fn notify_filter_query_skips_unchanged_folded_text() {
             .expect("isolated GTK filter-query test should start");
     assert!(status.success(), "isolated GTK filter-query test failed");
 }
+
+const SCROLL_PIN_GTK_CHILD: &str = "STRATA_SCROLL_PIN_GTK_CHILD";
+const SCROLL_PIN_TEST: &str =
+    "ui::browser::tests::waiting_to_scroll_does_not_pin_an_unallocated_view";
+
+fn assert_waiting_to_scroll_does_not_pin_an_unallocated_view() {
+    let model = gtk::StringList::new(&["fv\talpha"]);
+    let selection = gtk::NoSelection::new(Some(model));
+    let list = gtk::ListView::new(Some(selection), Some(gtk::SignalListItemFactory::new()));
+    let weak = list.downgrade();
+    scroll_collection_when_allocated(list.upcast_ref(), 0);
+    drop(list);
+    while glib::MainContext::default().iteration(false) {}
+    assert!(
+        weak.upgrade().is_none(),
+        "deferred scroll must not pin the collection view"
+    );
+}
+
+#[test]
+fn waiting_to_scroll_does_not_pin_an_unallocated_view() {
+    if std::env::var_os(SCROLL_PIN_GTK_CHILD).is_some() {
+        if gtk::init().is_err() {
+            return;
+        }
+        assert_waiting_to_scroll_does_not_pin_an_unallocated_view();
+        return;
+    }
+
+    let status =
+        std::process::Command::new(std::env::current_exe().expect("test executable should exist"))
+            .args(["--exact", SCROLL_PIN_TEST])
+            .env(SCROLL_PIN_GTK_CHILD, "1")
+            .status()
+            .expect("isolated GTK scroll pin test should start");
+    assert!(status.success(), "isolated GTK scroll pin test failed");
+}

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -3377,8 +3377,7 @@ fn update_bound_explorer_metadata(pane: &Pane, updates: &[(usize, FileEntry)]) {
                 &pane.source_index,
                 Some(&section.view_model),
                 item.position(),
-            )
-            else {
+            ) else {
                 return true;
             };
             let Some(entry) = updates.get(&position) else {

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -956,11 +956,15 @@ impl ModeViews {
             return;
         };
         let sections = Rc::downgrade(&pane.sections);
-        let entries = pane.model.clone();
+        let entries = pane.model.downgrade();
         super::browser::install_folder_context_menu(
             &state,
             pane.stack.upcast_ref(),
-            Rc::new(move || entries.n_items() > 0),
+            Rc::new(move || {
+                entries
+                    .upgrade()
+                    .is_some_and(|entries| entries.n_items() > 0)
+            }),
             Rc::new(move |picked| {
                 sections.upgrade().is_some_and(|sections| {
                     sections
@@ -1380,6 +1384,7 @@ fn build_grid_pane(
         flattened_models.append(&filtered_model.clone().upcast::<gio::ListModel>());
         let view_model = gtk::FlattenListModel::new(Some(flattened_models));
         let section = build_grid_view(&context, &view_model, true);
+        section.view.set_vexpand(true);
         sections.borrow_mut().push(section.clone());
         (section.view.clone(), section, None)
     };
@@ -2462,6 +2467,7 @@ fn build_explorer_pane(
         view.set_header_factory(Some(&type_group_header_factory()));
     }
     view.set_enable_rubberband(false);
+    view.set_vexpand(true);
     // GTK bundles single-click activation with hover selection, which collapses
     // multi-selection. Per-row gestures honor the configured click behavior instead.
     view.set_single_click_activate(false);
@@ -3136,25 +3142,7 @@ fn scroll_pane_to_source(pane: &Pane, source_position: usize) {
 }
 
 fn scroll_collection_to(view: &gtk::Widget, position: u32) {
-    apply_collection_scroll(view, position);
-    let view = view.clone();
-    glib::idle_add_local_once(move || {
-        apply_collection_scroll(&view, position);
-    });
-}
-
-fn apply_collection_scroll(view: &gtk::Widget, position: u32) {
-    if let Ok(list) = view.clone().downcast::<gtk::ListView>() {
-        if position < list.model().map_or(0, |model| model.n_items()) {
-            list.scroll_to(position, gtk::ListScrollFlags::FOCUS, None);
-        }
-        return;
-    }
-    if let Ok(grid) = view.clone().downcast::<gtk::GridView>()
-        && position < grid.model().map_or(0, |model| model.n_items())
-    {
-        grid.scroll_to(position, gtk::ListScrollFlags::FOCUS, None);
-    }
+    super::browser::scroll_collection_when_allocated(view, position);
 }
 
 fn set_mode_cut_style(widget: &impl IsA<gtk::Widget>, cut: bool) {

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -3373,8 +3373,11 @@ fn update_bound_explorer_metadata(pane: &Pane, updates: &[(usize, FileEntry)]) {
             let (Some(item), Some(row)) = (bound.item.upgrade(), bound.widget.upgrade()) else {
                 return false;
             };
-            let Some(position) =
-                source_position_for_view(&pane.model, Some(&section.view_model), item.position())
+            let Some(position) = source_position_for_view(
+                &pane.source_index,
+                Some(&section.view_model),
+                item.position(),
+            )
             else {
                 return true;
             };

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -22,6 +22,7 @@ use crate::{
 const EXPLORER_COLUMN_WIDTHS: [i32; 5] = [160, 110, 90, 120, 150];
 const EXPLORER_COLUMN_MIN_WIDTHS: [i32; 5] = [160, 80, 70, 80, 110];
 const DEFAULT_GRID_THUMBNAIL_SIZE: i32 = 64;
+const GRID_SCROLL_SETTLE_DELAY: std::time::Duration = std::time::Duration::from_millis(80);
 /// Margin and padding a grid card adds around its own width.
 const GRID_CARD_SPACING: i32 = 4;
 const FALLBACK_GRID_COLUMN_WIDTH: i32 = 160;
@@ -1278,6 +1279,7 @@ struct GridContext {
     new_entry_is_directory: Rc<Cell<bool>>,
     source_index: SourceIndexMap,
     sections: Weak<RefCell<Vec<PaneSection>>>,
+    scrolling: Rc<Cell<bool>>,
     density: Cell<BrowserDensity>,
 }
 
@@ -1348,6 +1350,7 @@ fn build_grid_pane(
         new_entry_is_directory: new_entry_is_directory.clone(),
         source_index: source_index.clone(),
         sections: Rc::downgrade(&sections),
+        scrolling: Rc::new(Cell::new(false)),
         density: Cell::new(options.density),
     });
     let (root, pane_section, groups) = if options.group_by_type {
@@ -1440,6 +1443,7 @@ fn build_grid_pane(
         .vexpand(true)
         .build();
     scroll.add_css_class("fixed-scrollbar");
+    install_grid_scroll_settle(&scroll, &context);
     if let Some(groups) = groups.clone() {
         let context = Rc::downgrade(&context);
         scroll
@@ -1647,6 +1651,7 @@ fn build_grid_view(
     });
     let browser_for_bind = Rc::downgrade(&context.browser);
     let source_index_for_bind = context.source_index.clone();
+    let scrolling_for_bind = context.scrolling.clone();
     let cuts_for_bind = context.cuts.clone();
     let thumbnail_size_for_bind = context.thumbnail_size.clone();
     let entry_kind_for_bind = context.new_entry_is_directory.clone();
@@ -1685,17 +1690,22 @@ fn build_grid_view(
             set_mode_cut_style(&card, cuts_for_bind.borrow().contains(&entry.location));
             label.set_label(&entry.display_name);
             label.set_tooltip_text(Some(&entry.display_name));
-            super::thumbnail::set_thumbnail_or_icon(
-                &icon,
-                &entry,
-                super::browser::entry_icon(&entry),
-                26,
-                thumbnail_size_for_bind.get(),
-            );
-            if let Some(position) = metadata_fill_position(source_position, &entry, false)
-                && let Some(browser) = browser.as_ref()
-            {
-                browser.request_metadata_fill(depth, position, entry.location.clone());
+            let fallback = super::browser::entry_icon(&entry);
+            if scrolling_for_bind.get() {
+                super::thumbnail::show_fallback_icon(&icon, fallback, 26);
+            } else {
+                super::thumbnail::set_thumbnail_or_icon(
+                    &icon,
+                    &entry,
+                    fallback,
+                    26,
+                    thumbnail_size_for_bind.get(),
+                );
+                if let Some(position) = metadata_fill_position(source_position, &entry, false)
+                    && let Some(browser) = browser.as_ref()
+                {
+                    browser.request_metadata_fill(depth, position, entry.location.clone());
+                }
             }
             icon.set_opacity(if entry.is_directory() { 1.0 } else { 0.72 });
         } else {
@@ -1880,12 +1890,69 @@ fn refresh_marquee_targets(pane: &Pane) {
         .collect();
 }
 
+fn install_grid_scroll_settle(scroll: &gtk::ScrolledWindow, context: &Rc<GridContext>) {
+    let pending = Rc::new(RefCell::new(None::<glib::SourceId>));
+    for adjustment in [scroll.vadjustment(), scroll.hadjustment()] {
+        let pending = pending.clone();
+        let context = Rc::downgrade(context);
+        adjustment.connect_value_changed(move |_| {
+            let Some(context) = context.upgrade() else {
+                return;
+            };
+            context.scrolling.set(true);
+            if let Some(source) = pending.borrow_mut().take() {
+                source.remove();
+            }
+            let pending_for_timeout = pending.clone();
+            let context = Rc::downgrade(&context);
+            pending.replace(Some(glib::timeout_add_local_once(
+                GRID_SCROLL_SETTLE_DELAY,
+                move || {
+                    pending_for_timeout.borrow_mut().take();
+                    let Some(context) = context.upgrade() else {
+                        return;
+                    };
+                    context.scrolling.set(false);
+                    refresh_grid_expensive_content(&context);
+                },
+            )));
+        });
+    }
+}
+
+fn refresh_grid_expensive_content(context: &GridContext) {
+    let Some(sections) = context.sections.upgrade() else {
+        return;
+    };
+    for section in sections.borrow().iter() {
+        refresh_grid_section(
+            &Rc::downgrade(&context.browser),
+            context.depth,
+            &context.source_index,
+            section,
+            context.thumbnail_size.get(),
+            true,
+        );
+    }
+}
+
 fn refresh_grid_thumbnail_size(
     browser: &Weak<Browser>,
     depth: usize,
     source_index: &SourceIndexMap,
     section: &PaneSection,
     size: i32,
+) {
+    refresh_grid_section(browser, depth, source_index, section, size, false);
+}
+
+fn refresh_grid_section(
+    browser: &Weak<Browser>,
+    depth: usize,
+    source_index: &SourceIndexMap,
+    section: &PaneSection,
+    size: i32,
+    request_metadata: bool,
 ) {
     let Some(browser) = browser.upgrade() else {
         return;
@@ -1920,6 +1987,11 @@ fn refresh_grid_thumbnail_size(
             26,
             size,
         );
+        if request_metadata
+            && let Some(position) = metadata_fill_position(Some(position), &entry, false)
+        {
+            browser.request_metadata_fill(depth, position, entry.location.clone());
+        }
         icon.set_opacity(if entry.is_directory() { 1.0 } else { 0.72 });
     });
 }

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -110,6 +110,65 @@ impl Default for ClickActivation {
     }
 }
 
+/// Maps a `StringList` item to its source index. Filter, sort, and flatten models
+/// pass those objects through, so bind can resolve without scanning the source.
+#[derive(Clone, Default)]
+struct SourceIndexMap {
+    by_item: Rc<RefCell<HashMap<glib::Object, usize>>>,
+}
+
+impl SourceIndexMap {
+    fn watch(source: &gtk::StringList) -> Self {
+        let map = Self::default();
+        let tracked = map.clone();
+        // Use the signal's list. Cloning it into this handler would pin the
+        // StringList (and every item) after the pane is dropped.
+        source.connect_items_changed(move |source, position, removed, added| {
+            tracked.apply(source, position, removed, added);
+        });
+        map.rebuild(source);
+        map
+    }
+
+    fn apply(&self, source: &gtk::StringList, position: u32, removed: u32, added: u32) {
+        let can_append = {
+            let by_item = self.by_item.borrow();
+            removed == 0
+                && position == by_item.len() as u32
+                && position.saturating_add(added) == source.n_items()
+        };
+        if can_append {
+            let mut by_item = self.by_item.borrow_mut();
+            for index in position..position.saturating_add(added) {
+                if let Some(item) = source.item(index) {
+                    by_item.insert(item, index as usize);
+                }
+            }
+            return;
+        }
+        self.rebuild(source);
+    }
+
+    fn rebuild(&self, source: &gtk::StringList) {
+        let n_items = source.n_items() as usize;
+        let mut by_item = HashMap::with_capacity(n_items);
+        for position in 0..source.n_items() {
+            if let Some(item) = source.item(position) {
+                by_item.insert(item, position as usize);
+            }
+        }
+        *self.by_item.borrow_mut() = by_item;
+    }
+
+    fn of_item(&self, item: &glib::Object) -> Option<usize> {
+        self.by_item.borrow().get(item).copied()
+    }
+
+    fn of_view_position(&self, view: &impl IsA<gio::ListModel>, position: u32) -> Option<usize> {
+        view.item(position).and_then(|item| self.of_item(&item))
+    }
+}
+
 struct ActiveModeRename {
     field: gtk::Entry,
     label: gtk::Label,
@@ -147,6 +206,7 @@ struct Pane {
     depth: usize,
     shell: gtk::Box,
     model: gtk::StringList,
+    source_index: SourceIndexMap,
     filter_model: Option<gtk::FilterListModel>,
     /// The section that owns the pane's chrome and hosts the inline new-entry row. In
     /// a grouped grid it holds nothing else, since entries live in group sections.
@@ -319,7 +379,11 @@ impl ModeViews {
             .item_sections()
             .iter()
             .flat_map(|section| {
-                selected_source_positions(&pane.model, &section.view_model, &section.selection)
+                selected_source_positions(
+                    &pane.source_index,
+                    &section.view_model,
+                    &section.selection,
+                )
             })
             .collect();
         positions.sort_unstable();
@@ -569,9 +633,6 @@ impl ModeViews {
             BrowserMode::Grid => "grid",
             BrowserMode::Explorer => "explorer",
         });
-        if let Some(depth) = self.browser.active_depth() {
-            self.focus_visible_pane(depth);
-        }
     }
 
     pub fn clear_inactive_mode(&mut self, mode: BrowserMode) {
@@ -653,10 +714,8 @@ impl ModeViews {
         }
         match event {
             BrowserEvent::Reset => {
-                clear_box(&self.grid_root);
-                self.grid_panes.clear();
-                clear_box(&self.explorer_root);
-                self.explorer_pane = None;
+                self.clear_grid();
+                self.clear_explorer();
             }
             BrowserEvent::ColumnsTruncated { .. } => match self.mode {
                 BrowserMode::Columns => {}
@@ -838,24 +897,28 @@ impl ModeViews {
         }
     }
 
-    fn focus_visible_pane(&self, depth: usize) {
-        match self.mode {
-            BrowserMode::Columns => {}
-            BrowserMode::Grid => {
-                if let Some(pane) = self.grid_panes.iter().find(|pane| pane.depth == depth) {
-                    pane.focus_view().grab_focus();
-                }
-            }
-            BrowserMode::Explorer => {
-                if let Some(pane) = self
-                    .explorer_pane
-                    .as_ref()
-                    .filter(|pane| pane.depth == depth)
-                {
-                    pane.focus_view().grab_focus();
-                }
-            }
-        }
+    pub fn focus_visible_pane(&self, depth: usize) {
+        let view = match self.mode {
+            BrowserMode::Columns => return,
+            BrowserMode::Grid => self
+                .grid_panes
+                .iter()
+                .find(|pane| pane.depth == depth)
+                .map(|pane| pane.focus_view()),
+            BrowserMode::Explorer => self
+                .explorer_pane
+                .as_ref()
+                .filter(|pane| pane.depth == depth)
+                .map(|pane| pane.focus_view()),
+        };
+        let Some(view) = view else {
+            return;
+        };
+        view.grab_focus();
+        let view = view.clone();
+        glib::idle_add_local_once(move || {
+            view.grab_focus();
+        });
     }
 
     fn all_panes(&self) -> Vec<&Pane> {
@@ -912,11 +975,17 @@ impl ModeViews {
     }
 
     fn clear_grid(&mut self) {
+        for pane in &self.grid_panes {
+            detach_pane_models(pane);
+        }
         clear_box(&self.grid_root);
         self.grid_panes.clear();
     }
 
     fn clear_explorer(&mut self) {
+        if let Some(pane) = self.explorer_pane.as_ref() {
+            detach_pane_models(pane);
+        }
         clear_box(&self.explorer_root);
         self.explorer_pane = None;
     }
@@ -949,9 +1018,9 @@ impl ModeViews {
             &snapshot.location.display_name(),
         );
         configure_grid_density(&pane, self.density);
-        apply_snapshot(&pane, &snapshot, &self.browser);
         self.install_context_menu(&pane);
         self.grid_root.append(&pane.shell);
+        apply_snapshot(&pane, &snapshot, &self.browser);
         self.grid_panes.push(pane);
     }
 
@@ -980,9 +1049,9 @@ impl ModeViews {
             depth,
             &snapshot.location.display_name(),
         );
-        apply_snapshot(&pane, &snapshot, &self.browser);
         self.install_context_menu(&pane);
         self.explorer_root.append(&pane.shell);
+        apply_snapshot(&pane, &snapshot, &self.browser);
         self.explorer_pane = Some(pane);
     }
 }
@@ -1203,7 +1272,7 @@ struct GridContext {
     thumbnail_size: Rc<Cell<i32>>,
     active_new_entry: Rc<RefCell<Option<ActiveModeNewEntry>>>,
     new_entry_is_directory: Rc<Cell<bool>>,
-    source: gtk::StringList,
+    source_index: SourceIndexMap,
     sections: Weak<RefCell<Vec<PaneSection>>>,
     density: Cell<BrowserDensity>,
 }
@@ -1242,6 +1311,7 @@ fn build_grid_pane(
         Some(controls.leading.clone().upcast()),
         Some(controls.actions.clone().upcast()),
     );
+    let source_index = SourceIndexMap::watch(&model);
     if let Some(destination) = browser.location_at(depth) {
         install_mode_directory_drop_target(&stack, destination, transfer_handler.clone());
     }
@@ -1254,9 +1324,10 @@ fn build_grid_pane(
     let filter = super::browser::entry_filter(show_hidden.clone(), filter_query.clone());
     let filtered_model = gtk::FilterListModel::new(Some(model.clone()), Some(filter.clone()));
     let filter_for_pane = filter.clone();
-    controls.filter_entry.connect_changed(move |entry| {
-        *filter_query.borrow_mut() = entry.text().to_lowercase();
-        filter.changed(gtk::FilterChange::Different);
+    let query_for_filter = filter_query.clone();
+    let filter_for_settled = filter.clone();
+    super::browser::debounce_filter_entry(&controls.filter_entry, move |text| {
+        super::browser::notify_filter_query(&filter_for_settled, &query_for_filter, text);
     });
     let new_entry_placeholder = gtk::StringList::new(&[]);
     let new_entry_is_directory = Rc::new(Cell::new(true));
@@ -1271,7 +1342,7 @@ fn build_grid_pane(
         thumbnail_size: options.thumbnail_size.clone(),
         active_new_entry: options.active_new_entry,
         new_entry_is_directory: new_entry_is_directory.clone(),
-        source: model.clone(),
+        source_index: source_index.clone(),
         sections: Rc::downgrade(&sections),
         density: Cell::new(options.density),
     });
@@ -1318,7 +1389,7 @@ fn build_grid_pane(
     let density_for_size = context.density.get();
     let sections_for_size = Rc::downgrade(&sections);
     let browser_for_size = Rc::downgrade(&context.browser);
-    let source_for_size = model.clone();
+    let source_index_for_size = source_index.clone();
     let thumbnail_size_for_change = options.thumbnail_size.clone();
     let value_for_change = controls.thumbnail_value.clone();
     controls
@@ -1331,7 +1402,7 @@ fn build_grid_pane(
             }
             let pending_for_timeout = pending_thumbnail_resize.clone();
             let browser = browser_for_size.clone();
-            let source = source_for_size.clone();
+            let source_index = source_index_for_size.clone();
             let sections = sections_for_size.clone();
             let groups_for_size = groups_for_pane.clone();
             let size_state = thumbnail_size_for_change.clone();
@@ -1343,7 +1414,7 @@ fn build_grid_pane(
                         return;
                     };
                     for section in sections.borrow().iter() {
-                        refresh_grid_thumbnail_size(&browser, depth, &source, section, size);
+                        refresh_grid_thumbnail_size(&browser, depth, &source_index, section, size);
                     }
                     if let Some(groups) = groups_for_size.as_ref() {
                         refresh_group_columns(groups, groups.container.width(), density_for_size);
@@ -1388,6 +1459,7 @@ fn build_grid_pane(
         depth,
         shell,
         model,
+        source_index,
         filter_model: Some(filtered_model),
         section: pane_section,
         sections,
@@ -1458,8 +1530,8 @@ fn build_grid_view(
     let browser_for_setup = Rc::downgrade(&context.browser);
     let previews_for_setup = context.click.previews.clone();
     let activation_for_setup = context.click.activation.clone();
-    let source_for_setup = context.source.clone();
     let filtered_for_setup = view_model.clone();
+    let source_index_for_setup = context.source_index.clone();
     let transfers_for_setup = context.transfer.clone();
     let peek_for_setup = context.state.clone();
     let active_for_setup = context.active_new_entry.clone();
@@ -1540,7 +1612,7 @@ fn build_grid_view(
             previews_for_setup.clone(),
             activation_for_setup.clone(),
             depth,
-            Some((source_for_setup.clone(), filtered_for_setup.clone())),
+            Some((source_index_for_setup.clone(), filtered_for_setup.clone())),
         );
         install_modified_selection_click(
             &card,
@@ -1553,7 +1625,7 @@ fn build_grid_view(
             item,
             peek_for_setup.clone(),
             browser_for_setup.clone(),
-            source_for_setup.clone(),
+            source_index_for_setup.clone(),
             filtered_for_setup.clone(),
             depth,
         );
@@ -1563,14 +1635,13 @@ fn build_grid_view(
             browser_for_setup.clone(),
             transfers_for_setup.clone(),
             depth,
-            Some((source_for_setup.clone(), filtered_for_setup.clone())),
+            Some((source_index_for_setup.clone(), filtered_for_setup.clone())),
         );
         item.set_child(Some(&card));
         register_bound_mode_item(&bound_items_for_setup, item, &card);
     });
     let browser_for_bind = Rc::downgrade(&context.browser);
-    let source_for_bind = context.source.clone();
-    let filtered_for_bind = view_model.clone();
+    let source_index_for_bind = context.source_index.clone();
     let cuts_for_bind = context.cuts.clone();
     let thumbnail_size_for_bind = context.thumbnail_size.clone();
     let entry_kind_for_bind = context.new_entry_is_directory.clone();
@@ -1596,8 +1667,9 @@ fn build_grid_view(
         let Some(field) = label.next_sibling().and_downcast::<gtk::Entry>() else {
             return;
         };
-        let source_position =
-            source_position_for_view(&source_for_bind, Some(&filtered_for_bind), item.position());
+        let source_position = item
+            .item()
+            .and_then(|value| source_index_for_bind.of_item(&value));
         let browser = browser_for_bind.upgrade();
         let entry = browser.as_ref().and_then(|browser| {
             source_position.and_then(|position| browser.entry_at(depth, position))
@@ -1643,12 +1715,12 @@ fn build_grid_view(
     configure_grid_view_density(&view, context.density.get());
 
     let weak_browser = Rc::downgrade(&context.browser);
-    let source_for_activation = context.source.clone();
+    let source_index_for_activation = context.source_index.clone();
     let filtered_for_activation = view_model.clone();
     view.connect_activate(move |_, position| {
         if let Some(browser) = weak_browser.upgrade()
             && let Some(position) = source_position_for_view(
-                &source_for_activation,
+                &source_index_for_activation,
                 Some(&filtered_for_activation),
                 position,
             )
@@ -1670,7 +1742,7 @@ fn build_grid_view(
             context.sections.clone(),
             &context.browser,
             depth,
-            context.source.clone(),
+            context.source_index.clone(),
         );
         install_exclusive_section_click(&section, context);
     }
@@ -1679,7 +1751,7 @@ fn build_grid_view(
             &state,
             &section,
             context.sections.clone(),
-            &context.source,
+            &context.source_index,
             depth,
         );
     }
@@ -1806,7 +1878,7 @@ fn refresh_marquee_targets(pane: &Pane) {
 fn refresh_grid_thumbnail_size(
     browser: &Weak<Browser>,
     depth: usize,
-    source: &gtk::StringList,
+    source_index: &SourceIndexMap,
     section: &PaneSection,
     size: i32,
 ) {
@@ -1830,9 +1902,7 @@ fn refresh_grid_thumbnail_size(
         else {
             return;
         };
-        let Some(position) =
-            source_position_for_view(source, Some(&section.view_model), item.position())
-        else {
+        let Some(position) = item.item().and_then(|value| source_index.of_item(&value)) else {
             return;
         };
         let Some(entry) = browser.entry_at(depth, position) else {
@@ -2149,6 +2219,7 @@ fn build_explorer_pane(
         Some(navigation.upcast()),
         Some(actions.upcast()),
     );
+    let source_index = SourceIndexMap::watch(&model);
     if let Some(destination) = browser.location_at(depth) {
         install_mode_directory_drop_target(&stack, destination, transfer_handler.clone());
     }
@@ -2161,9 +2232,10 @@ fn build_explorer_pane(
     let filter = super::browser::entry_filter(show_hidden.clone(), filter_query.clone());
     let filtered_model = gtk::FilterListModel::new(Some(model.clone()), Some(filter.clone()));
     let filter_for_pane = filter.clone();
-    filter_entry.connect_changed(move |entry| {
-        *filter_query.borrow_mut() = entry.text().to_lowercase();
-        filter.changed(gtk::FilterChange::Different);
+    let query_for_filter = filter_query.clone();
+    let filter_for_settled = filter.clone();
+    super::browser::debounce_filter_entry(&filter_entry, move |text| {
+        super::browser::notify_filter_query(&filter_for_settled, &query_for_filter, text);
     });
     let new_entry_placeholder = gtk::StringList::new(&[]);
     let new_entry_is_directory = Rc::new(Cell::new(true));
@@ -2195,7 +2267,7 @@ fn build_explorer_pane(
     let activation_for_setup = click_options.activation;
     let transfers_for_setup = transfer_handler.clone();
     let active_for_setup = active_new_entry.clone();
-    let source_for_setup = model.clone();
+    let source_index_for_setup = source_index.clone();
     let view_model_for_setup = view_model_object.clone();
     let folder_location = browser.location_at(depth);
     factory.connect_setup(move |_, item| {
@@ -2285,7 +2357,7 @@ fn build_explorer_pane(
             previews_for_setup.clone(),
             activation_for_setup.clone(),
             depth,
-            Some((source_for_setup.clone(), view_model_for_setup.clone())),
+            Some((source_index_for_setup.clone(), view_model_for_setup.clone())),
         );
         install_modified_selection_click(
             &row,
@@ -2299,14 +2371,13 @@ fn build_explorer_pane(
             browser_for_setup.clone(),
             transfers_for_setup.clone(),
             depth,
-            Some((source_for_setup.clone(), view_model_for_setup.clone())),
+            Some((source_index_for_setup.clone(), view_model_for_setup.clone())),
         );
         item.set_child(Some(&row));
         register_bound_mode_item(&bound_items_for_setup, item, &row);
     });
     let browser_for_bind = Rc::downgrade(&browser);
-    let source_for_bind = model.clone();
-    let view_model_for_bind = view_model_object.clone();
+    let source_index_for_bind = source_index.clone();
     let cuts_for_bind = cut_locations.clone();
     let entry_kind_for_bind = new_entry_is_directory.clone();
     factory.connect_bind(move |_, item| {
@@ -2340,11 +2411,9 @@ fn build_explorer_pane(
         let Some(modified) = kind.next_sibling().and_downcast::<gtk::Label>() else {
             return;
         };
-        let source_position = source_position_for_view(
-            &source_for_bind,
-            Some(&view_model_for_bind),
-            item.position(),
-        );
+        let source_position = item
+            .item()
+            .and_then(|value| source_index_for_bind.of_item(&value));
         let browser = browser_for_bind.upgrade();
         let entry = browser.as_ref().and_then(|browser| {
             source_position.and_then(|position| browser.entry_at(depth, position))
@@ -2397,12 +2466,12 @@ fn build_explorer_pane(
     // multi-selection. Per-row gestures honor the configured click behavior instead.
     view.set_single_click_activate(false);
     let weak_browser = Rc::downgrade(&browser);
-    let source_for_activation = model.clone();
+    let source_index_for_activation = source_index.clone();
     let view_model_for_activation = view_model_object.clone();
     view.connect_activate(move |_, position| {
         if let Some(browser) = weak_browser.upgrade()
             && let Some(position) = source_position_for_view(
-                &source_for_activation,
+                &source_index_for_activation,
                 Some(&view_model_for_activation),
                 position,
             )
@@ -2424,10 +2493,16 @@ fn build_explorer_pane(
         Rc::downgrade(&sections),
         &browser,
         depth,
-        model.clone(),
+        source_index.clone(),
     );
     if let Some(state) = options.state.as_ref().and_then(Weak::upgrade) {
-        install_section_context_menu(&state, &section, Rc::downgrade(&sections), &model, depth);
+        install_section_context_menu(
+            &state,
+            &section,
+            Rc::downgrade(&sections),
+            &source_index,
+            depth,
+        );
     }
     let scroll = gtk::ScrolledWindow::builder()
         .child(&view)
@@ -2457,6 +2532,7 @@ fn build_explorer_pane(
         depth,
         shell,
         model,
+        source_index,
         filter_model: Some(filtered_model),
         section,
         sections,
@@ -2639,7 +2715,7 @@ fn install_grid_peek(
     item: &gtk::ListItem,
     state: Option<Weak<super::browser::ViewState>>,
     browser: Weak<Browser>,
-    source: gtk::StringList,
+    source_index: SourceIndexMap,
     filtered: gio::ListModel,
     depth: usize,
 ) {
@@ -2647,22 +2723,25 @@ fn install_grid_peek(
         return;
     };
     let motion = gtk::EventControllerMotion::new();
-    let entered_item = item.clone();
-    let entered_card: gtk::Widget = card.clone().upcast();
+    let entered_item = item.downgrade();
     let state_for_enter = state.clone();
-    motion.connect_enter(move |_, _, _| {
+    motion.connect_enter(move |controller, _, _| {
+        let Some(entered_item) = entered_item.upgrade() else {
+            return;
+        };
         let position = entered_item.position();
         if position == gtk::INVALID_LIST_POSITION {
             return;
         }
-        let source_position = source_position_for_view(&source, Some(&filtered), position);
+        let source_position = source_position_for_view(&source_index, Some(&filtered), position);
         let entry = browser.upgrade().and_then(|browser| {
             source_position.and_then(|position| browser.entry_at(depth, position))
         });
-        if let (Some(state), Some(entry)) = (state_for_enter.upgrade(), entry)
+        if let (Some(state), Some(entry), Some(anchor)) =
+            (state_for_enter.upgrade(), entry, controller.widget())
             && entry.is_directory()
         {
-            state.schedule_peek(depth, entry.location, entered_card.clone());
+            state.schedule_peek(depth, entry.location, anchor);
         }
     });
     motion.connect_leave(move |_| {
@@ -2708,17 +2787,18 @@ fn install_explorer_drag_drop(
     browser: Weak<Browser>,
     transfer_handler: TransferHandlerSlot,
     depth: usize,
-    position_map: Option<(gtk::StringList, gio::ListModel)>,
+    position_map: Option<(SourceIndexMap, gio::ListModel)>,
 ) {
     let drag = gtk::DragSource::builder()
         .actions(gtk::gdk::DragAction::COPY | gtk::gdk::DragAction::MOVE)
         .build();
     drag.set_propagation_phase(gtk::PropagationPhase::Capture);
-    let dragged_item = item.clone();
+    let dragged_item = item.downgrade();
     let browser_for_drag = browser.clone();
     let map_for_drag = position_map.clone();
     drag.connect_prepare(move |source, x, y| {
         let browser = browser_for_drag.upgrade()?;
+        let dragged_item = dragged_item.upgrade()?;
         let position = dragged_item.position();
         if position == gtk::INVALID_LIST_POSITION {
             return None;
@@ -2742,39 +2822,58 @@ fn install_explorer_drag_drop(
         source.set_icon(Some(&paintable), x.round() as i32, y.round() as i32);
         super::browser::file_drag_content(&entries)
     });
-    let dragged_row = row.clone();
-    drag.connect_drag_begin(move |_, _| dragged_row.add_css_class("dragging"));
-    let dragged_row = row.clone();
-    drag.connect_drag_end(move |_, _, _| dragged_row.remove_css_class("dragging"));
+    let dragged_row = row.downgrade();
+    drag.connect_drag_begin(move |_, _| {
+        if let Some(row) = dragged_row.upgrade() {
+            row.add_css_class("dragging");
+        }
+    });
+    let dragged_row = row.downgrade();
+    drag.connect_drag_end(move |_, _, _| {
+        if let Some(row) = dragged_row.upgrade() {
+            row.remove_css_class("dragging");
+        }
+    });
     row.add_controller(drag);
 
     let drop = gtk::DropTarget::new(
         gtk::gdk::FileList::static_type(),
         gtk::gdk::DragAction::COPY | gtk::gdk::DragAction::MOVE,
     );
-    let highlighted_row = row.clone();
+    let highlighted_row = row.downgrade();
     drop.connect_enter(move |target, _, _| {
-        highlighted_row.add_css_class("drop-destination");
+        if let Some(row) = highlighted_row.upgrade() {
+            row.add_css_class("drop-destination");
+        }
         super::browser::file_drop_action(target)
     });
-    let highlighted_row = row.clone();
+    let highlighted_row = row.downgrade();
     drop.connect_motion(move |target, _, _| {
-        highlighted_row.add_css_class("drop-destination");
+        if let Some(row) = highlighted_row.upgrade() {
+            row.add_css_class("drop-destination");
+        }
         super::browser::file_drop_action(target)
     });
-    let highlighted_row = row.clone();
-    drop.connect_leave(move |_| highlighted_row.remove_css_class("drop-destination"));
-    let accepted_item = item.clone();
+    let highlighted_row = row.downgrade();
+    drop.connect_leave(move |_| {
+        if let Some(row) = highlighted_row.upgrade() {
+            row.remove_css_class("drop-destination");
+        }
+    });
+    let accepted_item = item.downgrade();
     let browser_for_accept = browser.clone();
     let map_for_accept = position_map.clone();
     drop.connect_accept(move |_, offered| {
         let Some(browser) = browser_for_accept.upgrade() else {
             return false;
         };
+        let Some(accepted_item) = accepted_item.upgrade() else {
+            return false;
+        };
         let position = accepted_item.position();
         let position = map_for_accept.as_ref().map_or(
             (position != gtk::INVALID_LIST_POSITION).then_some(position as usize),
-            |(source, filtered)| source_position_for_view(source, Some(filtered), position),
+            |(map, view)| source_position_for_view(map, Some(view), position),
         );
         position.is_some()
             && browser
@@ -2784,19 +2883,24 @@ fn install_explorer_drag_drop(
                 .formats()
                 .contains_type(gtk::gdk::FileList::static_type())
     });
-    let dropped_item = item.clone();
+    let dropped_item = item.downgrade();
     let browser_for_drop = browser;
     let map_for_drop = position_map;
-    let dropped_row = row.clone();
+    let dropped_row = row.downgrade();
     drop.connect_drop(move |target, value, _, _| {
-        dropped_row.remove_css_class("drop-destination");
+        if let Some(row) = dropped_row.upgrade() {
+            row.remove_css_class("drop-destination");
+        }
         let Some(browser) = browser_for_drop.upgrade() else {
+            return false;
+        };
+        let Some(dropped_item) = dropped_item.upgrade() else {
             return false;
         };
         let position = dropped_item.position();
         let position = map_for_drop.as_ref().map_or(
             (position != gtk::INVALID_LIST_POSITION).then_some(position as usize),
-            |(source, filtered)| source_position_for_view(source, Some(filtered), position),
+            |(map, view)| source_position_for_view(map, Some(view), position),
         );
         let Some(destination) = position
             .and_then(|position| browser.entry_at(depth, position))
@@ -2830,8 +2934,11 @@ fn install_modified_selection_click(
     let click = gtk::GestureClick::new();
     click.set_button(1);
     click.set_propagation_phase(gtk::PropagationPhase::Capture);
-    let item = item.clone();
+    let item = item.downgrade();
     click.connect_pressed(move |gesture, _, _, _| {
+        let Some(item) = item.upgrade() else {
+            return;
+        };
         let position = item.position();
         if position == gtk::INVALID_LIST_POSITION {
             return;
@@ -2861,17 +2968,14 @@ fn install_modified_selection_click(
 }
 
 fn source_position_for_view(
-    source: &gtk::StringList,
-    filtered: Option<&gio::ListModel>,
+    map: &SourceIndexMap,
+    view: Option<&gio::ListModel>,
     position: u32,
 ) -> Option<usize> {
-    let Some(filtered) = filtered else {
+    let Some(view) = view else {
         return Some(position as usize);
     };
-    let item = filtered.item(position)?;
-    (0..source.n_items())
-        .find(|candidate| source.item(*candidate).is_some_and(|value| value == item))
-        .map(|position| position as usize)
+    map.of_view_position(view, position)
 }
 
 fn metadata_fill_position(
@@ -2894,6 +2998,15 @@ fn view_position_for_source(
         return Some(position as u32);
     };
     let item = source.item(position as u32)?;
+    let guessed = position as u32;
+    // Unfiltered views (and FlattenListModel with an empty placeholder) keep source order.
+    if filtered.item(guessed).is_some_and(|value| value == item) {
+        return Some(guessed);
+    }
+    let shifted = guessed.saturating_add(1);
+    if filtered.item(shifted).is_some_and(|value| value == item) {
+        return Some(shifted);
+    }
     (0..filtered.n_items())
         .find(|candidate| filtered.item(*candidate).is_some_and(|value| value == item))
 }
@@ -2905,11 +3018,11 @@ fn install_preview_click(
     enabled: Rc<Cell<bool>>,
     click_activation: Rc<Cell<ClickActivation>>,
     depth: usize,
-    position_map: Option<(gtk::StringList, gio::ListModel)>,
+    position_map: Option<(SourceIndexMap, gio::ListModel)>,
 ) {
     let click = gtk::GestureClick::new();
     click.set_button(1);
-    let item = item.clone();
+    let item = item.downgrade();
     click.connect_released(move |gesture, press_count, _, _| {
         let modifiers = gesture.current_event_state();
         if modifiers
@@ -2917,6 +3030,9 @@ fn install_preview_click(
         {
             return;
         }
+        let Some(item) = item.upgrade() else {
+            return;
+        };
         let position = item.position();
         if position == gtk::INVALID_LIST_POSITION {
             return;
@@ -2968,7 +3084,7 @@ fn connect_selection(
     sections: Weak<RefCell<Vec<PaneSection>>>,
     browser: &Rc<Browser>,
     depth: usize,
-    source: gtk::StringList,
+    source_index: SourceIndexMap,
 ) {
     let syncing = section.syncing.clone();
     let view_model = section.view_model.clone();
@@ -2982,10 +3098,10 @@ fn connect_selection(
             let (Some(sections), Some(browser)) = (sections.upgrade(), browser.upgrade()) else {
                 return;
             };
-            let focused = selected_source_positions(&source, &view_model, selection)
+            let focused = selected_source_positions(&source_index, &view_model, selection)
                 .last()
                 .copied();
-            sync_browser_selection(&sections, &browser, depth, &source, focused);
+            sync_browser_selection(&sections, &browser, depth, &source_index, focused);
         });
 }
 
@@ -3004,6 +3120,43 @@ fn set_selections(pane: &Pane, positions: &[usize]) {
     }
 }
 
+fn scroll_pane_to_source(pane: &Pane, source_position: usize) {
+    for section in pane.item_sections() {
+        let Some(position) =
+            view_position_for_source(&pane.model, Some(&section.view_model), source_position)
+        else {
+            continue;
+        };
+        if position >= section.view_model.n_items() {
+            continue;
+        }
+        scroll_collection_to(&section.view, position);
+        return;
+    }
+}
+
+fn scroll_collection_to(view: &gtk::Widget, position: u32) {
+    apply_collection_scroll(view, position);
+    let view = view.clone();
+    glib::idle_add_local_once(move || {
+        apply_collection_scroll(&view, position);
+    });
+}
+
+fn apply_collection_scroll(view: &gtk::Widget, position: u32) {
+    if let Ok(list) = view.clone().downcast::<gtk::ListView>() {
+        if position < list.model().map_or(0, |model| model.n_items()) {
+            list.scroll_to(position, gtk::ListScrollFlags::FOCUS, None);
+        }
+        return;
+    }
+    if let Ok(grid) = view.clone().downcast::<gtk::GridView>()
+        && position < grid.model().map_or(0, |model| model.n_items())
+    {
+        grid.scroll_to(position, gtk::ListScrollFlags::FOCUS, None);
+    }
+}
+
 fn set_mode_cut_style(widget: &impl IsA<gtk::Widget>, cut: bool) {
     if cut {
         widget.add_css_class("cut");
@@ -3018,8 +3171,9 @@ fn refresh_cut_pane(pane: &Pane, browser: &Browser, cuts: &[Location]) {
             let (Some(item), Some(widget)) = (bound.item.upgrade(), bound.widget.upgrade()) else {
                 return false;
             };
-            let source =
-                source_position_for_view(&pane.model, Some(&section.view_model), item.position());
+            let source = item
+                .item()
+                .and_then(|value| pane.source_index.of_item(&value));
             let cut = source
                 .and_then(|position| browser.entry_at(pane.depth, position))
                 .is_some_and(|entry| cuts.contains(&entry.location));
@@ -3042,6 +3196,18 @@ fn replace_entries(pane: &Pane, browser: &Browser, count: usize) {
     pane.model.splice(0, pane.model.n_items(), &values_ref);
     sync_grid_groups(pane);
     show_count(pane);
+}
+
+fn detach_pane_models(pane: &Pane) {
+    pane.detached.set(true);
+    for section in pane.all_sections() {
+        section.syncing.set(true);
+        section.selection.set_model(None::<&gio::ListModel>);
+        super::browser::detach_collection_view(&section.view);
+    }
+    if let Some(filtered) = pane.filter_model.as_ref() {
+        filtered.set_model(None::<&gio::ListModel>);
+    }
 }
 
 fn reconnect_pane_model(pane: &Pane) {
@@ -3074,6 +3240,9 @@ fn show_count(pane: &Pane) {
 fn apply_snapshot(pane: &Pane, snapshot: &BrowserColumnSnapshot, browser: &Browser) {
     replace_entries(pane, browser, snapshot.count);
     set_selections(pane, &snapshot.selected_positions);
+    if let Some(&focused) = snapshot.selected_positions.last() {
+        scroll_pane_to_source(pane, focused);
+    }
     pane.truncated_hint.set_visible(snapshot.truncated);
     if snapshot.loading {
         pane.spinner.start();
@@ -3288,13 +3457,15 @@ fn bound_item_visitor(bound_items: Rc<RefCell<Vec<BoundModeItem>>>) -> super::ma
 }
 
 fn selected_source_positions(
-    source: &gtk::StringList,
+    source_index: &SourceIndexMap,
     view_model: &gio::ListModel,
     selection: &gtk::MultiSelection,
 ) -> Vec<usize> {
     bitset_positions(&selection.selection())
         .into_iter()
-        .filter_map(|position| source_position_for_view(source, Some(view_model), position as u32))
+        .filter_map(|position| {
+            source_position_for_view(source_index, Some(view_model), position as u32)
+        })
         .collect()
 }
 
@@ -3304,7 +3475,7 @@ fn sync_browser_selection(
     sections: &Rc<RefCell<Vec<PaneSection>>>,
     browser: &Browser,
     depth: usize,
-    source: &gtk::StringList,
+    source_index: &SourceIndexMap,
     focused: Option<usize>,
 ) {
     let mut positions: Vec<usize> = {
@@ -3312,7 +3483,7 @@ fn sync_browser_selection(
         sections
             .iter()
             .flat_map(|section| {
-                selected_source_positions(source, &section.view_model, &section.selection)
+                selected_source_positions(source_index, &section.view_model, &section.selection)
             })
             .collect()
     };
@@ -3330,7 +3501,7 @@ fn install_exclusive_section_click(section: &PaneSection, context: &Rc<GridConte
     click.set_propagation_phase(gtk::PropagationPhase::Capture);
     let sections = context.sections.clone();
     let browser = Rc::downgrade(&context.browser);
-    let source = context.source.clone();
+    let source_index = context.source_index.clone();
     let depth = context.depth;
     click.connect_pressed(move |gesture, _, x, y| {
         if gesture
@@ -3362,7 +3533,7 @@ fn install_exclusive_section_click(section: &PaneSection, context: &Rc<GridConte
             cleared = true;
         }
         if cleared {
-            sync_browser_selection(&sections, &browser, depth, &source, None);
+            sync_browser_selection(&sections, &browser, depth, &source_index, None);
         }
     });
     section.view.add_controller(click);
@@ -3390,15 +3561,15 @@ fn install_section_context_menu(
     state: &Rc<super::browser::ViewState>,
     section: &PaneSection,
     sections: Weak<RefCell<Vec<PaneSection>>>,
-    source: &gtk::StringList,
+    source_index: &SourceIndexMap,
     depth: usize,
 ) {
     let owner = section.clone();
     let pick_position = Rc::new(move |picked: &gtk::Widget| section_item_position(&owner, picked));
-    let source_model = source.clone();
+    let source_index = source_index.clone();
     let view_model = section.view_model.clone();
     let source_position = Rc::new(move |position| {
-        source_position_for_view(&source_model, Some(&view_model), position)
+        source_position_for_view(&source_index, Some(&view_model), position)
     });
     let owner_view = section.view.clone();
     let clear_other_selections = Rc::new(move || {

--- a/src/ui/browser_modes/tests.rs
+++ b/src/ui/browser_modes/tests.rs
@@ -2,10 +2,12 @@
 
 use super::{
     BrowserMode, ClickActivation, ClickCount, EXPLORER_COLUMN_MIN_WIDTHS, EXPLORER_COLUMN_WIDTHS,
-    compare_type_groups, explorer_column_width, metadata_fill_position,
+    SourceIndexMap, compare_type_groups, explorer_column_width, metadata_fill_position,
     should_activate_pointer_click, type_groups_of, value_type_group,
 };
 use crate::model::{EntryKind, FileEntry, Location, MetadataValue};
+use gtk::{gio, prelude::*};
+use std::process::Command;
 
 /// Model values as the panes store them: kind, hidden flag, then the display name.
 fn value(kind: char, name: &str) -> String {
@@ -136,4 +138,115 @@ fn entries_of_one_type_share_a_group() {
         value_type_group(&value('f', "notes.md")),
         value_type_group(&value('f', "notes.json"))
     );
+}
+
+const GTK_CHILD: &str = "STRATA_SOURCE_INDEX_MAP_GTK_CHILD";
+const SOURCE_INDEX_TEST: &str =
+    "ui::browser_modes::tests::source_index_map_tracks_filter_sort_and_placeholder";
+
+fn run_source_index_map_checks() {
+    let source = gtk::StringList::new(&["fv\talpha", "dh\t.secret", "fv\tneedle"]);
+    let map = SourceIndexMap::watch(&source);
+    assert_eq!(map.of_view_position(&source, 0), Some(0));
+    assert_eq!(map.of_view_position(&source, 2), Some(2));
+
+    source.append("fv\tlate");
+    assert_eq!(map.of_view_position(&source, 3), Some(3));
+
+    source.splice(1, 0, &["fv\tmiddle"]);
+    assert_eq!(
+        map.of_item(&source.item(1).expect("inserted item")),
+        Some(1)
+    );
+    assert_eq!(map.of_item(&source.item(4).expect("shifted item")), Some(4));
+
+    let hide_hidden = gtk::CustomFilter::new(|item| {
+        item.downcast_ref::<gtk::StringObject>()
+            .is_some_and(|value| value.string().as_bytes().get(1) != Some(&b'h'))
+    });
+    let visible = gtk::FilterListModel::new(Some(source.clone()), Some(hide_hidden));
+    assert_eq!(map.of_view_position(&visible, 0), Some(0));
+    assert_eq!(map.of_view_position(&visible, 1), Some(1));
+    assert_eq!(map.of_view_position(&visible, 3), Some(4));
+
+    let needle = gtk::CustomFilter::new(|item| {
+        item.downcast_ref::<gtk::StringObject>()
+            .is_some_and(|value| value.string().contains("needle"))
+    });
+    let matches = gtk::FilterListModel::new(Some(source.clone()), Some(needle));
+    assert_eq!(map.of_view_position(&matches, 0), Some(3));
+
+    let sorter = gtk::CustomSorter::new(|left, right| {
+        let left = left
+            .downcast_ref::<gtk::StringObject>()
+            .map(|value| value.string())
+            .unwrap_or_default();
+        let right = right
+            .downcast_ref::<gtk::StringObject>()
+            .map(|value| value.string())
+            .unwrap_or_default();
+        right.cmp(&left).into()
+    });
+    let sorted = gtk::SortListModel::new(Some(source.clone()), Some(sorter));
+    let first_sorted = sorted.item(0).expect("sorted model should have rows");
+    let mapped = map.of_item(&first_sorted);
+    assert!(mapped.is_some());
+    assert_ne!(
+        mapped,
+        Some(0),
+        "reverse sort should move the first source item off view index 0"
+    );
+    assert_eq!(map.of_view_position(&sorted, 0), mapped);
+
+    let placeholder = gtk::StringList::new(&["creating"]);
+    let stacked = gio::ListStore::new::<gio::ListModel>();
+    stacked.append(&placeholder.clone().upcast::<gio::ListModel>());
+    stacked.append(&source.clone().upcast::<gio::ListModel>());
+    let flattened = gtk::FlattenListModel::new(Some(stacked));
+    assert!(
+        map.of_view_position(&flattened, 0).is_none(),
+        "the inline placeholder is not a source entry"
+    );
+    assert_eq!(map.of_view_position(&flattened, 1), Some(0));
+
+    assert_eq!(
+        super::view_position_for_source(&source, Some(source.upcast_ref()), 4),
+        Some(4)
+    );
+    assert_eq!(
+        super::view_position_for_source(&source, Some(visible.upcast_ref()), 3),
+        Some(2)
+    );
+    assert_eq!(
+        super::view_position_for_source(&source, Some(flattened.upcast_ref()), 0),
+        Some(1)
+    );
+
+    let source = gtk::StringList::new(&["fv\talpha"]);
+    let weak = source.downgrade();
+    let map = SourceIndexMap::watch(&source);
+    drop(source);
+    drop(map);
+    assert!(
+        weak.upgrade().is_none(),
+        "watching must not pin the StringList after the pane drops"
+    );
+}
+
+#[test]
+fn source_index_map_tracks_filter_sort_and_placeholder() {
+    if std::env::var_os(GTK_CHILD).is_some() {
+        if gtk::init().is_err() {
+            return;
+        }
+        run_source_index_map_checks();
+        return;
+    }
+
+    let status = Command::new(std::env::current_exe().expect("test executable should exist"))
+        .args(["--exact", SOURCE_INDEX_TEST])
+        .env(GTK_CHILD, "1")
+        .status()
+        .expect("isolated GTK mapping test should start");
+    assert!(status.success(), "isolated GTK mapping test failed");
 }

--- a/src/ui/marquee.rs
+++ b/src/ui/marquee.rs
@@ -44,9 +44,11 @@ pub(super) struct Marquee {
 }
 
 struct MarqueeState {
-    view: gtk::Widget,
-    scroll: gtk::ScrolledWindow,
-    overlay: gtk::Overlay,
+    // Weak: the drag gesture lives on the view, and capturing these widgets
+    // would pin the collection (and its model) after a mode switch.
+    view: glib::WeakRef<gtk::Widget>,
+    scroll: glib::WeakRef<gtk::ScrolledWindow>,
+    overlay: glib::WeakRef<gtk::Overlay>,
     band: gtk::Box,
     targets: MarqueeTargets,
     is_item: ItemPredicate,
@@ -76,9 +78,9 @@ pub(super) fn install(setup: MarqueeSetup) -> Marquee {
 
     let view = setup.view;
     let state = Rc::new(MarqueeState {
-        view: view.clone(),
-        scroll: setup.scroll,
-        overlay: setup.overlay,
+        view: view.downgrade(),
+        scroll: setup.scroll.downgrade(),
+        overlay: setup.overlay.downgrade(),
         band,
         targets: setup.targets,
         is_item: setup.is_item,
@@ -109,7 +111,7 @@ pub(super) fn install(setup: MarqueeSetup) -> Marquee {
         gesture.set_state(gtk::EventSequenceState::Claimed);
         state_for_begin.begin((x, y), gesture.current_event_state());
     });
-    connect_drag_progress(&gesture, &state, &view);
+    connect_drag_progress(&gesture, &state);
     view.add_controller(gesture);
 
     Marquee { state }
@@ -129,22 +131,27 @@ impl Marquee {
         let gesture = gtk::GestureDrag::new();
         gesture.set_button(1);
         let state_for_begin = self.state.clone();
-        let surface_for_begin = surface.clone();
         gesture.connect_drag_begin(move |gesture, x, y| {
             state_for_begin.active.set(false);
-            let accepted = surface_for_begin
+            let Some(surface) = gesture.widget() else {
+                return;
+            };
+            let accepted = surface
                 .pick(x, y, gtk::PickFlags::DEFAULT)
-                .is_some_and(|picked| is_inert_chrome(&surface_for_begin, &picked));
-            if !accepted || !state_for_begin.view.is_mapped() {
+                .is_some_and(|picked| is_inert_chrome(&surface, &picked));
+            let Some(view) = state_for_begin.view() else {
+                return;
+            };
+            if !accepted || !view.is_mapped() {
                 return;
             }
-            let Some(anchor) = translate(&surface_for_begin, &state_for_begin.view, (x, y)) else {
+            let Some(anchor) = translate(&surface, &view, (x, y)) else {
                 return;
             };
             gesture.set_state(gtk::EventSequenceState::Claimed);
             state_for_begin.begin(anchor, gesture.current_event_state());
         });
-        connect_drag_progress(&gesture, &self.state, &surface);
+        connect_drag_progress(&gesture, &self.state);
         surface.add_controller(gesture);
     }
 }
@@ -196,10 +203,13 @@ pub(super) fn install_shared_origin_surface(
             return;
         };
         let state = marquee.state;
-        if !state.view.is_mapped() {
+        let Some(view) = state.view() else {
+            return;
+        };
+        if !view.is_mapped() {
             return;
         }
-        let Some(anchor) = translate(&surface_for_begin, &state.view, (x, y)) else {
+        let Some(anchor) = translate(&surface_for_begin, &view, (x, y)) else {
             return;
         };
         gesture.set_state(gtk::EventSequenceState::Claimed);
@@ -228,30 +238,43 @@ pub(super) fn install_shared_origin_surface(
 }
 
 /// Wires update/end handling for a drag whose coordinates are expressed in
-/// `origin`'s space.
-fn connect_drag_progress(
-    gesture: &gtk::GestureDrag,
-    state: &Rc<MarqueeState>,
-    origin: &gtk::Widget,
-) {
+/// the gesture widget's space.
+fn connect_drag_progress(gesture: &gtk::GestureDrag, state: &Rc<MarqueeState>) {
     let state_for_update = state.clone();
-    let origin_for_update = origin.clone();
     gesture.connect_drag_update(move |gesture, offset_x, offset_y| {
         let Some((start_x, start_y)) = gesture.start_point() else {
             return;
         };
-        state_for_update.drag_to(&origin_for_update, (start_x + offset_x, start_y + offset_y));
+        let Some(origin) = gesture.widget() else {
+            return;
+        };
+        state_for_update.drag_to(&origin, (start_x + offset_x, start_y + offset_y));
     });
     let state_for_end = state.clone();
     gesture.connect_drag_end(move |_, _, _| state_for_end.end());
 }
 
 impl MarqueeState {
+    fn view(&self) -> Option<gtk::Widget> {
+        self.view.upgrade()
+    }
+
+    fn scroll(&self) -> Option<gtk::ScrolledWindow> {
+        self.scroll.upgrade()
+    }
+
+    fn overlay(&self) -> Option<gtk::Overlay> {
+        self.overlay.upgrade()
+    }
+
     fn begin(&self, anchor: (f64, f64), modifiers: gtk::gdk::ModifierType) {
+        let (Some(view), Some(scroll)) = (self.view(), self.scroll()) else {
+            return;
+        };
         self.active.set(true);
         self.anchor.set(anchor);
         self.pointer
-            .set(translate(&self.view, &self.scroll, anchor).unwrap_or_default());
+            .set(translate(&view, &scroll, anchor).unwrap_or_default());
         self.initial.replace(
             self.targets
                 .borrow()
@@ -272,8 +295,10 @@ impl MarqueeState {
     }
 
     fn refresh(&self) {
-        let Some((current_x, current_y)) = translate(&self.scroll, &self.view, self.pointer.get())
-        else {
+        let (Some(view), Some(scroll)) = (self.view(), self.scroll()) else {
+            return;
+        };
+        let Some((current_x, current_y)) = translate(&scroll, &view, self.pointer.get()) else {
             return;
         };
         let (anchor_x, anchor_y) = self.anchor.get();
@@ -281,12 +306,15 @@ impl MarqueeState {
         let right = anchor_x.max(current_x);
         let top = anchor_y.min(current_y);
         let bottom = anchor_y.max(current_y);
-        self.place_band(left, top, right, bottom);
-        self.apply_selection(left, top, right, bottom);
+        self.place_band(&view, left, top, right, bottom);
+        self.apply_selection(&view, left, top, right, bottom);
     }
 
-    fn place_band(&self, left: f64, top: f64, right: f64, bottom: f64) {
-        let Some(view_bounds) = self.view.compute_bounds(&self.overlay) else {
+    fn place_band(&self, view: &gtk::Widget, left: f64, top: f64, right: f64, bottom: f64) {
+        let Some(overlay) = self.overlay() else {
+            return;
+        };
+        let Some(view_bounds) = view.compute_bounds(&overlay) else {
             return;
         };
         let placement = band_placement(
@@ -294,8 +322,8 @@ impl MarqueeState {
             f64::from(view_bounds.y()) + top,
             right - left,
             bottom - top,
-            f64::from(self.overlay.width()),
-            f64::from(self.overlay.height()),
+            f64::from(overlay.width()),
+            f64::from(overlay.height()),
         );
         let Some((x, y, width, height)) = placement else {
             self.band.set_visible(false);
@@ -307,10 +335,9 @@ impl MarqueeState {
         self.band.set_size_request(width, height);
     }
 
-    fn apply_selection(&self, left: f64, top: f64, right: f64, bottom: f64) {
+    fn apply_selection(&self, view: &gtk::Widget, left: f64, top: f64, right: f64, bottom: f64) {
         let initials = self.initial.borrow();
         let (control, shift) = self.modifiers.get();
-        let view = self.view.clone();
         let empty = gtk::Bitset::new_empty();
         for (index, target) in self.targets.borrow().iter().enumerate() {
             let initial = initials.get(index).unwrap_or(&empty);
@@ -323,7 +350,7 @@ impl MarqueeState {
                 if position == gtk::INVALID_LIST_POSITION {
                     return;
                 }
-                let Some(bounds) = widget.compute_bounds(&view) else {
+                let Some(bounds) = widget.compute_bounds(view) else {
                     return;
                 };
                 if !intersects(&bounds, left, top, right, bottom) {
@@ -352,30 +379,30 @@ impl MarqueeState {
         if !self.active.get() {
             return false;
         }
-        let (step_x, step_y) = self.auto_scroll_steps();
+        let Some(scroll) = self.scroll() else {
+            return false;
+        };
+        let (step_x, step_y) = self.auto_scroll_steps_for(&scroll);
         if step_x == 0.0 && step_y == 0.0 {
             return false;
         }
-        if advance(&self.scroll.hadjustment(), step_x) | advance(&self.scroll.vadjustment(), step_y)
-        {
+        if advance(&scroll.hadjustment(), step_x) | advance(&scroll.vadjustment(), step_y) {
             self.refresh();
         }
         true
     }
 
     fn auto_scroll_steps(&self) -> (f64, f64) {
+        self.scroll()
+            .map(|scroll| self.auto_scroll_steps_for(&scroll))
+            .unwrap_or((0.0, 0.0))
+    }
+
+    fn auto_scroll_steps_for(&self, scroll: &gtk::ScrolledWindow) -> (f64, f64) {
         let (x, y) = self.pointer.get();
         (
-            self.scrollable_step(
-                &self.scroll.hadjustment(),
-                x,
-                f64::from(self.scroll.width()),
-            ),
-            self.scrollable_step(
-                &self.scroll.vadjustment(),
-                y,
-                f64::from(self.scroll.height()),
-            ),
+            self.scrollable_step(&scroll.hadjustment(), x, f64::from(scroll.width())),
+            self.scrollable_step(&scroll.vadjustment(), y, f64::from(scroll.height())),
         )
     }
 
@@ -394,7 +421,10 @@ impl MarqueeState {
         if !self.active.get() {
             return;
         }
-        let Some(pointer) = translate(origin, &self.scroll, point) else {
+        let Some(scroll) = self.scroll() else {
+            return;
+        };
+        let Some(pointer) = translate(origin, &scroll, point) else {
             return;
         };
         self.pointer.set(pointer);

--- a/src/ui/marquee/tests.rs
+++ b/src/ui/marquee/tests.rs
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+use std::{process::Command, rc::Rc};
+
 use super::*;
+
+const GTK_CHILD: &str = "STRATA_MARQUEE_GTK_CHILD";
+const PIN_TEST: &str = "ui::marquee::tests::marquee_does_not_pin_the_collection_view";
 
 #[test]
 fn pointer_inside_the_viewport_does_not_scroll() {
@@ -61,4 +66,54 @@ fn items_touching_the_band_are_captured() {
 fn an_unmoved_band_still_captures_the_item_under_it() {
     let bounds = graphene::Rect::new(0.0, 100.0, 300.0, 24.0);
     assert!(intersects(&bounds, 20.0, 110.0, 20.0, 110.0));
+}
+
+fn assert_marquee_releases_the_collection_view() {
+    let overlay = gtk::Overlay::new();
+    let model = gtk::StringList::new(&["fv\talpha"]);
+    let selection = gtk::NoSelection::new(Some(model));
+    let list = gtk::ListView::new(Some(selection), Some(gtk::SignalListItemFactory::new()));
+    let scroll = gtk::ScrolledWindow::builder().child(&list).build();
+    overlay.set_child(Some(&scroll));
+    let weak_list = list.downgrade();
+    let weak_scroll = scroll.downgrade();
+    let marquee = install(MarqueeSetup {
+        view: list.clone().upcast(),
+        scroll,
+        overlay: overlay.clone(),
+        targets: Rc::new(RefCell::new(Vec::new())),
+        is_item: Rc::new(|_| false),
+    });
+    marquee.add_origin_surface(&overlay);
+    drop(list);
+    drop(marquee);
+    overlay.set_child(None::<&gtk::Widget>);
+    drop(overlay);
+    while glib::MainContext::default().iteration(false) {}
+    assert!(
+        weak_list.upgrade().is_none(),
+        "marquee must not pin the collection view after the pane drops"
+    );
+    assert!(
+        weak_scroll.upgrade().is_none(),
+        "marquee must not pin the scrolled window after the pane drops"
+    );
+}
+
+#[test]
+fn marquee_does_not_pin_the_collection_view() {
+    if std::env::var_os(GTK_CHILD).is_some() {
+        if gtk::init().is_err() {
+            return;
+        }
+        assert_marquee_releases_the_collection_view();
+        return;
+    }
+
+    let status = Command::new(std::env::current_exe().expect("test executable should exist"))
+        .args(["--exact", PIN_TEST])
+        .env(GTK_CHILD, "1")
+        .status()
+        .expect("isolated GTK marquee test should start");
+    assert!(status.success(), "isolated GTK marquee test failed");
 }

--- a/src/ui/thumbnail.rs
+++ b/src/ui/thumbnail.rs
@@ -1095,7 +1095,7 @@ fn cancel_thumbnail(image_id: usize) {
             settle
                 .pending
                 .retain(|park| park.target.image_id != image_id);
-            !settle.pending.is_empty() || settle.hooked
+            !settle.pending.is_empty() || (settle.hooked && settle.viewport.upgrade().is_some())
         });
     });
     let cancelled = PENDING_THUMBNAILS.with(|pending| {

--- a/src/ui/thumbnail/tests.rs
+++ b/src/ui/thumbnail/tests.rs
@@ -413,6 +413,31 @@ fn cancellation_removes_metadata_waiters() {
 }
 
 #[test]
+fn cancelling_drops_hooked_settle_groups_with_a_dead_viewport() {
+    SETTLE_VIEWS.with(|views| {
+        views.borrow_mut().insert(
+            42,
+            ViewSettle {
+                viewport: glib::WeakRef::new(),
+                pending: Vec::new(),
+                timer: None,
+                first_park: None,
+                hooked: true,
+            },
+        );
+    });
+
+    cancel_thumbnail(1);
+
+    SETTLE_VIEWS.with(|views| {
+        assert!(
+            !views.borrow().contains_key(&42),
+            "a hooked settle group whose viewport is gone should drop"
+        );
+    });
+}
+
+#[test]
 fn persist_queue_bounds_and_drains_oldest_first() {
     let mut queue = PersistQueue::new();
     for index in 0..MAX_PERSIST_QUEUE + 5 {


### PR DESCRIPTION
## Description

Three things stacked in large Grid/Explorer folders:

1. **Bind was O(visible × n).** Every visible row walked the `StringList` to turn a filter/sort index into a source index. Columns already had a position map; Grid and Explorer did not.
2. **Mode switches leaked the old pane.** Gestures and factories held strong widget refs, so each Grid ↔ Explorer ↔ Columns visit left the previous listing alive. Scrolling then got worse, not better.
3. **ListView measured while hidden.** Rebuild + `scroll_to` ran before the stack page was shown (or before the pane was parented), so GTK thought the viewport was one row until you scrolled.

**Where to look**

| What | File | Start here |
| --- | --- | --- |
| O(1) source index for Grid/Explorer bind, activate, peek, drag, selection | `src/ui/browser_modes.rs` | `SourceIndexMap` (`watch` / `apply` / `rebuild`). `watch()` rebuilds immediately: `StringList::new` does not emit `items_changed` for existing rows. The `items_changed` handler must use the signal’s `source`, not a cloned list, or the list stays pinned. |
| Show the new mode, then rebuild, then drop the old one | `src/ui/browser.rs` | `BrowserView::set_view_mode` |
| Parent the pane, then apply the snapshot (avoids the one-row viewport) | `src/ui/browser_modes.rs` | `rebuild_grid`, `rebuild_explorer` |
| Idle `scroll_to` / `grab_focus` after layout | `src/ui/browser_modes.rs` | `scroll_collection_to`, `focus_visible_pane` |
| Drop factory + model when a pane goes away | `src/ui/browser.rs`, `src/ui/browser_modes.rs` | `detach_collection_view`, `detach_pane_models` |
| Marquee must not pin the collection after a mode switch | `src/ui/marquee.rs` | `MarqueeState` is `WeakRef`; drag handlers take the widget from the gesture |
| Miller resize handle / reveal tick must not pin the column shell | `src/ui/browser.rs` | `shell.downgrade()` on the overlay handle and the miller scroller tick |
| Row controllers must not cycle `ListItem` ↔ child | miller factory in `src/ui/browser.rs`; `install_preview_click`, `install_grid_peek`, `install_explorer_drag_drop` in `src/ui/browser_modes.rs` | `item.downgrade()` / `row.downgrade()` |
| Dead hooked thumbnail groups must drop | `src/ui/thumbnail.rs` | `cancel_thumbnail` retain: keep only if pending work remains, or the viewport is still alive |
| Filter keystrokes notify MoreStrict/LessStrict instead of rebuilding | `src/ui/browser.rs` | `filter_change_for`, `notify_filter_query` (Grid/Explorer). Do not copy miller’s empty-query `set_filter(None)`: that would drop the hidden-files predicate. |

Tests match those pieces: `SourceIndexMap` (filter/sort/placeholder + unpin), miller `rebuild_position_map`, marquee unpin, `filter_change_for` / `notify_filter_query`, thumbnail dead-viewport drop. Mode-switch “one row until scroll” still needs the manual check below.

## Visual evidence

https://github.com/user-attachments/assets/a0fe28cd-10e1-4ec4-b218-9ee6b8f632f6


## How to test

Use a large local directory (tens of thousands of entries helps).

1. Open it in Grid, fling-scroll, then switch Grid → Explorer → Columns and back. Repeat several times.
2. Change the filter, hidden-files toggle, and type grouping in Grid and Explorer.
3. Select, open the context menu, drag, peek, create, and rename items.
4. Add or remove files in the folder while Grid or Explorer is open.
5. After a mode switch, confirm more than one row is visible without scrolling first.

**Expected result:** Scrolling stays usable after mode and filter changes and does not get worse on each visit. A mode switch shows a full viewport immediately. Activating or previewing an item still opens the one you clicked (not a neighbor after filter/sort).

## Related issue

Closes #305