### PR TITLE
feat(transfer): default cross-volume drops to copy

### DIFF
--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -3,8 +3,13 @@
 mod local_files;
 mod local_operations;
 mod local_preview;
+mod volume;
 
 pub use local_files::LocalFileSource;
 pub(crate) use local_files::location_for_file;
 pub use local_operations::LocalOperationProvider;
 pub use local_preview::LocalPreviewProvider;
+pub(crate) use volume::{
+    cached_volume_identity, flush_volume_identity_cache, prefetch_volume_identity,
+    query_volume_identity, register_volume_restatus,
+};

--- a/src/adapters/volume.rs
+++ b/src/adapters/volume.rs
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#[cfg(test)]
+mod tests;
+
+use std::{
+    cell::RefCell,
+    collections::{HashMap, VecDeque},
+    os::unix::fs::MetadataExt,
+    rc::Rc,
+};
+
+use gtk::{gio, glib, prelude::*};
+
+use crate::{model::Location, services::VolumeIdentity};
+
+const LRU_LIMIT: usize = 64;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct CacheKey {
+    location: Location,
+    follow_symlinks: bool,
+}
+
+struct RestatusHook {
+    run: Rc<dyn Fn() -> bool>,
+}
+
+struct VolumeCache {
+    epoch: u64,
+    entries: HashMap<CacheKey, VolumeIdentity>,
+    order: VecDeque<CacheKey>,
+    inflight: HashMap<CacheKey, u64>,
+    restatus: Vec<RestatusHook>,
+}
+
+impl VolumeCache {
+    fn new() -> Self {
+        Self {
+            epoch: 0,
+            entries: HashMap::new(),
+            order: VecDeque::new(),
+            inflight: HashMap::new(),
+            restatus: Vec::new(),
+        }
+    }
+
+    fn insert(&mut self, key: CacheKey, identity: VolumeIdentity) {
+        if self.entries.contains_key(&key) {
+            self.order.retain(|existing| existing != &key);
+        }
+        self.order.push_back(key.clone());
+        self.entries.insert(key, identity);
+        while self.entries.len() > LRU_LIMIT {
+            if let Some(oldest) = self.order.pop_front() {
+                self.entries.remove(&oldest);
+            }
+        }
+    }
+}
+
+thread_local! {
+    static VOLUME: RefCell<VolumeCache> = RefCell::new(VolumeCache::new());
+}
+
+pub(crate) fn query_volume_identity(
+    location: &Location,
+    follow_symlinks: bool,
+) -> Option<VolumeIdentity> {
+    let identity = query_volume_identity_uncached(location, follow_symlinks)?;
+    cache_success(location, follow_symlinks, identity.clone());
+    Some(identity)
+}
+
+pub(crate) fn cached_volume_identity(
+    location: &Location,
+    follow_symlinks: bool,
+) -> Option<VolumeIdentity> {
+    let key = CacheKey {
+        location: location.clone(),
+        follow_symlinks,
+    };
+    VOLUME.with(|cache| cache.borrow().entries.get(&key).cloned())
+}
+
+pub(crate) fn prefetch_volume_identity(location: Location, follow_symlinks: bool) {
+    if location.native_path().is_some() {
+        let _ = query_volume_identity(&location, follow_symlinks);
+        return;
+    }
+    let key = CacheKey {
+        location: location.clone(),
+        follow_symlinks,
+    };
+    let Some(epoch) = begin_inflight(&key) else {
+        return;
+    };
+    let file = gio_file(&location);
+    let flags = query_flags(follow_symlinks);
+    glib::MainContext::default().spawn_local(async move {
+        let info = file
+            .query_info_future(
+                gio::FILE_ATTRIBUTE_ID_FILESYSTEM,
+                flags,
+                glib::Priority::DEFAULT,
+            )
+            .await;
+        let remote = file
+            .query_filesystem_info_future(
+                gio::FILE_ATTRIBUTE_FILESYSTEM_REMOTE,
+                glib::Priority::DEFAULT,
+            )
+            .await
+            .ok();
+        let identity = info
+            .ok()
+            .and_then(|info| identity_from_gio(&location, &info, remote.as_ref()));
+        complete_inflight(key, epoch, identity);
+    });
+}
+
+pub(crate) fn flush_volume_identity_cache() {
+    let hooks = VOLUME.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        cache.epoch = cache.epoch.wrapping_add(1);
+        cache.entries.clear();
+        cache.order.clear();
+        cache.inflight.clear();
+        std::mem::take(&mut cache.restatus)
+    });
+    let live = hooks
+        .into_iter()
+        .filter(|hook| (hook.run)())
+        .collect::<Vec<_>>();
+    VOLUME.with(|cache| cache.borrow_mut().restatus.extend(live));
+}
+
+pub(crate) fn register_volume_restatus(run: Rc<dyn Fn() -> bool>) {
+    VOLUME.with(|cache| cache.borrow_mut().restatus.push(RestatusHook { run }));
+}
+
+pub(crate) fn location_is_remote(location: &Location) -> bool {
+    match location.native_path() {
+        Some(_) => false,
+        None => {
+            let scheme = location.backend_name();
+            scheme != "file" && scheme != "trash"
+        }
+    }
+}
+
+fn query_volume_identity_uncached(
+    location: &Location,
+    follow_symlinks: bool,
+) -> Option<VolumeIdentity> {
+    if let Some(path) = location.native_path() {
+        let metadata = if follow_symlinks {
+            std::fs::metadata(path)
+        } else {
+            std::fs::symlink_metadata(path)
+        };
+        let metadata = metadata.ok()?;
+        return Some(VolumeIdentity {
+            filesystem_id: format!("dev:{}", metadata.dev()),
+            is_remote: false,
+        });
+    }
+    let file = gio_file(location);
+    let info = file
+        .query_info(
+            gio::FILE_ATTRIBUTE_ID_FILESYSTEM,
+            query_flags(follow_symlinks),
+            None::<&gio::Cancellable>,
+        )
+        .ok()?;
+    let remote = file
+        .query_filesystem_info(
+            gio::FILE_ATTRIBUTE_FILESYSTEM_REMOTE,
+            None::<&gio::Cancellable>,
+        )
+        .ok();
+    identity_from_gio(location, &info, remote.as_ref())
+}
+
+fn identity_from_gio(
+    location: &Location,
+    info: &gio::FileInfo,
+    remote_info: Option<&gio::FileInfo>,
+) -> Option<VolumeIdentity> {
+    let filesystem_id = info.attribute_string(gio::FILE_ATTRIBUTE_ID_FILESYSTEM)?;
+    if filesystem_id.is_empty() {
+        return None;
+    }
+    let gio_remote = remote_info.is_some_and(|info| {
+        info.has_attribute(gio::FILE_ATTRIBUTE_FILESYSTEM_REMOTE)
+            && info.boolean(gio::FILE_ATTRIBUTE_FILESYSTEM_REMOTE)
+    });
+    Some(VolumeIdentity {
+        filesystem_id: filesystem_id.to_string(),
+        is_remote: location_is_remote(location) || gio_remote,
+    })
+}
+
+fn begin_inflight(key: &CacheKey) -> Option<u64> {
+    VOLUME.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if cache.entries.contains_key(key) || cache.inflight.contains_key(key) {
+            return None;
+        }
+        let epoch = cache.epoch;
+        cache.inflight.insert(key.clone(), epoch);
+        Some(epoch)
+    })
+}
+
+fn cache_success(location: &Location, follow_symlinks: bool, identity: VolumeIdentity) {
+    let key = CacheKey {
+        location: location.clone(),
+        follow_symlinks,
+    };
+    VOLUME.with(|cache| cache.borrow_mut().insert(key, identity));
+}
+
+fn complete_inflight(key: CacheKey, epoch: u64, identity: Option<VolumeIdentity>) {
+    let stale = VOLUME.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        let started = cache.inflight.remove(&key);
+        started != Some(epoch)
+    });
+    if stale {
+        return;
+    }
+    if let Some(identity) = identity {
+        VOLUME.with(|cache| cache.borrow_mut().insert(key, identity));
+    }
+    run_restatus_hooks();
+}
+
+fn run_restatus_hooks() {
+    let hooks = VOLUME.with(|cache| std::mem::take(&mut cache.borrow_mut().restatus));
+    let live = hooks
+        .into_iter()
+        .filter(|hook| (hook.run)())
+        .collect::<Vec<_>>();
+    VOLUME.with(|cache| cache.borrow_mut().restatus.extend(live));
+}
+
+fn query_flags(follow_symlinks: bool) -> gio::FileQueryInfoFlags {
+    if follow_symlinks {
+        gio::FileQueryInfoFlags::NONE
+    } else {
+        gio::FileQueryInfoFlags::NOFOLLOW_SYMLINKS
+    }
+}
+
+fn gio_file(location: &Location) -> gio::File {
+    location
+        .native_path()
+        .map(gio::File::for_path)
+        .unwrap_or_else(|| gio::File::for_uri(location.uri_value().unwrap_or_default()))
+}
+
+#[cfg(test)]
+pub(crate) fn volume_inflight_len() -> usize {
+    VOLUME.with(|cache| cache.borrow().inflight.len())
+}
+
+#[cfg(test)]
+pub(crate) fn volume_cache_len() -> usize {
+    VOLUME.with(|cache| cache.borrow().entries.len())
+}
+
+#[cfg(test)]
+pub(crate) fn volume_epoch() -> u64 {
+    VOLUME.with(|cache| cache.borrow().epoch)
+}

--- a/src/adapters/volume/tests.rs
+++ b/src/adapters/volume/tests.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::{fs, os::unix::fs::MetadataExt, path::Path, time::SystemTime};
+
+use super::*;
+use crate::model::Location;
+
+fn unique_root(label: &str) -> std::path::PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    std::env::temp_dir().join(format!("strata-volume-{label}-{unique}"))
+}
+
+fn distinct_device_dirs() -> Option<(tempfile::TempDir, tempfile::TempDir)> {
+    let first = tempfile::tempdir().ok()?;
+    let shm = Path::new("/dev/shm");
+    if !shm.is_dir() {
+        return None;
+    }
+    let second = tempfile::TempDir::new_in(shm).ok()?;
+    let first_dev = fs::metadata(first.path()).ok()?.dev();
+    let second_dev = fs::metadata(second.path()).ok()?.dev();
+    (first_dev != second_dev).then_some((first, second))
+}
+
+fn sample_identity() -> VolumeIdentity {
+    VolumeIdentity {
+        filesystem_id: "dev:test".into(),
+        is_remote: false,
+    }
+}
+
+#[test]
+fn two_subdirs_of_the_same_tempdir_are_the_same_volume() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let left = root.path().join("left");
+    let right = root.path().join("right");
+    fs::create_dir(&left).expect("left");
+    fs::create_dir(&right).expect("right");
+    let left_id = query_volume_identity(&Location::local(&left), true).expect("left identity");
+    let right_id = query_volume_identity(&Location::local(&right), true).expect("right identity");
+    assert!(left_id.matches(&right_id));
+}
+
+#[test]
+fn native_path_matches_itself() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let location = Location::local(root.path());
+    let first = query_volume_identity(&location, true).expect("identity");
+    let second = query_volume_identity(&location, true).expect("identity");
+    assert!(first.matches(&second));
+}
+
+#[test]
+fn dest_directory_symlink_to_another_device_is_different() {
+    let Some((home, stick)) = distinct_device_dirs() else {
+        return;
+    };
+    let source = home.path().join("file");
+    fs::write(&source, b"x").expect("source");
+    let link = home.path().join("usb");
+    std::os::unix::fs::symlink(stick.path(), &link).expect("symlink");
+    let dest_id = query_volume_identity(&Location::local(&link), true).expect("dest follows");
+    let source_id = query_volume_identity(&Location::local(&source), false).expect("source lstat");
+    assert!(
+        !dest_id.matches(&source_id),
+        "followed dest {} should differ from source {}",
+        dest_id.filesystem_id,
+        source_id.filesystem_id
+    );
+}
+
+#[test]
+fn missing_identity_is_not_cached() {
+    let root = unique_root("missing");
+    let location = Location::local(root.join("later"));
+    assert!(query_volume_identity(&location, true).is_none());
+    assert!(cached_volume_identity(&location, true).is_none());
+    fs::create_dir_all(root.join("later")).expect("create");
+    assert!(query_volume_identity(&location, true).is_some());
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn flush_clears_entries_and_inflight_and_bumps_epoch() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let location = Location::local(root.path());
+    assert!(query_volume_identity(&location, true).is_some());
+    assert!(cached_volume_identity(&location, true).is_some());
+    let before = volume_epoch();
+    flush_volume_identity_cache();
+    assert!(cached_volume_identity(&location, true).is_none());
+    assert_eq!(volume_cache_len(), 0);
+    assert_eq!(volume_inflight_len(), 0);
+    assert_ne!(volume_epoch(), before);
+}
+
+#[test]
+fn inflight_success_after_flush_does_not_reenter_the_lru() {
+    flush_volume_identity_cache();
+    let key = CacheKey {
+        location: Location::uri("smb://host/share"),
+        follow_symlinks: true,
+    };
+    let epoch = begin_inflight(&key).expect("first inflight");
+    assert_eq!(volume_inflight_len(), 1);
+    flush_volume_identity_cache();
+    assert_eq!(volume_inflight_len(), 0);
+    complete_inflight(key.clone(), epoch, Some(sample_identity()));
+    assert!(cached_volume_identity(&key.location, true).is_none());
+}
+
+#[test]
+fn native_query_after_flush_matches_a_fresh_stat() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let location = Location::local(root.path());
+    let before = query_volume_identity(&location, true).expect("before");
+    flush_volume_identity_cache();
+    let after = query_volume_identity(&location, true).expect("after flush");
+    assert!(before.matches(&after));
+}
+
+#[test]
+fn prefetch_coalesces_duplicate_uri_lookups() {
+    flush_volume_identity_cache();
+    let key = CacheKey {
+        location: Location::uri("smb://host/share"),
+        follow_symlinks: true,
+    };
+    assert!(begin_inflight(&key).is_some());
+    assert!(begin_inflight(&key).is_none());
+    assert_eq!(volume_inflight_len(), 1);
+}
+
+#[test]
+fn file_uri_query_uses_gio_filesystem_id() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let uri = gio::File::for_path(root.path()).uri();
+    let location = Location::uri(uri.to_string());
+    let identity = query_volume_identity(&location, true).expect("file uri identity");
+    assert!(!identity.filesystem_id.is_empty());
+    assert!(!identity.is_remote);
+}
+
+#[test]
+fn smb_and_sftp_uris_are_remote() {
+    assert!(!location_is_remote(&Location::local("/tmp")));
+    assert!(!location_is_remote(&Location::uri("trash:///foo")));
+    assert!(!location_is_remote(&Location::uri("file:///tmp")));
+    assert!(location_is_remote(&Location::uri("smb://host/share")));
+    assert!(location_is_remote(&Location::uri("sftp://host/path")));
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -6,6 +6,7 @@ mod operations;
 mod preview;
 mod release_channel;
 mod search;
+mod transfer_action;
 mod update_check;
 mod update_install;
 
@@ -29,6 +30,10 @@ pub use preview::{
 pub(crate) use preview::{
     content_family, has_plain_text_extension, is_extensionless_dotfile,
     is_non_executable_extensionless_dotfile,
+};
+pub(crate) use transfer_action::{
+    DropActionInput, DropOverride, TransferKind, VolumeIdentity, VolumeRelation, drop_is_noop,
+    preferred_transfer_kind, volume_relation,
 };
 // `best_update`, `rollback_target`, and `ReleaseSummary` are deliberately not
 // re-exported here: `rollback_target` is the never-downgrade bypass, and only

--- a/src/services/transfer_action.rs
+++ b/src/services/transfer_action.rs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#[cfg(test)]
+mod tests;
+
+use gio::prelude::*;
+
+use crate::model::Location;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct VolumeIdentity {
+    pub filesystem_id: String,
+    pub is_remote: bool,
+}
+
+impl VolumeIdentity {
+    pub(crate) fn matches(&self, other: &Self) -> bool {
+        !self.filesystem_id.is_empty()
+            && self.filesystem_id == other.filesystem_id
+            && self.is_remote == other.is_remote
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum VolumeRelation {
+    Same,
+    Different,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum DropOverride {
+    None,
+    ForceCopy,
+    ForceMove,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum TransferKind {
+    Copy,
+    Move,
+    Forbidden,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct DropActionInput {
+    pub can_copy: bool,
+    pub can_move: bool,
+    pub volume: VolumeRelation,
+    pub override_with: DropOverride,
+}
+
+/// Empty `sources` is Unknown (preload not ready; never vacuous Same).
+/// Unknown if dest or any source is unknown; Different if any source is not
+/// dest's volume; Same only when sources is non-empty and every source matches.
+pub(crate) fn volume_relation(
+    dest: Option<&VolumeIdentity>,
+    sources: &[Option<VolumeIdentity>],
+) -> VolumeRelation {
+    if sources.is_empty() {
+        return VolumeRelation::Unknown;
+    }
+    let Some(dest) = dest else {
+        return VolumeRelation::Unknown;
+    };
+    let mut any_different = false;
+    for source in sources {
+        let Some(source) = source else {
+            return VolumeRelation::Unknown;
+        };
+        if !dest.matches(source) {
+            any_different = true;
+        }
+    }
+    if any_different {
+        VolumeRelation::Different
+    } else {
+        VolumeRelation::Same
+    }
+}
+
+pub(crate) fn preferred_transfer_kind(input: DropActionInput) -> TransferKind {
+    if !input.can_copy && !input.can_move {
+        return TransferKind::Forbidden;
+    }
+    match input.override_with {
+        DropOverride::ForceCopy if input.can_copy => return TransferKind::Copy,
+        DropOverride::ForceMove if input.can_move => return TransferKind::Move,
+        DropOverride::ForceCopy | DropOverride::ForceMove | DropOverride::None => {}
+    }
+    match input.volume {
+        VolumeRelation::Same => {
+            if input.can_move {
+                TransferKind::Move
+            } else {
+                TransferKind::Copy
+            }
+        }
+        VolumeRelation::Different | VolumeRelation::Unknown => {
+            if input.can_copy {
+                TransferKind::Copy
+            } else {
+                TransferKind::Move
+            }
+        }
+    }
+}
+
+pub(crate) fn drop_is_noop(dest: &Location, sources: &[Location]) -> bool {
+    let destination = gio_file(dest);
+    sources.iter().any(|source| {
+        let source = gio_file(source);
+        let Some(name) = source.basename() else {
+            return false;
+        };
+        let target = destination.child(name);
+        source.equal(&target) || source.equal(&destination) || destination.has_prefix(&source)
+    })
+}
+
+fn gio_file(location: &Location) -> gio::File {
+    location
+        .native_path()
+        .map(gio::File::for_path)
+        .unwrap_or_else(|| gio::File::for_uri(location.uri_value().unwrap_or_default()))
+}

--- a/src/services/transfer_action/tests.rs
+++ b/src/services/transfer_action/tests.rs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use super::{
+    DropActionInput, DropOverride, TransferKind, VolumeIdentity, VolumeRelation, drop_is_noop,
+    preferred_transfer_kind, volume_relation,
+};
+use crate::model::Location;
+
+fn identity(id: &str, is_remote: bool) -> VolumeIdentity {
+    VolumeIdentity {
+        filesystem_id: id.into(),
+        is_remote,
+    }
+}
+
+fn kind(
+    can_copy: bool,
+    can_move: bool,
+    volume: VolumeRelation,
+    override_with: DropOverride,
+) -> TransferKind {
+    preferred_transfer_kind(DropActionInput {
+        can_copy,
+        can_move,
+        volume,
+        override_with,
+    })
+}
+
+#[test]
+fn volume_relation_treats_empty_sources_as_unknown() {
+    let dest = identity("dev:1", false);
+    assert_eq!(volume_relation(Some(&dest), &[]), VolumeRelation::Unknown);
+}
+
+#[test]
+fn volume_relation_is_unknown_when_dest_or_any_source_is_missing() {
+    let dest = identity("dev:1", false);
+    let same = identity("dev:1", false);
+    assert_eq!(
+        volume_relation(None, &[Some(same.clone())]),
+        VolumeRelation::Unknown
+    );
+    assert_eq!(
+        volume_relation(Some(&dest), &[Some(same), None]),
+        VolumeRelation::Unknown
+    );
+}
+
+#[test]
+fn volume_relation_is_different_if_any_source_disagrees() {
+    let dest = identity("dev:1", false);
+    let same = identity("dev:1", false);
+    let other = identity("dev:2", false);
+    assert_eq!(
+        volume_relation(Some(&dest), &[Some(same.clone())]),
+        VolumeRelation::Same
+    );
+    assert_eq!(
+        volume_relation(Some(&dest), &[Some(same), Some(other)]),
+        VolumeRelation::Different
+    );
+}
+
+#[test]
+fn volume_relation_treats_remote_flag_mismatch_as_different() {
+    let local = identity("same-id", false);
+    let remote = identity("same-id", true);
+    assert_eq!(
+        volume_relation(Some(&local), &[Some(remote)]),
+        VolumeRelation::Different
+    );
+}
+
+#[test]
+fn preferred_kind_copies_across_volumes_and_unknown() {
+    assert_eq!(
+        kind(true, true, VolumeRelation::Same, DropOverride::None),
+        TransferKind::Move
+    );
+    assert_eq!(
+        kind(true, true, VolumeRelation::Different, DropOverride::None),
+        TransferKind::Copy
+    );
+    assert_eq!(
+        kind(true, true, VolumeRelation::Unknown, DropOverride::None),
+        TransferKind::Copy
+    );
+}
+
+#[test]
+fn preferred_kind_honors_ctrl_copy_and_shift_move() {
+    assert_eq!(
+        kind(true, true, VolumeRelation::Same, DropOverride::ForceCopy),
+        TransferKind::Copy
+    );
+    assert_eq!(
+        kind(
+            true,
+            true,
+            VolumeRelation::Different,
+            DropOverride::ForceMove
+        ),
+        TransferKind::Move
+    );
+}
+
+#[test]
+fn preferred_kind_ignores_override_that_is_not_offered() {
+    assert_eq!(
+        kind(false, true, VolumeRelation::Same, DropOverride::ForceCopy),
+        TransferKind::Move
+    );
+    assert_eq!(
+        kind(
+            true,
+            false,
+            VolumeRelation::Different,
+            DropOverride::ForceMove
+        ),
+        TransferKind::Copy
+    );
+}
+
+#[test]
+fn preferred_kind_falls_back_when_only_one_action_is_offered() {
+    assert_eq!(
+        kind(false, true, VolumeRelation::Different, DropOverride::None),
+        TransferKind::Move
+    );
+    assert_eq!(
+        kind(true, false, VolumeRelation::Same, DropOverride::None),
+        TransferKind::Copy
+    );
+    assert_eq!(
+        kind(false, false, VolumeRelation::Same, DropOverride::None),
+        TransferKind::Forbidden
+    );
+}
+
+#[test]
+fn drop_is_noop_for_self_same_name_and_descendant() {
+    let source = Location::local("/fixture/source");
+    let parent = Location::local("/fixture");
+    let nested = Location::local("/fixture/source/nested");
+    let elsewhere = Location::local("/elsewhere");
+
+    assert!(drop_is_noop(&parent, std::slice::from_ref(&source)));
+    assert!(drop_is_noop(&source, std::slice::from_ref(&source)));
+    assert!(drop_is_noop(&nested, std::slice::from_ref(&source)));
+    assert!(!drop_is_noop(&elsewhere, std::slice::from_ref(&source)));
+    assert!(!drop_is_noop(&parent, &[]));
+}

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -12,19 +12,25 @@ use std::{
     time::{Duration, Instant},
 };
 
+use gtk::gdk::prelude::*;
 use gtk::{gdk, gio, glib, prelude::*};
 
 use crate::{
-    adapters::location_for_file,
+    adapters::{
+        cached_volume_identity, location_for_file, prefetch_volume_identity, query_volume_identity,
+        register_volume_restatus,
+    },
     app::{Browser, BrowserEvent},
     model::{
         EntryKind, FileEntry, FolderColor, FolderColorValue, Location, SortDirection, SortKey,
     },
     services::{
-        ArchiveFormat, FileSource, LoadHandle, LocationValidationError, MoveRecord,
-        OperationProvider, PasteItem, PreviewContent, SearchEvent, TransferConflict, UndoMoveItem,
-        UriCredentials, backend_unavailable_message, content_family, has_plain_text_extension,
-        index_tree, is_extensionless_dotfile, sanitize_uri_credentials, validate_basename,
+        ArchiveFormat, DropActionInput, DropOverride, FileSource, LoadHandle,
+        LocationValidationError, MoveRecord, OperationProvider, PasteItem, PreviewContent,
+        SearchEvent, TransferConflict, TransferKind, UndoMoveItem, UriCredentials, VolumeIdentity,
+        VolumeRelation, backend_unavailable_message, content_family, drop_is_noop,
+        has_plain_text_extension, index_tree, is_extensionless_dotfile, preferred_transfer_kind,
+        sanitize_uri_credentials, validate_basename, volume_relation,
     },
 };
 
@@ -4903,23 +4909,49 @@ impl ViewState {
             });
             row.add_controller(drag);
 
-            let drop = gtk::DropTarget::new(
-                gtk::gdk::FileList::static_type(),
-                gtk::gdk::DragAction::COPY | gtk::gdk::DragAction::MOVE,
-            );
+            let dest_for_row = {
+                let weak_state = weak_state.clone();
+                let item = item.downgrade();
+                let map = map_for_hover.clone();
+                move || {
+                    let state = weak_state.upgrade()?;
+                    let item = item.upgrade()?;
+                    map.source_position(item.position())
+                        .and_then(|position| state.browser.entry_at(depth, position))
+                        .filter(FileEntry::is_directory)
+                        .map(|entry| entry.location)
+                }
+            };
+            let PreparedFileDrop {
+                target: drop,
+                last_override,
+                destination: destination_of,
+            } = prepare_file_drop_target(dest_for_row);
             let highlighted_row = row.downgrade();
+            let destination_for_enter = destination_of.clone();
+            let override_for_enter = last_override.clone();
             drop.connect_enter(move |target, _, _| {
                 if let Some(row) = highlighted_row.upgrade() {
                     row.add_css_class("drop-destination");
                 }
-                file_drop_action(target)
+                file_drop_action(
+                    target,
+                    destination_for_enter().as_ref(),
+                    &override_for_enter,
+                )
             });
             let highlighted_row = row.downgrade();
+            let destination_for_motion = destination_of.clone();
+            let override_for_motion = last_override.clone();
             drop.connect_motion(move |target, _, _| {
                 if let Some(row) = highlighted_row.upgrade() {
                     row.add_css_class("drop-destination");
                 }
-                file_drop_action(target)
+                file_drop_action(
+                    target,
+                    destination_for_motion().as_ref(),
+                    &override_for_motion,
+                )
             });
             let highlighted_row = row.downgrade();
             drop.connect_leave(move |_| {
@@ -4948,9 +4980,9 @@ impl ViewState {
                 })
             });
             let weak_state_for_drop = weak_state.clone();
-            let dropped_item = item.downgrade();
-            let map_for_drop = map_for_hover.clone();
             let dropped_row = row.downgrade();
+            let destination_for_drop = destination_of;
+            let override_for_drop = last_override;
             drop.connect_drop(move |target, value, _, _| {
                 let Some(dropped_row) = dropped_row.upgrade() else {
                     return false;
@@ -4959,21 +4991,18 @@ impl ViewState {
                 let Some(state) = weak_state_for_drop.upgrade() else {
                     return false;
                 };
-                let Some(dropped_item) = dropped_item.upgrade() else {
-                    return false;
-                };
-                let Some(destination) = map_for_drop
-                    .source_position(dropped_item.position())
-                    .and_then(|position| state.browser.entry_at(depth, position))
-                    .filter(FileEntry::is_directory)
-                    .map(|entry| entry.location)
-                else {
+                let Some(destination) = destination_for_drop() else {
                     return false;
                 };
                 let Some(sources) = locations_from_file_list_value(value) else {
                     return false;
                 };
-                let move_sources = file_drop_action(target) == gtk::gdk::DragAction::MOVE;
+                let move_sources = file_drop_commits_move(
+                    target,
+                    Some(&destination),
+                    &sources,
+                    &override_for_drop,
+                );
                 slide_in_down(&dropped_row);
                 glib::timeout_add_local_once(Duration::from_millis(300), move || {
                     state.start_transfer(destination, sources, move_sources);
@@ -7585,18 +7614,38 @@ fn install_directory_drop_target(
     destination: Location,
 ) {
     widget.add_css_class("file-drop-zone");
-    let drop = gtk::DropTarget::new(
-        gtk::gdk::FileList::static_type(),
-        gtk::gdk::DragAction::COPY | gtk::gdk::DragAction::MOVE,
-    );
-    drop.connect_enter(|target, _, _| file_drop_action(target));
-    drop.connect_motion(|target, _, _| file_drop_action(target));
+    let PreparedFileDrop {
+        target: drop,
+        last_override,
+        destination: destination_of,
+    } = prepare_file_drop_target({
+        let destination = destination.clone();
+        move || Some(destination.clone())
+    });
+    let destination_for_enter = destination_of.clone();
+    let override_for_enter = last_override.clone();
+    drop.connect_enter(move |target, _, _| {
+        file_drop_action(
+            target,
+            destination_for_enter().as_ref(),
+            &override_for_enter,
+        )
+    });
+    let destination_for_motion = destination_of.clone();
+    let override_for_motion = last_override.clone();
+    drop.connect_motion(move |target, _, _| {
+        file_drop_action(
+            target,
+            destination_for_motion().as_ref(),
+            &override_for_motion,
+        )
+    });
     let weak = Rc::downgrade(state);
     drop.connect_drop(move |target, value, _, _| {
         let Some(state) = weak.upgrade() else {
             return false;
         };
-        transfer_dropped_files(&state, target, value, destination.clone())
+        transfer_dropped_files(&state, target, value, destination.clone(), &last_override)
     });
     widget.add_controller(drop);
 }
@@ -7641,6 +7690,7 @@ fn transfer_dropped_files(
     target: &gtk::DropTarget,
     value: &glib::Value,
     destination: Location,
+    last_override: &Cell<DropOverride>,
 ) -> bool {
     let Some(sources) = locations_from_file_list_value(value) else {
         return false;
@@ -7648,27 +7698,268 @@ fn transfer_dropped_files(
     if sources.is_empty() {
         return false;
     }
-    let move_sources = file_drop_action(target) == gtk::gdk::DragAction::MOVE;
+    let move_sources = file_drop_commits_move(target, Some(&destination), &sources, last_override);
     state.start_transfer(destination, sources, move_sources);
     true
 }
 
-pub(super) fn file_drop_action(target: &gtk::DropTarget) -> gtk::gdk::DragAction {
-    let Some(drop) = target.current_drop() else {
-        return gtk::gdk::DragAction::empty();
-    };
-    preferred_file_drop_action(drop.actions(), drop.drag().is_some())
+pub(super) struct PreparedFileDrop {
+    pub target: gtk::DropTarget,
+    pub last_override: Rc<Cell<DropOverride>>,
+    pub destination: Rc<dyn Fn() -> Option<Location>>,
 }
 
-fn preferred_file_drop_action(actions: gtk::gdk::DragAction, local: bool) -> gtk::gdk::DragAction {
-    if actions.contains(gtk::gdk::DragAction::MOVE)
-        && (local || !actions.contains(gtk::gdk::DragAction::COPY))
-    {
-        gtk::gdk::DragAction::MOVE
-    } else if actions.contains(gtk::gdk::DragAction::COPY) {
-        gtk::gdk::DragAction::COPY
+pub(super) fn prepare_file_drop_target(
+    destination: impl Fn() -> Option<Location> + 'static,
+) -> PreparedFileDrop {
+    let destination = Rc::new(destination) as Rc<dyn Fn() -> Option<Location>>;
+    let drop = gtk::DropTarget::new(
+        gtk::gdk::FileList::static_type(),
+        gtk::gdk::DragAction::COPY | gtk::gdk::DragAction::MOVE,
+    );
+    drop.set_preload(true);
+    let last_override = Rc::new(Cell::new(DropOverride::None));
+    let last = last_override.clone();
+    drop.connect_leave(move |_| {
+        last.set(DropOverride::None);
+    });
+    let dest = destination.clone();
+    let last = last_override.clone();
+    drop.connect_value_notify(move |target| {
+        restatus_file_drop(target, dest().as_ref(), &last);
+    });
+    let dest = destination.clone();
+    let last = last_override.clone();
+    let weak = drop.downgrade();
+    register_volume_restatus(Rc::new(move || {
+        let Some(target) = weak.upgrade() else {
+            return false;
+        };
+        restatus_file_drop(&target, dest().as_ref(), &last);
+        true
+    }));
+    PreparedFileDrop {
+        target: drop,
+        last_override,
+        destination,
+    }
+}
+
+fn restatus_file_drop(
+    target: &gtk::DropTarget,
+    destination: Option<&Location>,
+    last_override: &Cell<DropOverride>,
+) {
+    let Some(drop) = target.current_drop() else {
+        return;
+    };
+    let action = file_drop_action(target, destination, last_override);
+    drop.status(target.actions(), action);
+}
+
+pub(super) fn file_drop_action(
+    target: &gtk::DropTarget,
+    destination: Option<&Location>,
+    last_override: &Cell<DropOverride>,
+) -> gtk::gdk::DragAction {
+    let sources = drop_source_locations(target);
+    classify_file_drop(target, destination, &sources, last_override, false)
+}
+
+pub(super) fn file_drop_commits_move(
+    target: &gtk::DropTarget,
+    destination: Option<&Location>,
+    sources: &[Location],
+    last_override: &Cell<DropOverride>,
+) -> bool {
+    classify_file_drop(target, destination, sources, last_override, true)
+        == gtk::gdk::DragAction::MOVE
+}
+
+fn drop_source_locations(target: &gtk::DropTarget) -> Vec<Location> {
+    target
+        .value()
+        .as_ref()
+        .and_then(locations_from_file_list_value)
+        .unwrap_or_default()
+}
+
+fn classify_file_drop(
+    target: &gtk::DropTarget,
+    destination: Option<&Location>,
+    sources: &[Location],
+    last_override: &Cell<DropOverride>,
+    commit: bool,
+) -> gtk::gdk::DragAction {
+    let Some(drop) = target.current_drop() else {
+        if commit {
+            let override_with = commit_override(target, last_override);
+            let volume = volume_for_drop(destination, sources, true);
+            tracing::info!(
+                dest = destination.map(Location::diagnostic_path),
+                sources = sources.len(),
+                ?volume,
+                ?override_with,
+                "drop action classified without current drop"
+            );
+            return preferred_file_drop_action(
+                offered_file_actions(target.actions(), target.actions()),
+                override_with,
+                volume,
+                destination.is_some_and(|destination| drop_is_noop(destination, sources)),
+            );
+        }
+        return gtk::gdk::DragAction::empty();
+    };
+    let override_with = if commit {
+        commit_override(target, last_override)
     } else {
-        gtk::gdk::DragAction::empty()
+        hover_override(target, last_override)
+    };
+    let Some(destination) = destination else {
+        return gtk::gdk::DragAction::empty();
+    };
+    let is_noop = drop_is_noop(destination, sources);
+    let dest_id = volume_identity_for(destination, true, commit);
+    let source_ids = sources
+        .iter()
+        .map(|source| volume_identity_for(source, false, commit))
+        .collect::<Vec<_>>();
+    let volume = volume_relation(dest_id.as_ref(), &source_ids);
+    let offered = offered_file_actions(target.actions(), drop.actions());
+    if commit {
+        tracing::info!(
+            dest = %destination.diagnostic_path(),
+            dest_fs = dest_id.as_ref().map(|identity| identity.filesystem_id.as_str()),
+            sources = sources.len(),
+            source = sources.first().map(Location::diagnostic_path),
+            source_fs = source_ids.first().and_then(|identity| {
+                identity
+                    .as_ref()
+                    .map(|identity| identity.filesystem_id.as_str())
+            }),
+            ?volume,
+            ?override_with,
+            event_mods = ?target.current_event_state(),
+            keyboard_mods = ?drop_modifier_state(target),
+            drop_actions = ?drop.actions(),
+            ?offered,
+            "drop action classified"
+        );
+    }
+    preferred_file_drop_action(offered, override_with, volume, is_noop)
+}
+
+/// File transfers are performed by Strata, not by the drag protocol. A local
+/// drag often starts over the source pane (same-volume move) and the compositor
+/// then advertises only MOVE. That must not prevent a later cross-volume copy.
+fn offered_file_actions(
+    dest_actions: gtk::gdk::DragAction,
+    source_actions: gtk::gdk::DragAction,
+) -> gtk::gdk::DragAction {
+    let mut offered = gtk::gdk::DragAction::empty();
+    if dest_actions.contains(gtk::gdk::DragAction::COPY) {
+        offered |= gtk::gdk::DragAction::COPY;
+    }
+    if dest_actions.contains(gtk::gdk::DragAction::MOVE)
+        && source_actions.contains(gtk::gdk::DragAction::MOVE)
+    {
+        offered |= gtk::gdk::DragAction::MOVE;
+    }
+    if offered.is_empty() {
+        dest_actions & source_actions
+    } else {
+        offered
+    }
+}
+
+fn volume_for_drop(
+    destination: Option<&Location>,
+    sources: &[Location],
+    commit: bool,
+) -> VolumeRelation {
+    let dest = destination.and_then(|destination| volume_identity_for(destination, true, commit));
+    let source_ids = sources
+        .iter()
+        .map(|source| volume_identity_for(source, false, commit))
+        .collect::<Vec<_>>();
+    volume_relation(dest.as_ref(), &source_ids)
+}
+
+fn volume_identity_for(
+    location: &Location,
+    follow_symlinks: bool,
+    commit: bool,
+) -> Option<VolumeIdentity> {
+    if location.native_path().is_some() {
+        if !commit && let Some(cached) = cached_volume_identity(location, follow_symlinks) {
+            return Some(cached);
+        }
+        return query_volume_identity(location, follow_symlinks);
+    }
+    if let Some(cached) = cached_volume_identity(location, follow_symlinks) {
+        return Some(cached);
+    }
+    if !commit {
+        prefetch_volume_identity(location.clone(), follow_symlinks);
+    }
+    None
+}
+
+fn hover_override(target: &gtk::DropTarget, last: &Cell<DropOverride>) -> DropOverride {
+    let current = drop_override(target);
+    last.set(current);
+    current
+}
+
+fn commit_override(target: &gtk::DropTarget, last: &Cell<DropOverride>) -> DropOverride {
+    let current = drop_override(target);
+    if current != DropOverride::None {
+        last.set(current);
+        current
+    } else {
+        last.get()
+    }
+}
+
+fn drop_override(target: &gtk::DropTarget) -> DropOverride {
+    let mods = drop_modifier_state(target);
+    if mods.contains(gtk::gdk::ModifierType::CONTROL_MASK) {
+        DropOverride::ForceCopy
+    } else if mods.contains(gtk::gdk::ModifierType::SHIFT_MASK) {
+        DropOverride::ForceMove
+    } else {
+        DropOverride::None
+    }
+}
+
+fn drop_modifier_state(target: &gtk::DropTarget) -> gtk::gdk::ModifierType {
+    target
+        .widget()
+        .and_then(|widget| widget.display().default_seat())
+        .and_then(|seat| seat.keyboard())
+        .map(|keyboard| keyboard.modifier_state())
+        .unwrap_or_else(|| target.current_event_state())
+}
+
+fn preferred_file_drop_action(
+    actions: gtk::gdk::DragAction,
+    override_with: DropOverride,
+    volume: VolumeRelation,
+    is_noop: bool,
+) -> gtk::gdk::DragAction {
+    if is_noop {
+        return gtk::gdk::DragAction::empty();
+    }
+    match preferred_transfer_kind(DropActionInput {
+        can_copy: actions.contains(gtk::gdk::DragAction::COPY),
+        can_move: actions.contains(gtk::gdk::DragAction::MOVE),
+        volume,
+        override_with,
+    }) {
+        TransferKind::Copy => gtk::gdk::DragAction::COPY,
+        TransferKind::Move => gtk::gdk::DragAction::MOVE,
+        TransferKind::Forbidden => gtk::gdk::DragAction::empty(),
     }
 }
 
@@ -7683,6 +7974,9 @@ pub(super) fn locations_from_file_list_value(value: &glib::Value) -> Option<Vec<
 }
 
 pub(super) fn file_drag_content(entries: &[FileEntry]) -> Option<gtk::gdk::ContentProvider> {
+    for entry in entries {
+        prefetch_volume_identity(entry.location.clone(), false);
+    }
     let files = entries
         .iter()
         .map(|entry| gio_file_for_location(&entry.location))

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -521,20 +521,111 @@ fn incoming_file_lists_sanitize_remote_credentials() {
 }
 
 #[test]
-fn local_file_drops_prefer_move_while_external_drops_prefer_copy() {
+fn file_drop_action_follows_volume_relation_not_local_vs_external() {
     let both = gtk::gdk::DragAction::COPY | gtk::gdk::DragAction::MOVE;
 
     assert_eq!(
-        preferred_file_drop_action(both, true),
+        preferred_file_drop_action(
+            both,
+            crate::services::DropOverride::None,
+            crate::services::VolumeRelation::Same,
+            false,
+        ),
         gtk::gdk::DragAction::MOVE
     );
     assert_eq!(
-        preferred_file_drop_action(both, false),
+        preferred_file_drop_action(
+            both,
+            crate::services::DropOverride::None,
+            crate::services::VolumeRelation::Different,
+            false,
+        ),
         gtk::gdk::DragAction::COPY
     );
     assert_eq!(
-        preferred_file_drop_action(gtk::gdk::DragAction::MOVE, false),
+        preferred_file_drop_action(
+            both,
+            crate::services::DropOverride::None,
+            crate::services::VolumeRelation::Unknown,
+            false,
+        ),
+        gtk::gdk::DragAction::COPY
+    );
+    assert_eq!(
+        preferred_file_drop_action(
+            gtk::gdk::DragAction::MOVE,
+            crate::services::DropOverride::None,
+            crate::services::VolumeRelation::Different,
+            false,
+        ),
         gtk::gdk::DragAction::MOVE
+    );
+    assert_eq!(
+        preferred_file_drop_action(
+            both,
+            crate::services::DropOverride::ForceCopy,
+            crate::services::VolumeRelation::Same,
+            false,
+        ),
+        gtk::gdk::DragAction::COPY
+    );
+    assert_eq!(
+        preferred_file_drop_action(
+            both,
+            crate::services::DropOverride::ForceMove,
+            crate::services::VolumeRelation::Different,
+            false,
+        ),
+        gtk::gdk::DragAction::MOVE
+    );
+    assert_eq!(
+        preferred_file_drop_action(
+            both,
+            crate::services::DropOverride::None,
+            crate::services::VolumeRelation::Same,
+            true,
+        ),
+        gtk::gdk::DragAction::empty()
+    );
+}
+
+#[test]
+fn move_only_protocol_still_copies_across_volumes() {
+    let dest = gtk::gdk::DragAction::COPY | gtk::gdk::DragAction::MOVE;
+    let offered = offered_file_actions(dest, gtk::gdk::DragAction::MOVE);
+    assert!(offered.contains(gtk::gdk::DragAction::COPY));
+    assert_eq!(
+        preferred_file_drop_action(
+            offered,
+            crate::services::DropOverride::None,
+            crate::services::VolumeRelation::Different,
+            false,
+        ),
+        gtk::gdk::DragAction::COPY
+    );
+    assert_eq!(
+        preferred_file_drop_action(
+            offered,
+            crate::services::DropOverride::None,
+            crate::services::VolumeRelation::Same,
+            false,
+        ),
+        gtk::gdk::DragAction::MOVE
+    );
+}
+
+#[test]
+fn copy_only_source_does_not_move_on_the_same_volume() {
+    let dest = gtk::gdk::DragAction::COPY | gtk::gdk::DragAction::MOVE;
+    let offered = offered_file_actions(dest, gtk::gdk::DragAction::COPY);
+    assert_eq!(
+        preferred_file_drop_action(
+            offered,
+            crate::services::DropOverride::None,
+            crate::services::VolumeRelation::Same,
+            false,
+        ),
+        gtk::gdk::DragAction::COPY
     );
 }
 

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -2543,6 +2543,9 @@ fn build_explorer_pane(
     // GTK bundles single-click activation with hover selection, which collapses
     // multi-selection. Per-row gestures honor the configured click behavior instead.
     view.set_single_click_activate(false);
+    if let Some(destination) = browser.location_at(depth) {
+        install_mode_directory_drop_target(&view, destination, transfer_handler.clone());
+    }
     let weak_browser = Rc::downgrade(&browser);
     let source_index_for_activation = source_index.clone();
     let view_model_for_activation = view_model_object.clone();
@@ -2836,12 +2839,32 @@ fn install_mode_directory_drop_target(
     transfer_handler: TransferHandlerSlot,
 ) {
     widget.add_css_class("file-drop-zone");
-    let drop = gtk::DropTarget::new(
-        gtk::gdk::FileList::static_type(),
-        gtk::gdk::DragAction::COPY | gtk::gdk::DragAction::MOVE,
-    );
-    drop.connect_enter(|target, _, _| super::browser::file_drop_action(target));
-    drop.connect_motion(|target, _, _| super::browser::file_drop_action(target));
+    let super::browser::PreparedFileDrop {
+        target: drop,
+        last_override,
+        destination: destination_of,
+    } = super::browser::prepare_file_drop_target({
+        let destination = destination.clone();
+        move || Some(destination.clone())
+    });
+    let destination_for_enter = destination_of.clone();
+    let override_for_enter = last_override.clone();
+    drop.connect_enter(move |target, _, _| {
+        super::browser::file_drop_action(
+            target,
+            destination_for_enter().as_ref(),
+            &override_for_enter,
+        )
+    });
+    let destination_for_motion = destination_of;
+    let override_for_motion = last_override.clone();
+    drop.connect_motion(move |target, _, _| {
+        super::browser::file_drop_action(
+            target,
+            destination_for_motion().as_ref(),
+            &override_for_motion,
+        )
+    });
     drop.connect_drop(move |target, value, _, _| {
         let Some(sources) = super::browser::locations_from_file_list_value(value) else {
             return false;
@@ -2851,8 +2874,13 @@ fn install_mode_directory_drop_target(
         };
         handler(
             destination.clone(),
-            sources,
-            super::browser::file_drop_action(target) == gtk::gdk::DragAction::MOVE,
+            sources.clone(),
+            super::browser::file_drop_commits_move(
+                target,
+                Some(&destination),
+                &sources,
+                &last_override,
+            ),
         );
         true
     });
@@ -2914,23 +2942,54 @@ fn install_explorer_drag_drop(
     });
     row.add_controller(drag);
 
-    let drop = gtk::DropTarget::new(
-        gtk::gdk::FileList::static_type(),
-        gtk::gdk::DragAction::COPY | gtk::gdk::DragAction::MOVE,
-    );
+    let dest_for_row = {
+        let dropped_item = item.downgrade();
+        let browser_for_dest = browser.clone();
+        let map_for_dest = position_map.clone();
+        move || {
+            let browser = browser_for_dest.upgrade()?;
+            let dropped_item = dropped_item.upgrade()?;
+            let position = dropped_item.position();
+            let position = map_for_dest.as_ref().map_or(
+                (position != gtk::INVALID_LIST_POSITION).then_some(position as usize),
+                |(map, view)| source_position_for_view(map, Some(view), position),
+            );
+            position
+                .and_then(|position| browser.entry_at(depth, position))
+                .filter(FileEntry::is_directory)
+                .map(|entry| entry.location)
+        }
+    };
+    let super::browser::PreparedFileDrop {
+        target: drop,
+        last_override,
+        destination: destination_of,
+    } = super::browser::prepare_file_drop_target(dest_for_row);
     let highlighted_row = row.downgrade();
+    let destination_for_enter = destination_of.clone();
+    let override_for_enter = last_override.clone();
     drop.connect_enter(move |target, _, _| {
         if let Some(row) = highlighted_row.upgrade() {
             row.add_css_class("drop-destination");
         }
-        super::browser::file_drop_action(target)
+        super::browser::file_drop_action(
+            target,
+            destination_for_enter().as_ref(),
+            &override_for_enter,
+        )
     });
     let highlighted_row = row.downgrade();
+    let destination_for_motion = destination_of.clone();
+    let override_for_motion = last_override.clone();
     drop.connect_motion(move |target, _, _| {
         if let Some(row) = highlighted_row.upgrade() {
             row.add_css_class("drop-destination");
         }
-        super::browser::file_drop_action(target)
+        super::browser::file_drop_action(
+            target,
+            destination_for_motion().as_ref(),
+            &override_for_motion,
+        )
     });
     let highlighted_row = row.downgrade();
     drop.connect_leave(move |_| {
@@ -2961,30 +3020,14 @@ fn install_explorer_drag_drop(
                 .formats()
                 .contains_type(gtk::gdk::FileList::static_type())
     });
-    let dropped_item = item.downgrade();
-    let browser_for_drop = browser;
-    let map_for_drop = position_map;
     let dropped_row = row.downgrade();
+    let destination_for_drop = destination_of;
+    let override_for_drop = last_override;
     drop.connect_drop(move |target, value, _, _| {
         if let Some(row) = dropped_row.upgrade() {
             row.remove_css_class("drop-destination");
         }
-        let Some(browser) = browser_for_drop.upgrade() else {
-            return false;
-        };
-        let Some(dropped_item) = dropped_item.upgrade() else {
-            return false;
-        };
-        let position = dropped_item.position();
-        let position = map_for_drop.as_ref().map_or(
-            (position != gtk::INVALID_LIST_POSITION).then_some(position as usize),
-            |(map, view)| source_position_for_view(map, Some(view), position),
-        );
-        let Some(destination) = position
-            .and_then(|position| browser.entry_at(depth, position))
-            .filter(FileEntry::is_directory)
-            .map(|entry| entry.location)
-        else {
+        let Some(destination) = destination_for_drop() else {
             return false;
         };
         let Some(sources) = super::browser::locations_from_file_list_value(value) else {
@@ -2994,9 +3037,14 @@ fn install_explorer_drag_drop(
             return false;
         };
         handler(
-            destination,
-            sources,
-            super::browser::file_drop_action(target) == gtk::gdk::DragAction::MOVE,
+            destination.clone(),
+            sources.clone(),
+            super::browser::file_drop_commits_move(
+                target,
+                Some(&destination),
+                &sources,
+                &override_for_drop,
+            ),
         );
         true
     });

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -1259,6 +1259,11 @@ impl SidebarView {
 }
 
 impl SidebarState {
+    fn on_volume_monitor_event(self: &Rc<Self>) {
+        crate::adapters::flush_volume_identity_cache();
+        self.rebuild();
+    }
+
     fn rebuild(self: &Rc<Self>) {
         while let Some(child) = self.widget.first_child() {
             self.widget.remove(&child);
@@ -2388,37 +2393,37 @@ fn build_sidebar(view: BrowserView, theme_manager: Rc<super::theme::ThemeManager
     let weak = Rc::downgrade(&state);
     handlers.push(state.volume_monitor.connect_mount_added(move |_, _| {
         if let Some(state) = weak.upgrade() {
-            state.rebuild();
+            state.on_volume_monitor_event();
         }
     }));
     let weak = Rc::downgrade(&state);
     handlers.push(state.volume_monitor.connect_mount_removed(move |_, _| {
         if let Some(state) = weak.upgrade() {
-            state.rebuild();
+            state.on_volume_monitor_event();
         }
     }));
     let weak = Rc::downgrade(&state);
     handlers.push(state.volume_monitor.connect_mount_changed(move |_, _| {
         if let Some(state) = weak.upgrade() {
-            state.rebuild();
+            state.on_volume_monitor_event();
         }
     }));
     let weak = Rc::downgrade(&state);
     handlers.push(state.volume_monitor.connect_volume_added(move |_, _| {
         if let Some(state) = weak.upgrade() {
-            state.rebuild();
+            state.on_volume_monitor_event();
         }
     }));
     let weak = Rc::downgrade(&state);
     handlers.push(state.volume_monitor.connect_volume_removed(move |_, _| {
         if let Some(state) = weak.upgrade() {
-            state.rebuild();
+            state.on_volume_monitor_event();
         }
     }));
     let weak = Rc::downgrade(&state);
     handlers.push(state.volume_monitor.connect_volume_changed(move |_, _| {
         if let Some(state) = weak.upgrade() {
-            state.rebuild();
+            state.on_volume_monitor_event();
         }
     }));
     state.append_static_places();


### PR DESCRIPTION
## Description

Dragging within Strata onto another volume currently relocates the source because drop handling treats any same-process drag as a move. This change classifies source and destination volumes, then defaults a plain cross-volume or unknown-volume drop to copy.

Same-volume drops still move. Ctrl forces copy, Shift forces move (using the existing copy-then-delete path). Cut+Paste is unchanged and still moves. Destination directory symlinks are followed so a `~/usb` link onto a stick copies instead of deleting the original.

## Visual evidence

N/A — the visible change is the compositor copy vs move cursor and whether the source is removed, not layout or theming.

## How to test

1. Drag a file within `$HOME` onto another folder on the same volume.
2. Drag a file from `$HOME` onto a USB volume, `/tmp` if it is tmpfs, or another mounted disk.
3. Repeat (1) while holding Ctrl, and (2) while holding Shift.
4. Drag onto a directory symlink that points at another device.
5. Hover an empty mount-point folder, mount a USB there, and drop without leaving the row.

**Expected result:**

1. Move (source gone).
2. Copy (source remains).
3. Ctrl copies on the same volume; Shift moves onto the other volume only after the copy succeeds.
4. Copy (source remains).
5. Copy, not move. The cursor should switch to copy after the mount without needing a pointer wiggle.

Also confirm Cut then Paste across volumes still moves, and a cancelled Shift-move of a large directory leaves the source intact.

On Hyprland/Omarchy, check whether the cursor distinguishes copy vs move. If it does not, the default is still copy; a badge follow-up should be filed rather than treating the cue as shipped.

## Related issue

Closes #248