### PR TITLE
fix(browser): let List folders drag with single-click open

### DIFF
--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -484,6 +484,10 @@ pub struct Browser {
     deletion_permanent: Cell<bool>,
     restoration_operation: Cell<bool>,
     transfer_destination: RefCell<Option<Location>>,
+    /// Open folders already updated by an owned transfer. The next monitor
+    /// Rescan for these locations is ignored so GIO bursts do not reload.
+    /// Cleared when a new operation starts.
+    reconciled_watch_locations: RefCell<HashSet<Location>>,
     undo_claim: RefCell<Option<(u64, UndoEntry)>>,
     next_request: Cell<u64>,
     pending_sort: Cell<Option<(u64, usize)>>,
@@ -529,6 +533,7 @@ impl Browser {
             deletion_permanent: Cell::new(false),
             restoration_operation: Cell::new(false),
             transfer_destination: RefCell::new(None),
+            reconciled_watch_locations: RefCell::new(HashSet::new()),
             undo_claim: RefCell::new(None),
             next_request: Cell::new(1),
             pending_sort: Cell::new(None),
@@ -663,6 +668,7 @@ impl Browser {
         self.close_peek();
         self.loads.borrow_mut().clear();
         self.monitors.borrow_mut().clear();
+        self.reconciled_watch_locations.borrow_mut().clear();
         self.cancel_deferred_work();
         let request_id = self.new_request_id();
         self.state
@@ -1495,6 +1501,7 @@ impl Browser {
         }
         self.transfer_operation.set(None);
         self.transfer_destination.replace(None);
+        self.reconciled_watch_locations.borrow_mut().clear();
         self.deletion_operation.set(false);
         self.deletion_permanent.set(false);
         self.restoration_operation.set(false);
@@ -1764,11 +1771,19 @@ impl Browser {
                         select_name: first_name.unwrap_or_default(),
                     });
                 }
-                OperationEvent::Pasted { .. } => {
+                OperationEvent::Pasted { locations, .. } => {
                     browser.emit(BrowserEvent::TransferCompleted);
-                    for location in &refresh_locations {
-                        if location.native_path().is_none() {
-                            browser.refresh_columns_at(location);
+                    if let Some(destination) = destination.as_ref() {
+                        browser.apply_completed_transfer(
+                            &locations,
+                            destination,
+                            moving == Some(true),
+                        );
+                    } else {
+                        for location in &refresh_locations {
+                            if location.native_path().is_none() {
+                                browser.refresh_columns_at(location);
+                            }
                         }
                     }
                 }
@@ -1926,6 +1941,7 @@ impl Browser {
         self.close_peek();
         self.loads.borrow_mut().clear();
         self.monitors.borrow_mut().clear();
+        self.reconciled_watch_locations.borrow_mut().clear();
         self.cancel_deferred_work();
         let loads: Vec<_> = path
             .locations()
@@ -2999,19 +3015,7 @@ impl Browser {
             let Some(parent) = deletion_parent_location(location) else {
                 continue;
             };
-            let depths = {
-                let state = self.state.borrow();
-                let mut depths = Vec::new();
-                let mut depth = 0;
-                while let Some(open_location) = state.location_at(depth) {
-                    if open_location == parent {
-                        depths.push(depth);
-                    }
-                    depth += 1;
-                }
-                depths
-            };
-            for depth in depths {
+            for depth in self.depths_showing(&parent) {
                 self.handle_directory_change(
                     depth,
                     &parent,
@@ -3019,6 +3023,114 @@ impl Browser {
                 );
             }
         }
+    }
+
+    fn apply_completed_transfer(
+        self: &Rc<Self>,
+        sources: &[Location],
+        destination: &Location,
+        move_sources: bool,
+    ) {
+        if sources.len() > MAX_INCREMENTAL_OPERATION_UPDATES {
+            self.refresh_columns_at(destination);
+            if move_sources {
+                let parents: HashSet<_> = sources.iter().filter_map(Location::parent).collect();
+                for parent in parents {
+                    self.refresh_columns_at(&parent);
+                }
+            }
+            return;
+        }
+
+        let dest_showing = !self.depths_showing(destination).is_empty();
+        let mut dest_needs_refresh = false;
+        let mut transferred = false;
+        for source in sources {
+            let Some(target) = source.transfer_target(destination) else {
+                continue;
+            };
+            if &target == source {
+                continue;
+            }
+            transferred = true;
+            let entry = self.entry_by_location(source);
+            if move_sources {
+                self.remove_deleted_locations(std::slice::from_ref(source));
+            }
+            if let Some(entry) = entry {
+                self.upsert_entry_in_open_columns(FileEntry {
+                    location: target,
+                    ..entry
+                });
+            } else if dest_showing {
+                dest_needs_refresh = true;
+            }
+        }
+        if dest_needs_refresh {
+            self.refresh_columns_at(destination);
+        }
+        if !transferred {
+            return;
+        }
+        self.mark_transfer_reconciled(destination);
+        if move_sources {
+            for parent in sources.iter().filter_map(Location::parent) {
+                self.mark_transfer_reconciled(&parent);
+            }
+        }
+    }
+
+    fn upsert_entry_in_open_columns(self: &Rc<Self>, entry: FileEntry) {
+        let Some(parent) = entry.location.parent() else {
+            return;
+        };
+        for depth in self.depths_showing(&parent) {
+            self.handle_directory_change(depth, &parent, DirectoryChange::Upsert(entry.clone()));
+        }
+    }
+
+    fn entry_by_location(&self, location: &Location) -> Option<FileEntry> {
+        self.state.borrow().columns.iter().find_map(|column| {
+            column
+                .entries
+                .iter()
+                .find(|entry| entry.location == *location)
+                .cloned()
+        })
+    }
+
+    fn depths_showing(&self, location: &Location) -> Vec<usize> {
+        let state = self.state.borrow();
+        let mut depths = Vec::new();
+        let mut depth = 0;
+        while let Some(open_location) = state.location_at(depth) {
+            if &open_location == location {
+                depths.push(depth);
+            }
+            depth += 1;
+        }
+        depths
+    }
+
+    fn mark_transfer_reconciled(&self, location: &Location) {
+        if self.depths_showing(location).is_empty() {
+            return;
+        }
+        self.reconciled_watch_locations
+            .borrow_mut()
+            .insert(location.clone());
+    }
+
+    fn drop_descendant_columns(self: &Rc<Self>, len: usize) {
+        self.close_peek();
+        let Some((depth, position)) = self.state.borrow_mut().truncate_to(len) else {
+            return;
+        };
+        self.loads.borrow_mut().truncate(len);
+        self.monitors.borrow_mut().truncate(len);
+        self.truncate_deferred_from(len);
+        self.emit(BrowserEvent::ColumnsTruncated { len });
+        self.emit(BrowserEvent::FocusChanged { depth, position });
     }
 
     pub fn retry_column(self: &Rc<Self>, depth: usize) {
@@ -3116,6 +3228,9 @@ impl Browser {
         change: DirectoryChange,
     ) {
         if matches!(&change, DirectoryChange::Rescan) {
+            if self.reconciled_watch_locations.borrow_mut().remove(watched) {
+                return;
+            }
             self.refresh_column(depth);
             return;
         }
@@ -3148,8 +3263,13 @@ impl Browser {
             .borrow()
             .path_after_external_change(depth, &change);
         if let Some(path) = path_update {
-            self.restore_path(path);
-            return;
+            let new_len = path.locations().len();
+            if new_len > 0 && new_len < self.state.borrow().columns.len() {
+                self.drop_descendant_columns(new_len);
+            } else {
+                self.restore_path(path);
+                return;
+            }
         }
         let application = self
             .state

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -306,6 +306,51 @@ impl FileSource for FakeFileSource {
     }
 }
 
+struct TwoFolderSource;
+
+impl FileSource for TwoFolderSource {
+    fn validate_location(&self, _location: &Location) -> Result<(), LocationValidationError> {
+        Ok(())
+    }
+
+    fn enumerate(&self, request: DirectoryRequest, emit: Rc<dyn Fn(DirectoryEvent)>) -> LoadHandle {
+        let entries = match request
+            .location
+            .native_path()
+            .and_then(|path| path.to_str())
+        {
+            Some("/fixture") => vec![
+                folder_listing_entry("/fixture/alpha", "alpha"),
+                folder_listing_entry("/fixture/bravo", "bravo"),
+            ],
+            _ => Vec::new(),
+        };
+        emit(DirectoryEvent::Batch {
+            request_id: request.id,
+            entries,
+        });
+        emit(DirectoryEvent::Finished {
+            request_id: request.id,
+            truncated: false,
+            can_trash: None,
+        });
+        LoadHandle::new(|| {})
+    }
+}
+
+fn folder_listing_entry(path: &str, name: &str) -> FileEntry {
+    FileEntry {
+        location: Location::local(path),
+        native_name: OsString::from(name),
+        display_name: name.into(),
+        kind: EntryKind::Directory,
+        size: MetadataValue::Unknown,
+        modified_unix_seconds: MetadataValue::Unknown,
+        is_hidden: false,
+        mode: MetadataValue::Unknown,
+    }
+}
+
 struct TrashFileSource;
 
 impl FileSource for TrashFileSource {
@@ -1252,6 +1297,251 @@ fn completed_deletions_remove_entries_without_reloading_the_column() {
             .borrow()
             .iter()
             .any(|event| matches!(event, BrowserEvent::ColumnReloaded { .. }))
+    );
+}
+
+#[test]
+fn moving_into_an_open_column_splices_instead_of_reloading() {
+    let browser = Browser::new(Rc::new(TwoFolderSource));
+    browser.set_operation_provider(Rc::new(ImmediateOperationProvider));
+    browser.navigate(Location::local("/fixture"));
+    browser.descend(0, Location::local("/fixture/bravo"));
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let observed = events.clone();
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
+
+    browser.transfer(
+        Location::local("/fixture/bravo"),
+        vec![PasteItem {
+            source: Location::local("/fixture/alpha"),
+            conflict: TransferConflict::FailIfExists,
+        }],
+        true,
+    );
+
+    assert_eq!(column_names(&browser, 0), vec!["bravo".to_owned()]);
+    assert_eq!(column_names(&browser, 1), vec!["alpha".to_owned()]);
+    assert_eq!(
+        browser.entry_at(1, 0).map(|entry| entry.location),
+        Some(Location::local("/fixture/bravo/alpha"))
+    );
+    assert!(events.borrow().iter().any(|event| matches!(
+        event,
+        BrowserEvent::EntriesSpliced { depth: 0, splices, .. }
+            if splices.iter().any(|splice| splice.removed == 1)
+    )));
+    assert!(events.borrow().iter().any(|event| matches!(
+        event,
+        BrowserEvent::EntriesSpliced { depth: 1, splices, .. }
+            if splices.iter().any(|splice| splice.entries.len() == 1)
+    )));
+    assert!(!events.borrow().iter().any(|event| {
+        matches!(
+            event,
+            BrowserEvent::ColumnReloaded { .. } | BrowserEvent::Reset
+        )
+    }));
+}
+
+#[test]
+fn moving_an_open_folder_out_closes_child_columns_without_reloading() {
+    let browser = Browser::new(Rc::new(TwoFolderSource));
+    browser.set_operation_provider(Rc::new(ImmediateOperationProvider));
+    browser.navigate(Location::local("/fixture"));
+    browser.descend(0, Location::local("/fixture/alpha"));
+    assert_eq!(
+        browser.location_at(1),
+        Some(Location::local("/fixture/alpha"))
+    );
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let observed = events.clone();
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
+
+    browser.transfer(
+        Location::local("/fixture/bravo"),
+        vec![PasteItem {
+            source: Location::local("/fixture/alpha"),
+            conflict: TransferConflict::FailIfExists,
+        }],
+        true,
+    );
+
+    assert_eq!(column_names(&browser, 0), vec!["bravo".to_owned()]);
+    assert_eq!(browser.location_at(1), None);
+    assert!(
+        events
+            .borrow()
+            .iter()
+            .any(|event| matches!(event, BrowserEvent::ColumnsTruncated { len: 1 }))
+    );
+    assert!(!events.borrow().iter().any(|event| {
+        matches!(
+            event,
+            BrowserEvent::ColumnReloaded { .. } | BrowserEvent::Reset
+        )
+    }));
+}
+
+#[test]
+fn copying_into_an_open_column_inserts_without_removing_the_source() {
+    let browser = Browser::new(Rc::new(TwoFolderSource));
+    browser.set_operation_provider(Rc::new(ImmediateOperationProvider));
+    browser.navigate(Location::local("/fixture"));
+    browser.descend(0, Location::local("/fixture/bravo"));
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let observed = events.clone();
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
+
+    browser.transfer(
+        Location::local("/fixture/bravo"),
+        vec![PasteItem {
+            source: Location::local("/fixture/alpha"),
+            conflict: TransferConflict::FailIfExists,
+        }],
+        false,
+    );
+
+    assert_eq!(
+        column_names(&browser, 0),
+        vec!["alpha".to_owned(), "bravo".to_owned()]
+    );
+    assert_eq!(column_names(&browser, 1), vec!["alpha".to_owned()]);
+    assert!(!events.borrow().iter().any(|event| {
+        matches!(
+            event,
+            BrowserEvent::ColumnReloaded { .. } | BrowserEvent::Reset
+        )
+    }));
+}
+
+#[test]
+fn owned_transfer_ignores_the_follow_up_monitor_rescan() {
+    let browser = Browser::new(Rc::new(TwoFolderSource));
+    browser.set_operation_provider(Rc::new(ImmediateOperationProvider));
+    browser.navigate(Location::local("/fixture"));
+    browser.descend(0, Location::local("/fixture/bravo"));
+    browser.transfer(
+        Location::local("/fixture/bravo"),
+        vec![PasteItem {
+            source: Location::local("/fixture/alpha"),
+            conflict: TransferConflict::FailIfExists,
+        }],
+        true,
+    );
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let observed = events.clone();
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
+
+    browser.handle_directory_change(0, &Location::local("/fixture"), DirectoryChange::Rescan);
+
+    assert_eq!(column_names(&browser, 0), vec!["bravo".to_owned()]);
+    assert!(
+        !events
+            .borrow()
+            .iter()
+            .any(|event| matches!(event, BrowserEvent::ColumnReloaded { .. }))
+    );
+}
+
+#[test]
+fn owned_transfer_does_not_ignore_rescan_for_a_closed_destination() {
+    let browser = Browser::new(Rc::new(TwoFolderSource));
+    browser.set_operation_provider(Rc::new(ImmediateOperationProvider));
+    browser.navigate(Location::local("/fixture"));
+    browser.transfer(
+        Location::local("/fixture/bravo"),
+        vec![PasteItem {
+            source: Location::local("/fixture/alpha"),
+            conflict: TransferConflict::FailIfExists,
+        }],
+        true,
+    );
+    browser.descend(0, Location::local("/fixture/bravo"));
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let observed = events.clone();
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
+
+    browser.handle_directory_change(
+        1,
+        &Location::local("/fixture/bravo"),
+        DirectoryChange::Rescan,
+    );
+
+    assert!(
+        events
+            .borrow()
+            .iter()
+            .any(|event| matches!(event, BrowserEvent::ColumnReloaded { depth: 1 }))
+    );
+}
+
+#[test]
+fn a_new_operation_clears_the_owned_transfer_rescan_ignore() {
+    let browser = Browser::new(Rc::new(TwoFolderSource));
+    browser.set_operation_provider(Rc::new(ImmediateOperationProvider));
+    UNDO_MOVE_REQUESTS.with(|requests| requests.borrow_mut().clear());
+    browser.navigate(Location::local("/fixture"));
+    browser.descend(0, Location::local("/fixture/bravo"));
+    browser.transfer(
+        Location::local("/fixture/bravo"),
+        vec![PasteItem {
+            source: Location::local("/fixture/alpha"),
+            conflict: TransferConflict::FailIfExists,
+        }],
+        true,
+    );
+    let (generation, records) = browser.pending_undo_move().expect("pending move undo");
+    assert!(
+        browser.undo_move(
+            generation,
+            records
+                .iter()
+                .cloned()
+                .map(|record| UndoMoveItem {
+                    record,
+                    conflict: TransferConflict::FailIfExists,
+                })
+                .collect(),
+        )
+    );
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let observed = events.clone();
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
+
+    browser.handle_directory_change(0, &Location::local("/fixture"), DirectoryChange::Rescan);
+
+    assert!(
+        events
+            .borrow()
+            .iter()
+            .any(|event| matches!(event, BrowserEvent::ColumnReloaded { depth: 0 }))
+    );
+}
+
+#[test]
+fn a_no_op_move_does_not_ignore_the_next_rescan() {
+    let browser = Browser::new(Rc::new(TwoFolderSource));
+    browser.set_operation_provider(Rc::new(ImmediateOperationProvider));
+    browser.navigate(Location::local("/fixture"));
+    browser.transfer(
+        Location::local("/fixture"),
+        vec![PasteItem {
+            source: Location::local("/fixture/alpha"),
+            conflict: TransferConflict::FailIfExists,
+        }],
+        true,
+    );
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let observed = events.clone();
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
+
+    browser.handle_directory_change(0, &Location::local("/fixture"), DirectoryChange::Rescan);
+
+    assert!(
+        events
+            .borrow()
+            .iter()
+            .any(|event| matches!(event, BrowserEvent::ColumnReloaded { depth: 0 }))
     );
 }
 

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -944,9 +944,18 @@ impl NavigationState {
             return None;
         }
         self.record_navigation();
+        self.truncate_to(depth)
+    }
+
+    /// Drops descendant columns without recording history. Used when an
+    /// operation or monitor event invalidates the open path.
+    pub fn truncate_to(&mut self, len: usize) -> Option<(usize, Option<usize>)> {
+        if len == 0 || len >= self.columns.len() {
+            return None;
+        }
         self.peek = None;
-        self.columns.truncate(depth);
-        let parent_depth = depth - 1;
+        self.columns.truncate(len);
+        let parent_depth = len - 1;
         self.active_column = Some(parent_depth);
         Some((parent_depth, self.columns[parent_depth].selected))
     }

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -4890,6 +4890,7 @@ impl ViewState {
             });
             row.add_controller(motion);
 
+            let folder_drag_started = Rc::new(Cell::new(false));
             let drag = gtk::DragSource::builder()
                 .actions(gtk::gdk::DragAction::COPY | gtk::gdk::DragAction::MOVE)
                 .build();
@@ -4918,7 +4919,9 @@ impl ViewState {
                 file_drag_content(&entries)
             });
             let dragged_row = row.downgrade();
+            let folder_drag_for_begin = folder_drag_started.clone();
             drag.connect_drag_begin(move |_, _| {
+                folder_drag_for_begin.set(true);
                 if let Some(row) = dragged_row.upgrade() {
                     row.add_css_class("dragging");
                 }
@@ -5020,7 +5023,14 @@ impl ViewState {
             let selection_anchor_for_click = mouse_selection_anchor.clone();
             let modified_for_click = modified_selection_for_rows.clone();
             let map_for_click = map_for_hover.clone();
+            let clicked_item_for_release = clicked_item.clone();
+            let selection_for_release = selection_for_click.clone();
+            let map_for_release = map_for_click.clone();
+            let weak_state_for_release = weak_state_for_click.clone();
+            let folder_drag_for_press = folder_drag_started.clone();
+            let folder_drag_for_release = folder_drag_started;
             selection_click.connect_pressed(move |gesture, press_count, _, _| {
+                folder_drag_for_press.set(false);
                 let Some(clicked_item) = clicked_item.upgrade() else {
                     return;
                 };
@@ -5066,28 +5076,56 @@ impl ViewState {
                     (weak_state_for_click.upgrade(), source_position)
                 {
                     let entry = state.browser.entry_at(depth, source_position);
-                    if entry.as_ref().is_some_and(|entry| {
-                        should_activate_single_click(
-                            press_count,
-                            entry.is_directory(),
-                            state.columns_click_activation.get(),
-                            control,
-                            shift,
-                            preserve_group,
-                        )
-                    }) {
-                        gesture.set_state(gtk::EventSequenceState::Claimed);
-                        state.browser.activate(depth, source_position);
-                    } else if should_preview_pointer_press(
-                        press_count,
-                        control,
-                        shift,
-                        preserve_group,
-                    ) && entry.as_ref().is_some_and(|entry| {
-                        entry_responds_to_preview_click(entry, state.single_click_previews.get())
-                    }) {
+                    if should_preview_pointer_press(press_count, control, shift, preserve_group)
+                        && entry.as_ref().is_some_and(|entry| {
+                            entry_responds_to_preview_click(
+                                entry,
+                                state.single_click_previews.get(),
+                            )
+                        })
+                    {
                         state.browser.preview(depth, source_position);
                     }
+                }
+            });
+            selection_click.connect_released(move |gesture, press_count, _, _| {
+                let Some(clicked_item) = clicked_item_for_release.upgrade() else {
+                    return;
+                };
+                let position = clicked_item.position();
+                if position == gtk::INVALID_LIST_POSITION {
+                    return;
+                }
+                let modifiers = gesture.current_event_state();
+                let control = modifiers.contains(gtk::gdk::ModifierType::CONTROL_MASK);
+                let shift = modifiers.contains(gtk::gdk::ModifierType::SHIFT_MASK);
+                let preserve_group = !control
+                    && !shift
+                    && should_preserve_drag_selection(
+                        selection_for_release.is_selected(position),
+                        selection_for_release.selection().size(),
+                    );
+                let Some(source_position) = map_for_release.source_position(position) else {
+                    return;
+                };
+                let Some(state) = weak_state_for_release.upgrade() else {
+                    return;
+                };
+                let is_directory = state
+                    .browser
+                    .entry_at(depth, source_position)
+                    .is_some_and(|entry| entry.is_directory());
+                if should_activate_column_release(
+                    folder_drag_for_release.get(),
+                    press_count,
+                    is_directory,
+                    state.columns_click_activation.get(),
+                    control,
+                    shift,
+                    preserve_group,
+                ) {
+                    gesture.set_state(gtk::EventSequenceState::Claimed);
+                    state.browser.activate(depth, source_position);
                 }
             });
             row.add_controller(selection_click);
@@ -7898,6 +7936,28 @@ fn should_activate_single_click(
         activation.files
     };
     press_count == 1 && configured == ClickCount::One && !control && !shift && !preserve_group
+}
+
+/// Columns single-click open waits for release. Claiming the press sequence
+/// stops GtkDragSource from starting a folder drag.
+fn should_activate_column_release(
+    drag_started: bool,
+    press_count: i32,
+    is_directory: bool,
+    activation: ClickActivation,
+    control: bool,
+    shift: bool,
+    preserve_group: bool,
+) -> bool {
+    !drag_started
+        && should_activate_single_click(
+            press_count,
+            is_directory,
+            activation,
+            control,
+            shift,
+            preserve_group,
+        )
 }
 
 fn should_preview_pointer_press(

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -764,6 +764,24 @@ fn pointer_activation_respects_entry_type_click_count_and_modifiers() {
 }
 
 #[test]
+fn column_single_click_folders_activate_on_release_so_drags_can_start() {
+    let activation = ClickActivation {
+        files: ClickCount::Two,
+        folders: ClickCount::One,
+    };
+
+    assert!(should_activate_column_release(
+        false, 1, true, activation, false, false, false,
+    ));
+    assert!(!should_activate_column_release(
+        true, 1, true, activation, false, false, false,
+    ));
+    assert!(!should_activate_column_release(
+        false, 1, false, activation, false, false, false,
+    ));
+}
+
+#[test]
 fn pressing_an_item_in_a_multi_selection_preserves_the_drag_group() {
     assert!(should_preserve_drag_selection(true, 2));
     assert!(should_preserve_drag_selection(true, 8));


### PR DESCRIPTION
## Description

List view opens folders on mouse-down when single-click activation is on, which claims the pointer and blocks `GtkDragSource`. Folder open now waits for mouse-up, and is skipped if a drag already started. A short click still opens the folder.

## Visual evidence

N/A — pointer interaction only; no layout or visual change.

## How to test

1. Use List view with default settings (folders 1 click, files 2 clicks).
2. Click a folder without moving: it should open.
3. Press a folder and drag it onto another folder or into another column: the drag should start and the drop should move or copy.
4. Drag a file the same way: unchanged.
5. Ctrl/Shift-click folders: selection only, no open.

**Expected result:** Folders drag in List view. Single-click open still works when the pointer does not start a drag.

## Related issue

Closes #339 