### PR TITLE
feat(navigation): jump to top/bottom of the active pane with Ctrl+Up/Ctrl+Down

### DIFF
--- a/src/app/navigation/tests.rs
+++ b/src/app/navigation/tests.rs
@@ -517,6 +517,25 @@ fn paging_skips_hidden_entries_when_hidden_files_are_not_shown() {
 }
 
 #[test]
+fn paging_by_usize_max_jumps_to_the_first_or_last_visible_entry() {
+    let mut state = NavigationState::default();
+    state.navigate(location("/home"), RequestId(1));
+    state.apply_batch(
+        RequestId(1),
+        vec![
+            hidden_entry("/home/alpha", "alpha"),
+            named_entry("/home/bravo", "bravo"),
+            named_entry("/home/charlie", "charlie"),
+            hidden_entry("/home/delta", "delta"),
+        ],
+    );
+
+    assert!(state.select(0, 2));
+    assert_eq!(state.page_selection(1, usize::MAX), Some((0, 2)));
+    assert_eq!(state.page_selection(-1, usize::MAX), Some((0, 1)));
+}
+
+#[test]
 fn paging_an_empty_column_keeps_the_selection_unchanged() {
     let mut state = NavigationState::default();
     state.navigate(location("/home"), RequestId(1));

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -1125,6 +1125,21 @@ impl BrowserView {
         true
     }
 
+    /// Moves the focus to the first or last visible entry of the active pane, for
+    /// `Ctrl+Up` and `Ctrl+Down`.
+    pub fn jump_selection(&self, direction: i32) -> bool {
+        let focused = self.state.overlay.root().and_then(|root| root.focus());
+        let Some((view, scroll)) = focused
+            .as_ref()
+            .and_then(super::scrolling::focused_collection)
+        else {
+            return false;
+        };
+        self.state.browser.page_selection(direction, usize::MAX);
+        super::scrolling::reveal_jump(&view, &scroll, direction);
+        true
+    }
+
     pub fn dismiss_empty_focused_filter(&self) -> bool {
         let focused = self.state.overlay.root().and_then(|root| root.focus());
         let empty = self.state.mode_views.borrow().empty_filter_has_focus()

--- a/src/ui/scrolling.rs
+++ b/src/ui/scrolling.rs
@@ -264,6 +264,18 @@ pub(super) fn reveal_selection(
     advance(&scroll.vadjustment(), f64::from(direction) * page.distance);
 }
 
+/// Brings the newly selected item into sight after jumping to the first or last
+/// entry, scrolling all the way to that edge of the pane.
+pub(super) fn reveal_jump(view: &gtk::Widget, scroll: &gtk::ScrolledWindow, direction: i32) {
+    if scroll.child().is_some_and(|child| &child == view)
+        && let Some(position) = selected_position(view)
+    {
+        scroll_to_item(view, position);
+        return;
+    }
+    advance(&scroll.vadjustment(), f64::from(direction) * f64::MAX);
+}
+
 fn selected_position(view: &gtk::Widget) -> Option<u32> {
     let model = match (
         view.downcast_ref::<gtk::ListView>(),

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -2269,6 +2269,7 @@ fn keybindings_page() -> gtk::Widget {
     append_heading(&content, "NAVIGATION");
     for (label, keys) in [
         ("Move through items", "J / K  or  ↑ / ↓"),
+        ("Jump to top / bottom", "Ctrl + ↑ / Ctrl + ↓"),
         ("Open folder", "L / → / Enter"),
         ("Go to parent", "H / ←"),
         ("Edit location", "Ctrl + L"),

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -943,6 +943,12 @@ fn install_keyboard_navigation(
             browser.extend_selection(1);
             return glib::Propagation::Stop;
         }
+        if control && !shift && key == gtk::gdk::Key::Up && view.jump_selection(-1) {
+            return glib::Propagation::Stop;
+        }
+        if control && !shift && key == gtk::gdk::Key::Down && view.jump_selection(1) {
+            return glib::Propagation::Stop;
+        }
         if !shift
             && matches!(key, gtk::gdk::Key::k | gtk::gdk::Key::Up)
             && view.focus_header_from_top_item()


### PR DESCRIPTION
## Description

Adds `Ctrl+Up` and `Ctrl+Down` to jump the keyboard focus straight to the first or last visible entry in the active pane/Miller column, instead of stepping one item or one page at a time. It reuses the existing page-selection clamping logic (`NavigationState::page_selection`) with an unbounded page size so the jump lands exactly on the edge entry, respecting hidden-file visibility the same way `Page Up`/`Page Down` already do. The pane scrolls all the way to that edge to match. Also adds the shortcut to the Settings keybindings reference.

## Visual evidence

N/A — keyboard-only navigation behavior, no visual change to the UI besides the new Settings reference row.

## How to test

1. Open a folder with more entries than fit in one pane (or shrink the window).
2. Click into the file list and press `Ctrl+Down`.
   **Expected result:** focus and selection jump directly to the last entry, and the pane scrolls to the bottom.
3. Press `Ctrl+Up`.
   **Expected result:** focus and selection jump directly to the first entry, and the pane scrolls to the top.
4. Repeat in a Miller column and with hidden files toggled on/off to confirm hidden entries are skipped/included correctly.
5. Open Settings → Keybindings and confirm "Jump to top / bottom" is listed under Navigation.

## Related issue

Closes #357
