### PR TITLE
fix(remote): compare remote locations hierarchically in is_within

### DIFF
--- a/src/app/navigation/tests.rs
+++ b/src/app/navigation/tests.rs
@@ -288,6 +288,21 @@ fn external_removals_close_affected_descendant_columns() {
 }
 
 #[test]
+fn remote_external_removals_close_the_exact_open_column() {
+    let root = Location::uri("sftp://user@host/mnt/share");
+    let removed = Location::uri("sftp://user@host/mnt/share/removed");
+    let mut state = NavigationState::default();
+    state.navigate(root.clone(), RequestId(1));
+    assert!(state.descend(0, removed.clone(), RequestId(2)));
+
+    let path = state
+        .path_after_external_change(0, &DirectoryChange::Remove(removed))
+        .expect("the removed remote column should be closed");
+
+    assert_eq!(path.locations(), &[root]);
+}
+
+#[test]
 fn selecting_a_sibling_replaces_deeper_columns() {
     let mut state = NavigationState::default();
     state.navigate(location("/home"), RequestId(1));

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -120,7 +120,9 @@ impl Location {
         let (Some(uri), Some(parent_uri)) = (self.uri_value(), other.uri_value()) else {
             return false;
         };
-        gio::File::for_uri(uri).has_prefix(&gio::File::for_uri(parent_uri))
+        let file = gio::File::for_uri(uri);
+        let parent = gio::File::for_uri(parent_uri);
+        file.equal(&parent) || file.has_prefix(&parent)
     }
 
     pub fn compare(&self, other: &Self) -> Ordering {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -114,9 +114,13 @@ impl Location {
     }
 
     pub fn is_within(&self, other: &Self) -> bool {
-        self.native_path()
-            .zip(other.native_path())
-            .is_some_and(|(path, parent)| path.starts_with(parent))
+        if let Some((path, parent)) = self.native_path().zip(other.native_path()) {
+            return path.starts_with(parent);
+        }
+        let (Some(uri), Some(parent_uri)) = (self.uri_value(), other.uri_value()) else {
+            return false;
+        };
+        gio::File::for_uri(uri).has_prefix(&gio::File::for_uri(parent_uri))
     }
 
     pub fn compare(&self, other: &Self) -> Ordering {

--- a/src/model/tests.rs
+++ b/src/model/tests.rs
@@ -45,6 +45,37 @@ fn remote_locations_keep_uri_parents_and_breadcrumbs() {
 }
 
 #[test]
+fn is_within_matches_native_descendants() {
+    let child = Location::local("/home/user/project/src");
+    let parent = Location::local("/home/user/project");
+    let unrelated = Location::local("/home/other");
+
+    assert!(child.is_within(&parent));
+    assert!(!parent.is_within(&child));
+    assert!(!child.is_within(&unrelated));
+}
+
+#[test]
+fn is_within_matches_remote_descendants() {
+    let child = Location::uri("sftp://user@host/mnt/share/folder");
+    let parent = Location::uri("sftp://user@host/mnt/share");
+    let unrelated = Location::uri("sftp://user@host/other");
+
+    assert!(child.is_within(&parent));
+    assert!(!parent.is_within(&child));
+    assert!(!child.is_within(&unrelated));
+}
+
+#[test]
+fn is_within_never_crosses_native_and_remote_locations() {
+    let native = Location::local("/mnt/share/folder");
+    let remote = Location::uri("sftp://user@host/mnt/share");
+
+    assert!(!native.is_within(&remote));
+    assert!(!remote.is_within(&native));
+}
+
+#[test]
 fn backend_names_distinguish_native_remote_and_malformed_locations() {
     assert_eq!(
         Location::local("/home/alice/private").backend_name(),

--- a/src/model/tests.rs
+++ b/src/model/tests.rs
@@ -62,6 +62,7 @@ fn is_within_matches_remote_descendants() {
     let unrelated = Location::uri("sftp://user@host/other");
 
     assert!(child.is_within(&parent));
+    assert!(parent.is_within(&parent));
     assert!(!parent.is_within(&child));
     assert!(!child.is_within(&unrelated));
 }


### PR DESCRIPTION
## Description

`Location::is_within` only compared native filesystem paths, so it always returned `false` for URI locations (SMB, SFTP, FTP, WebDAV). This broke `navigate_home_if_within` in `src/ui/window.rs` after ejecting or disconnecting a remote mount that was actively being browsed (the Miller columns kept showing stale content instead of returning Home), and also affects the `DirectoryChange::Remove` handling in `src/app/navigation.rs` that truncates stale Miller columns.

Fix: use `gio::File::has_prefix` (already used elsewhere in this file) to compare URI locations hierarchically, falling back to the existing native-path comparison when both locations are native.

## How to test

1. Connect to a remote location (SMB or SFTP).
2. Browse a few levels deep into it.
3. In the sidebar, eject/disconnect that device.

**Expected result:** the browser navigates back to Home, matching what already happens when a local removable drive is ejected while active.

I verified this exact flow end to end against a real SFTP host, both before the fix (view stayed stale after eject) and after (view returns Home).

## Related issue

Closes #351