### PR TITLE
feat(installer): add optional and unattended setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Strata combines spatial Miller-column navigation with familiar Grid and Explorer
 
 - [Features](#features)
 - [Installation](#installation)
+  - [Interactive installation](#interactive-installation)
   - [AI-assisted installation](#ai-assisted-installation)
   - [Manual installation](#manual-installation)
 - [Usage and desktop integration](#usage-and-desktop-integration)
@@ -58,6 +59,22 @@ Strata combines spatial Miller-column navigation with familiar Grid and Explorer
 ## Installation
 
 Arch Linux and Omarchy are the primary supported environments. Current binaries require **glibc 2.39 or newer** and the runtime libraries listed below.
+
+### Interactive installation
+
+The interactive installer detects the Linux architecture, glibc version, Arch
+Linux, and Omarchy 3 or 4. It installs the latest verified stable release and
+offers optional desktop-menu, default-folder-handler, SMB, and Omarchy keybind
+integration:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/lgse/strata/main/install.sh | bash
+```
+
+The installer shows every privileged package operation before asking to run it.
+It verifies both the published SHA-256 digest and GitHub Actions provenance before
+installing anything from the release archive. The binary is installed per-user at
+`~/.local/bin/strata`.
 
 ### AI-assisted installation
 
@@ -93,24 +110,7 @@ Then:
   desktop association if one was requested. Do not weaken the preview sandbox.
 ```
 
-### Manual release installation
-
-The interactive installer detects the Linux architecture, glibc version, Arch
-Linux, and Omarchy 3 or 4. It installs the latest verified stable release and
-offers optional desktop-menu, default-folder-handler, SMB, and Omarchy keybind
-integration:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/lgse/strata/main/install.sh | bash
-```
-
-The installer shows every privileged package operation before asking to run it.
-It verifies both the published SHA-256 digest and GitHub Actions provenance before
-installing anything from the release archive. The binary is installed per-user at
-`~/.local/bin/strata`.
-
-<details>
-<summary>Manual download and verification</summary>
+### Manual installation
 
 Install the release archive directly if you prefer to perform each step yourself.
 
@@ -159,15 +159,13 @@ strata
 
 If `command -v` fails, add `$HOME/.local/bin` to your shell's `PATH`. Every archive contains `SOURCE_COMMIT`, identifying the exact source revision used by GitHub Actions.
 
-</details>
-
 #### Debug a release crash
 
 Download the matching `strata-<version>-<target>.debug` asset from the same release and place it beside the installed `strata` binary, keeping its filename unchanged. Then run `coredumpctl debug strata`; GDB will load its Rust function names and source lines.
 
 #### 3. Update or uninstall
 
-For a manual release installation, use **Settings → Updates** for verified in-app updates, or repeat the download, verification, and `install` steps for a newer release. An in-app update also refreshes an already installed desktop entry and application icon from the new archive; it never creates desktop metadata that was not installed before. Package-managed installations are updated only by their system package manager. To remove a per-user installation:
+For a manual installation, use **Settings → Updates** for verified in-app updates, or repeat the download, verification, and `install` steps for a newer release. An in-app update also refreshes an already installed desktop entry and application icon from the new archive; it never creates desktop metadata that was not installed before. Package-managed installations are updated only by their system package manager. To remove a per-user installation:
 
 ```bash
 rm -f ~/.local/bin/strata \

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ Arch Linux and Omarchy are the primary supported environments. Current binaries 
 
 The interactive installer detects the Linux architecture, glibc version, Arch
 Linux, and Omarchy 3 or 4. It installs the latest verified stable release and
-offers optional desktop-menu, default-folder-handler, SMB, and Omarchy keybind
-integration:
+offers optional desktop-menu, default-folder-handler, SMB, broader image/RAW,
+and Omarchy keybind integration:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/lgse/strata/main/install.sh | bash
@@ -75,6 +75,24 @@ The installer shows every privileged package operation before asking to run it.
 It verifies both the published SHA-256 digest and GitHub Actions provenance before
 installing anything from the release archive. The binary is installed per-user at
 `~/.local/bin/strata`.
+
+For an unattended Arch or Omarchy installation, pass `--non-interactive`. This
+installs required dependencies and the binary without prompting; optional
+integrations remain disabled unless explicitly selected:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/lgse/strata/main/install.sh \
+  | bash -s -- --non-interactive \
+      --with-smb \
+      --with-raw \
+      --with-desktop-entry \
+      --with-folder-association \
+      --with-omarchy-keybinds
+```
+
+Each `--with-*` flag implies `--non-interactive`, and folder association implies
+the desktop entry. Non-interactive package installation requires passwordless
+sudo or cached credentials. Run `./install.sh --help` for the full option list.
 
 ### AI-assisted installation
 

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,14 @@ REQUIRED_PACKAGES=(
   bubblewrap desktop-file-utils ffmpeg ffmpegthumbnailer fontconfig gst-libav
   gst-plugins-good gtk4 gtksourceview5 poppler-glib github-cli xdg-utils
 )
+RAW_PREVIEW_PACKAGES=(imagemagick libraw dcraw)
+
+NON_INTERACTIVE=no
+WITH_SMB=ask
+WITH_RAW=ask
+WITH_DESKTOP_ENTRY=ask
+WITH_FOLDER_ASSOCIATION=ask
+WITH_OMARCHY_KEYBINDS=ask
 
 info() {
   printf '\n\033[1;34m==>\033[0m %s\n' "$*"
@@ -71,6 +79,58 @@ prompt() {
   [[ $answer == [Yy] || $answer == [Yy][Ee][Ss] ]]
 }
 
+usage() {
+  cat <<'EOF'
+Usage: install.sh [options]
+
+Without options, Strata asks about dependencies and desktop integration.
+
+Options:
+  --non-interactive             Never prompt; install required components only
+  --with-smb                    Install SMB network-share support
+  --with-raw                    Install broader image and camera RAW support
+  --with-desktop-entry          Add Strata to the desktop application menu
+  --with-folder-association     Make Strata the default folder handler
+  --with-omarchy-keybinds       Replace Omarchy's file-manager keybinds
+  -h, --help                    Show this help
+
+Integration flags imply --non-interactive. Folder association also installs the
+required desktop entry.
+EOF
+}
+
+parse_args() {
+  while (($# > 0)); do
+    case $1 in
+      --non-interactive) NON_INTERACTIVE=yes ;;
+      --with-smb) NON_INTERACTIVE=yes; WITH_SMB=yes ;;
+      --with-raw) NON_INTERACTIVE=yes; WITH_RAW=yes ;;
+      --with-desktop-entry) NON_INTERACTIVE=yes; WITH_DESKTOP_ENTRY=yes ;;
+      --with-folder-association)
+        NON_INTERACTIVE=yes
+        WITH_DESKTOP_ENTRY=yes
+        WITH_FOLDER_ASSOCIATION=yes
+        ;;
+      --with-omarchy-keybinds) NON_INTERACTIVE=yes; WITH_OMARCHY_KEYBINDS=yes ;;
+      -h | --help) usage; exit 0 ;;
+      *) die "Unknown option: $1 (run with --help for usage)." ;;
+    esac
+    shift
+  done
+}
+
+want_option() {
+  local selection=$1 question=$2 default=${3:-no}
+  case $selection in
+    yes) return 0 ;;
+    no) return 1 ;;
+    ask)
+      [[ $NON_INTERACTIVE == no ]] && prompt "$question" "$default"
+      ;;
+    *) die "Invalid installer option state: $selection" ;;
+  esac
+}
+
 version_at_least() {
   local actual=$1 required=$2 first
   first=$(printf '%s\n%s\n' "$required" "$actual" | sort -V | head -n 1)
@@ -118,6 +178,15 @@ latest_stable_version() {
   printf '%s\n' "${BASH_REMATCH[1]}"
 }
 
+run_pacman() {
+  if [[ $NON_INTERACTIVE == yes ]]; then
+    sudo -n pacman -S --needed --noconfirm -- "$@" \
+      || die "Non-interactive package installation failed; passwordless sudo or cached credentials may be required."
+  else
+    sudo pacman -S --needed -- "$@"
+  fi
+}
+
 install_arch_dependencies() {
   local missing=() package
   for package in "${REQUIRED_PACKAGES[@]}"; do
@@ -130,13 +199,29 @@ install_arch_dependencies() {
   fi
 
   printf 'Required packages: %s\n' "${missing[*]}"
-  prompt "Install these packages with sudo pacman?" \
-    || die "Required runtime packages were not installed."
-  sudo pacman -S --needed -- "${missing[@]}"
+  if [[ $NON_INTERACTIVE == no ]]; then
+    prompt "Install these packages with sudo pacman?" \
+      || die "Required runtime packages were not installed."
+  fi
+  run_pacman "${missing[@]}"
+}
+
+install_optional_arch_packages() {
+  local description=$1 package missing=()
+  shift
+  for package in "$@"; do
+    pacman -Q "$package" >/dev/null 2>&1 || missing+=("$package")
+  done
+  if ((${#missing[@]} == 0)); then
+    info "$description is already installed."
+  else
+    printf '%s packages: %s\n' "$description" "${missing[*]}"
+    run_pacman "${missing[@]}"
+  fi
 }
 
 install_desktop_entry() {
-  local extracted=$1 desktop_dir icon_dir escaped_bin staged
+  local extracted=$1 make_default=$2 desktop_dir icon_dir escaped_bin staged
   desktop_dir=${XDG_DATA_HOME:-$HOME/.local/share}/applications
   icon_dir=${XDG_DATA_HOME:-$HOME/.local/share}/icons/hicolor
   staged=$TEMP_DIR/$APP_ID.desktop
@@ -153,7 +238,7 @@ install_desktop_entry() {
     && gtk-update-icon-cache -qtf "$icon_dir" 2>/dev/null || true
   info "Added Strata to the desktop application menu."
 
-  if prompt "Make Strata the default application for opening folders?" no; then
+  if [[ $make_default == yes ]]; then
     command -v xdg-mime >/dev/null 2>&1 \
       || die "xdg-mime is required to change the folder association."
     xdg-mime default "$APP_ID.desktop" inode/directory
@@ -233,13 +318,16 @@ EOF
 
 main() {
   local target glibc distro_id distro_like omarchy_major version archive extracted url
-  local local_bin_on_path=no
+  local local_bin_on_path=no make_default=no
 
+  parse_args "$@"
   [[ $(uname -s) == Linux ]] || die "The prebuilt Strata release supports Linux only."
   [[ $EUID -ne 0 ]] || die "Run this installer as your normal desktop user, not as root."
-  [[ -e /dev/tty && -r /dev/tty && -w /dev/tty ]] \
-    || die "This interactive installer needs a terminal."
-  PROMPT_DEVICE=/dev/tty
+  if [[ $NON_INTERACTIVE == no ]]; then
+    [[ -e /dev/tty && -r /dev/tty && -w /dev/tty ]] \
+      || die "This interactive installer needs a terminal."
+    PROMPT_DEVICE=/dev/tty
+  fi
   [[ :$PATH: == *":$HOME/.local/bin:"* ]] && local_bin_on_path=yes
   show_banner
 
@@ -272,12 +360,20 @@ main() {
   if [[ $distro_id == arch || $distro_like == *arch* || -n $omarchy_major ]]; then
     command -v pacman >/dev/null 2>&1 || die "This Arch-based system does not provide pacman."
     install_arch_dependencies
-    if prompt "Install optional SMB network-share support (gvfs-smb)?" no; then
-      sudo pacman -S --needed -- gvfs-smb
+    if want_option "$WITH_SMB" "Install optional SMB network-share support (gvfs-smb)?"; then
+      install_optional_arch_packages "SMB support" gvfs-smb
+    fi
+    if want_option "$WITH_RAW" \
+      "Install optional broader image and camera RAW support (imagemagick, libraw, dcraw)?"; then
+      install_optional_arch_packages "Image and camera RAW support" \
+        "${RAW_PREVIEW_PACKAGES[@]}"
     fi
   else
     printf '\nStrata needs GTK 4.12+, GtkSourceView 5, Poppler GLib, Fontconfig, Bubblewrap,\n'
     printf 'FFmpeg, ffmpegthumbnailer, and GStreamer runtime plugins.\n'
+    if [[ $NON_INTERACTIVE == yes ]]; then
+      die "Non-interactive dependency installation currently supports Arch-based systems only."
+    fi
     prompt "Have you installed the equivalent packages for this distribution?" \
       || die "Install the runtime dependencies, then run this installer again."
   fi
@@ -309,19 +405,29 @@ main() {
     || die "The verified archive is missing desktop integration files."
 
   BIN_PATH=$HOME/.local/bin/strata
-  if [[ -e $BIN_PATH ]] && ! prompt "Replace the existing $BIN_PATH?" no; then
-    die "Installation cancelled without replacing the existing file."
+  if [[ -e $BIN_PATH ]]; then
+    if [[ $NON_INTERACTIVE == yes ]]; then
+      die "$BIN_PATH already exists; remove it or run the interactive installer to replace it."
+    fi
+    prompt "Replace the existing $BIN_PATH?" no \
+      || die "Installation cancelled without replacing the existing file."
   fi
   install -Dm755 "$extracted/strata" "$BIN_PATH"
   export PATH="$HOME/.local/bin:$PATH"
   info "Installed $BIN_PATH"
 
-  if prompt "Add Strata to your desktop application menu?"; then
-    install_desktop_entry "$extracted"
+  if want_option "$WITH_DESKTOP_ENTRY" "Add Strata to your desktop application menu?" yes; then
+    if want_option "$WITH_FOLDER_ASSOCIATION" \
+      "Make Strata the default application for opening folders?"; then
+      make_default=yes
+    fi
+    install_desktop_entry "$extracted" "$make_default"
   fi
 
-  if [[ -n $omarchy_major ]] \
-    && prompt "Replace Omarchy's Nautilus file-manager keybinds with Strata?" no; then
+  if want_option "$WITH_OMARCHY_KEYBINDS" \
+    "Replace Omarchy's Nautilus file-manager keybinds with Strata?"; then
+    [[ -n $omarchy_major ]] \
+      || die "--with-omarchy-keybinds requires Omarchy 3 or 4."
     configure_omarchy_bindings "$omarchy_major"
   fi
 

--- a/scripts/test_installer.py
+++ b/scripts/test_installer.py
@@ -40,6 +40,40 @@ class InstallerTests(unittest.TestCase):
         self.assertIn("Interactive installer", result.stdout)
         self.assertNotIn("\033", result.stdout)
 
+    def test_unattended_flags_select_only_requested_integrations(self) -> None:
+        result = bash(
+            "parse_args --with-folder-association --with-raw; "
+            'printf "%s %s %s %s %s %s" "$NON_INTERACTIVE" "$WITH_SMB" '
+            '"$WITH_RAW" "$WITH_DESKTOP_ENTRY" "$WITH_FOLDER_ASSOCIATION" '
+            '"$WITH_OMARCHY_KEYBINDS"'
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "yes ask yes yes yes ask")
+
+    def test_non_interactive_mode_declines_unspecified_options(self) -> None:
+        result = bash("NON_INTERACTIVE=yes; ! want_option ask ignored")
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_non_interactive_pacman_disables_sudo_and_pacman_prompts(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fake_sudo = pathlib.Path(directory) / "sudo"
+            fake_sudo.write_text('#!/bin/sh\nprintf "%s\\n" "$@"\n')
+            fake_sudo.chmod(0o755)
+            result = bash(
+                "NON_INTERACTIVE=yes; run_pacman gvfs-smb",
+                env={"PATH": f"{directory}:{os.environ['PATH']}"},
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            result.stdout.splitlines(),
+            ["-n", "pacman", "-S", "--needed", "--noconfirm", "--", "gvfs-smb"],
+        )
+
+    def test_unknown_installer_option_is_rejected(self) -> None:
+        result = bash("parse_args --definitely-unknown")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Unknown option", result.stderr)
+
     def test_version_comparison_accepts_minimum_and_newer(self) -> None:
         for version in ("2.39", "2.39.1", "2.40"):
             with self.subTest(version=version):


### PR DESCRIPTION
## Description

Promote interactive installation in the README and separate the direct archive instructions into a Manual installation section. Add a prompt for broader image and camera RAW dependencies plus conservative non-interactive flags for unattended Arch and Omarchy installs.

Unspecified integrations remain disabled in non-interactive mode, folder association implies a desktop entry, and unattended package operations disable both sudo and pacman prompts.

## Visual evidence

N/A — terminal-only installer and documentation changes; there are no application UI changes.

## How to test

1. Run `./install.sh --help` and review the unattended options.
2. Run `./install.sh` on Arch or Omarchy and confirm it separately asks about SMB and broader image/RAW support.
3. From a clean install state, run `./install.sh --non-interactive` and confirm it installs required components without enabling optional integrations.
4. Repeat with selected `--with-*` flags and confirm only those integrations are enabled.

**Expected result:** Interactive installation asks about both optional dependency groups, while unattended installation never prompts or changes an integration that was not explicitly selected.

## Related issue

Closes #331