### PR TITLE
fix(updater): force refresh on first open

### DIFF
--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -134,13 +134,19 @@ fn update_check_due(last: Option<Instant>, now: Instant) -> bool {
     last.is_none_or(|completed| now.duration_since(completed) >= UPDATE_DUE_INTERVAL)
 }
 
+fn force_due_update_check(last: Option<Instant>) -> bool {
+    last.is_none()
+}
+
 pub(super) fn maybe_run_due_update_check(manager: &Rc<ThemeManager>, notice: &UpdateNoticeHandler) {
     if !manager.checks_for_updates() || CHECK_IN_FLIGHT.get() {
         return;
     }
-    if !update_check_due(LAST_COMPLETED_CHECK.get(), Instant::now()) {
+    let last_completed = LAST_COMPLETED_CHECK.get();
+    if !update_check_due(last_completed, Instant::now()) {
         return;
     }
+    let force = force_due_update_check(last_completed);
     CHECK_IN_FLIGHT.set(true);
     let channel = manager.release_channel();
     let weak_manager = Rc::downgrade(manager);
@@ -150,7 +156,7 @@ pub(super) fn maybe_run_due_update_check(manager: &Rc<ThemeManager>, notice: &Up
             channel,
             crate::build_info::installed_version(),
             method,
-            false,
+            force,
         );
         glib::timeout_add_local(Duration::from_millis(100), move || {
             match receiver.try_recv() {

--- a/src/ui/settings/tests.rs
+++ b/src/ui/settings/tests.rs
@@ -10,12 +10,13 @@ use crate::services::{
 use super::{
     CHANNEL_ORDER, COMPACT_NAVIGATION_BREAKPOINT, DIALOG_HEIGHT, DIALOG_MARGIN, DIALOG_WIDTH,
     RELEASE_CHANNEL_DESCRIPTION, RELEASE_CHANNEL_TITLE, UPDATE_DUE_INTERVAL, aur_update_command,
-    channel_index, effective_update_channel, install_guard, installed_version_status,
-    is_stale_check, managed_channel_description, managed_install_summary, offer_still_eligible,
-    omarchy_update_command, resolve_update_method_async, responsive_dialog_size,
-    shows_available_release_notes, theme_background_is_light, theme_name_matches, update_check_due,
-    update_check_message, update_dialog_status, update_status_markup, uses_compact_navigation,
-    video_preview_backend_label, video_preview_control_state,
+    channel_index, effective_update_channel, force_due_update_check, install_guard,
+    installed_version_status, is_stale_check, managed_channel_description, managed_install_summary,
+    offer_still_eligible, omarchy_update_command, resolve_update_method_async,
+    responsive_dialog_size, shows_available_release_notes, theme_background_is_light,
+    theme_name_matches, update_check_due, update_check_message, update_dialog_status,
+    update_status_markup, uses_compact_navigation, video_preview_backend_label,
+    video_preview_control_state,
 };
 use crate::sandbox::MediaPreviewBackend;
 
@@ -391,6 +392,14 @@ fn due_check_respects_its_ttl() {
         Some(now - UPDATE_DUE_INTERVAL + Duration::from_secs(1)),
         now
     ));
+}
+
+#[test]
+fn the_first_session_check_bypasses_the_persisted_cache() {
+    use std::time::Instant;
+
+    assert!(force_due_update_check(None));
+    assert!(!force_due_update_check(Some(Instant::now())));
 }
 
 #[test]


### PR DESCRIPTION
## Description

Force the first automatic updater check in each app session to bypass the persisted GitHub cache. Later checks continue to use the existing cache and 24-hour in-session throttle.

## Visual evidence

N/A — this changes updater request behavior without changing the interface.

## How to test

1. Populate the update-check cache with a response inside its normal freshness window.
2. Restart Strata with automatic update checks enabled and observe the first scheduled update request.

**Expected result:** The first automatic check performs a conditional GitHub refresh instead of returning directly from the persisted cache; later checks retain the existing throttling behavior.

## Related issue

Closes #325