### PR TITLE
perf(browser): keep Grid scrolling and thumbnail resizing smooth

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -107,6 +107,7 @@ pub mod icons {
 }
 
 const FONT_VERSION: &str = "2.304";
+const ICON_TEXTURE_PX: i32 = 96;
 const ICON_TEXTURE_CACHE_LIMIT: usize = 256;
 const JETBRAINS_MONO: &[u8] = include_bytes!("../data/fonts/JetBrainsMono[wght].ttf");
 
@@ -278,7 +279,7 @@ fn primary_icon_texture(name: &str, color: &str) -> Option<gdk::Texture> {
             1,
         );
     }
-    texture_from_svg(name, color, source)
+    texture_from_svg(name, color, svg_at_texture_size(source))
 }
 
 fn folder_decoration_texture(decoration: &str, color: &str) -> Option<gdk::Texture> {
@@ -288,14 +289,11 @@ fn folder_decoration_texture(decoration: &str, color: &str) -> Option<gdk::Textu
     )
     .ok()?;
     let folder = std::str::from_utf8(folder_data.as_ref()).ok()?;
-    let mut source = recolor_icon_source(folder, color)
-        .replacen("width=\"24\"", "width=\"96\"", 1)
-        .replacen("height=\"24\"", "height=\"96\"", 1)
-        .replacen(
-            "fill=\"none\"",
-            &format!("fill=\"{color}\" fill-opacity=\"0.92\""),
-            1,
-        );
+    let mut source = svg_at_texture_size(recolor_icon_source(folder, color)).replacen(
+        "fill=\"none\"",
+        &format!("fill=\"{color}\" fill-opacity=\"0.92\""),
+        1,
+    );
     if let Some(emoji) = icons::custom_emoji(decoration) {
         return folder_emoji_texture(&source, emoji, color);
     }
@@ -409,6 +407,12 @@ fn svg_body(source: &str) -> Option<&str> {
     let start = source.find('>')? + 1;
     let end = source.rfind("</svg>")?;
     source.get(start..end)
+}
+
+fn svg_at_texture_size(source: String) -> String {
+    source
+        .replacen("width=\"24\"", &format!("width=\"{ICON_TEXTURE_PX}\""), 1)
+        .replacen("height=\"24\"", &format!("height=\"{ICON_TEXTURE_PX}\""), 1)
 }
 
 fn texture_from_svg(cache_name: &str, color: &str, source: String) -> Option<gdk::Texture> {

--- a/src/assets/tests.rs
+++ b/src/assets/tests.rs
@@ -3,7 +3,8 @@
 use gtk::prelude::TextureExt;
 
 use super::{
-    contrasting_foreground, folder_decoration_texture, icons, recolor_icon_source, svg_body,
+    contrasting_foreground, folder_decoration_texture, icons, primary_icon_texture,
+    recolor_icon_source, svg_body,
 };
 
 #[test]
@@ -69,6 +70,14 @@ fn svg_body_preserves_bundled_icon_geometry() {
 fn folder_emoji_renders_at_high_resolution() {
     gio::resources_register_include!("strata.gresource").expect("resources register");
     let texture = folder_decoration_texture("emoji:🚀", "#e5484d").expect("emoji renders");
+    assert_eq!(texture.width(), 96);
+    assert_eq!(texture.height(), 96);
+}
+
+#[test]
+fn primary_icons_rasterize_at_high_resolution() {
+    gio::resources_register_include!("strata.gresource").expect("resources register");
+    let texture = primary_icon_texture(icons::DOCUMENTS, "#8bc9eb").expect("icon renders");
     assert_eq!(texture.width(), 96);
     assert_eq!(texture.height(), 96);
 }

--- a/src/style.css
+++ b/src/style.css
@@ -3314,7 +3314,10 @@ menubutton.grid-thumbnail-menu > button:focus-visible {
 
 .grid-card-label {
   color: @theme_text;
-  min-height: 2.6em;
+}
+
+.grid-fast-scroll .grid-card {
+  transition: none;
 }
 
 .grid-card.drop-destination,

--- a/src/style.css
+++ b/src/style.css
@@ -3314,6 +3314,7 @@ menubutton.grid-thumbnail-menu > button:focus-visible {
 
 .grid-card-label {
   color: @theme_text;
+  min-height: 2.6em;
 }
 
 .grid-card.drop-destination,

--- a/src/style.css
+++ b/src/style.css
@@ -3194,6 +3194,10 @@ entry.theme-search {
   font-size: 0.8em;
 }
 
+.grid-thumbnail-scale {
+  padding: 0 16px;
+}
+
 .grid-thumbnail-scale trough {
   background: alpha(@theme_muted, 0.72);
   border: 1px solid alpha(@theme_border, 0.68);

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -1148,6 +1148,7 @@ struct GridControls {
     filter_button: gtk::ToggleButton,
     thumbnail_scale: gtk::Scale,
     thumbnail_value: gtk::Label,
+    thumbnail_popover: gtk::Popover,
     empty_trash_button: Option<gtk::Button>,
 }
 
@@ -1265,6 +1266,7 @@ fn grid_controls(browser: &Rc<Browser>, depth: usize, thumbnail_size: i32) -> Gr
         filter_button,
         thumbnail_scale,
         thumbnail_value,
+        thumbnail_popover,
         empty_trash_button: is_trash.then_some(empty_trash),
     }
 }
@@ -1282,6 +1284,80 @@ fn disable_scale_long_press_zoom(scale: &gtk::Scale) {
     for long_press in long_presses {
         scale.remove_controller(&long_press);
     }
+}
+
+fn close_thumbnail_popover_on_outside_scroll(popover: &gtk::Popover, scroll: &gtk::ScrolledWindow) {
+    let wheel = gtk::EventControllerScroll::new(
+        gtk::EventControllerScrollFlags::VERTICAL | gtk::EventControllerScrollFlags::HORIZONTAL,
+    );
+    wheel.set_propagation_phase(gtk::PropagationPhase::Capture);
+    let popover_for_scroll = popover.clone();
+    let scroll = scroll.clone();
+    wheel.connect_scroll(move |controller, dx, dy| {
+        if !popover_for_scroll.is_visible() || pointer_over_popover(&popover_for_scroll) {
+            return glib::Propagation::Proceed;
+        }
+        popover_for_scroll.popdown();
+        apply_scrolled_window_wheel(&scroll, controller, dx, dy);
+        glib::Propagation::Stop
+    });
+    popover.add_controller(wheel);
+}
+
+fn pointer_over_popover(popover: &gtk::Popover) -> bool {
+    let Some(surface) = popover.surface() else {
+        return false;
+    };
+    let Some(pointer) = popover
+        .display()
+        .default_seat()
+        .and_then(|seat| seat.pointer())
+    else {
+        return false;
+    };
+    let Some((x, y, _)) = surface.device_position(&pointer) else {
+        return false;
+    };
+    (0.0..f64::from(surface.width())).contains(&x)
+        && (0.0..f64::from(surface.height())).contains(&y)
+}
+
+fn apply_scrolled_window_wheel(
+    scroll: &gtk::ScrolledWindow,
+    controller: &gtk::EventControllerScroll,
+    mut dx: f64,
+    mut dy: f64,
+) {
+    if controller
+        .current_event_state()
+        .contains(gtk::gdk::ModifierType::SHIFT_MASK)
+    {
+        std::mem::swap(&mut dx, &mut dy);
+    }
+    let unit = controller.unit();
+    if dx != 0.0 {
+        apply_adjustment_scroll(&scroll.hadjustment(), dx, unit);
+    }
+    if dy != 0.0 {
+        apply_adjustment_scroll(&scroll.vadjustment(), dy, unit);
+    }
+}
+
+fn apply_adjustment_scroll(adjustment: &gtk::Adjustment, delta: f64, unit: gtk::gdk::ScrollUnit) {
+    let max = (adjustment.upper() - adjustment.page_size()).max(adjustment.lower());
+    adjustment.set_value(
+        (adjustment.value() + scroll_delta_for_unit(delta, adjustment.page_size(), unit))
+            .clamp(adjustment.lower(), max),
+    );
+}
+
+fn scroll_delta_for_unit(delta: f64, page_size: f64, unit: gtk::gdk::ScrollUnit) -> f64 {
+    delta
+        * match unit {
+            gtk::gdk::ScrollUnit::Wheel => page_size.powf(2.0 / 3.0),
+            gtk::gdk::ScrollUnit::Surface => 2.5,
+            _ => 1.0,
+        }
 }
 
 /// Shared wiring every grid view in a pane needs, so a pane that groups entries by
@@ -1445,6 +1521,7 @@ fn build_grid_pane(
         .vexpand(true)
         .build();
     scroll.add_css_class("fixed-scrollbar");
+    close_thumbnail_popover_on_outside_scroll(&controls.thumbnail_popover, &scroll);
     install_grid_scroll_settle(&scroll, &context);
     if let Some(groups) = groups.clone() {
         let context = Rc::downgrade(&context);

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -1294,21 +1294,28 @@ fn close_thumbnail_popover_on_outside_scroll(popover: &gtk::Popover, scroll: &gt
     let popover_for_scroll = popover.clone();
     let scroll = scroll.clone();
     wheel.connect_scroll(move |controller, dx, dy| {
-        if !popover_for_scroll.is_visible() || pointer_over_popover(&popover_for_scroll) {
+        if !popover_for_scroll.is_visible() || pointer_over_widget(&popover_for_scroll) {
             return glib::Propagation::Proceed;
         }
+        let over_grid = pointer_over_widget(&scroll);
         popover_for_scroll.popdown();
-        apply_scrolled_window_wheel(&scroll, controller, dx, dy);
+        if over_grid {
+            apply_scrolled_window_wheel(&scroll, controller, dx, dy);
+        }
         glib::Propagation::Stop
     });
     popover.add_controller(wheel);
 }
 
-fn pointer_over_popover(popover: &gtk::Popover) -> bool {
-    let Some(surface) = popover.surface() else {
+fn pointer_over_widget(widget: &impl IsA<gtk::Widget>) -> bool {
+    let widget = widget.as_ref();
+    let Some(native) = widget.native() else {
         return false;
     };
-    let Some(pointer) = popover
+    let Some(surface) = native.surface() else {
+        return false;
+    };
+    let Some(pointer) = widget
         .display()
         .default_seat()
         .and_then(|seat| seat.pointer())
@@ -1318,8 +1325,11 @@ fn pointer_over_popover(popover: &gtk::Popover) -> bool {
     let Some((x, y, _)) = surface.device_position(&pointer) else {
         return false;
     };
-    (0.0..f64::from(surface.width())).contains(&x)
-        && (0.0..f64::from(surface.height())).contains(&y)
+    let (ox, oy) = native.surface_transform();
+    let Some(bounds) = widget.compute_bounds(native.upcast_ref::<gtk::Widget>()) else {
+        return false;
+    };
+    bounds.contains_point(&gtk::graphene::Point::new((x - ox) as f32, (y - oy) as f32))
 }
 
 fn apply_scrolled_window_wheel(

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -28,6 +28,8 @@ const GRID_CARD_SPACING: i32 = 4;
 const FALLBACK_GRID_COLUMN_WIDTH: i32 = 160;
 const MIN_GRID_THUMBNAIL_SIZE: i32 = 64;
 const MAX_GRID_THUMBNAIL_SIZE: i32 = 256;
+const GRID_CARD_LABEL_CHARS: i32 = 16;
+const GRID_CARD_LABEL_LINES: i32 = 2;
 
 #[derive(Clone)]
 struct ExplorerColumnLayout {
@@ -1544,12 +1546,13 @@ fn build_grid_view(
     let transfers_for_setup = context.transfer.clone();
     let peek_for_setup = context.state.clone();
     let active_for_setup = context.active_new_entry.clone();
+    let thumbnail_size_for_setup = context.thumbnail_size.clone();
     let folder_location = context.browser.location_at(depth);
     factory.connect_setup(move |_, item| {
         let Some(item) = item.downcast_ref::<gtk::ListItem>() else {
             return;
         };
-        let card = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        let card = gtk::Box::new(gtk::Orientation::Vertical, 3);
         card.add_css_class("grid-card");
         card.add_css_class("file-appear");
         let weak_card = card.downgrade();
@@ -1560,26 +1563,19 @@ fn build_grid_view(
         });
         card.set_halign(gtk::Align::Center);
         card.set_valign(gtk::Align::Center);
-        let centered = gtk::CenterBox::new();
-        centered.set_orientation(gtk::Orientation::Vertical);
-        centered.set_vexpand(true);
-        let item_content = gtk::Box::new(gtk::Orientation::Vertical, 3);
-        item_content.set_halign(gtk::Align::Center);
-        item_content.set_valign(gtk::Align::Center);
         let icon = gtk::Image::new();
-        icon.set_pixel_size(26);
+        super::thumbnail::ensure_image_slot(
+            &icon,
+            grid_card_icon_slot(thumbnail_size_for_setup.get()),
+        );
         icon.add_css_class("grid-card-icon");
         let label = gtk::Label::new(None);
         label.add_css_class("grid-card-label");
         label.add_css_class("alternate-rename-label");
-        label.set_justify(gtk::Justification::Center);
-        label.set_width_chars(12);
-        label.set_max_width_chars(16);
-        label.set_wrap(true);
-        label.set_wrap_mode(gtk::pango::WrapMode::WordChar);
+        configure_grid_card_label(&label);
         let field = gtk::Entry::new();
         field.add_css_class("inline-rename");
-        field.set_width_chars(12);
+        field.set_width_chars(GRID_CARD_LABEL_CHARS);
         field.set_visible(false);
         field.connect_changed(|field| {
             super::browser::update_basename_validation(field);
@@ -1609,11 +1605,9 @@ fn build_grid_view(
             );
         });
         field.add_controller(focus);
-        item_content.append(&icon);
-        item_content.append(&label);
-        item_content.append(&field);
-        centered.set_center_widget(Some(&item_content));
-        card.append(&centered);
+        card.append(&icon);
+        card.append(&label);
+        card.append(&field);
         install_preview_click(
             &card,
             item,
@@ -1662,19 +1656,7 @@ fn build_grid_view(
         let Some(card) = item.child().and_downcast::<gtk::Box>() else {
             return;
         };
-        let Some(centered) = card.first_child().and_downcast::<gtk::CenterBox>() else {
-            return;
-        };
-        let Some(item_content) = centered.center_widget().and_downcast::<gtk::Box>() else {
-            return;
-        };
-        let Some(icon) = item_content.first_child().and_downcast::<gtk::Image>() else {
-            return;
-        };
-        let Some(label) = icon.next_sibling().and_downcast::<gtk::Label>() else {
-            return;
-        };
-        let Some(field) = label.next_sibling().and_downcast::<gtk::Entry>() else {
+        let Some((icon, label, field)) = grid_card_parts(&card) else {
             return;
         };
         let source_position = item
@@ -1684,37 +1666,39 @@ fn build_grid_view(
         let entry = browser.as_ref().and_then(|browser| {
             source_position.and_then(|position| browser.entry_at(depth, position))
         });
+        let thumbnail_size = grid_card_icon_slot(thumbnail_size_for_bind.get());
         if let Some(entry) = entry {
             label.set_visible(true);
             field.set_visible(false);
-            set_mode_cut_style(&card, cuts_for_bind.borrow().contains(&entry.location));
             label.set_label(&entry.display_name);
-            label.set_tooltip_text(Some(&entry.display_name));
             let fallback = super::browser::entry_icon(&entry);
-            if scrolling_for_bind.get() {
-                super::thumbnail::show_fallback_icon(&icon, fallback, 26);
-            } else {
+            if grid_bind_requests_metadata(scrolling_for_bind.get()) {
+                set_mode_cut_style(&card, cuts_for_bind.borrow().contains(&entry.location));
+                label.set_tooltip_text(Some(&entry.display_name));
                 super::thumbnail::set_thumbnail_or_icon(
                     &icon,
                     &entry,
                     fallback,
-                    26,
-                    thumbnail_size_for_bind.get(),
+                    thumbnail_size,
+                    thumbnail_size,
                 );
                 if let Some(position) = metadata_fill_position(source_position, &entry, false)
                     && let Some(browser) = browser.as_ref()
                 {
                     browser.request_metadata_fill(depth, position, entry.location.clone());
                 }
+                icon.set_opacity(if entry.is_directory() { 1.0 } else { 0.72 });
+            } else {
+                super::thumbnail::show_fallback_icon(&icon, fallback, thumbnail_size);
             }
-            icon.set_opacity(if entry.is_directory() { 1.0 } else { 0.72 });
         } else {
-            card.remove_css_class("cut-item");
+            set_mode_cut_style(&card, false);
             let icon_name = if entry_kind_for_bind.get() {
                 crate::assets::icons::FOLDER
             } else {
                 crate::assets::icons::DOCUMENTS
             };
+            super::thumbnail::ensure_image_slot(&icon, thumbnail_size);
             crate::assets::set_primary_icon(&icon, icon_name);
             icon.set_opacity(1.0);
             label.set_visible(false);
@@ -1924,6 +1908,7 @@ fn refresh_grid_expensive_content(context: &GridContext) {
     let Some(sections) = context.sections.upgrade() else {
         return;
     };
+    let cuts = context.cuts.borrow();
     for section in sections.borrow().iter() {
         refresh_grid_section(
             &Rc::downgrade(&context.browser),
@@ -1932,6 +1917,7 @@ fn refresh_grid_expensive_content(context: &GridContext) {
             section,
             context.thumbnail_size.get(),
             true,
+            Some(&cuts),
         );
     }
 }
@@ -1943,7 +1929,7 @@ fn refresh_grid_thumbnail_size(
     section: &PaneSection,
     size: i32,
 ) {
-    refresh_grid_section(browser, depth, source_index, section, size, false);
+    refresh_grid_section(browser, depth, source_index, section, size, false, None);
 }
 
 fn refresh_grid_section(
@@ -1953,25 +1939,21 @@ fn refresh_grid_section(
     section: &PaneSection,
     size: i32,
     request_metadata: bool,
+    cuts: Option<&HashSet<Location>>,
 ) {
     let Some(browser) = browser.upgrade() else {
         return;
     };
+    let size = grid_card_icon_slot(size);
     section.bound_items.borrow().iter().for_each(|bound| {
-        let Some(item) = bound.item.upgrade() else {
-            return;
-        };
         let Some(card) = bound.widget.upgrade().and_downcast::<gtk::Box>() else {
             return;
         };
-        let Some(icon) = card
-            .first_child()
-            .and_downcast::<gtk::CenterBox>()
-            .and_then(|centered| centered.center_widget())
-            .and_downcast::<gtk::Box>()
-            .and_then(|content| content.first_child())
-            .and_downcast::<gtk::Image>()
-        else {
+        let Some((icon, label, _)) = grid_card_parts(&card) else {
+            return;
+        };
+        super::thumbnail::ensure_image_slot(&icon, size);
+        let Some(item) = bound.item.upgrade() else {
             return;
         };
         let Some(position) = item.item().and_then(|value| source_index.of_item(&value)) else {
@@ -1984,16 +1966,45 @@ fn refresh_grid_section(
             &icon,
             &entry,
             super::browser::entry_icon(&entry),
-            26,
+            size,
             size,
         );
-        if request_metadata
-            && let Some(position) = metadata_fill_position(Some(position), &entry, false)
-        {
-            browser.request_metadata_fill(depth, position, entry.location.clone());
+        if request_metadata {
+            label.set_tooltip_text(Some(&entry.display_name));
+            if let Some(cuts) = cuts {
+                set_mode_cut_style(&card, cuts.contains(&entry.location));
+            }
+            if let Some(position) = metadata_fill_position(Some(position), &entry, false) {
+                browser.request_metadata_fill(depth, position, entry.location.clone());
+            }
         }
         icon.set_opacity(if entry.is_directory() { 1.0 } else { 0.72 });
     });
+}
+
+fn grid_card_icon_slot(thumbnail_size: i32) -> i32 {
+    thumbnail_size.clamp(MIN_GRID_THUMBNAIL_SIZE, MAX_GRID_THUMBNAIL_SIZE)
+}
+
+fn grid_bind_requests_metadata(scrolling: bool) -> bool {
+    !scrolling
+}
+
+fn configure_grid_card_label(label: &gtk::Label) {
+    label.set_justify(gtk::Justification::Center);
+    label.set_width_chars(GRID_CARD_LABEL_CHARS);
+    label.set_max_width_chars(GRID_CARD_LABEL_CHARS);
+    label.set_lines(GRID_CARD_LABEL_LINES);
+    label.set_ellipsize(gtk::pango::EllipsizeMode::End);
+    label.set_wrap(true);
+    label.set_wrap_mode(gtk::pango::WrapMode::WordChar);
+}
+
+fn grid_card_parts(card: &gtk::Box) -> Option<(gtk::Image, gtk::Label, gtk::Entry)> {
+    let icon = card.first_child()?.downcast::<gtk::Image>().ok()?;
+    let label = icon.next_sibling()?.downcast::<gtk::Label>().ok()?;
+    let field = label.next_sibling()?.downcast::<gtk::Entry>().ok()?;
+    Some((icon, label, field))
 }
 
 fn configure_grid_density(pane: &Pane, density: BrowserDensity) {

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -1212,6 +1212,7 @@ fn grid_controls(browser: &Rc<Browser>, depth: usize, thumbnail_size: i32) -> Gr
         f64::from(MAX_GRID_THUMBNAIL_SIZE),
         16.0,
     );
+    thumbnail_scale.set_increments(16.0, 1.0);
     thumbnail_scale.add_css_class("grid-thumbnail-scale");
     thumbnail_scale.set_draw_value(false);
     thumbnail_scale.set_value(f64::from(thumbnail_size));

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -1754,7 +1754,7 @@ fn build_grid_view(
             if label.text().as_deref() != Some(entry.display_name.as_str()) {
                 label.set_text(Some(&entry.display_name));
             }
-            if grid_bind_requests_metadata(scrolling_for_bind.get()) {
+            if !scrolling_for_bind.get() {
                 set_mode_cut_style(&card, cuts_for_bind.borrow().contains(&entry.location));
                 label.set_tooltip_text(Some(&entry.display_name));
                 super::thumbnail::set_thumbnail_or_icon(
@@ -2087,10 +2087,6 @@ fn ensure_grid_card_slot(card: &gtk::Box, thumbnail_size: i32) {
     if card.width_request() != width || card.height_request() != height {
         card.set_size_request(width, height);
     }
-}
-
-fn grid_bind_requests_metadata(scrolling: bool) -> bool {
-    !scrolling
 }
 
 fn configure_grid_card_label(label: &gtk::Inscription) {

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -1216,6 +1216,7 @@ fn grid_controls(browser: &Rc<Browser>, depth: usize, thumbnail_size: i32) -> Gr
     thumbnail_scale.set_draw_value(false);
     thumbnail_scale.set_value(f64::from(thumbnail_size));
     thumbnail_scale.set_size_request(220, -1);
+    disable_scale_long_press_zoom(&thumbnail_scale);
     let thumbnail_extremes = gtk::Box::new(gtk::Orientation::Horizontal, 0);
     thumbnail_extremes.add_css_class("grid-thumbnail-extremes");
     let small = gtk::Label::new(Some("Small"));
@@ -1264,6 +1265,21 @@ fn grid_controls(browser: &Rc<Browser>, depth: usize, thumbnail_size: i32) -> Gr
         thumbnail_scale,
         thumbnail_value,
         empty_trash_button: is_trash.then_some(empty_trash),
+    }
+}
+
+fn disable_scale_long_press_zoom(scale: &gtk::Scale) {
+    let controllers = scale.observe_controllers();
+    let long_presses: Vec<gtk::GestureLongPress> = (0..controllers.n_items())
+        .filter_map(|index| {
+            controllers
+                .item(index)?
+                .downcast::<gtk::GestureLongPress>()
+                .ok()
+        })
+        .collect();
+    for long_press in long_presses {
+        scale.remove_controller(&long_press);
     }
 }
 

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -30,6 +30,8 @@ const MIN_GRID_THUMBNAIL_SIZE: i32 = 64;
 const MAX_GRID_THUMBNAIL_SIZE: i32 = 256;
 const GRID_CARD_LABEL_CHARS: i32 = 16;
 const GRID_CARD_LABEL_LINES: i32 = 2;
+const GRID_CARD_LABEL_LINE_PX: i32 = 18;
+const GRID_CARD_PAD_Y: i32 = 4;
 
 #[derive(Clone)]
 struct ExplorerColumnLayout {
@@ -174,7 +176,7 @@ impl SourceIndexMap {
 
 struct ActiveModeRename {
     field: gtk::Entry,
-    label: gtk::Label,
+    label: gtk::Widget,
 }
 
 struct ActiveModeNewEntry {
@@ -512,9 +514,7 @@ impl ModeViews {
         let Some(widget) = widget else {
             return false;
         };
-        let Some(label) =
-            descendant_with_class(&widget, "alternate-rename-label").and_downcast::<gtk::Label>()
-        else {
+        let Some(label) = descendant_with_class(&widget, "alternate-rename-label") else {
             return false;
         };
         let Some(field) =
@@ -1547,6 +1547,7 @@ fn build_grid_view(
     let peek_for_setup = context.state.clone();
     let active_for_setup = context.active_new_entry.clone();
     let thumbnail_size_for_setup = context.thumbnail_size.clone();
+    let scrolling_for_setup = context.scrolling.clone();
     let folder_location = context.browser.location_at(depth);
     factory.connect_setup(move |_, item| {
         let Some(item) = item.downcast_ref::<gtk::ListItem>() else {
@@ -1554,22 +1555,24 @@ fn build_grid_view(
         };
         let card = gtk::Box::new(gtk::Orientation::Vertical, 3);
         card.add_css_class("grid-card");
-        card.add_css_class("file-appear");
-        let weak_card = card.downgrade();
-        glib::idle_add_local_once(move || {
-            if let Some(card) = weak_card.upgrade() {
-                card.remove_css_class("file-appear");
-            }
-        });
-        card.set_halign(gtk::Align::Center);
-        card.set_valign(gtk::Align::Center);
+        if !scrolling_for_setup.get() {
+            card.add_css_class("file-appear");
+            let weak_card = card.downgrade();
+            glib::idle_add_local_once(move || {
+                if let Some(card) = weak_card.upgrade() {
+                    card.remove_css_class("file-appear");
+                }
+            });
+        }
+        card.set_halign(gtk::Align::Fill);
+        card.set_valign(gtk::Align::Fill);
+        card.set_overflow(gtk::Overflow::Hidden);
+        let thumbnail_size = grid_card_icon_slot(thumbnail_size_for_setup.get());
+        ensure_grid_card_slot(&card, thumbnail_size);
         let icon = gtk::Image::new();
-        super::thumbnail::ensure_image_slot(
-            &icon,
-            grid_card_icon_slot(thumbnail_size_for_setup.get()),
-        );
+        super::thumbnail::ensure_image_slot(&icon, thumbnail_size);
         icon.add_css_class("grid-card-icon");
-        let label = gtk::Label::new(None);
+        let label = gtk::Inscription::new(None);
         label.add_css_class("grid-card-label");
         label.add_css_class("alternate-rename-label");
         configure_grid_card_label(&label);
@@ -1667,18 +1670,20 @@ fn build_grid_view(
             source_position.and_then(|position| browser.entry_at(depth, position))
         });
         let thumbnail_size = grid_card_icon_slot(thumbnail_size_for_bind.get());
+        ensure_grid_card_slot(&card, thumbnail_size);
         if let Some(entry) = entry {
             label.set_visible(true);
             field.set_visible(false);
-            label.set_label(&entry.display_name);
-            let fallback = super::browser::entry_icon(&entry);
+            if label.text().as_deref() != Some(entry.display_name.as_str()) {
+                label.set_text(Some(&entry.display_name));
+            }
             if grid_bind_requests_metadata(scrolling_for_bind.get()) {
                 set_mode_cut_style(&card, cuts_for_bind.borrow().contains(&entry.location));
                 label.set_tooltip_text(Some(&entry.display_name));
                 super::thumbnail::set_thumbnail_or_icon(
                     &icon,
                     &entry,
-                    fallback,
+                    super::browser::entry_icon(&entry),
                     thumbnail_size,
                     thumbnail_size,
                 );
@@ -1688,8 +1693,6 @@ fn build_grid_view(
                     browser.request_metadata_fill(depth, position, entry.location.clone());
                 }
                 icon.set_opacity(if entry.is_directory() { 1.0 } else { 0.72 });
-            } else {
-                super::thumbnail::show_fallback_icon(&icon, fallback, thumbnail_size);
             }
         } else {
             set_mode_cut_style(&card, false);
@@ -1879,16 +1882,19 @@ fn install_grid_scroll_settle(scroll: &gtk::ScrolledWindow, context: &Rc<GridCon
     for adjustment in [scroll.vadjustment(), scroll.hadjustment()] {
         let pending = pending.clone();
         let context = Rc::downgrade(context);
+        let scroll = scroll.clone();
         adjustment.connect_value_changed(move |_| {
             let Some(context) = context.upgrade() else {
                 return;
             };
             context.scrolling.set(true);
+            scroll.add_css_class("grid-fast-scroll");
             if let Some(source) = pending.borrow_mut().take() {
                 source.remove();
             }
             let pending_for_timeout = pending.clone();
             let context = Rc::downgrade(&context);
+            let scroll = scroll.clone();
             pending.replace(Some(glib::timeout_add_local_once(
                 GRID_SCROLL_SETTLE_DELAY,
                 move || {
@@ -1897,6 +1903,7 @@ fn install_grid_scroll_settle(scroll: &gtk::ScrolledWindow, context: &Rc<GridCon
                         return;
                     };
                     context.scrolling.set(false);
+                    scroll.remove_css_class("grid-fast-scroll");
                     refresh_grid_expensive_content(&context);
                 },
             )));
@@ -1953,6 +1960,7 @@ fn refresh_grid_section(
             return;
         };
         super::thumbnail::ensure_image_slot(&icon, size);
+        ensure_grid_card_slot(&card, size);
         let Some(item) = bound.item.upgrade() else {
             return;
         };
@@ -1986,23 +1994,40 @@ fn grid_card_icon_slot(thumbnail_size: i32) -> i32 {
     thumbnail_size.clamp(MIN_GRID_THUMBNAIL_SIZE, MAX_GRID_THUMBNAIL_SIZE)
 }
 
+fn grid_card_extent(thumbnail_size: i32) -> (i32, i32) {
+    let slot = grid_card_icon_slot(thumbnail_size);
+    let width = slot.max(FALLBACK_GRID_COLUMN_WIDTH - GRID_CARD_SPACING);
+    let height = slot + GRID_CARD_LABEL_LINE_PX * GRID_CARD_LABEL_LINES + GRID_CARD_PAD_Y + 3;
+    (width, height)
+}
+
+fn ensure_grid_card_slot(card: &gtk::Box, thumbnail_size: i32) {
+    let (width, height) = grid_card_extent(thumbnail_size);
+    if card.width_request() != width || card.height_request() != height {
+        card.set_size_request(width, height);
+    }
+}
+
 fn grid_bind_requests_metadata(scrolling: bool) -> bool {
     !scrolling
 }
 
-fn configure_grid_card_label(label: &gtk::Label) {
-    label.set_justify(gtk::Justification::Center);
-    label.set_width_chars(GRID_CARD_LABEL_CHARS);
-    label.set_max_width_chars(GRID_CARD_LABEL_CHARS);
-    label.set_lines(GRID_CARD_LABEL_LINES);
-    label.set_ellipsize(gtk::pango::EllipsizeMode::End);
-    label.set_wrap(true);
+fn configure_grid_card_label(label: &gtk::Inscription) {
+    let chars = GRID_CARD_LABEL_CHARS as u32;
+    let lines = GRID_CARD_LABEL_LINES as u32;
+    label.set_min_chars(chars);
+    label.set_nat_chars(chars);
+    label.set_min_lines(lines);
+    label.set_nat_lines(lines);
+    label.set_xalign(0.5);
+    label.set_yalign(0.0);
     label.set_wrap_mode(gtk::pango::WrapMode::WordChar);
+    label.set_text_overflow(gtk::InscriptionOverflow::EllipsizeEnd);
 }
 
-fn grid_card_parts(card: &gtk::Box) -> Option<(gtk::Image, gtk::Label, gtk::Entry)> {
+fn grid_card_parts(card: &gtk::Box) -> Option<(gtk::Image, gtk::Inscription, gtk::Entry)> {
     let icon = card.first_child()?.downcast::<gtk::Image>().ok()?;
-    let label = icon.next_sibling()?.downcast::<gtk::Label>().ok()?;
+    let label = icon.next_sibling()?.downcast::<gtk::Inscription>().ok()?;
     let field = label.next_sibling()?.downcast::<gtk::Entry>().ok()?;
     Some((icon, label, field))
 }

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -1394,12 +1394,9 @@ fn build_grid_pane(
         (section.view.clone(), section, None)
     };
 
-    let pending_thumbnail_resize = Rc::new(RefCell::new(None::<glib::SourceId>));
     let groups_for_pane = groups.clone();
     let density_for_size = context.density.get();
     let sections_for_size = Rc::downgrade(&sections);
-    let browser_for_size = Rc::downgrade(&context.browser);
-    let source_index_for_size = source_index.clone();
     let thumbnail_size_for_change = options.thumbnail_size.clone();
     let value_for_change = controls.thumbnail_value.clone();
     controls
@@ -1407,30 +1404,16 @@ fn build_grid_pane(
         .connect_value_changed(move |scale| {
             let size = scale.value().round() as i32;
             value_for_change.set_label(&format!("{size} px"));
-            if let Some(pending) = pending_thumbnail_resize.take() {
-                pending.remove();
+            thumbnail_size_for_change.set(size);
+            let Some(sections) = sections_for_size.upgrade() else {
+                return;
+            };
+            for section in sections.borrow().iter() {
+                resize_grid_thumbnail_slots(section, size);
             }
-            let pending_for_timeout = pending_thumbnail_resize.clone();
-            let browser = browser_for_size.clone();
-            let source_index = source_index_for_size.clone();
-            let sections = sections_for_size.clone();
-            let groups_for_size = groups_for_pane.clone();
-            let size_state = thumbnail_size_for_change.clone();
-            let source_id =
-                glib::timeout_add_local_once(std::time::Duration::from_millis(100), move || {
-                    pending_for_timeout.take();
-                    size_state.set(size);
-                    let Some(sections) = sections.upgrade() else {
-                        return;
-                    };
-                    for section in sections.borrow().iter() {
-                        refresh_grid_thumbnail_size(&browser, depth, &source_index, section, size);
-                    }
-                    if let Some(groups) = groups_for_size.as_ref() {
-                        refresh_group_columns(groups, groups.container.width(), density_for_size);
-                    }
-                });
-            pending_thumbnail_resize.replace(Some(source_id));
+            if let Some(groups) = groups_for_pane.as_ref() {
+                refresh_group_columns(groups, groups.container.width(), density_for_size);
+            }
         });
 
     let scroll = gtk::ScrolledWindow::builder()
@@ -1929,14 +1912,18 @@ fn refresh_grid_expensive_content(context: &GridContext) {
     }
 }
 
-fn refresh_grid_thumbnail_size(
-    browser: &Weak<Browser>,
-    depth: usize,
-    source_index: &SourceIndexMap,
-    section: &PaneSection,
-    size: i32,
-) {
-    refresh_grid_section(browser, depth, source_index, section, size, false, None);
+fn resize_grid_thumbnail_slots(section: &PaneSection, size: i32) {
+    let size = grid_card_icon_slot(size);
+    section.bound_items.borrow().iter().for_each(|bound| {
+        let Some(card) = bound.widget.upgrade().and_downcast::<gtk::Box>() else {
+            return;
+        };
+        let Some((icon, _, _)) = grid_card_parts(&card) else {
+            return;
+        };
+        super::thumbnail::ensure_image_slot(&icon, size);
+        ensure_grid_card_slot(&card, size);
+    });
 }
 
 fn refresh_grid_section(

--- a/src/ui/browser_modes/tests.rs
+++ b/src/ui/browser_modes/tests.rs
@@ -2,10 +2,10 @@
 
 use super::{
     BrowserMode, ClickActivation, ClickCount, EXPLORER_COLUMN_MIN_WIDTHS, EXPLORER_COLUMN_WIDTHS,
-    GRID_CARD_LABEL_CHARS, GRID_CARD_LABEL_LINES, MAX_GRID_THUMBNAIL_SIZE, MIN_GRID_THUMBNAIL_SIZE,
-    SourceIndexMap, compare_type_groups, explorer_column_width, grid_bind_requests_metadata,
-    grid_card_icon_slot, metadata_fill_position, should_activate_pointer_click, type_groups_of,
-    value_type_group,
+    GRID_CARD_LABEL_CHARS, GRID_CARD_LABEL_LINE_PX, GRID_CARD_LABEL_LINES, MAX_GRID_THUMBNAIL_SIZE,
+    MIN_GRID_THUMBNAIL_SIZE, SourceIndexMap, compare_type_groups, explorer_column_width,
+    grid_bind_requests_metadata, grid_card_extent, grid_card_icon_slot, metadata_fill_position,
+    should_activate_pointer_click, type_groups_of, value_type_group,
 };
 use crate::model::{EntryKind, FileEntry, Location, MetadataValue};
 use gtk::{gio, prelude::*};
@@ -107,6 +107,12 @@ fn grid_cards_keep_a_uniform_icon_slot_and_two_line_label() {
     assert_eq!(grid_card_icon_slot(512), MAX_GRID_THUMBNAIL_SIZE);
     assert_eq!(GRID_CARD_LABEL_LINES, 2);
     assert_eq!(GRID_CARD_LABEL_CHARS, 16);
+    let (width, height) = grid_card_extent(64);
+    assert!(width >= grid_card_icon_slot(64));
+    assert!(height >= grid_card_icon_slot(64) + GRID_CARD_LABEL_LINES * GRID_CARD_LABEL_LINE_PX);
+    let (wide, tall) = grid_card_extent(256);
+    assert!(wide >= 256);
+    assert!(tall > height);
     assert!(!grid_bind_requests_metadata(true));
     assert!(grid_bind_requests_metadata(false));
 }

--- a/src/ui/browser_modes/tests.rs
+++ b/src/ui/browser_modes/tests.rs
@@ -2,9 +2,8 @@
 
 use super::{
     BrowserMode, ClickActivation, ClickCount, EXPLORER_COLUMN_MIN_WIDTHS, EXPLORER_COLUMN_WIDTHS,
-    GRID_CARD_LABEL_CHARS, GRID_CARD_LABEL_LINE_PX, GRID_CARD_LABEL_LINES, MAX_GRID_THUMBNAIL_SIZE,
-    MIN_GRID_THUMBNAIL_SIZE, SourceIndexMap, compare_type_groups, explorer_column_width,
-    grid_bind_requests_metadata, grid_card_extent, grid_card_icon_slot, metadata_fill_position,
+    MAX_GRID_THUMBNAIL_SIZE, MIN_GRID_THUMBNAIL_SIZE, SourceIndexMap, compare_type_groups,
+    explorer_column_width, grid_card_extent, grid_card_icon_slot, metadata_fill_position,
     scroll_delta_for_unit, should_activate_pointer_click, type_groups_of, value_type_group,
 };
 use crate::model::{EntryKind, FileEntry, Location, MetadataValue};
@@ -101,29 +100,28 @@ fn alternate_modes_request_missing_metadata_for_bound_entries() {
 
 #[test]
 fn grid_cards_keep_a_uniform_icon_slot_and_two_line_label() {
-    assert_eq!(grid_card_icon_slot(64), 64);
-    assert_eq!(grid_card_icon_slot(128), 128);
     assert_eq!(grid_card_icon_slot(26), MIN_GRID_THUMBNAIL_SIZE);
+    assert_eq!(grid_card_icon_slot(128), 128);
     assert_eq!(grid_card_icon_slot(512), MAX_GRID_THUMBNAIL_SIZE);
-    assert_eq!(GRID_CARD_LABEL_LINES, 2);
-    assert_eq!(GRID_CARD_LABEL_CHARS, 16);
-    let (width, height) = grid_card_extent(64);
-    assert!(width >= grid_card_icon_slot(64));
-    assert!(height >= grid_card_icon_slot(64) + GRID_CARD_LABEL_LINES * GRID_CARD_LABEL_LINE_PX);
-    let (wide, tall) = grid_card_extent(256);
-    assert!(wide >= 256);
-    assert!(tall > height);
-    assert!(!grid_bind_requests_metadata(true));
-    assert!(grid_bind_requests_metadata(false));
+    assert_eq!(grid_card_extent(26), grid_card_extent(64));
+    assert_eq!(grid_card_extent(64), (156, 107));
+    assert_eq!(grid_card_extent(128), (156, 171));
+    assert_eq!(grid_card_extent(256), (256, 299));
+    assert_eq!(grid_card_extent(512), grid_card_extent(256));
 }
 
 #[test]
 fn grid_scroll_maps_a_wheel_notch_from_page_size() {
-    let step = scroll_delta_for_unit(1.0, 1000.0, gtk::gdk::ScrollUnit::Wheel);
-    assert!((step - 1000.0_f64.powf(2.0 / 3.0)).abs() < 1e-9);
+    let wheel = scroll_delta_for_unit(1.0, 1000.0, gtk::gdk::ScrollUnit::Wheel);
+    assert!((wheel - 100.0).abs() < 1e-9);
+    assert!(scroll_delta_for_unit(1.0, 8000.0, gtk::gdk::ScrollUnit::Wheel) > wheel);
     assert_eq!(
         scroll_delta_for_unit(4.0, 100.0, gtk::gdk::ScrollUnit::Surface),
         10.0
+    );
+    assert_eq!(
+        scroll_delta_for_unit(1.0, 50.0, gtk::gdk::ScrollUnit::Surface),
+        scroll_delta_for_unit(1.0, 999.0, gtk::gdk::ScrollUnit::Surface)
     );
 }
 

--- a/src/ui/browser_modes/tests.rs
+++ b/src/ui/browser_modes/tests.rs
@@ -2,8 +2,10 @@
 
 use super::{
     BrowserMode, ClickActivation, ClickCount, EXPLORER_COLUMN_MIN_WIDTHS, EXPLORER_COLUMN_WIDTHS,
-    SourceIndexMap, compare_type_groups, explorer_column_width, metadata_fill_position,
-    should_activate_pointer_click, type_groups_of, value_type_group,
+    GRID_CARD_LABEL_CHARS, GRID_CARD_LABEL_LINES, MAX_GRID_THUMBNAIL_SIZE, MIN_GRID_THUMBNAIL_SIZE,
+    SourceIndexMap, compare_type_groups, explorer_column_width, grid_bind_requests_metadata,
+    grid_card_icon_slot, metadata_fill_position, should_activate_pointer_click, type_groups_of,
+    value_type_group,
 };
 use crate::model::{EntryKind, FileEntry, Location, MetadataValue};
 use gtk::{gio, prelude::*};
@@ -95,6 +97,18 @@ fn alternate_modes_request_missing_metadata_for_bound_entries() {
     assert_eq!(metadata_fill_position(Some(7), &entry, true), Some(7));
     entry.mode = MetadataValue::Known(0o100644);
     assert_eq!(metadata_fill_position(Some(7), &entry, true), None);
+}
+
+#[test]
+fn grid_cards_keep_a_uniform_icon_slot_and_two_line_label() {
+    assert_eq!(grid_card_icon_slot(64), 64);
+    assert_eq!(grid_card_icon_slot(128), 128);
+    assert_eq!(grid_card_icon_slot(26), MIN_GRID_THUMBNAIL_SIZE);
+    assert_eq!(grid_card_icon_slot(512), MAX_GRID_THUMBNAIL_SIZE);
+    assert_eq!(GRID_CARD_LABEL_LINES, 2);
+    assert_eq!(GRID_CARD_LABEL_CHARS, 16);
+    assert!(!grid_bind_requests_metadata(true));
+    assert!(grid_bind_requests_metadata(false));
 }
 
 #[test]

--- a/src/ui/browser_modes/tests.rs
+++ b/src/ui/browser_modes/tests.rs
@@ -5,7 +5,7 @@ use super::{
     GRID_CARD_LABEL_CHARS, GRID_CARD_LABEL_LINE_PX, GRID_CARD_LABEL_LINES, MAX_GRID_THUMBNAIL_SIZE,
     MIN_GRID_THUMBNAIL_SIZE, SourceIndexMap, compare_type_groups, explorer_column_width,
     grid_bind_requests_metadata, grid_card_extent, grid_card_icon_slot, metadata_fill_position,
-    should_activate_pointer_click, type_groups_of, value_type_group,
+    scroll_delta_for_unit, should_activate_pointer_click, type_groups_of, value_type_group,
 };
 use crate::model::{EntryKind, FileEntry, Location, MetadataValue};
 use gtk::{gio, prelude::*};
@@ -115,6 +115,16 @@ fn grid_cards_keep_a_uniform_icon_slot_and_two_line_label() {
     assert!(tall > height);
     assert!(!grid_bind_requests_metadata(true));
     assert!(grid_bind_requests_metadata(false));
+}
+
+#[test]
+fn grid_scroll_maps_a_wheel_notch_from_page_size() {
+    let step = scroll_delta_for_unit(1.0, 1000.0, gtk::gdk::ScrollUnit::Wheel);
+    assert!((step - 1000.0_f64.powf(2.0 / 3.0)).abs() < 1e-9);
+    assert_eq!(
+        scroll_delta_for_unit(4.0, 100.0, gtk::gdk::ScrollUnit::Surface),
+        10.0
+    );
 }
 
 #[test]

--- a/src/ui/thumbnail.rs
+++ b/src/ui/thumbnail.rs
@@ -42,6 +42,12 @@ thread_local! {
         RefCell::new(HashMap::new());
     static TRACKED_CUSTOMIZED_ICONS: RefCell<Vec<TrackedCustomizedIcon>> =
         const { RefCell::new(Vec::new()) };
+    static TRACKED_THUMBNAILS: RefCell<Vec<TrackedThumbnail>> = const { RefCell::new(Vec::new()) };
+}
+
+struct TrackedThumbnail {
+    image: glib::WeakRef<gtk::Image>,
+    path: PathBuf,
 }
 
 struct TrackedCustomizedIcon {
@@ -398,7 +404,8 @@ fn set_thumbnail_for_path(request: ThumbnailRequest<'_>) {
     match THUMBNAIL_CACHE.with(|cache| cache.borrow_mut().get(&key)) {
         Some(CacheHit::Ready(bytes)) => {
             cancel_thumbnail(request.image.as_ptr() as usize);
-            apply_thumbnail(request.image, &bytes, thumbnail_size);
+            ensure_image_slot(request.image, thumbnail_size);
+            apply_thumbnail(request.image, &bytes, &path);
             return;
         }
         Some(CacheHit::Failed) => {
@@ -412,16 +419,17 @@ fn set_thumbnail_for_path(request: ThumbnailRequest<'_>) {
         }
         None => {}
     }
-    let (image_id, request_id) = if request.image.paintable().is_none() {
+    let (image_id, request_id) = if displayed_thumbnail_matches(request.image, request.path) {
+        prepare_thumbnail_target(request.image, thumbnail_size)
+    } else {
         set_fallback_icon(
             request.image,
             Some(request.path),
             request.fallback_icon,
             request.icon_size,
         )
-    } else {
-        prepare_thumbnail_target(request.image, thumbnail_size)
     };
+    ensure_image_slot(request.image, thumbnail_size);
     let weak_image = glib::WeakRef::new();
     weak_image.set(Some(request.image));
     ACTIVE_REQUESTS.with(|requests| {
@@ -743,7 +751,7 @@ fn fire_parks(mut drained: Vec<SettledPark>, viewport: Option<&gtk::ScrolledWind
         {
             match hit {
                 CacheHit::Ready(bytes) => {
-                    apply_thumbnail(image, &bytes, park.key.thumbnail_size);
+                    apply_thumbnail(image, &bytes, &park.key.path);
                 }
                 CacheHit::Failed => {}
             }
@@ -925,7 +933,7 @@ fn start_thumbnail_jobs() {
 async fn run_thumbnail_job(job: ThumbnailJob) {
     let job_id = job.id;
     let key = job.key.clone();
-    let thumbnail_size = key.thumbnail_size;
+    let path = key.path.clone();
     let result = gio::spawn_blocking(move || {
         if let Some(mtime) = job.key.modified
             && let Some(png) = super::thumbnail_cache::lookup(&job.key.path, mtime)
@@ -950,7 +958,7 @@ async fn run_thumbnail_job(job: ThumbnailJob) {
                 crate::metrics::mark_thumbnail_completed();
                 let bytes = glib::Bytes::from_owned(png.clone());
                 THUMBNAIL_CACHE.with(|cache| cache.borrow_mut().insert(key.clone(), bytes.clone()));
-                finish_thumbnail_targets(targets, Some(&bytes), thumbnail_size);
+                finish_thumbnail_targets(targets, Some(&bytes), &path);
                 // Unverifiable keys (unknown mtime) skip persistence: nothing validates them later.
                 if rendered && let Some(mtime) = key.modified {
                     enqueue_persist(key.path.clone(), mtime, png);
@@ -959,7 +967,7 @@ async fn run_thumbnail_job(job: ThumbnailJob) {
             Ok(Err(_)) | Err(_) => {
                 crate::metrics::mark_thumbnail_cancelled();
                 THUMBNAIL_CACHE.with(|cache| cache.borrow_mut().insert_failure(key));
-                finish_thumbnail_targets(targets, None, thumbnail_size);
+                finish_thumbnail_targets(targets, None, &path);
             }
         }
     }
@@ -1039,11 +1047,7 @@ fn take_pending_targets(key: &ThumbnailKey, job_id: u64) -> Option<Vec<PendingTa
     })
 }
 
-fn finish_thumbnail_targets(
-    targets: Vec<PendingTarget>,
-    bytes: Option<&glib::Bytes>,
-    thumbnail_size: i32,
-) {
+fn finish_thumbnail_targets(targets: Vec<PendingTarget>, bytes: Option<&glib::Bytes>, path: &Path) {
     for target in targets {
         let is_current = ACTIVE_REQUESTS.with(|requests| {
             let mut requests = requests.borrow_mut();
@@ -1068,7 +1072,7 @@ fn finish_thumbnail_targets(
             crate::metrics::mark_thumbnail_stale();
             continue;
         };
-        apply_thumbnail(&image, bytes, thumbnail_size);
+        apply_thumbnail(&image, bytes, path);
         crate::metrics::mark_thumbnail_applied();
     }
 }
@@ -1080,13 +1084,55 @@ fn known_metadata<T: Copy>(value: &MetadataValue<T>) -> Option<T> {
     }
 }
 
-fn apply_thumbnail(image: &gtk::Image, bytes: &glib::Bytes, thumbnail_size: i32) {
+fn apply_thumbnail(image: &gtk::Image, bytes: &glib::Bytes, path: &Path) {
     if let Ok(texture) = gdk::Texture::from_bytes(bytes) {
         crate::assets::remove_primary_icon(image);
-        ensure_image_slot(image, thumbnail_size);
         image.set_paintable(Some(&texture));
         image.set_opacity(1.0);
+        register_displayed_thumbnail(image, path);
     }
+}
+
+fn displayed_thumbnail_matches(image: &gtk::Image, path: &Path) -> bool {
+    TRACKED_THUMBNAILS.with(|thumbnails| {
+        let mut thumbnails = thumbnails.borrow_mut();
+        thumbnails.retain(|tracked| tracked.image.upgrade().is_some());
+        thumbnails
+            .iter()
+            .find(|tracked| tracked.image.upgrade().as_ref() == Some(image))
+            .is_some_and(|tracked| tracked.path == path)
+    })
+}
+
+fn register_displayed_thumbnail(image: &gtk::Image, path: &Path) {
+    let weak_ref = glib::WeakRef::new();
+    weak_ref.set(Some(image));
+    TRACKED_THUMBNAILS.with(|thumbnails| {
+        let mut thumbnails = thumbnails.borrow_mut();
+        thumbnails.retain(|tracked| tracked.image.upgrade().is_some());
+        if let Some(existing) = thumbnails
+            .iter_mut()
+            .find(|tracked| tracked.image.upgrade().as_ref() == Some(image))
+        {
+            existing.path = path.to_path_buf();
+        } else {
+            thumbnails.push(TrackedThumbnail {
+                image: weak_ref,
+                path: path.to_path_buf(),
+            });
+        }
+    });
+}
+
+fn clear_displayed_thumbnail(image: &gtk::Image) {
+    TRACKED_THUMBNAILS.with(|thumbnails| {
+        thumbnails.borrow_mut().retain(|tracked| {
+            tracked
+                .image
+                .upgrade()
+                .is_some_and(|tracked_image| tracked_image != *image)
+        });
+    });
 }
 
 pub(super) fn show_fallback_icon(image: &gtk::Image, icon: &str, size: i32) {
@@ -1146,6 +1192,7 @@ fn set_fallback_icon(
     size: i32,
 ) -> (usize, u64) {
     let ids = prepare_thumbnail_target(image, size);
+    clear_displayed_thumbnail(image);
     if let Some(p) = path {
         let customized = apply_path_customization(image, p, icon);
         register_tracked_icon(image, p, icon, customized);

--- a/src/ui/thumbnail.rs
+++ b/src/ui/thumbnail.rs
@@ -1058,8 +1058,7 @@ fn known_metadata<T: Copy>(value: &MetadataValue<T>) -> Option<T> {
 fn apply_thumbnail(image: &gtk::Image, bytes: &glib::Bytes, thumbnail_size: i32) {
     if let Ok(texture) = gdk::Texture::from_bytes(bytes) {
         crate::assets::remove_primary_icon(image);
-        image.set_pixel_size(thumbnail_size);
-        image.set_size_request(thumbnail_size, thumbnail_size);
+        ensure_image_slot(image, thumbnail_size);
         image.set_paintable(Some(&texture));
         image.set_opacity(1.0);
     }
@@ -1098,6 +1097,15 @@ pub(super) fn cancel_thumbnails_in(widget: &gtk::Widget) {
     }
 }
 
+pub(super) fn ensure_image_slot(image: &gtk::Image, size: i32) {
+    if image.pixel_size() != size {
+        image.set_pixel_size(size);
+    }
+    if image.width_request() != size || image.height_request() != size {
+        image.set_size_request(size, size);
+    }
+}
+
 fn set_fallback_icon(
     image: &gtk::Image,
     path: Option<&Path>,
@@ -1107,8 +1115,7 @@ fn set_fallback_icon(
     let request = NEXT_REQUEST.fetch_add(1, Ordering::Relaxed);
     let image_id = image.as_ptr() as usize;
     cancel_thumbnail(image_id);
-    image.set_pixel_size(size);
-    image.set_size_request(size, size);
+    ensure_image_slot(image, size);
     if let Some(p) = path {
         let customized = apply_path_customization(image, p, icon);
         register_tracked_icon(image, p, icon, customized);

--- a/src/ui/thumbnail.rs
+++ b/src/ui/thumbnail.rs
@@ -412,7 +412,7 @@ fn set_thumbnail_for_path(request: ThumbnailRequest<'_>) {
         }
         None => {}
     }
-    let (image_id, request_id) = if should_paint_fallback(request.image.paintable().is_some()) {
+    let (image_id, request_id) = if request.image.paintable().is_none() {
         set_fallback_icon(
             request.image,
             Some(request.path),
@@ -1129,10 +1129,6 @@ pub(super) fn ensure_image_slot(image: &gtk::Image, size: i32) {
     if image.width_request() != size || image.height_request() != size {
         image.set_size_request(size, size);
     }
-}
-
-fn should_paint_fallback(has_content: bool) -> bool {
-    !has_content
 }
 
 fn prepare_thumbnail_target(image: &gtk::Image, size: i32) -> (usize, u64) {

--- a/src/ui/thumbnail.rs
+++ b/src/ui/thumbnail.rs
@@ -368,20 +368,26 @@ fn set_thumbnail_for_path(request: ThumbnailRequest<'_>) {
     let has_custom_icon = super::theme::ThemeManager::shared()
         .custom_icon(request.path)
         .is_some();
-    let (image_id, request_id) = set_fallback_icon(
-        request.image,
-        Some(request.path),
-        request.fallback_icon,
-        request.icon_size,
-    );
     if has_custom_icon {
+        set_fallback_icon(
+            request.image,
+            Some(request.path),
+            request.fallback_icon,
+            request.icon_size,
+        );
         return;
     }
     let path = request.path.to_path_buf();
+    let thumbnail_size = request.thumbnail_size.clamp(16, 256);
     let Some(kind) = thumbnail_kind(&path) else {
+        set_fallback_icon(
+            request.image,
+            Some(request.path),
+            request.fallback_icon,
+            request.icon_size,
+        );
         return;
     };
-    let thumbnail_size = request.thumbnail_size.clamp(16, 256);
     let key = ThumbnailKey {
         path: path.clone(),
         modified: request.modified,
@@ -391,12 +397,31 @@ fn set_thumbnail_for_path(request: ThumbnailRequest<'_>) {
     // Disk validation moves to fire time so offscreen rows never touch the disk.
     match THUMBNAIL_CACHE.with(|cache| cache.borrow_mut().get(&key)) {
         Some(CacheHit::Ready(bytes)) => {
+            cancel_thumbnail(request.image.as_ptr() as usize);
             apply_thumbnail(request.image, &bytes, thumbnail_size);
             return;
         }
-        Some(CacheHit::Failed) => return,
+        Some(CacheHit::Failed) => {
+            set_fallback_icon(
+                request.image,
+                Some(request.path),
+                request.fallback_icon,
+                request.icon_size,
+            );
+            return;
+        }
         None => {}
     }
+    let (image_id, request_id) = if should_paint_fallback(request.image.paintable().is_some()) {
+        set_fallback_icon(
+            request.image,
+            Some(request.path),
+            request.fallback_icon,
+            request.icon_size,
+        )
+    } else {
+        prepare_thumbnail_target(request.image, thumbnail_size)
+    };
     let weak_image = glib::WeakRef::new();
     weak_image.set(Some(request.image));
     ACTIVE_REQUESTS.with(|requests| {
@@ -1106,23 +1131,32 @@ pub(super) fn ensure_image_slot(image: &gtk::Image, size: i32) {
     }
 }
 
+fn should_paint_fallback(has_content: bool) -> bool {
+    !has_content
+}
+
+fn prepare_thumbnail_target(image: &gtk::Image, size: i32) -> (usize, u64) {
+    let request = NEXT_REQUEST.fetch_add(1, Ordering::Relaxed);
+    let image_id = image.as_ptr() as usize;
+    cancel_thumbnail(image_id);
+    ensure_image_slot(image, size);
+    (image_id, request)
+}
+
 fn set_fallback_icon(
     image: &gtk::Image,
     path: Option<&Path>,
     icon: &str,
     size: i32,
 ) -> (usize, u64) {
-    let request = NEXT_REQUEST.fetch_add(1, Ordering::Relaxed);
-    let image_id = image.as_ptr() as usize;
-    cancel_thumbnail(image_id);
-    ensure_image_slot(image, size);
+    let ids = prepare_thumbnail_target(image, size);
     if let Some(p) = path {
         let customized = apply_path_customization(image, p, icon);
         register_tracked_icon(image, p, icon, customized);
     } else {
         crate::assets::set_primary_icon(image, icon);
     }
-    (image_id, request)
+    ids
 }
 
 fn apply_path_customization(image: &gtk::Image, path: &Path, fallback_icon: &str) -> bool {

--- a/src/ui/thumbnail/tests.rs
+++ b/src/ui/thumbnail/tests.rs
@@ -182,7 +182,7 @@ fn failed_jobs_release_their_active_requests() {
             image: glib::WeakRef::new(),
         }],
         None,
-        64,
+        Path::new("image.png"),
     );
 
     ACTIVE_REQUESTS.with(|requests| assert!(requests.borrow().is_empty()));

--- a/src/ui/thumbnail/tests.rs
+++ b/src/ui/thumbnail/tests.rs
@@ -14,7 +14,7 @@ use super::{
     SETTLE_VIEWS, SettledPark, THUMBNAIL_QUEUE, ThumbnailCache, ThumbnailKey, ThumbnailKind,
     ThumbnailQueue, ViewSettle, cancel_thumbnail, finish_thumbnail_targets,
     fire_settled_thumbnails, note_metadata, retry_deferred_thumbnail, schedule_or_defer,
-    take_pending_targets, thumbnail_kind,
+    should_paint_fallback, take_pending_targets, thumbnail_kind,
 };
 
 fn key(index: usize) -> ThumbnailKey {
@@ -24,6 +24,12 @@ fn key(index: usize) -> ThumbnailKey {
         file_size: Some(1),
         thumbnail_size: 64,
     }
+}
+
+#[test]
+fn fallback_icon_is_skipped_when_the_image_already_has_content() {
+    assert!(should_paint_fallback(false));
+    assert!(!should_paint_fallback(true));
 }
 
 #[test]

--- a/src/ui/thumbnail/tests.rs
+++ b/src/ui/thumbnail/tests.rs
@@ -14,7 +14,7 @@ use super::{
     SETTLE_VIEWS, SettledPark, THUMBNAIL_QUEUE, ThumbnailCache, ThumbnailKey, ThumbnailKind,
     ThumbnailQueue, ViewSettle, cancel_thumbnail, finish_thumbnail_targets,
     fire_settled_thumbnails, note_metadata, retry_deferred_thumbnail, schedule_or_defer,
-    should_paint_fallback, take_pending_targets, thumbnail_kind,
+    take_pending_targets, thumbnail_kind,
 };
 
 fn key(index: usize) -> ThumbnailKey {
@@ -24,12 +24,6 @@ fn key(index: usize) -> ThumbnailKey {
         file_size: Some(1),
         thumbnail_size: 64,
     }
-}
-
-#[test]
-fn fallback_icon_is_skipped_when_the_image_already_has_content() {
-    assert!(should_paint_fallback(false));
-    assert!(!should_paint_fallback(true));
 }
 
 #[test]


### PR DESCRIPTION
## Description

Grid thumb-drags through large listings still rebuilt every visible card: mixed 26px fallbacks vs thumbnail-sized images, wrapping labels, and extra layout. Cards now keep a fixed icon slot and a two-line `GtkInscription` name. While the scrollbar thumb is moving, bind only updates the name; icons, tooltips, cut styling, and opacity wait for the existing 80 ms settle.

The thumbnail slider is also less jumpy: it scales the current texture in place instead of flashing a generic icon, drops GTK's long-press fine-tune so the thumb does not snap to 64 or 256, and moves 1px per wheel notch. Scrolling over the listing closes the popover and moves the grid; scrolling over the sidebar or other chrome just closes it.

## Visual evidence

https://github.com/user-attachments/assets/64163761-2b2b-4e13-9165-69af196abd61

## How to test

1. `./scripts/generate-fixture.sh target/fixtures` if needed, then `cargo build --release && target/release/strata target/fixtures/100000`.
2. Switch to Grid. Drag the vertical scrollbar thumb from top to bottom and back.
3. Repeat in Explorer on the same directory, and try Page Up/Down in Grid.
4. After the thumb stops, confirm names are correct and thumbnails appear.
5. Open Thumbnail size. Drag the slider slowly at both ends; it should ease off 64 and 256 without snapping.
6. With the popover still open, roll the wheel over the slider (1px per notch), then over the listing (popover closes, grid scrolls), then over the sidebar (popover closes, grid does not move).
7. Drag the slider across a folder of images and confirm existing thumbnails grow in place without flashing generic icons.

**Expected result:** Grid thumb-drag is close to Explorer/Columns. Names follow the thumb. Thumbnails appear after settle. Short names leave empty space in the two-line slot instead of shrinking the cell. The slider stays controllable at the ends, wheel-scrolls in 1px steps, dismisses when scrolling the listing or sidebar, only moves the grid when the pointer is over the listing, and resizes pictures without an icon flash.

## Related issue

Closes #322