### PR TITLE
fix(browser): hide Move to Trash when the location cannot support it

### DIFF
--- a/src/adapters/local_files.rs
+++ b/src/adapters/local_files.rs
@@ -46,6 +46,7 @@ enum NativeEnumeration {
         entries: Vec<FileEntry>,
         truncated: bool,
         metadata_complete: bool,
+        can_trash: Option<bool>,
     },
     Failed(String),
     Cancelled,
@@ -251,6 +252,16 @@ fn scan_native_directory(
         Ok(children) => children,
         Err(error) => return NativeEnumeration::Failed(error.to_string()),
     };
+    // A single stat-speed query on the directory itself, not per entry -- this is cheap
+    // enough to always run rather than threading a separate opt-out through the request.
+    let can_trash = gio::File::for_path(path)
+        .query_info(
+            gio::FILE_ATTRIBUTE_ACCESS_CAN_TRASH,
+            gio::FileQueryInfoFlags::NONE,
+            Some(cancellable),
+        )
+        .ok()
+        .map(|info| info.boolean(gio::FILE_ATTRIBUTE_ACCESS_CAN_TRASH));
     let hidden_names = native_hidden_names(path);
     let mut entries = Vec::new();
     let mut truncated = false;
@@ -320,6 +331,7 @@ fn scan_native_directory(
         entries,
         truncated,
         metadata_complete,
+        can_trash,
     }
 }
 
@@ -350,6 +362,7 @@ fn enumerate_native(
                 entries,
                 truncated,
                 metadata_complete,
+                can_trash,
             } => {
                 let total_entries = entries.len();
                 if !entries.is_empty() {
@@ -393,6 +406,7 @@ fn enumerate_native(
                 emit(DirectoryEvent::Finished {
                     request_id,
                     truncated,
+                    can_trash,
                 });
             }
             NativeEnumeration::Failed(message) => {
@@ -473,6 +487,26 @@ impl FileSource for LocalFileSource {
         }
 
         let task = glib::MainContext::default().spawn_local(async move {
+            let directory = location
+                .native_path()
+                .map(gio::File::for_path)
+                .unwrap_or_else(|| gio::File::for_uri(location.uri_value().unwrap_or_default()));
+            // Given its own full time budget rather than sharing the enumeration deadline
+            // below: a single stat-speed query on the directory itself, not per entry, so it
+            // should never be the reason a load looks truncated.
+            let can_trash = glib::future_with_timeout(
+                request.time_budget,
+                directory.query_info_future(
+                    gio::FILE_ATTRIBUTE_ACCESS_CAN_TRASH,
+                    gio::FileQueryInfoFlags::NONE,
+                    glib::Priority::DEFAULT,
+                ),
+            )
+            .await
+            .ok()
+            .and_then(Result::ok)
+            .map(|info| info.boolean(gio::FILE_ATTRIBUTE_ACCESS_CAN_TRASH));
+
             let deadline = started + request.time_budget;
             let finish_truncated = |entries: usize, reason: &'static str| {
                 tracing::warn!(
@@ -485,12 +519,9 @@ impl FileSource for LocalFileSource {
                 emit(DirectoryEvent::Finished {
                     request_id,
                     truncated: true,
+                    can_trash,
                 });
             };
-            let directory = location
-                .native_path()
-                .map(gio::File::for_path)
-                .unwrap_or_else(|| gio::File::for_uri(location.uri_value().unwrap_or_default()));
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
                 finish_truncated(0, "time budget");
@@ -556,6 +587,7 @@ impl FileSource for LocalFileSource {
                         emit(DirectoryEvent::Finished {
                             request_id,
                             truncated: false,
+                            can_trash,
                         });
                         break;
                     }

--- a/src/adapters/local_files.rs
+++ b/src/adapters/local_files.rs
@@ -23,9 +23,8 @@ use crate::{
     },
 };
 
-const LIST_ATTRIBUTES: &str =
-    "standard::display-name,standard::name,standard::type,standard::is-hidden,standard::is-symlink";
-const FULL_ATTRIBUTES: &str = "standard::display-name,standard::name,standard::type,standard::is-hidden,standard::is-symlink,standard::size,time::modified";
+const LIST_ATTRIBUTES: &str = "standard::display-name,standard::name,standard::type,standard::is-hidden,standard::is-symlink,access::can-trash";
+const FULL_ATTRIBUTES: &str = "standard::display-name,standard::name,standard::type,standard::is-hidden,standard::is-symlink,standard::size,time::modified,access::can-trash";
 const METADATA_ATTRIBUTES: &str = "standard::type,standard::size,time::modified";
 const MAX_PENDING_MONITOR_CHANGES: usize = 256;
 const MAX_HIDDEN_FILE_BYTES: u64 = 1024 * 1024;
@@ -105,6 +104,11 @@ fn info_is_hidden(info: &gio::FileInfo) -> bool {
 
 fn info_is_symlink(info: &gio::FileInfo) -> bool {
     info.has_attribute(gio::FILE_ATTRIBUTE_STANDARD_IS_SYMLINK) && info.is_symlink()
+}
+
+fn info_can_trash(info: &gio::FileInfo) -> Option<bool> {
+    info.has_attribute(gio::FILE_ATTRIBUTE_ACCESS_CAN_TRASH)
+        .then(|| info.boolean(gio::FILE_ATTRIBUTE_ACCESS_CAN_TRASH))
 }
 
 fn entry_from_info(location: Location, info: gio::FileInfo) -> FileEntry {
@@ -252,16 +256,6 @@ fn scan_native_directory(
         Ok(children) => children,
         Err(error) => return NativeEnumeration::Failed(error.to_string()),
     };
-    // A single stat-speed query on the directory itself, not per entry -- this is cheap
-    // enough to always run rather than threading a separate opt-out through the request.
-    let can_trash = gio::File::for_path(path)
-        .query_info(
-            gio::FILE_ATTRIBUTE_ACCESS_CAN_TRASH,
-            gio::FileQueryInfoFlags::NONE,
-            Some(cancellable),
-        )
-        .ok()
-        .map(|info| info.boolean(gio::FILE_ATTRIBUTE_ACCESS_CAN_TRASH));
     let hidden_names = native_hidden_names(path);
     let mut entries = Vec::new();
     let mut truncated = false;
@@ -301,6 +295,20 @@ fn scan_native_directory(
             is_hidden,
         });
     }
+
+    // `access::can-trash` describes the queried item, not its children. Probe one
+    // actual entry so a directory that cannot itself be removed (such as `$HOME`)
+    // does not incorrectly hide Trash for the entries it contains.
+    let can_trash = entries.first().and_then(|entry| {
+        gio::File::for_path(entry.location.native_path()?)
+            .query_info(
+                gio::FILE_ATTRIBUTE_ACCESS_CAN_TRASH,
+                gio::FileQueryInfoFlags::NONE,
+                Some(cancellable),
+            )
+            .ok()
+            .and_then(|info| info_can_trash(&info))
+    });
 
     let mut metadata_complete = true;
     if request.include_metadata && !entries.is_empty() && Instant::now() < deadline {
@@ -491,40 +499,26 @@ impl FileSource for LocalFileSource {
                 .native_path()
                 .map(gio::File::for_path)
                 .unwrap_or_else(|| gio::File::for_uri(location.uri_value().unwrap_or_default()));
-            // Given its own full time budget rather than sharing the enumeration deadline
-            // below: a single stat-speed query on the directory itself, not per entry, so it
-            // should never be the reason a load looks truncated.
-            let can_trash = glib::future_with_timeout(
-                request.time_budget,
-                directory.query_info_future(
-                    gio::FILE_ATTRIBUTE_ACCESS_CAN_TRASH,
-                    gio::FileQueryInfoFlags::NONE,
-                    glib::Priority::DEFAULT,
-                ),
-            )
-            .await
-            .ok()
-            .and_then(Result::ok)
-            .map(|info| info.boolean(gio::FILE_ATTRIBUTE_ACCESS_CAN_TRASH));
-
             let deadline = started + request.time_budget;
-            let finish_truncated = |entries: usize, reason: &'static str| {
-                tracing::warn!(
-                    request_id = request_id.0,
-                    entries,
-                    elapsed_ms = started.elapsed().as_millis() as u64,
-                    reason,
-                    "directory load truncated"
-                );
-                emit(DirectoryEvent::Finished {
-                    request_id,
-                    truncated: true,
-                    can_trash,
-                });
-            };
+            let finish_truncated =
+                |entries: usize, reason: &'static str, can_trash: Option<bool>| {
+                    tracing::warn!(
+                        request_id = request_id.0,
+                        entries,
+                        elapsed_ms = started.elapsed().as_millis() as u64,
+                        reason,
+                        "directory load truncated"
+                    );
+                    emit(DirectoryEvent::Finished {
+                        request_id,
+                        truncated: true,
+                        can_trash,
+                    });
+                };
+            let mut can_trash = None;
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
-                finish_truncated(0, "time budget");
+                finish_truncated(0, "time budget", can_trash);
                 return;
             }
             let attributes = if request.include_metadata {
@@ -557,7 +551,7 @@ impl FileSource for LocalFileSource {
                     return;
                 }
                 Err(_) => {
-                    finish_truncated(0, "time budget");
+                    finish_truncated(0, "time budget", can_trash);
                     return;
                 }
             };
@@ -567,7 +561,7 @@ impl FileSource for LocalFileSource {
             loop {
                 let remaining = deadline.saturating_duration_since(Instant::now());
                 if remaining.is_zero() {
-                    finish_truncated(total_entries, "time budget");
+                    finish_truncated(total_entries, "time budget", can_trash);
                     break;
                 }
                 match glib::future_with_timeout(
@@ -592,6 +586,9 @@ impl FileSource for LocalFileSource {
                         break;
                     }
                     Ok(Ok(files)) => {
+                        if can_trash.is_none() {
+                            can_trash = files.iter().find_map(info_can_trash);
+                        }
                         let mut entries: Vec<_> = files
                             .into_iter()
                             .filter_map(|info| {
@@ -617,7 +614,7 @@ impl FileSource for LocalFileSource {
                             entries,
                         });
                         if entry_budget_exhausted {
-                            finish_truncated(total_entries, "entry budget");
+                            finish_truncated(total_entries, "entry budget", can_trash);
                             break;
                         }
                     }
@@ -635,7 +632,7 @@ impl FileSource for LocalFileSource {
                         break;
                     }
                     Err(_) => {
-                        finish_truncated(total_entries, "time budget");
+                        finish_truncated(total_entries, "time budget", can_trash);
                         break;
                     }
                 }

--- a/src/adapters/local_files/tests.rs
+++ b/src/adapters/local_files/tests.rs
@@ -416,6 +416,13 @@ fn finished_truncated(events: &[DirectoryEvent]) -> Option<bool> {
     })
 }
 
+fn finished_can_trash(events: &[DirectoryEvent]) -> Option<Option<bool>> {
+    events.iter().find_map(|event| match event {
+        DirectoryEvent::Finished { can_trash, .. } => Some(*can_trash),
+        _ => None,
+    })
+}
+
 #[test]
 fn enumerate_reports_truncated_once_the_entry_budget_is_exceeded() {
     let root = unique_fixture_root("entry-budget");
@@ -444,6 +451,33 @@ fn enumerate_reports_truncated_once_the_entry_budget_is_exceeded() {
         batched_entry_count(&events),
         3,
         "loading should retain exactly the configured maximum"
+    );
+}
+
+#[test]
+fn enumerate_resolves_can_trash_for_a_real_local_directory() {
+    // Not asserting *which* answer: whether a given CI/dev machine's temp
+    // directory happens to support Trash is environment-specific and not
+    // something this test should depend on (issue #284). What must hold
+    // everywhere is that the `access::can-trash` query on a real, accessible
+    // local directory actually resolves to an answer instead of silently
+    // coming back `None`, which would mean the query never ran at all.
+    let root = unique_fixture_root("can-trash");
+    fs::create_dir_all(&root).expect("the fixture directory should be created");
+
+    let events = run_enumerate(DirectoryRequest {
+        id: RequestId(1),
+        location: Location::local(&root),
+        batch_size: 64,
+        include_metadata: false,
+        max_entries: 10,
+        time_budget: Duration::from_secs(10),
+    });
+    fs::remove_dir_all(&root).expect("the fixture directory should be removed");
+
+    assert!(
+        finished_can_trash(&events).is_some_and(|can_trash| can_trash.is_some()),
+        "a real, accessible local directory should always resolve access::can-trash"
     );
 }
 

--- a/src/adapters/local_files/tests.rs
+++ b/src/adapters/local_files/tests.rs
@@ -455,15 +455,19 @@ fn enumerate_reports_truncated_once_the_entry_budget_is_exceeded() {
 }
 
 #[test]
-fn enumerate_resolves_can_trash_for_a_real_local_directory() {
-    // Not asserting *which* answer: whether a given CI/dev machine's temp
-    // directory happens to support Trash is environment-specific and not
-    // something this test should depend on (issue #284). What must hold
-    // everywhere is that the `access::can-trash` query on a real, accessible
-    // local directory actually resolves to an answer instead of silently
-    // coming back `None`, which would mean the query never ran at all.
+fn enumerate_resolves_can_trash_from_a_child_entry() {
     let root = unique_fixture_root("can-trash");
     fs::create_dir_all(&root).expect("the fixture directory should be created");
+    let child = root.join("child.txt");
+    fs::write(&child, b"content").expect("the fixture file should be written");
+    let expected = gio::File::for_path(&child)
+        .query_info(
+            gio::FILE_ATTRIBUTE_ACCESS_CAN_TRASH,
+            gio::FileQueryInfoFlags::NONE,
+            None::<&gio::Cancellable>,
+        )
+        .expect("the child capability query should succeed")
+        .boolean(gio::FILE_ATTRIBUTE_ACCESS_CAN_TRASH);
 
     let events = run_enumerate(DirectoryRequest {
         id: RequestId(1),
@@ -475,10 +479,7 @@ fn enumerate_resolves_can_trash_for_a_real_local_directory() {
     });
     fs::remove_dir_all(&root).expect("the fixture directory should be removed");
 
-    assert!(
-        finished_can_trash(&events).is_some_and(|can_trash| can_trash.is_some()),
-        "a real, accessible local directory should always resolve access::can-trash"
-    );
+    assert_eq!(finished_can_trash(&events), Some(Some(expected)));
 }
 
 #[test]

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -346,6 +346,8 @@ struct SortPlan {
     ordering_preferences: ViewPreferences,
     staged_preferences: ViewPreferences,
     retry_metadata: bool,
+    truncated: bool,
+    can_trash: Option<bool>,
 }
 
 enum PublishTerminal {
@@ -360,6 +362,7 @@ enum RemoteTerminal {
     Finished {
         request_id: RequestId,
         truncated: bool,
+        can_trash: Option<bool>,
     },
     Failed {
         request_id: RequestId,
@@ -555,6 +558,10 @@ impl Browser {
 
     pub fn location_at(&self, depth: usize) -> Option<Location> {
         self.state.borrow().location_at(depth)
+    }
+
+    pub fn can_trash_at(&self, depth: usize) -> Option<bool> {
+        self.state.borrow().can_trash_at(depth)
     }
 
     pub fn focus_active(&self) {
@@ -1914,8 +1921,12 @@ impl Browser {
             RemoteTerminal::Finished {
                 request_id,
                 truncated,
+                can_trash,
             } => {
-                let finished = self.state.borrow_mut().finish(request_id, truncated);
+                let finished = self
+                    .state
+                    .borrow_mut()
+                    .finish(request_id, truncated, can_trash);
                 if let Some(depth) = finished {
                     self.emit(BrowserEvent::LoadFinished { depth, truncated });
                     self.ensure_sorted_after_load(depth);
@@ -1950,7 +1961,13 @@ impl Browser {
 
     /// Sorts a staged snapshot off-thread, then installs, reconciles, and publishes
     /// it with the loading state up throughout: no provisional list is exposed.
-    fn finish_staged_load(self: &Rc<Self>, depth: usize, request_id: RequestId, truncated: bool) {
+    fn finish_staged_load(
+        self: &Rc<Self>,
+        depth: usize,
+        request_id: RequestId,
+        truncated: bool,
+        can_trash: Option<bool>,
+    ) {
         let staging = self.staging.borrow_mut().remove(&depth);
         let Some(staging) = staging.filter(|staged| staged.request_id == request_id) else {
             return;
@@ -1985,8 +2002,9 @@ impl Browser {
                 ordering_preferences,
                 staged_preferences: preferences,
                 retry_metadata,
+                truncated,
+                can_trash,
             },
-            truncated,
         );
     }
 
@@ -1998,18 +2016,10 @@ impl Browser {
         request_id: RequestId,
         entries: Vec<FileEntry>,
         plan: SortPlan,
-        truncated: bool,
     ) {
         if entries.len() <= SORT_INLINE_LIMIT {
             let sorted = sort_entries(entries, plan.ordering_preferences);
-            self.finish_staged_sort(
-                depth,
-                request_id,
-                sorted,
-                plan.staged_preferences,
-                truncated,
-                plan.retry_metadata,
-            );
+            self.finish_staged_sort(depth, request_id, sorted, plan);
             return;
         }
         let weak: Weak<Self> = Rc::downgrade(self);
@@ -2020,14 +2030,7 @@ impl Browser {
                 return;
             };
             match sorted {
-                Ok(sorted) => browser.finish_staged_sort(
-                    depth,
-                    request_id,
-                    sorted,
-                    plan.staged_preferences,
-                    truncated,
-                    plan.retry_metadata,
-                ),
+                Ok(sorted) => browser.finish_staged_sort(depth, request_id, sorted, plan),
                 Err(_) => browser.fail_staged_sort(depth, request_id),
             }
         });
@@ -2038,10 +2041,12 @@ impl Browser {
         depth: usize,
         request_id: RequestId,
         sorted: Vec<FileEntry>,
-        staged_preferences: ViewPreferences,
-        truncated: bool,
-        retry_metadata: bool,
+        plan: SortPlan,
     ) {
+        let staged_preferences = plan.staged_preferences;
+        let truncated = plan.truncated;
+        let can_trash = plan.can_trash;
+        let retry_metadata = plan.retry_metadata;
         let sorting = self.sorting.borrow_mut().remove(&depth);
         let Some(sorting) = sorting.filter(|sorting| sorting.request_id == request_id) else {
             return;
@@ -2079,11 +2084,13 @@ impl Browser {
             if matches!(current.sort_key, SortKey::Size | SortKey::Modified)
                 && self.state.borrow().column_unknown_metadata(depth).is_some()
             {
-                self.state.borrow_mut().finish(request_id, truncated);
+                self.state
+                    .borrow_mut()
+                    .finish(request_id, truncated, can_trash);
                 self.emit(BrowserEvent::LoadFinished { depth, truncated });
                 self.ensure_sorted_after_load(depth);
             } else {
-                self.resort_installed_column(depth, request_id, current, truncated);
+                self.resort_installed_column(depth, request_id, current, truncated, can_trash);
             }
             return;
         }
@@ -2101,7 +2108,9 @@ impl Browser {
             .get(depth)
             .map(|column| column.entries.len())
             .unwrap_or(0);
-        self.state.borrow_mut().finish(request_id, truncated);
+        self.state
+            .borrow_mut()
+            .finish(request_id, truncated, can_trash);
         self.publish_staged(
             depth,
             request_id,
@@ -2121,6 +2130,7 @@ impl Browser {
         request_id: RequestId,
         preferences: ViewPreferences,
         truncated: bool,
+        can_trash: Option<bool>,
     ) {
         let Some(entries) = self
             .state
@@ -2146,8 +2156,9 @@ impl Browser {
                 ordering_preferences: preferences,
                 staged_preferences: preferences,
                 retry_metadata: false,
+                truncated,
+                can_trash,
             },
-            truncated,
         );
     }
 
@@ -3022,6 +3033,7 @@ impl Browser {
             DirectoryEvent::Finished {
                 request_id,
                 truncated,
+                can_trash,
             } => {
                 // Bound to a variable first: an if-let scrutinee borrow would stay live
                 // across the flush and panic inside it.
@@ -3030,7 +3042,7 @@ impl Browser {
                 match (target, open) {
                     (Some((depth, true)), Some(_)) => {
                         self.stage_batch(request_id, depth, Vec::new());
-                        self.finish_staged_load(depth, request_id, truncated);
+                        self.finish_staged_load(depth, request_id, truncated, can_trash);
                     }
                     (Some((depth, _)), Some(_)) => {
                         self.remote_terminals.borrow_mut().insert(
@@ -3038,6 +3050,7 @@ impl Browser {
                             RemoteTerminal::Finished {
                                 request_id,
                                 truncated,
+                                can_trash,
                             },
                         );
                         self.flush_coalesced_capped(Some(depth));

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -108,6 +108,7 @@ impl FileSource for WatchingFileSource {
         emit(DirectoryEvent::Finished {
             request_id: request.id,
             truncated: false,
+            can_trash: None,
         });
         LoadHandle::new(|| {})
     }
@@ -182,6 +183,7 @@ impl FileSource for RetryFileSource {
             emit(DirectoryEvent::Finished {
                 request_id: request.id,
                 truncated: false,
+                can_trash: None,
             });
         }
         LoadHandle::new(|| {})
@@ -237,6 +239,7 @@ impl FileSource for FilePreviewSource {
         emit(DirectoryEvent::Finished {
             request_id: request.id,
             truncated: false,
+            can_trash: None,
         });
         LoadHandle::new(|| {})
     }
@@ -264,6 +267,7 @@ impl FileSource for RestoredSortingSource {
         emit(DirectoryEvent::Finished {
             request_id: request.id,
             truncated: false,
+            can_trash: None,
         });
         LoadHandle::new(|| {})
     }
@@ -290,6 +294,7 @@ impl FileSource for FakeFileSource {
         emit(DirectoryEvent::Finished {
             request_id: request.id,
             truncated: false,
+            can_trash: None,
         });
         LoadHandle::new(|| {})
     }
@@ -318,6 +323,7 @@ impl FileSource for TrashFileSource {
         emit(DirectoryEvent::Finished {
             request_id: request.id,
             truncated: false,
+            can_trash: None,
         });
         LoadHandle::new(|| {})
     }
@@ -337,6 +343,7 @@ impl FileSource for CountingFileSource {
         emit(DirectoryEvent::Finished {
             request_id: request.id,
             truncated: false,
+            can_trash: None,
         });
         LoadHandle::new(|| {})
     }
@@ -1696,6 +1703,7 @@ impl FileSource for SortFillSource {
         emit(DirectoryEvent::Finished {
             request_id: request.id,
             truncated: false,
+            can_trash: None,
         });
         LoadHandle::new(|| {})
     }
@@ -1832,6 +1840,7 @@ fn load_finish_applies_rows_queued_behind_the_count_threshold() {
     emit(DirectoryEvent::Finished {
         request_id,
         truncated: false,
+        can_trash: None,
     });
 
     let names: Vec<_> = browser.state.borrow().columns[0]
@@ -1879,6 +1888,7 @@ fn remote_load_finishes_only_after_every_queued_row_is_applied() {
     emit(DirectoryEvent::Finished {
         request_id,
         truncated: false,
+        can_trash: None,
     });
 
     assert!(
@@ -2108,6 +2118,7 @@ impl FileSource for ScriptedSource {
         emit(DirectoryEvent::Finished {
             request_id: request.id,
             truncated: false,
+            can_trash: None,
         });
         LoadHandle::new(|| {})
     }
@@ -2516,6 +2527,7 @@ fn refresh_drops_staging_and_its_sort() {
     emit(DirectoryEvent::Finished {
         request_id,
         truncated: false,
+        can_trash: None,
     });
     assert_eq!(replaced_count(&events), 1);
     assert_eq!(
@@ -2552,6 +2564,7 @@ fn close_column_clears_the_truncated_depth() {
     emit(DirectoryEvent::Finished {
         request_id,
         truncated: false,
+        can_trash: None,
     });
 
     browser.descend(0, Location::local("/fixture/sub"));
@@ -2563,6 +2576,7 @@ fn close_column_clears_the_truncated_depth() {
     sub_emit(DirectoryEvent::Finished {
         request_id: sub_id,
         truncated: false,
+        can_trash: None,
     });
     let published = replaced_count(&events);
     assert_eq!(published, 2);
@@ -2879,6 +2893,7 @@ fn native_initial_load_publishes_sorted_once() {
     emit(DirectoryEvent::Finished {
         request_id,
         truncated: false,
+        can_trash: None,
     });
     assert_eq!(replaced_count(&events), 1);
     assert_eq!(
@@ -2903,6 +2918,7 @@ fn empty_native_initial_load_finishes_without_a_batch() {
     emit(DirectoryEvent::Finished {
         request_id,
         truncated: false,
+        can_trash: None,
     });
 
     assert_eq!(replaced_count(&events), 1);
@@ -2942,6 +2958,7 @@ fn incomplete_native_metadata_uses_name_order_until_a_full_retry_finishes() {
     emit(DirectoryEvent::Finished {
         request_id,
         truncated: false,
+        can_trash: None,
     });
 
     assert_eq!(
@@ -2989,6 +3006,7 @@ fn staged_load_reconciles_monitor_deltas_without_resurrection() {
     emit(DirectoryEvent::Finished {
         request_id,
         truncated: false,
+        can_trash: None,
     });
     assert_eq!(
         column_names(&browser, 0),
@@ -3127,6 +3145,7 @@ fn staged_sorts_order_every_key_in_both_directions() {
         emit(DirectoryEvent::Finished {
             request_id,
             truncated: false,
+            can_trash: None,
         });
         assert_eq!(
             column_names(&browser, 0),
@@ -3167,6 +3186,7 @@ fn large_load_streams_prefix_then_tails_with_terminal_last() {
     emit(DirectoryEvent::Finished {
         request_id,
         truncated: false,
+        can_trash: None,
     });
     pump_until(|| {
         events
@@ -3243,6 +3263,7 @@ fn remote_rows_flush_within_the_latency_bound() {
     emit(DirectoryEvent::Finished {
         request_id,
         truncated: false,
+        can_trash: None,
     });
     assert!(
         events
@@ -3274,16 +3295,21 @@ fn resort_after_mid_load_preference_change_republishes() {
         },
     );
     let sorted = vec![batch_entry("b.txt"), batch_entry("a.txt")];
+    let staged_preferences = ViewPreferences {
+        sort_key: crate::model::SortKey::Size,
+        ..ViewPreferences::default()
+    };
     browser.finish_staged_sort(
         0,
         request_id,
         sorted,
-        ViewPreferences {
-            sort_key: crate::model::SortKey::Size,
-            ..ViewPreferences::default()
+        SortPlan {
+            ordering_preferences: staged_preferences,
+            staged_preferences,
+            retry_metadata: false,
+            truncated: false,
+            can_trash: None,
         },
-        false,
-        false,
     );
     assert_eq!(
         column_names(&browser, 0),
@@ -3331,6 +3357,7 @@ impl FileSource for MixedPeekFileSource {
         emit(DirectoryEvent::Finished {
             request_id: request.id,
             truncated: false,
+            can_trash: None,
         });
         LoadHandle::new(|| {})
     }

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -42,10 +42,10 @@ pub struct ColumnState {
     selection_target: Option<Location>,
     pub load_state: LoadState,
     pub truncated: bool,
-    /// Whether entries here can be moved to Trash, resolved once when the
-    /// directory loads (see `DirectoryEvent::Finished`). `None` before the first
-    /// load finishes, or when the check itself couldn't be answered; treated as
-    /// "assume trashable" by consumers.
+    /// Whether entries here can be moved to Trash, resolved from a listed entry
+    /// when the directory loads (see `DirectoryEvent::Finished`). `None` before
+    /// the first load finishes, for an empty directory, or when the capability
+    /// couldn't be answered; treated as "assume trashable" by consumers.
     pub can_trash: Option<bool>,
     preferences: ViewPreferences,
     request_id: RequestId,

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -42,6 +42,11 @@ pub struct ColumnState {
     selection_target: Option<Location>,
     pub load_state: LoadState,
     pub truncated: bool,
+    /// Whether entries here can be moved to Trash, resolved once when the
+    /// directory loads (see `DirectoryEvent::Finished`). `None` before the first
+    /// load finishes, or when the check itself couldn't be answered; treated as
+    /// "assume trashable" by consumers.
+    pub can_trash: Option<bool>,
     preferences: ViewPreferences,
     request_id: RequestId,
     select_first_on_load: bool,
@@ -168,6 +173,7 @@ impl NavigationState {
                 selection_target: None,
                 load_state: LoadState::Loading,
                 truncated: false,
+                can_trash: None,
                 preferences,
                 request_id,
                 select_first_on_load: false,
@@ -236,6 +242,7 @@ impl NavigationState {
             selection_target: None,
             load_state: LoadState::Loading,
             truncated: false,
+            can_trash: None,
             preferences: self.preferences,
             request_id,
             select_first_on_load: false,
@@ -477,6 +484,7 @@ impl NavigationState {
         column.selected = None;
         column.load_state = LoadState::Loading;
         column.truncated = false;
+        column.can_trash = None;
         column.request_id = request_id;
         Some(column.location.clone())
     }
@@ -575,10 +583,20 @@ impl NavigationState {
         Some(self.columns.get(depth)?.location.clone())
     }
 
-    pub fn finish(&mut self, request_id: RequestId, truncated: bool) -> Option<usize> {
+    pub fn can_trash_at(&self, depth: usize) -> Option<bool> {
+        self.columns.get(depth)?.can_trash
+    }
+
+    pub fn finish(
+        &mut self,
+        request_id: RequestId,
+        truncated: bool,
+        can_trash: Option<bool>,
+    ) -> Option<usize> {
         let (depth, column) = self.column_for_request_mut(request_id)?;
         column.select_first_on_load = false;
         column.truncated = truncated;
+        column.can_trash = can_trash;
         column.load_state = if column.entries.is_empty() {
             LoadState::Empty
         } else {

--- a/src/app/navigation/tests.rs
+++ b/src/app/navigation/tests.rs
@@ -319,7 +319,7 @@ fn empty_is_distinct_from_loading_and_error() {
     state.navigate(location("/empty"), RequestId(1));
     assert_eq!(state.columns[0].load_state, LoadState::Loading);
 
-    assert_eq!(state.finish(RequestId(1), false), Some(0));
+    assert_eq!(state.finish(RequestId(1), false, None), Some(0));
     assert_eq!(state.columns[0].load_state, LoadState::Empty);
 }
 
@@ -328,7 +328,7 @@ fn truncated_load_state_survives_until_reload() {
     let mut state = NavigationState::default();
     state.navigate(location("/partial"), RequestId(1));
 
-    assert_eq!(state.finish(RequestId(1), true), Some(0));
+    assert_eq!(state.finish(RequestId(1), true, None), Some(0));
     assert!(state.columns[0].truncated);
 
     state.reload_column(0, RequestId(2));

--- a/src/services/file_source.rs
+++ b/src/services/file_source.rs
@@ -185,11 +185,10 @@ pub enum DirectoryEvent {
         /// `true` if the load stopped short of covering the full directory, because it hit the
         /// entry or time budget; already-emitted `Batch` entries are then a lower bound.
         truncated: bool,
-        /// Whether this location supports moving entries to Trash, from a single
-        /// `access::can-trash` query on the directory itself. `None` when the query
-        /// couldn't be answered (e.g. it timed out); treated as "assume trashable" by
-        /// consumers, since that matches offering Trash and letting the operation itself
-        /// fail if it turns out not to be supported.
+        /// Whether this location supports moving entries to Trash, resolved from an
+        /// entry in the directory. `None` when the location is empty or the capability
+        /// couldn't be answered; treated as "assume trashable" by consumers, since that
+        /// matches offering Trash and letting the operation itself fail if unsupported.
         can_trash: Option<bool>,
     },
     /// Consumers must not present these partial values as a completed sort.

--- a/src/services/file_source.rs
+++ b/src/services/file_source.rs
@@ -185,6 +185,12 @@ pub enum DirectoryEvent {
         /// `true` if the load stopped short of covering the full directory, because it hit the
         /// entry or time budget; already-emitted `Batch` entries are then a lower bound.
         truncated: bool,
+        /// Whether this location supports moving entries to Trash, from a single
+        /// `access::can-trash` query on the directory itself. `None` when the query
+        /// couldn't be answered (e.g. it timed out); treated as "assume trashable" by
+        /// consumers, since that matches offering Trash and letting the operation itself
+        /// fail if it turns out not to be supported.
+        can_trash: Option<bool>,
     },
     /// Consumers must not present these partial values as a completed sort.
     MetadataIncomplete { request_id: RequestId },

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -6345,6 +6345,9 @@ pub(super) fn install_item_context_menu(
         let entries = state.browser.selected_entries();
         preview.set_visible(entry_supports_quick_preview(&entry));
         open_terminal.set_visible(entry.is_directory() && can_open_terminal(&entry.location));
+        let trash_visible = move_to_trash_is_visible(in_trash, state.browser.can_trash_at(depth));
+        move_to_trash.set_visible(trash_visible);
+        trash_multiple.set_visible(trash_visible);
         permanent_delete.set_visible(!in_trash);
         permanent_delete_multiple.set_visible(!in_trash);
         pin.set_visible(entry.is_directory() && !is_trash_location(&entry.location));
@@ -8771,6 +8774,20 @@ fn is_trash_location(location: &Location) -> bool {
     location
         .uri_value()
         .is_some_and(|uri| uri.starts_with("trash:"))
+}
+
+/// Whether the "Move to Trash" context-menu option should be shown (issue #284).
+///
+/// Always visible while already browsing Trash, where it's really "Permanently
+/// delete" under a shared label -- `can_trash` describes an ordinary location's
+/// Trash support and has no bearing there. Otherwise, visible unless the
+/// location's `access::can-trash` check came back a definite `Some(false)`;
+/// `None` (not yet resolved, or the check itself couldn't be answered) defaults
+/// to visible, since offering Trash and letting the operation fail is the
+/// existing, safer fallback (issue #179) rather than ever hiding the only
+/// delete option this menu has.
+fn move_to_trash_is_visible(in_trash: bool, can_trash: Option<bool>) -> bool {
+    in_trash || can_trash.unwrap_or(true)
 }
 
 fn compact_display_path(location: &Location) -> String {

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1451,3 +1451,28 @@ fn retryable_delete_entries_is_empty_when_nothing_matches() {
 
     assert!(kept.is_empty());
 }
+
+#[test]
+fn move_to_trash_hides_only_for_a_confirmed_unsupported_location() {
+    assert!(!move_to_trash_is_visible(false, Some(false)));
+}
+
+#[test]
+fn move_to_trash_shows_for_a_confirmed_supported_location() {
+    assert!(move_to_trash_is_visible(false, Some(true)));
+}
+
+#[test]
+fn move_to_trash_defaults_to_visible_before_the_check_resolves() {
+    // `None` covers both "the load hasn't finished yet" and "the check itself
+    // couldn't be answered" -- neither should ever hide the only delete option.
+    assert!(move_to_trash_is_visible(false, None));
+}
+
+#[test]
+fn move_to_trash_stays_visible_inside_trash_regardless_of_can_trash() {
+    // Inside Trash this button is really "Permanently delete" under a shared
+    // label; an ordinary location's Trash support is irrelevant there.
+    assert!(move_to_trash_is_visible(true, Some(false)));
+    assert!(move_to_trash_is_visible(true, None));
+}


### PR DESCRIPTION
## Description

"Move to Trash" was always shown regardless of whether the current location actually supports trashing, so on a location that doesn't (e.g. a tmpfs mount, or certain removable/network filesystems), choosing it just fails.

This resolves it proactively instead of reactively: each directory load now runs a single `access::can-trash` GIO query against the directory itself, and the cached result is read synchronously when building the item context menu. An unresolved check (query times out, etc.) still defaults to showing the option — never hides the only delete path — and Trash itself always shows "Move to Trash" regardless of the check, since restoring from Trash is really a move back to the original location.

## Visual evidence

Right-click context menu on a file, comparing a trash-unsupported location (tmpfs) against a trash-supported one (btrfs): 
<img width="936" height="1020" alt="image" src="https://github.com/user-attachments/assets/240925ae-18b6-4a97-a508-85f8b20ee6f3" />

<img width="936" height="1020" alt="image" src="https://github.com/user-attachments/assets/30e6abce-348a-4742-bcd3-1521221d0281" />


## How to test

1. Create a file on a location that doesn't support trash, e.g. `touch /tmp/no-trash-file.txt` (tmpfs generally doesn't support `access::can-trash`).
2. In Strata, navigate to that location and right-click the file.
3. Create a file on a normal trash-supported location, e.g. your home directory, and right-click it there too.

**Expected result:** the tmpfs file's context menu shows "Permanently delete" but not "Move to Trash"; the home-directory file's context menu shows both. Trash itself continues to always show "Move to Trash" (used for restoring items).

## Related issue

Closes #284

