### PR TITLE
fix(navigation): make address bar editing predictable

### DIFF
--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -547,7 +547,7 @@ impl BrowserView {
             let clicked_button = gesture
                 .widget()
                 .and_then(|widget| widget.pick(x, y, gtk::PickFlags::DEFAULT))
-                .is_some_and(is_breadcrumb_target);
+                .is_some_and(is_breadcrumb_button_target);
             if !clicked_button && let Some(state) = weak_state.upgrade() {
                 state.begin_location_edit();
             }
@@ -833,6 +833,15 @@ impl BrowserView {
                 .and_then(|root| root.focus())
                 .as_ref()
                 .is_some_and(|focused| focused == entry || focused.is_ancestor(entry))
+    }
+
+    pub(super) fn location_edit_is_active(&self) -> bool {
+        self.state.location_stack.visible_child_name().as_deref() == Some("entry")
+    }
+
+    pub(super) fn location_edit_contains(&self, target: &gtk::Widget) -> bool {
+        let location_stack = self.state.location_stack.upcast_ref::<gtk::Widget>();
+        target == location_stack || target.is_ancestor(location_stack)
     }
 
     pub fn cancel_location_edit(&self) {
@@ -7875,13 +7884,9 @@ fn is_file_row_target(target: gtk::Widget) -> bool {
     file_row_target(target).is_some()
 }
 
-fn is_breadcrumb_target(mut target: gtk::Widget) -> bool {
+fn is_breadcrumb_button_target(mut target: gtk::Widget) -> bool {
     loop {
-        if target.is::<gtk::Button>()
-            || target.has_css_class("breadcrumb")
-            || target.has_css_class("breadcrumb-separator")
-            || target.has_css_class("current-breadcrumb")
-        {
+        if target.is::<gtk::Button>() {
             return true;
         }
         let Some(parent) = target.parent() else {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -460,6 +460,22 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
         }
     });
     window.add_controller(rename_cancel);
+    let location_cancel_view = browser.clone();
+    let location_cancel = gtk::GestureClick::new();
+    location_cancel.set_propagation_phase(gtk::PropagationPhase::Capture);
+    location_cancel.connect_pressed(move |gesture, _, x, y| {
+        if !location_cancel_view.location_edit_is_active() {
+            return;
+        }
+        let on_location_edit = gesture
+            .widget()
+            .and_then(|widget| widget.pick(x, y, gtk::PickFlags::DEFAULT))
+            .is_some_and(|target| location_cancel_view.location_edit_contains(&target));
+        if !on_location_edit {
+            location_cancel_view.cancel_location_edit();
+        }
+    });
+    window.add_controller(location_cancel);
     install_modal_focus_trap(&window);
     install_keyboard_navigation(&window, &browser, &sidebar, &sidebar_toggle, &preview);
     let browser_controller = browser.browser();


### PR DESCRIPTION
## Description

Make mouse interaction with the address bar predictable. Clicking the current breadcrumb, separators, or empty breadcrumb space now enters location editing, while navigable breadcrumb buttons retain their existing actions. Clicking outside the editor cancels it and restores the current path without navigating.

## Visual evidence


https://github.com/user-attachments/assets/8b2c68e7-2900-445c-8b4e-2e167fcebb9c



## How to test

1. Navigate to a path containing multiple breadcrumb segments.
2. Click the current segment, a separator, and empty space between segments.
3. Type a different path, then click the sidebar, file list, or toolbar.
4. Confirm earlier breadcrumb buttons and the copy-path button still perform their normal actions.

**Expected result:** Each non-button breadcrumb area enters edit mode. Clicking outside cancels editing, discards uncommitted text, restores the breadcrumbs, and preserves the clicked target's normal action.

## Related issue

Closes #288
Closes #246
