### PR TITLE
feat(desktop): implement org.freedesktop.FileManager1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,6 +244,7 @@ jobs:
           printf '%s\n' "$SOURCE_SHA" > "dist/$package/SOURCE_COMMIT"
           cp README.md LICENSE THIRD_PARTY_LICENSES.md "dist/$package/"
           install -m 644 data/io.github.lgse.Strata.desktop "dist/$package/"
+          install -m 644 data/io.github.lgse.Strata.FileManager1.service "dist/$package/"
           install -m 644 data/icons/scalable/apps/io.github.lgse.Strata.svg "dist/$package/"
           tar -C dist -czf "dist/$package.tar.gz" "$package"
           (cd dist && sha256sum "$package.tar.gz" > "$package.tar.gz.sha256")

--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,17 @@ install-local: build
 	install -d "$(DATA_HOME)/applications"
 	sed 's|^Exec=strata |Exec=$(BIN_DIR)/strata |' data/io.github.lgse.Strata.desktop \
 		> "$(DATA_HOME)/applications/io.github.lgse.Strata.desktop"
+	install -d "$(DATA_HOME)/dbus-1/services"
+	sed 's|^Exec=/usr/bin/strata |Exec=$(BIN_DIR)/strata |' \
+		data/io.github.lgse.Strata.FileManager1.service \
+		> "$(DATA_HOME)/dbus-1/services/io.github.lgse.Strata.FileManager1.service"
 	update-desktop-database "$(DATA_HOME)/applications" 2>/dev/null || true
 	gtk-update-icon-cache -qtf "$(DATA_HOME)/icons/hicolor" 2>/dev/null || true
 
 uninstall-local:
 	rm -f "$(BIN_DIR)/strata" \
 		"$(DATA_HOME)/applications/io.github.lgse.Strata.desktop" \
+		"$(DATA_HOME)/dbus-1/services/io.github.lgse.Strata.FileManager1.service" \
 		"$(DATA_HOME)/icons/hicolor/scalable/apps/io.github.lgse.Strata.svg"
 	update-desktop-database "$(DATA_HOME)/applications" 2>/dev/null || true
 	gtk-update-icon-cache -qtf "$(DATA_HOME)/icons/hicolor" 2>/dev/null || true

--- a/Makefile
+++ b/Makefile
@@ -19,17 +19,28 @@ install-local: build
 	install -d "$(DATA_HOME)/applications"
 	sed 's|^Exec=strata |Exec=$(BIN_DIR)/strata |' data/io.github.lgse.Strata.desktop \
 		> "$(DATA_HOME)/applications/io.github.lgse.Strata.desktop"
-	install -d "$(DATA_HOME)/dbus-1/services"
-	sed 's|^Exec=/usr/bin/strata |Exec=$(BIN_DIR)/strata |' \
-		data/io.github.lgse.Strata.FileManager1.service \
-		> "$(DATA_HOME)/dbus-1/services/io.github.lgse.Strata.FileManager1.service"
 	update-desktop-database "$(DATA_HOME)/applications" 2>/dev/null || true
 	gtk-update-icon-cache -qtf "$(DATA_HOME)/icons/hicolor" 2>/dev/null || true
 
-uninstall-local:
+install-file-manager: build
+	install -d "$(DATA_HOME)/dbus-1/services"
+	@conflict="$$(grep -l '^Name=org\.freedesktop\.FileManager1$$' \
+		"$(DATA_HOME)"/dbus-1/services/*.service 2>/dev/null | \
+		grep -v '/io.github.lgse.Strata.FileManager1.service$$' | head -n 1)"; \
+	if [ -n "$$conflict" ]; then \
+		echo "Refusing to override the per-user FileManager1 provider: $$conflict" >&2; \
+		exit 1; \
+	fi
+	sed 's|^Exec=/usr/bin/strata |Exec=$(BIN_DIR)/strata |' \
+		data/io.github.lgse.Strata.FileManager1.service \
+		> "$(DATA_HOME)/dbus-1/services/io.github.lgse.Strata.FileManager1.service"
+
+uninstall-file-manager:
+	rm -f "$(DATA_HOME)/dbus-1/services/io.github.lgse.Strata.FileManager1.service"
+
+uninstall-local: uninstall-file-manager
 	rm -f "$(BIN_DIR)/strata" \
 		"$(DATA_HOME)/applications/io.github.lgse.Strata.desktop" \
-		"$(DATA_HOME)/dbus-1/services/io.github.lgse.Strata.FileManager1.service" \
 		"$(DATA_HOME)/icons/hicolor/scalable/apps/io.github.lgse.Strata.svg"
 	update-desktop-database "$(DATA_HOME)/applications" 2>/dev/null || true
 	gtk-update-icon-cache -qtf "$(DATA_HOME)/icons/hicolor" 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -227,11 +227,24 @@ xdg-mime query default inode/directory
 
 The final command should print `io.github.lgse.Strata.desktop`. The desktop entry's filename matches the `io.github.lgse.Strata` application ID that Strata's windows report, so desktop shells match a running window to this entry and draw its `Icon` value. Log out and back in if a shell caches launcher icons.
 
-When building from source, `make install-local` installs the binary, icon, desktop entry, and file-manager service in the same locations, and `make uninstall-local` removes them.
+When building from source, `make install-local` installs the binary, icon, and desktop entry in the same locations, and `make uninstall-local` removes them.
 
 ### "Open file location" from other applications
 
-Browsers and GTK/GNOME applications reveal a file by calling the `org.freedesktop.FileManager1` D-Bus interface instead of consulting the `inode/directory` association, so they need Strata registered as an activatable service as well:
+Browsers and GTK/GNOME applications reveal a file by calling the `org.freedesktop.FileManager1` D-Bus interface instead of consulting the `inode/directory` association. Enable Strata as the per-user activatable provider explicitly after installing it:
+
+```bash
+make install-file-manager
+```
+
+For an AUR package, copy its inactive service template into your per-user service directory:
+
+```bash
+install -Dm644 /usr/share/strata/io.github.lgse.Strata.FileManager1.service \
+  ~/.local/share/dbus-1/services/io.github.lgse.Strata.FileManager1.service
+```
+
+For a release archive installation, install the included service manually instead:
 
 ```bash
 cd ~/Downloads/"${archive%.tar.gz}"
@@ -241,7 +254,9 @@ sed "s|^Exec=/usr/bin/strata |Exec=$HOME/.local/bin/strata |" \
   > ~/.local/share/dbus-1/services/io.github.lgse.Strata.FileManager1.service
 ```
 
-The per-user file takes precedence over the one shipped by another file manager. Strata then answers `ShowFolders`, `ShowItems`, and `ShowItemProperties`, opening the directory that holds the named items with those items selected:
+A per-user provider takes precedence over system providers shipped by other file managers. Before enabling Strata manually, remove any other per-user service whose `Name` is `org.freedesktop.FileManager1`; two providers for the same name in one service directory are chosen arbitrarily. If another file manager already owns the bus name, exit it before testing. Use `make uninstall-file-manager` for a source installation, or remove the per-user service file, to disable Strata again.
+
+Strata then answers `ShowFolders`, `ShowItems`, and `ShowItemProperties`, opening the directory that holds the named items with those items selected:
 
 ```bash
 busctl --user call org.freedesktop.FileManager1 /org/freedesktop/FileManager1 \

--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ Then:
 - Ask whether I want a per-user desktop entry and inode/directory association;
   if yes, install the archive's io.github.lgse.Strata.desktop and io.github.lgse.Strata.svg
   under ~/.local/share, pointing Exec at the installed binary, then refresh the
-  desktop database and icon cache.
+  desktop database and icon cache. Install the archive's
+  io.github.lgse.Strata.FileManager1.service the same way so "Open file location"
+  in other applications reveals files in Strata.
 - Launch `strata`, report its installed version/source release, and verify the
   desktop association if one was requested. Do not weaken the preview sandbox.
 ```
@@ -225,7 +227,26 @@ xdg-mime query default inode/directory
 
 The final command should print `io.github.lgse.Strata.desktop`. The desktop entry's filename matches the `io.github.lgse.Strata` application ID that Strata's windows report, so desktop shells match a running window to this entry and draw its `Icon` value. Log out and back in if a shell caches launcher icons.
 
-When building from source, `make install-local` installs the binary, icon, and desktop entry in the same locations, and `make uninstall-local` removes them.
+When building from source, `make install-local` installs the binary, icon, desktop entry, and file-manager service in the same locations, and `make uninstall-local` removes them.
+
+### "Open file location" from other applications
+
+Browsers and GTK/GNOME applications reveal a file by calling the `org.freedesktop.FileManager1` D-Bus interface instead of consulting the `inode/directory` association, so they need Strata registered as an activatable service as well:
+
+```bash
+cd ~/Downloads/"${archive%.tar.gz}"
+install -d ~/.local/share/dbus-1/services
+sed "s|^Exec=/usr/bin/strata |Exec=$HOME/.local/bin/strata |" \
+  io.github.lgse.Strata.FileManager1.service \
+  > ~/.local/share/dbus-1/services/io.github.lgse.Strata.FileManager1.service
+```
+
+The per-user file takes precedence over the one shipped by another file manager. Strata then answers `ShowFolders`, `ShowItems`, and `ShowItemProperties`, opening the directory that holds the named items with those items selected:
+
+```bash
+busctl --user call org.freedesktop.FileManager1 /org/freedesktop/FileManager1 \
+  org.freedesktop.FileManager1 ShowItems ass 1 "file://$HOME/Downloads" ""
+```
 
 ### Make Strata the Omarchy file manager
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ Arch Linux and Omarchy are the primary supported environments. Current binaries 
 
 The interactive installer detects the Linux architecture, glibc version, Arch
 Linux, and Omarchy 3 or 4. It installs the latest verified stable release and
-offers optional desktop-menu, default-folder-handler, SMB, broader image/RAW,
-and Omarchy keybind integration:
+offers optional desktop-menu, default-folder-handler, "Open file location", SMB,
+broader image/RAW, and Omarchy keybind integration:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/lgse/strata/main/install.sh | bash
@@ -91,8 +91,9 @@ curl -fsSL https://raw.githubusercontent.com/lgse/strata/main/install.sh \
 ```
 
 Each `--with-*` flag implies `--non-interactive`, and folder association implies
-the desktop entry. Non-interactive package installation requires passwordless
-sudo or cached credentials. Run `./install.sh --help` for the full option list.
+the desktop entry and `--with-file-manager`. Use `--with-file-manager` by itself
+to enable only "Open file location" integration. Non-interactive package
+installation requires passwordless sudo or cached credentials. Run `./install.sh --help` for the full option list.
 
 ### AI-assisted installation
 
@@ -123,9 +124,11 @@ Then:
 - Ask whether I want a per-user desktop entry and inode/directory association;
   if yes, install the archive's io.github.lgse.Strata.desktop and io.github.lgse.Strata.svg
   under ~/.local/share, pointing Exec at the installed binary, then refresh the
-  desktop database and icon cache. Install the archive's
-  io.github.lgse.Strata.FileManager1.service the same way so "Open file location"
-  in other applications reveals files in Strata.
+  desktop database and icon cache.
+- Separately ask whether Strata should handle "Open file location" requests. If
+  yes, verify no other per-user service provides org.freedesktop.FileManager1,
+  then install the archive's io.github.lgse.Strata.FileManager1.service under
+  ~/.local/share/dbus-1/services with Exec pointing at the installed binary.
 - Launch `strata`, report its installed version/source release, and verify the
   desktop association if one was requested. Do not weaken the preview sandbox.
 ```
@@ -190,6 +193,7 @@ For a manual installation, use **Settings → Updates** for verified in-app upda
 ```bash
 rm -f ~/.local/bin/strata \
   ~/.local/share/applications/io.github.lgse.Strata.desktop \
+  ~/.local/share/dbus-1/services/io.github.lgse.Strata.FileManager1.service \
   ~/.local/share/icons/hicolor/scalable/apps/io.github.lgse.Strata.svg
 update-desktop-database ~/.local/share/applications 2>/dev/null || true
 gtk-update-icon-cache -qtf ~/.local/share/icons/hicolor 2>/dev/null || true
@@ -231,7 +235,9 @@ When building from source, `make install-local` installs the binary, icon, and d
 
 ### "Open file location" from other applications
 
-Browsers and GTK/GNOME applications reveal a file by calling the `org.freedesktop.FileManager1` D-Bus interface instead of consulting the `inode/directory` association. Enable Strata as the per-user activatable provider explicitly after installing it:
+Browsers and GTK/GNOME applications reveal a file by calling the `org.freedesktop.FileManager1` D-Bus interface instead of consulting the `inode/directory` association. The interactive installer offers this separately; for unattended installation, pass `--with-file-manager`. Folder association enables it automatically.
+
+For a source installation, enable Strata as the per-user activatable provider explicitly:
 
 ```bash
 make install-file-manager

--- a/data/io.github.lgse.Strata.FileManager1.service
+++ b/data/io.github.lgse.Strata.FileManager1.service
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.freedesktop.FileManager1
+Exec=/usr/bin/strata --gapplication-service

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -98,7 +98,7 @@ Verify any change to this with `vercmp` directly. The download URL always uses t
 
 The launcher and application icon are installed from the release archive, not from this repository, so the package always matches the binary it ships. Releases published before desktop metadata was added to the archive produce a package with a working `strata` command and no launcher; `package()` prints a warning rather than failing, so the package stays installable. Drop the conditional once the oldest release either package pins carries the metadata.
 
-The archive also ships `io.github.lgse.Strata.FileManager1.service`, which makes Strata the D-Bus-activatable owner of `org.freedesktop.FileManager1` so "Open file location" in other applications reveals the file in Strata. It is named after Strata rather than after the bus name, so installing it never conflicts with the file another file manager's package owns; the bus name it declares is what D-Bus matches on. It is installed under the same release-archive conditional as the launcher.
+The archive also ships `io.github.lgse.Strata.FileManager1.service`, which users can install under `$XDG_DATA_HOME/dbus-1/services` to make Strata the D-Bus-activatable owner of `org.freedesktop.FileManager1`. Packages must not install it into a system service directory: multiple files providing that name in one directory are selected arbitrarily, and merely installing Strata must not change the user's preferred file manager. They may install the inactive template under `/usr/share/strata` so users can opt in without downloading the archive. Keep activation an explicit per-user choice as documented in the README.
 
 ## Other distributions
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -98,6 +98,8 @@ Verify any change to this with `vercmp` directly. The download URL always uses t
 
 The launcher and application icon are installed from the release archive, not from this repository, so the package always matches the binary it ships. Releases published before desktop metadata was added to the archive produce a package with a working `strata` command and no launcher; `package()` prints a warning rather than failing, so the package stays installable. Drop the conditional once the oldest release either package pins carries the metadata.
 
+The archive also ships `io.github.lgse.Strata.FileManager1.service`, which makes Strata the D-Bus-activatable owner of `org.freedesktop.FileManager1` so "Open file location" in other applications reveals the file in Strata. It is named after Strata rather than after the bus name, so installing it never conflicts with the file another file manager's package owns; the bus name it declares is what D-Bus matches on. It is installed under the same release-archive conditional as the launcher.
+
 ## Other distributions
 
 Debian/Ubuntu, Fedora, Flatpak, and AppImage each have their own dependency, sandboxing, update, and review requirements and are tracked as separate issues. The AUR marker must not be reused for them until those provider-specific semantics are designed.

--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,7 @@ WITH_SMB=ask
 WITH_RAW=ask
 WITH_DESKTOP_ENTRY=ask
 WITH_FOLDER_ASSOCIATION=ask
+WITH_FILE_MANAGER=ask
 WITH_OMARCHY_KEYBINDS=ask
 
 info() {
@@ -91,11 +92,12 @@ Options:
   --with-raw                    Install broader image and camera RAW support
   --with-desktop-entry          Add Strata to the desktop application menu
   --with-folder-association     Make Strata the default folder handler
+  --with-file-manager           Handle "Open file location" requests
   --with-omarchy-keybinds       Replace Omarchy's file-manager keybinds
   -h, --help                    Show this help
 
 Integration flags imply --non-interactive. Folder association also installs the
-required desktop entry.
+required desktop entry and enables "Open file location" integration.
 EOF
 }
 
@@ -110,7 +112,9 @@ parse_args() {
         NON_INTERACTIVE=yes
         WITH_DESKTOP_ENTRY=yes
         WITH_FOLDER_ASSOCIATION=yes
+        WITH_FILE_MANAGER=yes
         ;;
+      --with-file-manager) NON_INTERACTIVE=yes; WITH_FILE_MANAGER=yes ;;
       --with-omarchy-keybinds) NON_INTERACTIVE=yes; WITH_OMARCHY_KEYBINDS=yes ;;
       -h | --help) usage; exit 0 ;;
       *) die "Unknown option: $1 (run with --help for usage)." ;;
@@ -248,6 +252,28 @@ install_desktop_entry() {
       || die "The folder association did not change (current value: $current)."
     info "Strata is now the default application for folders."
   fi
+}
+
+install_file_manager_service() {
+  local extracted=$1 service_dir target conflict escaped_bin staged
+  service_dir=${XDG_DATA_HOME:-$HOME/.local/share}/dbus-1/services
+  target=$service_dir/$APP_ID.FileManager1.service
+
+  [[ -r $extracted/$APP_ID.FileManager1.service ]] \
+    || die "The verified archive is missing FileManager1 integration."
+  install -d "$service_dir"
+  conflict=$(grep -l '^Name=org\.freedesktop\.FileManager1$' \
+    "$service_dir"/*.service 2>/dev/null \
+    | grep -v "/$APP_ID.FileManager1.service$" | head -n 1 || true)
+  [[ -z $conflict ]] \
+    || die "Another per-user FileManager1 provider is already installed: $conflict"
+
+  staged=$TEMP_DIR/$APP_ID.FileManager1.service
+  escaped_bin=${BIN_PATH//&/\\&}
+  sed "s|^Exec=/usr/bin/strata |Exec=$escaped_bin |" \
+    "$extracted/$APP_ID.FileManager1.service" >"$staged"
+  install -Dm644 "$staged" "$target"
+  info 'Strata now handles "Open file location" requests.'
 }
 
 configure_omarchy_bindings() {
@@ -420,8 +446,14 @@ main() {
     if want_option "$WITH_FOLDER_ASSOCIATION" \
       "Make Strata the default application for opening folders?"; then
       make_default=yes
+      WITH_FILE_MANAGER=yes
     fi
     install_desktop_entry "$extracted" "$make_default"
+  fi
+
+  if want_option "$WITH_FILE_MANAGER" \
+    'Use Strata for "Open file location" from other applications?'; then
+    install_file_manager_service "$extracted"
   fi
 
   if want_option "$WITH_OMARCHY_KEYBINDS" \

--- a/packaging/aur/PKGBUILD.in
+++ b/packaging/aur/PKGBUILD.in
@@ -52,6 +52,14 @@ package() {
     warning "Strata ${_releasever} ships no desktop entry or application icon; installing without a launcher."
   fi
 
+  # Owns org.freedesktop.FileManager1 so "Open file location" in other apps
+  # reaches Strata. The file name is Strata's own so it never collides with
+  # another file manager's package.
+  if [[ -f "${dist}/io.github.lgse.Strata.FileManager1.service" ]]; then
+    install -Dm644 "${dist}/io.github.lgse.Strata.FileManager1.service" \
+      "${pkgdir}/usr/share/dbus-1/services/io.github.lgse.Strata.FileManager1.service"
+  fi
+
   install -Dm644 /dev/stdin "${pkgdir}/usr/share/strata/install-source.toml" <<'MARKER'
 manager = "pacman"
 package = "@PKGNAME@"

--- a/packaging/aur/PKGBUILD.in
+++ b/packaging/aur/PKGBUILD.in
@@ -52,12 +52,9 @@ package() {
     warning "Strata ${_releasever} ships no desktop entry or application icon; installing without a launcher."
   fi
 
-  # Owns org.freedesktop.FileManager1 so "Open file location" in other apps
-  # reaches Strata. The file name is Strata's own so it never collides with
-  # another file manager's package.
   if [[ -f "${dist}/io.github.lgse.Strata.FileManager1.service" ]]; then
     install -Dm644 "${dist}/io.github.lgse.Strata.FileManager1.service" \
-      "${pkgdir}/usr/share/dbus-1/services/io.github.lgse.Strata.FileManager1.service"
+      "${pkgdir}/usr/share/strata/io.github.lgse.Strata.FileManager1.service"
   fi
 
   install -Dm644 /dev/stdin "${pkgdir}/usr/share/strata/install-source.toml" <<'MARKER'

--- a/packaging/aur/strata-bin/PKGBUILD
+++ b/packaging/aur/strata-bin/PKGBUILD
@@ -52,6 +52,14 @@ package() {
     warning "Strata ${_releasever} ships no desktop entry or application icon; installing without a launcher."
   fi
 
+  # Owns org.freedesktop.FileManager1 so "Open file location" in other apps
+  # reaches Strata. The file name is Strata's own so it never collides with
+  # another file manager's package.
+  if [[ -f "${dist}/io.github.lgse.Strata.FileManager1.service" ]]; then
+    install -Dm644 "${dist}/io.github.lgse.Strata.FileManager1.service" \
+      "${pkgdir}/usr/share/dbus-1/services/io.github.lgse.Strata.FileManager1.service"
+  fi
+
   install -Dm644 /dev/stdin "${pkgdir}/usr/share/strata/install-source.toml" <<'MARKER'
 manager = "pacman"
 package = "strata-bin"

--- a/packaging/aur/strata-bin/PKGBUILD
+++ b/packaging/aur/strata-bin/PKGBUILD
@@ -52,12 +52,9 @@ package() {
     warning "Strata ${_releasever} ships no desktop entry or application icon; installing without a launcher."
   fi
 
-  # Owns org.freedesktop.FileManager1 so "Open file location" in other apps
-  # reaches Strata. The file name is Strata's own so it never collides with
-  # another file manager's package.
   if [[ -f "${dist}/io.github.lgse.Strata.FileManager1.service" ]]; then
     install -Dm644 "${dist}/io.github.lgse.Strata.FileManager1.service" \
-      "${pkgdir}/usr/share/dbus-1/services/io.github.lgse.Strata.FileManager1.service"
+      "${pkgdir}/usr/share/strata/io.github.lgse.Strata.FileManager1.service"
   fi
 
   install -Dm644 /dev/stdin "${pkgdir}/usr/share/strata/install-source.toml" <<'MARKER'

--- a/packaging/aur/strata-rc-bin/PKGBUILD
+++ b/packaging/aur/strata-rc-bin/PKGBUILD
@@ -52,6 +52,14 @@ package() {
     warning "Strata ${_releasever} ships no desktop entry or application icon; installing without a launcher."
   fi
 
+  # Owns org.freedesktop.FileManager1 so "Open file location" in other apps
+  # reaches Strata. The file name is Strata's own so it never collides with
+  # another file manager's package.
+  if [[ -f "${dist}/io.github.lgse.Strata.FileManager1.service" ]]; then
+    install -Dm644 "${dist}/io.github.lgse.Strata.FileManager1.service" \
+      "${pkgdir}/usr/share/dbus-1/services/io.github.lgse.Strata.FileManager1.service"
+  fi
+
   install -Dm644 /dev/stdin "${pkgdir}/usr/share/strata/install-source.toml" <<'MARKER'
 manager = "pacman"
 package = "strata-rc-bin"

--- a/packaging/aur/strata-rc-bin/PKGBUILD
+++ b/packaging/aur/strata-rc-bin/PKGBUILD
@@ -52,12 +52,9 @@ package() {
     warning "Strata ${_releasever} ships no desktop entry or application icon; installing without a launcher."
   fi
 
-  # Owns org.freedesktop.FileManager1 so "Open file location" in other apps
-  # reaches Strata. The file name is Strata's own so it never collides with
-  # another file manager's package.
   if [[ -f "${dist}/io.github.lgse.Strata.FileManager1.service" ]]; then
     install -Dm644 "${dist}/io.github.lgse.Strata.FileManager1.service" \
-      "${pkgdir}/usr/share/dbus-1/services/io.github.lgse.Strata.FileManager1.service"
+      "${pkgdir}/usr/share/strata/io.github.lgse.Strata.FileManager1.service"
   fi
 
   install -Dm644 /dev/stdin "${pkgdir}/usr/share/strata/install-source.toml" <<'MARKER'

--- a/scripts/test_installer.py
+++ b/scripts/test_installer.py
@@ -43,16 +43,62 @@ class InstallerTests(unittest.TestCase):
     def test_unattended_flags_select_only_requested_integrations(self) -> None:
         result = bash(
             "parse_args --with-folder-association --with-raw; "
-            'printf "%s %s %s %s %s %s" "$NON_INTERACTIVE" "$WITH_SMB" '
+            'printf "%s %s %s %s %s %s %s" "$NON_INTERACTIVE" "$WITH_SMB" '
             '"$WITH_RAW" "$WITH_DESKTOP_ENTRY" "$WITH_FOLDER_ASSOCIATION" '
-            '"$WITH_OMARCHY_KEYBINDS"'
+            '"$WITH_FILE_MANAGER" "$WITH_OMARCHY_KEYBINDS"'
         )
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(result.stdout, "yes ask yes yes yes ask")
+        self.assertEqual(result.stdout, "yes ask yes yes yes yes ask")
+
+    def test_file_manager_flag_can_be_selected_independently(self) -> None:
+        result = bash(
+            "parse_args --with-file-manager; "
+            'printf "%s %s %s" "$NON_INTERACTIVE" "$WITH_DESKTOP_ENTRY" '
+            '"$WITH_FILE_MANAGER"'
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "yes ask yes")
 
     def test_non_interactive_mode_declines_unspecified_options(self) -> None:
         result = bash("NON_INTERACTIVE=yes; ! want_option ask ignored")
         self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_file_manager_service_uses_the_installed_binary(self) -> None:
+        with tempfile.TemporaryDirectory() as home:
+            result = bash(
+                'TEMP_DIR="$HOME/tmp"; mkdir -p "$TEMP_DIR"; '
+                'BIN_PATH="$HOME/.local/bin/strata"; '
+                'install_file_manager_service "$(dirname "$1")/data"',
+                env={"HOME": home, "XDG_DATA_HOME": f"{home}/data"},
+            )
+            service = (
+                pathlib.Path(home)
+                / "data/dbus-1/services/io.github.lgse.Strata.FileManager1.service"
+            )
+            contents = service.read_text()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(f"Exec={home}/.local/bin/strata --gapplication-service", contents)
+
+    def test_file_manager_service_refuses_another_per_user_provider(self) -> None:
+        with tempfile.TemporaryDirectory() as home:
+            service_dir = pathlib.Path(home) / "data/dbus-1/services"
+            service_dir.mkdir(parents=True)
+            other = service_dir / "other.service"
+            other.write_text(
+                "[D-BUS Service]\n"
+                "Name=org.freedesktop.FileManager1\n"
+                "Exec=/usr/bin/other-files\n"
+            )
+            result = bash(
+                'TEMP_DIR="$HOME/tmp"; mkdir -p "$TEMP_DIR"; '
+                'BIN_PATH="$HOME/.local/bin/strata"; '
+                'install_file_manager_service "$(dirname "$1")/data"',
+                env={"HOME": home, "XDG_DATA_HOME": f"{home}/data"},
+            )
+            target = service_dir / "io.github.lgse.Strata.FileManager1.service"
+            self.assertFalse(target.exists())
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Another per-user FileManager1 provider", result.stderr)
 
     def test_non_interactive_pacman_disables_sudo_and_pacman_prompts(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/src/adapters/file_manager1.rs
+++ b/src/adapters/file_manager1.rs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! `org.freedesktop.FileManager1`, the interface browsers and GTK/GNOME apps
+//! call for "Open file location". Those callers talk to the well-known bus
+//! name directly instead of going through `xdg-open` and `mimeapps.list`, so
+//! without this Strata is skipped even when it owns `inode/directory`.
+
+use gtk::{gio, glib, prelude::*};
+
+use crate::model::Location;
+
+use super::location_for_file;
+
+const BUS_NAME: &str = "org.freedesktop.FileManager1";
+const OBJECT_PATH: &str = "/org/freedesktop/FileManager1";
+const INTERFACE_XML: &str = r#"<node>
+  <interface name="org.freedesktop.FileManager1">
+    <method name="ShowFolders">
+      <arg type="as" name="URIs" direction="in"/>
+      <arg type="s" name="StartupId" direction="in"/>
+    </method>
+    <method name="ShowItems">
+      <arg type="as" name="URIs" direction="in"/>
+      <arg type="s" name="StartupId" direction="in"/>
+    </method>
+    <method name="ShowItemProperties">
+      <arg type="as" name="URIs" direction="in"/>
+      <arg type="s" name="StartupId" direction="in"/>
+    </method>
+  </interface>
+</node>"#;
+
+/// One window to open: the directory to browse, the entries to select inside
+/// it, and whether the caller asked for their properties.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct RevealRequest {
+    pub directory: Location,
+    pub selection: Vec<String>,
+    pub properties: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Method {
+    Folders,
+    Items,
+    ItemProperties,
+}
+
+impl Method {
+    fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "ShowFolders" => Some(Self::Folders),
+            "ShowItems" => Some(Self::Items),
+            "ShowItemProperties" => Some(Self::ItemProperties),
+            _ => None,
+        }
+    }
+
+    fn reveals_parent(self) -> bool {
+        !matches!(self, Self::Folders)
+    }
+
+    fn wants_properties(self) -> bool {
+        matches!(self, Self::ItemProperties)
+    }
+}
+
+/// Claims the well-known name on `connection` and answers reveal calls with
+/// `handler`, once per directory the call named.
+pub(crate) fn export_file_manager(
+    connection: &gio::DBusConnection,
+    handler: impl Fn(RevealRequest) + 'static,
+) -> Result<(), glib::Error> {
+    let node = gio::DBusNodeInfo::for_xml(INTERFACE_XML)?;
+    let interface = node.lookup_interface(BUS_NAME).ok_or_else(|| {
+        glib::Error::new(gio::IOErrorEnum::Failed, "missing interface definition")
+    })?;
+    connection
+        .register_object(OBJECT_PATH, &interface)
+        .method_call(move |_, _, _, _, method, parameters, invocation| {
+            let Some(method) = Method::from_name(method) else {
+                invocation.return_error(gio::DBusError::UnknownMethod, "unknown method");
+                return;
+            };
+            let Some((uris, _startup_id)) = parameters.get::<(Vec<String>, String)>() else {
+                invocation.return_error(gio::DBusError::InvalidArgs, "expected (as, s)");
+                return;
+            };
+            for request in reveal_requests(method, &uris) {
+                handler(request);
+            }
+            invocation.return_value(None);
+        })
+        .build()?;
+    gio::bus_own_name_on_connection(
+        connection,
+        BUS_NAME,
+        gio::BusNameOwnerFlags::NONE,
+        |_, name| tracing::debug!(name, "acquired file manager bus name"),
+        |_, name| tracing::debug!(name, "file manager bus name held elsewhere"),
+    );
+    Ok(())
+}
+
+/// Groups the named URIs into one request per directory, keeping the order
+/// the caller listed them in so the first URI opens the first window.
+fn reveal_requests(method: Method, uris: &[String]) -> Vec<RevealRequest> {
+    let mut requests: Vec<RevealRequest> = Vec::new();
+    for uri in uris {
+        let target = gio::File::for_uri(uri);
+        let (directory, name) = match method.reveals_parent().then(|| target.parent()).flatten() {
+            Some(parent) => (parent, target.basename()),
+            // A filesystem root has no parent to reveal it in.
+            None => (target, None),
+        };
+        let Some(directory) = location_for_file(&directory) else {
+            continue;
+        };
+        let name = name.map(|name| name.to_string_lossy().into_owned());
+        match requests
+            .iter_mut()
+            .find(|request| request.directory == directory)
+        {
+            Some(request) => request.selection.extend(name),
+            None => requests.push(RevealRequest {
+                directory,
+                selection: name.into_iter().collect(),
+                properties: method.wants_properties(),
+            }),
+        }
+    }
+    requests
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/adapters/file_manager1/tests.rs
+++ b/src/adapters/file_manager1/tests.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::path::Path;
+
+use super::{Method, RevealRequest, reveal_requests};
+
+fn uris(values: &[&str]) -> Vec<String> {
+    values.iter().map(|value| (*value).to_owned()).collect()
+}
+
+#[test]
+fn show_items_reveals_the_parent_directory_with_the_item_selected() {
+    let requests = reveal_requests(
+        Method::Items,
+        &uris(&["file:///home/user/Downloads/example.md"]),
+    );
+
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].directory.native_path(),
+        Some(Path::new("/home/user/Downloads"))
+    );
+    assert_eq!(requests[0].selection, vec!["example.md".to_owned()]);
+    assert!(!requests[0].properties);
+}
+
+#[test]
+fn show_folders_opens_the_named_directories_without_a_selection() {
+    let requests = reveal_requests(Method::Folders, &uris(&["file:///home/user/Downloads"]));
+
+    assert_eq!(
+        requests
+            .iter()
+            .map(|request| request.directory.native_path())
+            .collect::<Vec<_>>(),
+        vec![Some(Path::new("/home/user/Downloads"))]
+    );
+    assert!(requests[0].selection.is_empty());
+}
+
+#[test]
+fn items_sharing_a_directory_are_selected_together_in_one_window() {
+    let requests = reveal_requests(
+        Method::Items,
+        &uris(&[
+            "file:///home/user/Downloads/first.md",
+            "file:///home/user/Pictures/photo.png",
+            "file:///home/user/Downloads/second.md",
+        ]),
+    );
+
+    assert_eq!(
+        requests
+            .iter()
+            .map(|request| (request.directory.native_path(), request.selection.clone()))
+            .collect::<Vec<_>>(),
+        vec![
+            (
+                Some(Path::new("/home/user/Downloads")),
+                vec!["first.md".to_owned(), "second.md".to_owned()]
+            ),
+            (
+                Some(Path::new("/home/user/Pictures")),
+                vec!["photo.png".to_owned()]
+            ),
+        ]
+    );
+}
+
+#[test]
+fn show_item_properties_marks_the_request() {
+    let requests = reveal_requests(
+        Method::ItemProperties,
+        &uris(&["file:///home/user/Downloads/example.md"]),
+    );
+
+    assert_eq!(
+        requests,
+        vec![RevealRequest {
+            directory: crate::model::Location::local("/home/user/Downloads"),
+            selection: vec!["example.md".to_owned()],
+            properties: true,
+        }]
+    );
+}
+
+#[test]
+fn a_root_without_a_parent_is_opened_directly() {
+    let requests = reveal_requests(Method::Items, &uris(&["file:///"]));
+
+    assert_eq!(
+        requests
+            .iter()
+            .map(|request| (request.directory.native_path(), request.selection.clone()))
+            .collect::<Vec<_>>(),
+        vec![(Some(Path::new("/")), Vec::new())]
+    );
+}
+
+#[test]
+fn a_remote_uri_reveals_its_parent_as_a_uri_location() {
+    let requests = reveal_requests(Method::Items, &uris(&["sftp://host/home/user/notes.txt"]));
+
+    assert_eq!(requests.len(), 1);
+    assert!(
+        requests[0]
+            .directory
+            .uri_value()
+            .is_some_and(|uri| uri.ends_with("/home/user")),
+        "unexpected parent location: {:?}",
+        requests[0].directory
+    );
+    assert_eq!(requests[0].selection, vec!["notes.txt".to_owned()]);
+}

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+mod file_manager1;
 mod local_files;
 mod local_operations;
 mod local_preview;
 
+pub(crate) use file_manager1::{RevealRequest, export_file_manager};
 pub use local_files::LocalFileSource;
 pub(crate) use local_files::location_for_file;
 pub use local_operations::LocalOperationProvider;

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,12 +75,28 @@ fn main() -> gtk::glib::ExitCode {
         .flags(gio::ApplicationFlags::HANDLES_OPEN)
         .build();
 
+    application.connect_startup(export_file_manager_interface);
     application.connect_activate(ui::present);
     application.connect_open(|application, files, _| {
         let location = files.first().and_then(gio::File::path);
         ui::present_location(application, location);
     });
     application.run()
+}
+
+/// Answers "Open file location" from browsers and other desktop apps, which
+/// call `org.freedesktop.FileManager1` instead of the `inode/directory`
+/// handler.
+fn export_file_manager_interface(application: &gtk::Application) {
+    let Some(connection) = application.dbus_connection() else {
+        return;
+    };
+    let target = application.clone();
+    if let Err(error) = adapters::export_file_manager(&connection, move |request| {
+        ui::present_reveal(&target, request);
+    }) {
+        tracing::warn!(%error, "unable to export the file manager interface");
+    }
 }
 
 fn restart_with_local_vfs_if_gvfs_is_unresponsive() {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -323,6 +323,9 @@ pub(super) struct ViewState {
     pin_status_handler: RefCell<Option<PinStatusHandler>>,
     print_handler: RefCell<Option<PrintHandler>>,
     pending_select: RefCell<Vec<String>>,
+    /// Set when the pending selection came from a properties request, so the
+    /// dialog opens once the entry it describes is actually loaded.
+    pending_select_properties: Cell<bool>,
     pending_extract_retry: RefCell<Option<(FileEntry, Location)>>,
     /// The entries a just-dispatched, non-permanent delete requested,
     /// snapshotted so a `CompletedWithErrors` response naming entries that
@@ -482,6 +485,7 @@ impl BrowserView {
             pin_status_handler: RefCell::new(None),
             print_handler: RefCell::new(None),
             pending_select: RefCell::new(Vec::new()),
+            pending_select_properties: Cell::new(false),
             pending_extract_retry: RefCell::new(None),
             pending_delete_entries: RefCell::new(Vec::new()),
             pending_navigate: RefCell::new(None),
@@ -567,10 +571,15 @@ impl BrowserView {
         self.state.overlay.clone().upcast()
     }
 
-    pub fn navigate(&self, path: impl AsRef<Path>) {
-        self.state
-            .browser
-            .navigate(Location::local(path.as_ref().to_path_buf()));
+    pub fn navigate_location(&self, location: Location) {
+        self.state.browser.navigate(location);
+    }
+
+    /// Selects `names` in the active column once it finishes loading,
+    /// optionally opening the properties dialog for the focused one.
+    pub fn select_after_load(&self, names: Vec<String>, properties: bool) {
+        self.state.pending_select.borrow_mut().extend(names);
+        self.state.pending_select_properties.set(properties);
     }
 
     pub fn browser(&self) -> Rc<Browser> {
@@ -4084,11 +4093,15 @@ impl ViewState {
                 }
                 if self.browser.active_depth() == Some(*depth) {
                     let names = self.pending_select.take();
+                    let properties = self.pending_select_properties.replace(false);
                     if !names.is_empty() {
                         let weak = Rc::downgrade(self);
                         glib::idle_add_local_once(move || {
                             if let Some(state) = weak.upgrade() {
                                 state.browser.select_entries_by_name(&names);
+                                if properties && let Some(entry) = state.browser.focused_entry() {
+                                    state.show_entry_properties(entry);
+                                }
                             }
                         });
                     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -15,4 +15,4 @@ mod thumbnail;
 mod thumbnail_cache;
 mod window;
 
-pub use window::{present, present_location};
+pub use window::{present, present_location, present_reveal};

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -11,7 +11,10 @@ use std::{
 use gtk::{gio, glib, prelude::*};
 
 use crate::{
-    adapters::{LocalFileSource, LocalOperationProvider, LocalPreviewProvider, location_for_file},
+    adapters::{
+        LocalFileSource, LocalOperationProvider, LocalPreviewProvider, RevealRequest,
+        location_for_file,
+    },
     app::{Browser, BrowserEvent},
     model::{EntryKind, FileEntry, Location, MetadataValue},
     services::{BuildKind, ReleaseMetadata, sanitize_uri_credentials},
@@ -48,10 +51,35 @@ fn mouse_history_action(button: u32) -> Option<MouseHistoryAction> {
 }
 
 pub fn present(application: &gtk::Application) {
-    present_location(application, None);
+    present_target(application, None, Vec::new(), false);
 }
 
 pub fn present_location(application: &gtk::Application, location: Option<PathBuf>) {
+    present_target(
+        application,
+        location.map(Location::local),
+        Vec::new(),
+        false,
+    );
+}
+
+/// Opens the window an `org.freedesktop.FileManager1` caller asked for: the
+/// directory holding the named items, with those items selected.
+pub fn present_reveal(application: &gtk::Application, request: RevealRequest) {
+    present_target(
+        application,
+        Some(request.directory),
+        request.selection,
+        request.properties,
+    );
+}
+
+fn present_target(
+    application: &gtk::Application,
+    location: Option<Location>,
+    selection: Vec<String>,
+    properties: bool,
+) {
     let present_started = std::time::Instant::now();
     crate::assets::register_icon_theme();
     let theme_manager = super::theme::ThemeManager::shared();
@@ -486,11 +514,14 @@ pub fn present_location(application: &gtk::Application, location: Option<PathBuf
     });
     window.present();
     crate::metrics::mark_window_presented();
-    let pending_location = location.unwrap_or_else(home_directory);
+    let pending_location = location.unwrap_or_else(|| Location::local(home_directory()));
+    if !selection.is_empty() {
+        browser.select_after_load(selection, properties);
+    }
     let idle_browser = browser.clone();
     glib::idle_add_local_once(move || {
         let started = std::time::Instant::now();
-        idle_browser.navigate(pending_location);
+        idle_browser.navigate_location(pending_location);
         tracing::debug!(
             elapsed_ms = started.elapsed().as_millis() as u64,
             "present navigation started"


### PR DESCRIPTION
## Description

"Open file location" / "Show in Folder" in Firefox-family browsers and GTK/GNOME apps does not go through `xdg-open` or `mimeapps.list`: those callers talk to the `org.freedesktop.FileManager1` bus name directly. Strata did not implement that interface, so the action silently fell through to whichever file manager owns the name (Nautilus, or Dolphin) even when Strata was the `inode/directory` default.

Strata now claims `org.freedesktop.FileManager1` on its session-bus connection at startup and answers all three methods:

- `ShowFolders` opens each named directory.
- `ShowItems` opens the directory holding the named items with those items selected; items that share a directory are selected together in one window.
- `ShowItemProperties` does the same and opens the properties dialog for the item.

`data/io.github.lgse.Strata.FileManager1.service` makes the interface D-Bus activatable so a reveal works when Strata is not running. Activation is an explicit per-user choice: the interactive installer offers it, `--with-file-manager` enables it unattended, and choosing `--with-folder-association` implies it. `make install-file-manager` enables it for source installations, release archives include the service for manual setup, and AUR packages place an inactive template under `/usr/share/strata`. This avoids adding a second system provider whose selection against Nautilus or Dolphin would be arbitrary. Setup refuses to override another per-user provider, and the README covers enabling and disabling it.

## Visual evidence

N/A — no interface elements changed. The reveal reuses the existing window, selection, and properties dialog; only what a window opens on is new.

## How to test

1. Build and install: `make install-local && make install-file-manager` (or copy `data/io.github.lgse.Strata.FileManager1.service` to `~/.local/share/dbus-1/services/` with `Exec` pointing at the built binary). Exit another file manager first if it already owns `org.freedesktop.FileManager1`.
2. With Strata not running, reveal a file the way a browser does:
   ```bash
   mkdir -p /tmp/reveal && touch /tmp/reveal/alpha.md /tmp/reveal/beta.md
   busctl --user call org.freedesktop.FileManager1 /org/freedesktop/FileManager1 \
     org.freedesktop.FileManager1 ShowItems ass 1 "file:///tmp/reveal/beta.md" ""
   ```
3. Repeat with `ShowFolders ass 1 "file:///tmp/reveal" ""` and with `ShowItemProperties ass 1 "file:///tmp/reveal/beta.md" ""`, and repeat step 2 while Strata is already running.
4. Run `./install.sh --help` and confirm `--with-file-manager` is listed. In the interactive installer, confirm "Open file location" is offered independently when folder association is declined.
5. Download a file in Firefox/Zen and use "Open Containing Folder" from the downloads panel.

**Expected result:** Strata opens (D-Bus activated when it was not running) showing `/tmp/reveal` with `beta.md` selected; `ShowFolders` opens the directory with no selection; `ShowItemProperties` also opens the properties dialog for `beta.md`; the browser's reveal opens Strata instead of Nautilus or Dolphin.

## Related issue

Closes #290


