### PR TITLE
feat(omarchy): offer one-time default file manager setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,9 +194,13 @@ When building from source, `make install-local` installs the binary, icon, and d
 
 ### Make Strata the Omarchy file manager
 
-The XDG association above handles folders opened by applications. On current Lua-based Omarchy releases, also override the stock Nautilus shortcuts in `~/.config/hypr/bindings.lua` so Omarchy launches Strata directly.
+The XDG association above handles folders opened by applications. Omarchy's own file-manager shortcuts launch Nautilus directly and never consult that association, so both have to be changed.
 
-First inspect the active bindings and back up your user configuration:
+On a supported Omarchy installation Strata offers to do this for you the first time it starts, and the same action is always available under **Settings → General → Omarchy integration**. Accepting sets the `inode/directory` handler and adds a marked block of file-manager bindings to your own Hyprland configuration — `~/.config/hypr/bindings.lua` on Omarchy Quattro, `~/.config/hypr/bindings.conf` on Omarchy 3.x. Your file is backed up first, the rest of it is left alone, and if `hyprctl configerrors` reports a problem the previous bindings are restored. Re-running the action repairs the block rather than adding a second copy; deleting the block restores Omarchy's defaults.
+
+Files under `/usr/share/omarchy/` are never touched, so these overrides survive Omarchy updates.
+
+To do it by hand instead, first inspect the active bindings and back up your user configuration:
 
 ```bash
 omarchy menu keybindings --print | grep -i "file manager"
@@ -228,7 +232,16 @@ hyprctl configerrors
 omarchy menu keybindings --print | grep -i "file manager"
 ```
 
-`hyprctl configerrors` should produce no errors. These user overrides survive Omarchy updates; do not edit files under `/usr/share/omarchy/`.
+`hyprctl configerrors` should produce no errors. Do not edit files under `/usr/share/omarchy/`; they are package-owned and are replaced on update.
+
+On Omarchy 3.x the same overrides go in `~/.config/hypr/bindings.conf` using Hyprland's own syntax:
+
+```ini
+unbind = SUPER SHIFT, F
+unbind = SUPER ALT SHIFT, F
+bindd = SUPER SHIFT, F, File manager, exec, uwsm-app -- strata
+bindd = SUPER ALT SHIFT, F, File manager (cwd), exec, uwsm-app -- strata "$(omarchy-cmd-terminal-cwd)"
+```
 
 ### Network shares
 

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -2,6 +2,7 @@
 
 mod file_source;
 mod install_source;
+mod omarchy_setup;
 mod operations;
 mod preview;
 mod release_channel;
@@ -17,6 +18,7 @@ pub use file_source::{
 };
 pub(crate) use install_source::ensure_self_managed;
 pub use install_source::{InstallSource, ManagedInstall};
+pub(crate) use omarchy_setup::{OmarchyIntegration, integration as omarchy_integration};
 pub use operations::{
     ArchiveFormat, CancelledOperation, CompressRequest, CreateDirectoryRequest, CreateFileRequest,
     DeleteRequest, ExtractRequest, OperationEvent, OperationProvider, OperationRequestId,

--- a/src/services/omarchy_setup.rs
+++ b/src/services/omarchy_setup.rs
@@ -1,0 +1,398 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Makes Strata Omarchy's default file manager.
+//!
+//! Two separate pieces of system state have to agree before folders always
+//! open in Strata: the XDG `inode/directory` association (used when an
+//! application asks the desktop to open a folder) and Omarchy's own
+//! file-manager keyboard shortcuts, which launch Nautilus directly and never
+//! consult the association.
+//!
+//! Omarchy ships two generations of user Hyprland configuration and only the
+//! user's own file is ever touched; `/usr/share/omarchy/` is package-owned and
+//! is replaced on update.
+
+use std::{
+    fs,
+    io::{self},
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use gtk::{gio, prelude::*};
+
+pub const DESKTOP_ENTRY: &str = "io.github.lgse.Strata.desktop";
+const DIRECTORY_MIME: &str = "inode/directory";
+const BLOCK_TAG: &str = "strata:file-manager-bindings";
+const MANAGED_NOTE: &str =
+    "Managed by Strata. Delete this block to restore Omarchy's file-manager shortcuts.";
+
+/// Which generation of Omarchy user configuration is installed. The two
+/// generations use different files and different binding syntax.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OmarchyGeneration {
+    /// Omarchy 3.x: `~/.config/hypr/bindings.conf`, Hyprland's own syntax.
+    Legacy,
+    /// Omarchy Quattro: `~/.config/hypr/bindings.lua`, Lua helpers.
+    Quattro,
+}
+
+impl OmarchyGeneration {
+    fn bindings_file_name(self) -> &'static str {
+        match self {
+            OmarchyGeneration::Legacy => "bindings.conf",
+            OmarchyGeneration::Quattro => "bindings.lua",
+        }
+    }
+
+    fn comment_prefix(self) -> &'static str {
+        match self {
+            OmarchyGeneration::Legacy => "#",
+            OmarchyGeneration::Quattro => "--",
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            OmarchyGeneration::Legacy => "Omarchy 3.x",
+            OmarchyGeneration::Quattro => "Omarchy Quattro",
+        }
+    }
+}
+
+/// A failure that left the system exactly as it was found.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SetupError {
+    pub summary: String,
+    pub detail: String,
+}
+
+impl SetupError {
+    fn new(summary: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self {
+            summary: summary.into(),
+            detail: detail.into(),
+        }
+    }
+}
+
+/// A detected, supported Omarchy installation and the current state of the
+/// two integrations.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OmarchyIntegration {
+    pub generation: OmarchyGeneration,
+    pub bindings_path: PathBuf,
+    pub folder_association: bool,
+    pub shortcuts: bool,
+}
+
+impl OmarchyIntegration {
+    pub fn is_complete(&self) -> bool {
+        self.folder_association && self.shortcuts
+    }
+
+    /// A one-line description of what still needs doing.
+    pub fn status_summary(&self) -> String {
+        match (self.folder_association, self.shortcuts) {
+            (true, true) => format!("Strata is the {} file manager.", self.generation.label()),
+            (true, false) => {
+                "Folders open in Strata, but Omarchy's shortcuts still launch Nautilus.".to_owned()
+            }
+            (false, true) => {
+                "Omarchy's shortcuts launch Strata, but folders still open in another application."
+                    .to_owned()
+            }
+            (false, false) => format!(
+                "Folder associations and {}'s file-manager shortcuts still point elsewhere.",
+                self.generation.label()
+            ),
+        }
+    }
+
+    /// Applies both integrations, restoring the previous bindings if Hyprland
+    /// rejects the result.
+    pub fn apply(&self) -> Result<(), SetupError> {
+        if desktop_entry().is_none() {
+            return Err(SetupError::new(
+                "Strata's desktop entry is missing",
+                format!(
+                    "{DESKTOP_ENTRY} is not installed, so folders cannot be associated with Strata. Install Strata's desktop entry, then try again."
+                ),
+            ));
+        }
+
+        let original = fs::read_to_string(&self.bindings_path).map_err(|error| {
+            SetupError::new(
+                "Unable to read your Hyprland bindings",
+                format!("{}: {error}", self.bindings_path.display()),
+            )
+        })?;
+        let updated = with_managed_block(&original, self.generation);
+        let backup = backup_path(&self.bindings_path);
+        fs::copy(&self.bindings_path, &backup).map_err(|error| {
+            SetupError::new(
+                "Unable to back up your Hyprland bindings",
+                format!("{}: {error}", backup.display()),
+            )
+        })?;
+
+        if let Err(error) = crate::storage::atomic_write(&self.bindings_path, updated.as_bytes()) {
+            return Err(SetupError::new(
+                "Unable to update your Hyprland bindings",
+                format!("{}: {error}", self.bindings_path.display()),
+            ));
+        }
+
+        if let Err(error) = self.reload_hyprland() {
+            self.restore(&original, &backup);
+            return Err(error);
+        }
+
+        if let Err(error) = set_folder_association() {
+            self.restore(&original, &backup);
+            return Err(error);
+        }
+
+        if let Err(error) = self.verify() {
+            self.restore(&original, &backup);
+            return Err(error);
+        }
+
+        let _ = fs::remove_file(&backup);
+        Ok(())
+    }
+
+    fn reload_hyprland(&self) -> Result<(), SetupError> {
+        // A missing hyprctl means Strata is not running under Hyprland; the
+        // bindings are still correct for the next login.
+        match run_hyprctl(&["reload"]) {
+            Ok(_) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => {
+                return Err(SetupError::new(
+                    "Unable to reload Hyprland",
+                    format!("hyprctl reload failed: {error}"),
+                ));
+            }
+        }
+        let errors = run_hyprctl(&["configerrors"]).unwrap_or_default();
+        if config_errors_reported(&errors) {
+            return Err(SetupError::new(
+                "Hyprland rejected the new bindings",
+                format!("Your previous bindings were restored.\n\n{}", errors.trim()),
+            ));
+        }
+        Ok(())
+    }
+
+    fn verify(&self) -> Result<(), SetupError> {
+        let written = fs::read_to_string(&self.bindings_path).unwrap_or_default();
+        if !has_managed_block(&written, self.generation) {
+            return Err(SetupError::new(
+                "The new bindings could not be verified",
+                format!(
+                    "{} no longer contains Strata's managed block.",
+                    self.bindings_path.display()
+                ),
+            ));
+        }
+        if !folder_association_is_strata() {
+            return Err(SetupError::new(
+                "The folder association could not be verified",
+                format!("{DIRECTORY_MIME} still opens in another application."),
+            ));
+        }
+        Ok(())
+    }
+
+    fn restore(&self, original: &str, backup: &Path) {
+        if crate::storage::atomic_write(&self.bindings_path, original.as_bytes()).is_err() {
+            tracing::warn!(
+                backup = %backup.display(),
+                "unable to restore Hyprland bindings; the backup was kept"
+            );
+            return;
+        }
+        let _ = fs::remove_file(backup);
+        let _ = run_hyprctl(&["reload"]);
+    }
+}
+
+/// Reports the integration state, or `None` when this is not a supported
+/// Omarchy installation.
+pub fn integration() -> Option<OmarchyIntegration> {
+    integration_at(&omarchy_share_dir(), &hypr_config_dir())
+}
+
+fn integration_at(share: &Path, hypr_config: &Path) -> Option<OmarchyIntegration> {
+    let generation = detect_generation(share, hypr_config)?;
+    let bindings_path = hypr_config.join(generation.bindings_file_name());
+    let contents = fs::read_to_string(&bindings_path).ok()?;
+    Some(OmarchyIntegration {
+        generation,
+        folder_association: folder_association_is_strata(),
+        shortcuts: has_managed_block(&contents, generation),
+        bindings_path,
+    })
+}
+
+/// Quattro moved user bindings to Lua, but upgraded systems keep the old
+/// `bindings.conf` on disk, so the installed Omarchy version decides which
+/// file is live and the user file only confirms it.
+fn detect_generation(share: &Path, hypr_config: &Path) -> Option<OmarchyGeneration> {
+    let candidate = match major_version(share) {
+        Some(major) if major >= 4 => OmarchyGeneration::Quattro,
+        Some(_) => OmarchyGeneration::Legacy,
+        None if hypr_config.join("hyprland.lua").is_file() => OmarchyGeneration::Quattro,
+        None if hypr_config.join("hyprland.conf").is_file() => OmarchyGeneration::Legacy,
+        None => return None,
+    };
+    hypr_config
+        .join(candidate.bindings_file_name())
+        .is_file()
+        .then_some(candidate)
+}
+
+fn major_version(share: &Path) -> Option<u32> {
+    let version = fs::read_to_string(share.join("version")).ok()?;
+    version.trim().split('.').next()?.parse().ok()
+}
+
+fn omarchy_share_dir() -> PathBuf {
+    std::env::var_os("OMARCHY_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/usr/share/omarchy"))
+}
+
+fn hypr_config_dir() -> PathBuf {
+    gtk::glib::home_dir().join(".config/hypr")
+}
+
+fn desktop_entry() -> Option<gio::AppInfo> {
+    gio::AppInfo::all()
+        .into_iter()
+        .find(|info| info.id().is_some_and(|id| id == DESKTOP_ENTRY))
+}
+
+fn folder_association_is_strata() -> bool {
+    gio::AppInfo::default_for_type(DIRECTORY_MIME, false)
+        .and_then(|info| info.id())
+        .is_some_and(|id| id == DESKTOP_ENTRY)
+}
+
+fn set_folder_association() -> Result<(), SetupError> {
+    let entry = desktop_entry().ok_or_else(|| {
+        SetupError::new(
+            "Strata's desktop entry is missing",
+            format!("{DESKTOP_ENTRY} is not installed."),
+        )
+    })?;
+    entry
+        .set_as_default_for_type(DIRECTORY_MIME)
+        .map_err(|error| {
+            SetupError::new(
+                "Unable to make Strata the default for folders",
+                error.to_string(),
+            )
+        })
+}
+
+fn run_hyprctl(args: &[&str]) -> io::Result<String> {
+    let output = Command::new("hyprctl")
+        .args(args)
+        .stdin(Stdio::null())
+        .output()?;
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// `hyprctl configerrors` prints nothing, or a "no errors" line, when the
+/// configuration is clean.
+fn config_errors_reported(output: &str) -> bool {
+    let trimmed = output.trim();
+    !trimmed.is_empty() && !trimmed.to_ascii_lowercase().contains("no errors")
+}
+
+fn backup_path(bindings: &Path) -> PathBuf {
+    let seconds = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs())
+        .unwrap_or_default();
+    let mut name = bindings.file_name().unwrap_or_default().to_os_string();
+    name.push(format!(".strata.bak.{seconds}"));
+    bindings.with_file_name(name)
+}
+
+fn begin_marker(generation: OmarchyGeneration) -> String {
+    format!("{} {BLOCK_TAG}:begin", generation.comment_prefix())
+}
+
+fn end_marker(generation: OmarchyGeneration) -> String {
+    format!("{} {BLOCK_TAG}:end", generation.comment_prefix())
+}
+
+fn managed_block(generation: OmarchyGeneration) -> String {
+    let comment = generation.comment_prefix();
+    let bindings = match generation {
+        OmarchyGeneration::Legacy => concat!(
+            "unbind = SUPER SHIFT, F\n",
+            "unbind = SUPER ALT SHIFT, F\n",
+            "bindd = SUPER SHIFT, F, File manager, exec, uwsm-app -- strata\n",
+            "bindd = SUPER ALT SHIFT, F, File manager (cwd), exec, uwsm-app -- strata \"$(omarchy-cmd-terminal-cwd)\"\n",
+        ),
+        OmarchyGeneration::Quattro => concat!(
+            "hl.unbind(\"SUPER + SHIFT + F\")\n",
+            "hl.unbind(\"SUPER + ALT + SHIFT + F\")\n",
+            "o.bind(\"SUPER + SHIFT + F\", \"File manager\", { launch = \"strata\" })\n",
+            "o.bind(\"SUPER + ALT + SHIFT + F\", \"File manager (cwd)\",\n",
+            "  \"uwsm-app -- strata \\\"$(omarchy-cmd-terminal-cwd)\\\"\")\n",
+        ),
+    };
+    format!(
+        "{}\n{comment} {MANAGED_NOTE}\n{bindings}{}\n",
+        begin_marker(generation),
+        end_marker(generation)
+    )
+}
+
+/// Replaces an existing managed block, or appends one, leaving every other
+/// line untouched so the edit is idempotent and repeatable.
+fn with_managed_block(contents: &str, generation: OmarchyGeneration) -> String {
+    let stripped = without_managed_block(contents, generation);
+    let body = stripped.trim_end();
+    if body.is_empty() {
+        return managed_block(generation);
+    }
+    format!("{body}\n\n{}", managed_block(generation))
+}
+
+fn without_managed_block(contents: &str, generation: OmarchyGeneration) -> String {
+    let begin = begin_marker(generation);
+    let end = end_marker(generation);
+    let mut kept = String::with_capacity(contents.len());
+    let mut inside = false;
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if !inside && trimmed == begin {
+            inside = true;
+            continue;
+        }
+        if inside {
+            inside = trimmed != end;
+            continue;
+        }
+        kept.push_str(line);
+        kept.push('\n');
+    }
+    kept
+}
+
+fn has_managed_block(contents: &str, generation: OmarchyGeneration) -> bool {
+    let begin = begin_marker(generation);
+    let end = end_marker(generation);
+    let mut lines = contents.lines().map(str::trim);
+    lines.any(|line| line == begin) && lines.any(|line| line == end)
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/services/omarchy_setup/tests.rs
+++ b/src/services/omarchy_setup/tests.rs
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use super::{
+    OmarchyGeneration, backup_path, config_errors_reported, detect_generation, has_managed_block,
+    managed_block, with_managed_block, without_managed_block,
+};
+
+static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(0);
+
+#[test]
+fn quattro_block_is_appended_after_existing_bindings() {
+    let existing =
+        "-- personal overrides\no.bind(\"SUPER + SHIFT + M\", \"Fix monitors\", \"x\")\n";
+
+    let updated = with_managed_block(existing, OmarchyGeneration::Quattro);
+
+    assert!(updated.starts_with(existing));
+    assert!(updated.contains("hl.unbind(\"SUPER + SHIFT + F\")"));
+    assert!(updated.contains("{ launch = \"strata\" }"));
+    assert!(has_managed_block(&updated, OmarchyGeneration::Quattro));
+}
+
+#[test]
+fn legacy_block_uses_hyprland_binding_syntax() {
+    let updated = with_managed_block(
+        "bindd = SUPER, RETURN, Terminal, exec, foot\n",
+        OmarchyGeneration::Legacy,
+    );
+
+    assert!(updated.contains("unbind = SUPER SHIFT, F"));
+    assert!(updated.contains("bindd = SUPER SHIFT, F, File manager, exec, uwsm-app -- strata"));
+    assert!(has_managed_block(&updated, OmarchyGeneration::Legacy));
+}
+
+#[test]
+fn reapplying_replaces_the_block_instead_of_stacking_copies() {
+    let existing = "-- keep me\n";
+
+    let once = with_managed_block(existing, OmarchyGeneration::Quattro);
+    let twice = with_managed_block(&once, OmarchyGeneration::Quattro);
+
+    assert_eq!(once, twice);
+    assert_eq!(twice.matches("hl.unbind(\"SUPER + SHIFT + F\")").count(), 1);
+}
+
+#[test]
+fn removing_the_block_restores_surrounding_bindings() {
+    let existing = "-- keep me\no.bind(\"SUPER + K\", \"Thing\", \"thing\")\n";
+
+    let applied = with_managed_block(existing, OmarchyGeneration::Quattro);
+    let reverted = without_managed_block(&applied, OmarchyGeneration::Quattro);
+
+    assert_eq!(reverted.trim_end(), existing.trim_end());
+    assert!(!has_managed_block(&reverted, OmarchyGeneration::Quattro));
+}
+
+#[test]
+fn an_empty_bindings_file_receives_only_the_block() {
+    assert_eq!(
+        with_managed_block("\n \n", OmarchyGeneration::Legacy),
+        managed_block(OmarchyGeneration::Legacy)
+    );
+}
+
+#[test]
+fn a_users_own_strata_binding_is_not_mistaken_for_the_managed_block() {
+    let hand_written =
+        "o.bind(\"SUPER + ALT + SHIFT + F\", \"File manager\", { launch = \"strata\" })\n";
+
+    assert!(!has_managed_block(hand_written, OmarchyGeneration::Quattro));
+}
+
+#[test]
+fn quattro_is_detected_from_the_installed_version() -> io::Result<()> {
+    let directory = test_directory()?;
+    let share = directory.join("share");
+    let hypr = directory.join("hypr");
+    fs::create_dir_all(&share)?;
+    fs::create_dir_all(&hypr)?;
+    fs::write(share.join("version"), "4.0.0.alpha\n")?;
+    fs::write(hypr.join("bindings.lua"), "")?;
+    fs::write(hypr.join("bindings.conf"), "")?;
+
+    assert_eq!(
+        detect_generation(&share, &hypr),
+        Some(OmarchyGeneration::Quattro)
+    );
+    fs::remove_dir_all(directory)
+}
+
+#[test]
+fn a_three_x_install_keeps_using_the_conf_bindings() -> io::Result<()> {
+    let directory = test_directory()?;
+    let share = directory.join("share");
+    let hypr = directory.join("hypr");
+    fs::create_dir_all(&share)?;
+    fs::create_dir_all(&hypr)?;
+    fs::write(share.join("version"), "3.1.2\n")?;
+    fs::write(hypr.join("bindings.conf"), "")?;
+
+    assert_eq!(
+        detect_generation(&share, &hypr),
+        Some(OmarchyGeneration::Legacy)
+    );
+    fs::remove_dir_all(directory)
+}
+
+#[test]
+fn detection_fails_without_the_generations_bindings_file() -> io::Result<()> {
+    let directory = test_directory()?;
+    let share = directory.join("share");
+    let hypr = directory.join("hypr");
+    fs::create_dir_all(&share)?;
+    fs::create_dir_all(&hypr)?;
+    fs::write(share.join("version"), "4.0.0")?;
+    fs::write(hypr.join("bindings.conf"), "")?;
+
+    assert_eq!(detect_generation(&share, &hypr), None);
+    fs::remove_dir_all(directory)
+}
+
+#[test]
+fn detection_fails_outside_omarchy() -> io::Result<()> {
+    let directory = test_directory()?;
+    let share = directory.join("share");
+    let hypr = directory.join("hypr");
+    fs::create_dir_all(&share)?;
+    fs::create_dir_all(&hypr)?;
+
+    assert_eq!(detect_generation(&share, &hypr), None);
+    fs::remove_dir_all(directory)
+}
+
+#[test]
+fn only_reported_configuration_errors_count_as_failure() {
+    assert!(!config_errors_reported(""));
+    assert!(!config_errors_reported("\n  \n"));
+    assert!(!config_errors_reported("no errors"));
+    assert!(config_errors_reported(
+        "Config error in line 42: unknown keyword"
+    ));
+}
+
+#[test]
+fn the_backup_sits_beside_the_bindings_file() {
+    let backup = backup_path(&PathBuf::from("/home/user/.config/hypr/bindings.lua"));
+
+    assert_eq!(backup.parent(), Some(Path::new("/home/user/.config/hypr")));
+    assert!(
+        backup
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with("bindings.lua.strata.bak."))
+    );
+}
+
+fn test_directory() -> io::Result<PathBuf> {
+    loop {
+        let path = std::env::temp_dir().join(format!(
+            "strata-omarchy-setup-{}-{}",
+            std::process::id(),
+            NEXT_TEST_DIRECTORY.fetch_add(1, Ordering::Relaxed)
+        ));
+        match fs::create_dir(&path) {
+            Ok(()) => return Ok(path),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+            Err(error) => return Err(error),
+        }
+    }
+}

--- a/src/style.css
+++ b/src/style.css
@@ -999,6 +999,38 @@ menubutton.form-control:disabled > button {
   color: @theme_accent;
 }
 
+.settings-action {
+  background: alpha(@theme_accent, 0.1);
+  border: 1px solid @theme_accent;
+  border-radius: 5px;
+  box-shadow: none;
+  color: @theme_accent;
+  min-height: 26px;
+  padding: 2px 11px;
+  transition: transform 160ms ease-out, background 160ms ease-out;
+}
+
+.settings-action:hover {
+  background: alpha(@theme_accent, 0.18);
+}
+
+.settings-action:active {
+  background: alpha(@theme_accent, 0.28);
+  transform: scale(0.97);
+}
+
+.settings-action:focus-visible {
+  outline: 2px solid @theme_accent;
+  outline-offset: 1px;
+}
+
+.settings-action:disabled {
+  background: alpha(@theme_muted, 0.3);
+  border-color: alpha(@theme_border, 0.38);
+  color: @theme_dim_text;
+  opacity: 0.7;
+}
+
 .click-activation-options {
   padding: 6px 10px;
 }

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -26,7 +26,10 @@ use super::{
     blur::BlurBin,
     browser::{BrowserView, dismiss_modal_layer, modal_layer},
     browser_modes::{BrowserMode, ClickActivation, ClickCount},
-    controls::{form_entry, menu_option, modal_layout, segmented_control},
+    controls::{
+        MESSAGE_DIALOG_WIDTH_CHARS, form_entry, menu_option, message_dialog_description,
+        modal_layout, segmented_control,
+    },
     theme::{TextSize, Theme, ThemeManager, ThemeTokens},
 };
 
@@ -736,6 +739,11 @@ fn general_page(
     });
     preferences.append(&motion_row);
 
+    if let Some(row) = omarchy_integration_row(&manager) {
+        append_heading(&preferences, "OMARCHY INTEGRATION");
+        preferences.append(&row);
+    }
+
     append_heading(&preferences, "CLICK ACTIVATION");
     let activation_options = gtk::Box::new(gtk::Orientation::Vertical, 4);
     let mut responsive_activation_rows = Vec::new();
@@ -777,6 +785,184 @@ fn general_page(
         vec![video_row],
         responsive_activation_rows,
     )
+}
+
+const OMARCHY_SETUP_TITLE: &str = "Make Strata your file manager?";
+const OMARCHY_SETUP_EXPLANATION: &str = "Strata will become the default application for folders and will take over Omarchy's file-manager shortcuts, which currently launch Nautilus. Only your own Hyprland configuration is edited, and it is backed up first.";
+const OMARCHY_SETUP_MANUAL: &str =
+    "https://github.com/lgse/strata#make-strata-the-omarchy-file-manager";
+
+/// The shared "make Strata the default file manager" dialog, used by both the
+/// one-time first-run prompt and the Settings action.
+pub(super) fn show_omarchy_setup_dialog(
+    parent: &gtk::Window,
+    integration: services::OmarchyIntegration,
+    on_answered: Rc<dyn Fn(bool)>,
+) {
+    let Some(window_overlay) = parent.child().and_downcast::<gtk::Overlay>() else {
+        on_answered(false);
+        return;
+    };
+    let blurred_root = window_overlay.child().and_downcast::<BlurBin>();
+    if let Some(root) = blurred_root.as_ref() {
+        root.set_blurred(true);
+    }
+
+    let repairing = integration.folder_association || integration.shortcuts;
+    let layout = modal_layout(
+        icons::FOLDER,
+        if repairing {
+            "Finish the Omarchy setup?"
+        } else {
+            OMARCHY_SETUP_TITLE
+        },
+        &integration.status_summary(),
+        if repairing { "Repair" } else { "Make Default" },
+    );
+    layout.content.add_css_class("message-dialog");
+    layout.content.set_size_request(560, -1);
+    layout.cancel.set_label("Not Now");
+    layout
+        .body
+        .append(&message_dialog_description(OMARCHY_SETUP_EXPLANATION));
+    let target = gtk::Label::new(Some(&format!(
+        "Shortcuts: {}",
+        integration.bindings_path.display()
+    )));
+    target.add_css_class("settings-option-description");
+    target.set_xalign(0.0);
+    target.set_wrap(true);
+    target.set_wrap_mode(gtk::pango::WrapMode::WordChar);
+    target.set_max_width_chars(MESSAGE_DIALOG_WIDTH_CHARS as i32);
+    layout.body.append(&target);
+    let status = gtk::Label::new(None);
+    status.add_css_class("update-dialog-status");
+    status.set_xalign(0.0);
+    status.set_wrap(true);
+    status.set_visible(false);
+    layout.body.append(&status);
+    let manual = gtk::LinkButton::with_label(OMARCHY_SETUP_MANUAL, "Set this up manually");
+    manual.add_css_class("release-notes-fallback");
+    manual.set_halign(gtk::Align::Start);
+    manual.set_visible(false);
+    layout.body.append(&manual);
+
+    let content = layout.content.clone();
+    let layer = modal_layer(&content, &window_overlay, blurred_root.clone(), None);
+    window_overlay.add_overlay(&layer);
+    layout.confirm.grab_focus();
+
+    let answered = Rc::new(Cell::new(false));
+    let dismiss: Rc<dyn Fn(bool)> = Rc::new({
+        let layer = layer.clone();
+        let overlay = window_overlay.clone();
+        let root = blurred_root.clone();
+        let answered = answered.clone();
+        let on_answered = on_answered.clone();
+        move |applied| {
+            if answered.replace(true) {
+                return;
+            }
+            dismiss_modal_layer(&layer, &overlay, root.as_ref());
+            on_answered(applied);
+        }
+    });
+
+    for button in [&layout.cancel, &layout.close] {
+        let dismiss = dismiss.clone();
+        button.connect_clicked(move |_| dismiss(false));
+    }
+    let escape = gtk::EventControllerKey::new();
+    let escape_dismiss = dismiss.clone();
+    escape.connect_key_pressed(move |_, key, _, _| {
+        if key == gtk::gdk::Key::Escape {
+            escape_dismiss(false);
+            glib::Propagation::Stop
+        } else {
+            glib::Propagation::Proceed
+        }
+    });
+    layer.add_controller(escape);
+
+    let confirm_dismiss = dismiss.clone();
+    let confirm_cancel = layout.cancel.clone();
+    layout.confirm.connect_clicked(move |button| {
+        button.set_sensitive(false);
+        match integration.apply() {
+            Ok(()) => confirm_dismiss(true),
+            Err(error) => {
+                button.set_sensitive(true);
+                status.set_text(&format!("{}: {}", error.summary, error.detail));
+                status.set_visible(true);
+                manual.set_visible(true);
+                confirm_cancel.set_label("Close");
+            }
+        }
+    });
+}
+
+/// The Settings entry point, so the integration can be applied or repaired
+/// later without resetting first-run state.
+fn omarchy_integration_row(manager: &Rc<ThemeManager>) -> Option<gtk::Box> {
+    let integration = services::omarchy_integration()?;
+    let row = gtk::Box::new(gtk::Orientation::Horizontal, 12);
+    row.add_css_class("settings-option");
+    let copy = gtk::Box::new(gtk::Orientation::Vertical, 2);
+    copy.set_hexpand(true);
+    let title = gtk::Label::new(Some("Default file manager"));
+    title.set_xalign(0.0);
+    title.add_css_class("settings-option-title");
+    let description = gtk::Label::new(Some(&integration.status_summary()));
+    description.set_xalign(0.0);
+    description.set_wrap(true);
+    description.add_css_class("settings-option-description");
+    copy.append(&title);
+    copy.append(&description);
+    let action = gtk::Button::with_label(if integration.is_complete() {
+        "Repair"
+    } else {
+        "Make Default"
+    });
+    action.add_css_class("settings-action");
+    action.set_valign(gtk::Align::Center);
+    row.append(&copy);
+    row.append(&action);
+
+    let manager = manager.clone();
+    let description_for_click = description.clone();
+    let action_for_click = action.clone();
+    action.connect_clicked(move |button| {
+        let Some(parent) = button.root().and_downcast::<gtk::Window>() else {
+            return;
+        };
+        let Some(integration) = services::omarchy_integration() else {
+            description_for_click.set_text("Strata could not identify this Omarchy installation.");
+            button.set_sensitive(false);
+            return;
+        };
+        let manager = manager.clone();
+        let description = description_for_click.clone();
+        let action = action_for_click.clone();
+        show_omarchy_setup_dialog(
+            &parent,
+            integration,
+            Rc::new(move |applied| {
+                if applied {
+                    manager.set_omarchy_default_prompt_answered(true);
+                }
+                if let Some(current) = services::omarchy_integration() {
+                    description.set_text(&current.status_summary());
+                    action.set_label(if current.is_complete() {
+                        "Repair"
+                    } else {
+                        "Make Default"
+                    });
+                }
+            }),
+        );
+    });
+
+    Some(row)
 }
 
 fn updates_page(

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -150,6 +150,8 @@ struct Preferences {
     auto_refresh_interval: u32,
     #[serde(default = "default_release_channel")]
     release_channel: String,
+    #[serde(default)]
+    omarchy_default_prompt_answered: bool,
 }
 
 impl Default for Preferences {
@@ -183,6 +185,7 @@ impl Default for Preferences {
             preview_volume: default_full_volume(),
             auto_refresh_interval: 0,
             release_channel: default_release_channel(),
+            omarchy_default_prompt_answered: false,
         }
     }
 }
@@ -633,6 +636,23 @@ impl ThemeManager {
         }
         self.previewing.set(false);
         self.apply_selected();
+        self.save_preferences();
+    }
+
+    /// Whether the one-time "make Strata the default file manager" prompt has
+    /// been answered. Declining is remembered so it never reappears; the
+    /// Settings action stays available either way.
+    pub fn omarchy_default_prompt_answered(&self) -> bool {
+        self.preferences.borrow().omarchy_default_prompt_answered
+    }
+
+    pub fn set_omarchy_default_prompt_answered(&self, answered: bool) {
+        if self.preferences.borrow().omarchy_default_prompt_answered == answered {
+            return;
+        }
+        self.preferences
+            .borrow_mut()
+            .omarchy_default_prompt_answered = answered;
         self.save_preferences();
     }
 

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -478,6 +478,38 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
         );
     });
     schedule_due_update_check(&theme_manager, &update_notice);
+    schedule_omarchy_setup_prompt(&window, &theme_manager);
+}
+
+/// Offers the one-time Omarchy default-file-manager setup, once the window is
+/// up and only while something is actually missing. Declining is persisted, so
+/// the prompt never returns; Settings keeps the action available.
+fn schedule_omarchy_setup_prompt(window: &gtk::ApplicationWindow, manager: &Rc<ThemeManager>) {
+    if manager.omarchy_default_prompt_answered() {
+        return;
+    }
+    let window = window.clone().upcast::<gtk::Window>();
+    let manager = manager.clone();
+    glib::timeout_add_local_once(std::time::Duration::from_secs(2), move || {
+        if manager.omarchy_default_prompt_answered() {
+            return;
+        }
+        let Some(integration) = crate::services::omarchy_integration() else {
+            return;
+        };
+        if integration.is_complete() {
+            manager.set_omarchy_default_prompt_answered(true);
+            return;
+        }
+        let manager_for_answer = manager.clone();
+        super::settings::show_omarchy_setup_dialog(
+            &window,
+            integration,
+            Rc::new(move |_applied| {
+                manager_for_answer.set_omarchy_default_prompt_answered(true);
+            }),
+        );
+    });
 }
 
 fn schedule_after_first_paint(window: &gtk::ApplicationWindow, sidebar: &SidebarView) {


### PR DESCRIPTION
## Description

Installing Strata on Omarchy left two separate pieces of state pointing elsewhere: the XDG `inode/directory` association, and Omarchy's own file-manager shortcuts, which launch Nautilus directly and never consult that association. Setting one without the other gives inconsistent behaviour, and the manual steps differ between Omarchy 3.x and Quattro.

Strata now detects both on the first eligible launch and offers to do the setup. The same action lives under **Settings → General → Omarchy integration**, so the integration can be applied or repaired later without resetting first-run state. Declining is persisted, so the prompt does not come back.

Setup resolves the generation from the installed Omarchy version rather than from which files happen to exist, since an upgraded Quattro system still has `bindings.conf` on disk. Only the user's own bindings are edited — `~/.config/hypr/bindings.lua` on Quattro, `~/.config/hypr/bindings.conf` on 3.x — through a marked block that is replaced rather than duplicated on re-run, after taking a backup. `hyprctl configerrors` gates the result: if Hyprland rejects the new bindings, the previous file is restored and the failure is reported with a link to the manual instructions. Nothing under `/usr/share/omarchy/` is touched.

## Visual evidence

The first-run dialog, on Omarchy Quattro 4.0.0.alpha (Tokyo Night):

> **Make Strata your file manager?**
> Folder associations and Omarchy Quattro's file-manager shortcuts still point elsewhere.
>
> Strata will become the default application for folders and will take over Omarchy's file-manager shortcuts, which currently launch Nautilus. Only your own Hyprland configuration is edited, and it is backed up first.
>
> Shortcuts: ~/.config/hypr/bindings.lua
>
> `Not Now`  `Make Default`

Screenshot attached separately — it uses the existing themed modal (`modal_layout` + `modal_layer`) and semantic `@theme_*` colors throughout, so it follows theme changes live.

## How to test

Run against a throwaway home so nothing real is modified:

1. `mkdir -p /tmp/fakehome/.config/hypr && cp ~/.config/hypr/{hyprland.lua,bindings.lua} /tmp/fakehome/.config/hypr/`
2. `HOME=/tmp/fakehome XDG_CONFIG_HOME=/tmp/fakehome/.config XDG_DATA_HOME=~/.local/share ./target/debug/strata /tmp/fakehome`
3. Wait ~2s for the prompt, then press **Make Default**.
4. Inspect `/tmp/fakehome/.config/hypr/bindings.lua` and `/tmp/fakehome/.config/mimeapps.list`.
5. Restart the same command, then open **Settings → General**.

**Expected result:** step 4 shows a `strata:file-manager-bindings` block appended after the pre-existing bindings, which are unchanged, no `.strata.bak.*` file left behind, and `inode/directory=io.github.lgse.Strata.desktop` in `mimeapps.list`. Step 5 does not prompt again, and the **Omarchy integration** row reads "Strata is the Omarchy Quattro file manager." with a **Repair** button that is idempotent — pressing it does not add a second block.

On a non-Omarchy system, no prompt appears and the Settings row is absent.

## Related issue

Closes #299
