### PR TITLE
fix(browser): align Explorer row hover and click hit targets

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -3473,6 +3473,7 @@ menubutton.grid-thumbnail-menu > button:focus-visible {
   color: @theme_text;
   outline: none;
   transition: background 160ms ease-out, color 160ms ease-out;
+  padding: 0;
 }
 
 .explorer-list row:hover {


### PR DESCRIPTION
## Description

Explorer list rows inherited GTK theme padding on the `ListView` row node. That padding made the hover background paint onto the 1px strip between rows, while click selection still used the inner allocation, so hovering a divider could highlight the next row without selecting it.

This sets `.explorer-list row { padding: 0; }` so hover highlight and click selection share the same geometry.

## Visual evidence

Before: the recording attached to #251 shows the hover/click mismatch on the row divider.

After: the hover highlight and click target agree on every pixel of the row, including the border between adjacent files.

## How to test

1. Open a folder in Explorer / list view with several adjacent files (for example `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`).
2. Move the pointer slowly along the horizontal divider between two rows until the lower row’s hover highlight appears.
3. Without moving the pointer, click.

**Expected result:** The highlighted row is selected. There is no divider strip where hover and click disagree.

## Related issue

Closes #251