### PR TITLE
feat(remote): use native GtkMountOperation for SFTP host-key trust

### DIFF
--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -3698,15 +3698,20 @@ impl ViewState {
             Option<MountPromptDetails>,
         ) + 'static,
     ) {
-        if self.overlay.root().and_downcast::<gtk::Window>().is_none() {
+        let Some(window) = self.overlay.root().and_downcast::<gtk::Window>() else {
             return;
-        }
+        };
         let activity = BrowserView {
             state: self.clone(),
         }
         .begin_global_activity("Connecting…");
         let file = gio_file_for_location(&location);
-        let operation = gio::MountOperation::new();
+        // A native gtk::MountOperation (rather than a bare gio::MountOperation)
+        // is required so GTK's own "ask-question" dialog handles host-key and
+        // certificate trust decisions for us; we only override "ask-password"
+        // below with Strata's own dialog, stopping that one signal's default
+        // handler so the two don't both try to reply.
+        let operation = gtk::MountOperation::new(Some(&window));
         let prompt_overlay = self.overlay.clone();
         let active_prompt = Rc::new(RefCell::new(None::<gtk::Box>));
         let prompt_for_signal = active_prompt.clone();
@@ -3719,6 +3724,12 @@ impl ViewState {
         let already_prompted = Cell::new(credentials_for_signal.borrow().is_some());
         operation.connect_ask_password(
             move |operation, message, default_user, default_domain, flags| {
+                // Suppress GtkMountOperation's own native password dialog: we
+                // reply ourselves (immediately or via our custom prompt)
+                // below. "ask-question" is deliberately left unconnected so
+                // its native default handler still runs for host-key/cert
+                // trust prompts.
+                operation.stop_signal_emission_by_name("ask-password");
                 details_for_signal.replace(Some(MountPromptDetails {
                     message: message.to_owned(),
                     default_user: default_user.to_owned(),
@@ -3726,7 +3737,7 @@ impl ViewState {
                     flags,
                 }));
                 if let Some(credentials) = credentials_for_signal.borrow_mut().take() {
-                    apply_mount_credentials(operation, &credentials);
+                    apply_mount_credentials(operation.upcast_ref(), &credentials);
                     operation.reply(gio::MountOperationResult::Handled);
                     return;
                 }
@@ -3736,7 +3747,7 @@ impl ViewState {
                 let retry = already_prompted.replace(true);
                 let prompt = show_authentication_dialog(
                     &prompt_overlay,
-                    Some(operation),
+                    Some(operation.upcast_ref()),
                     message,
                     (default_user, default_domain),
                     flags,


### PR DESCRIPTION
## Description

First slice of #63: SFTP password authentication, generalizing the existing SMB mount/retry flow, plus host-key/certificate trust decisions.

The mount flow used a bare `gio::MountOperation`, which never connects a handler for `ask-question` (needed for host-key/certificate trust prompts). The safe `gio` Rust bindings don't expose that signal at all (its `choices` parameter is a raw `char**` the binding generator can't marshal), so wiring it up directly would require new unsafe FFI with no precedent elsewhere in this codebase.

Instead, this switches to a native `gtk::MountOperation`, which already implements `ask-question` in C with its own dialog, no application code required. Strata's existing custom "ask-password" dialog is preserved by stopping that one signal's default emission (`stop_signal_emission_by_name`) so the native dialog and ours don't both try to reply.

Net effect: SFTP (and any other scheme needing host-key/certificate trust) now gets a real, safe trust decision instead of silently failing, while the password prompt keeps Strata's own styling.

## Scope

In scope: password authentication over `sftp://`, host-key/certificate trust via the native dialog, existing cancel/retry-on-wrong-credentials behavior (unchanged, still Strata's own dialog).

Out of scope, left for a follow-up PR against #63: SSH key and encrypted-key passphrase authentication, and a disposable OpenSSH fixture for automated integration coverage.

## How to test

1. `Ctrl+L`, type `sftp://user@host` (or `sftp://user@host:port`) for a reachable SSH server, press Enter.
2. First connection to an unfamiliar host: a native "Identity Verification Failed" dialog appears; confirm to proceed.
3. Strata's own "Authentication required" dialog appears; enter the password.
4. Confirm normal Miller-column browsing over SFTP.
5. Retry cancelling the password dialog (returns to the prior location, no error) and submitting a wrong password (dialog reopens asking again, no flicker).

**Expected result:** all five steps behave as described.

I verified this exact flow end to end against a real SFTP host (host-key confirmation, password auth, cancel, and wrong-password retry all confirmed working).

## Related issue

Refs #63