### PR TITLE
ci: reject AI agent commit attribution

### DIFF
--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -34,41 +34,55 @@ jobs:
               per_page: 100,
             });
 
-            const claudeName = /\bclaude(?:\s+(?:sonnet|opus|haiku))?\b/i;
-            const anthropicEmail = /@anthropic\.com$/i;
-            const coAuthor = /^\s*co-authored-by:.*(?:\bclaude\b|@anthropic\.com)/im;
-            const claudeMetadata = /^\s*claude-[a-z-]+\s*:/im;
+            // Match explicit coding-agent signatures without rejecting unrelated automation such as Dependabot.
+            const agentNames = String.raw`(?:claude(?:\s+(?:sonnet|opus|haiku|code))?|anthropic|cursor(?:\s+agent)?|junie|(?:openai\s+)?codex|chatgpt|github\s+copilot|copilot(?:\s+coding\s+agent)?|gemini(?:\s+code\s+assist)?|google(?:\s+labs)?\s+jules|jules|devin(?:\s+ai)?|windsurf(?:\s+agent)?|cascade|codeium|aider|cline|roo\s+code|qodo|amazon\s+q(?:\s+developer)?|openhands|swe-agent|sourcegraph\s+cody|replit\s+agent|ai\s+(?:coding\s+)?agent)`;
+            const agentIdentity = new RegExp(`\\b${agentNames}\\b`, "i");
+            const agentEmail = /(?:^|[+._-])(?:claude|anthropic|cursor(?:agent)?|junie|codex|chatgpt|copilot|gemini|jules|devin|windsurf|cascade|codeium|aider|cline|qodo|openhands|swe-agent)(?:[+._-]|@)|@(anthropic|cursor|openai|devin|codeium)\.(?:com|ai)$/i;
+            const agentLogin = /^(?:claude|anthropic-ai|cursor(?:agent)?|junie|codex|openai-codex|chatgpt|github-copilot|copilot(?:-swe-agent)?|gemini-code-assist|google-labs-jules|jules|devin-ai-integration|windsurf|codeium|aider|cline|roo-code|qodo|amazon-q-developer|openhands|swe-agent|sourcegraph-cody|replit-agent)(?:\[bot\])?$/i;
+            const allowedAutomationLogins = new Set(["dependabot[bot]"]);
+            const agentTrailer = new RegExp(`^\\s*(?:co-authored-by|signed-off-by):.*${agentNames}`, "im");
+            const agentMetadata = new RegExp(`^\\s*(?:[^A-Za-z0-9\\s]+\\s*)?(?:(?:claude|cursor|junie|codex|copilot|gemini|jules|devin|windsurf|cascade|codeium|aider|cline|qodo|openhands)-[a-z-]+\\s*:|generated (?:by|with)\\s*:?.*${agentNames})`, "im");
             const attributionFailures = [];
 
             for (const commit of commits) {
-              const identities = [
+              const gitIdentities = [
                 ["author", commit.commit.author],
                 ["committer", commit.commit.committer],
               ];
+              const githubIdentities = [
+                ["author", commit.author],
+                ["committer", commit.committer],
+              ];
 
               const reasons = [];
-              for (const [role, identity] of identities) {
-                if (claudeName.test(identity?.name ?? "") ||
-                    anthropicEmail.test(identity?.email ?? "")) {
+              for (const [role, identity] of gitIdentities) {
+                if (agentIdentity.test(identity?.name ?? "") ||
+                    agentEmail.test(identity?.email ?? "")) {
                   reasons.push(`${role} identity`);
+                }
+              }
+              for (const [role, identity] of githubIdentities) {
+                const login = identity?.login?.toLowerCase() ?? "";
+                if (!allowedAutomationLogins.has(login) && agentLogin.test(login)) {
+                  reasons.push(`${role} GitHub account`);
                 }
               }
 
               const message = commit.commit.message;
-              if (coAuthor.test(message)) reasons.push("Co-authored-by trailer");
-              if (claudeMetadata.test(message)) reasons.push("Claude metadata");
+              if (agentTrailer.test(message)) reasons.push("agent attribution trailer");
+              if (agentMetadata.test(message)) reasons.push("agent metadata");
 
               if (reasons.length > 0) {
-                attributionFailures.push(`${commit.sha.slice(0, 7)}: ${reasons.join(", ")}`);
+                attributionFailures.push(`${commit.sha.slice(0, 7)}: ${[...new Set(reasons)].join(", ")}`);
               }
             }
 
             if (attributionFailures.length > 0) {
-              errors.push(`Claude attribution found in ${attributionFailures.length} commit(s)`);
+              errors.push(`AI agent attribution found in ${attributionFailures.length} commit(s)`);
               core.summary
-                .addHeading("Claude attribution must be removed")
+                .addHeading("AI-agent-authored commits are not accepted")
                 .addList(attributionFailures)
-                .addRaw("Rewrite the listed commits to remove Claude/Anthropic author or co-author identities and Claude-* metadata, then force-push the pull request branch.");
+                .addRaw("Remove the listed commits, recreate the changes and commits as your own work under your own identity, then force-push the pull request branch.");
             }
 
             if (errors.length > 0) {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,11 @@ fix(navigation): preserve selection after reload
 
 Use `!` after the type or scope and add a `BREAKING CHANGE:` footer when a change is incompatible. Keep unrelated changes in separate commits.
 
+Commits must be authored by the contributor submitting them. Do not submit
+commits authored or co-authored by an AI coding agent. If an agent created
+commits, remove them and recreate the changes and commits as your own work under
+your own identity before opening or updating the pull request.
+
 ## Required checks
 
 Before opening a pull request:


### PR DESCRIPTION
## Description

Generalize the pull request commit-attribution policy from Claude-only detection to explicit signatures from common AI coding agents. Check Git identities, linked GitHub accounts, attribution trailers, and generated metadata, while explicitly allowing Dependabot. Document that contributors must recreate agent commits under their own identity.

## Visual evidence

N/A — CI policy and contributor documentation only.

## How to test

1. Open or update a test PR containing a commit attributed to Claude, Cursor, Junie, Codex, Copilot, Gemini, or another listed coding agent.
2. Confirm the metadata policy fails and identifies the commit. Then verify a normal contributor commit and a Dependabot commit pass the attribution check.

**Expected result:** AI-agent-attributed commits fail with rewrite guidance; contributor and Dependabot commits remain allowed.

## Related issue

Closes #356