### PR TITLE
feat(operations): capability-gate the permanent delete action

### DIFF
--- a/src/adapters/local_files.rs
+++ b/src/adapters/local_files.rs
@@ -23,8 +23,8 @@ use crate::{
     },
 };
 
-const LIST_ATTRIBUTES: &str = "standard::display-name,standard::name,standard::type,standard::is-hidden,standard::is-symlink,access::can-trash";
-const FULL_ATTRIBUTES: &str = "standard::display-name,standard::name,standard::type,standard::is-hidden,standard::is-symlink,standard::size,time::modified,unix::mode,access::can-trash";
+const LIST_ATTRIBUTES: &str = "standard::display-name,standard::name,standard::type,standard::is-hidden,standard::is-symlink,access::can-trash,access::can-delete";
+const FULL_ATTRIBUTES: &str = "standard::display-name,standard::name,standard::type,standard::is-hidden,standard::is-symlink,standard::size,time::modified,unix::mode,access::can-trash,access::can-delete";
 const METADATA_ATTRIBUTES: &str = "standard::type,standard::size,time::modified,unix::mode";
 const MAX_PENDING_MONITOR_CHANGES: usize = 256;
 const MAX_HIDDEN_FILE_BYTES: u64 = 1024 * 1024;
@@ -46,6 +46,7 @@ enum NativeEnumeration {
         truncated: bool,
         metadata_complete: bool,
         can_trash: Option<bool>,
+        can_delete: Option<bool>,
     },
     Failed(String),
     Cancelled,
@@ -109,6 +110,11 @@ fn info_is_symlink(info: &gio::FileInfo) -> bool {
 fn info_can_trash(info: &gio::FileInfo) -> Option<bool> {
     info.has_attribute(gio::FILE_ATTRIBUTE_ACCESS_CAN_TRASH)
         .then(|| info.boolean(gio::FILE_ATTRIBUTE_ACCESS_CAN_TRASH))
+}
+
+fn info_can_delete(info: &gio::FileInfo) -> Option<bool> {
+    info.has_attribute(gio::FILE_ATTRIBUTE_ACCESS_CAN_DELETE)
+        .then(|| info.boolean(gio::FILE_ATTRIBUTE_ACCESS_CAN_DELETE))
 }
 
 fn info_mode(info: &gio::FileInfo) -> MetadataValue<u32> {
@@ -308,19 +314,21 @@ fn scan_native_directory(
         });
     }
 
-    // `access::can-trash` describes the queried item, not its children. Probe one
-    // actual entry so a directory that cannot itself be removed (such as `$HOME`)
-    // does not incorrectly hide Trash for the entries it contains.
-    let can_trash = entries.first().and_then(|entry| {
+    // `access::can-trash`/`access::can-delete` describe the queried item, not its
+    // children. Probe one actual entry so a directory that cannot itself be removed
+    // (such as `$HOME`) does not incorrectly hide Trash/delete for the entries it
+    // contains.
+    let probed_capabilities = entries.first().and_then(|entry| {
         gio::File::for_path(entry.location.native_path()?)
             .query_info(
-                gio::FILE_ATTRIBUTE_ACCESS_CAN_TRASH,
+                "access::can-trash,access::can-delete",
                 gio::FileQueryInfoFlags::NONE,
                 Some(cancellable),
             )
             .ok()
-            .and_then(|info| info_can_trash(&info))
     });
+    let can_trash = probed_capabilities.as_ref().and_then(info_can_trash);
+    let can_delete = probed_capabilities.as_ref().and_then(info_can_delete);
 
     let mut metadata_complete = true;
     if request.include_metadata && !entries.is_empty() && Instant::now() < deadline {
@@ -352,6 +360,7 @@ fn scan_native_directory(
         truncated,
         metadata_complete,
         can_trash,
+        can_delete,
     }
 }
 
@@ -383,6 +392,7 @@ fn enumerate_native(
                 truncated,
                 metadata_complete,
                 can_trash,
+                can_delete,
             } => {
                 let total_entries = entries.len();
                 if !entries.is_empty() {
@@ -427,6 +437,7 @@ fn enumerate_native(
                     request_id,
                     truncated,
                     can_trash,
+                    can_delete,
                 });
             }
             NativeEnumeration::Failed(message) => {
@@ -512,25 +523,29 @@ impl FileSource for LocalFileSource {
                 .map(gio::File::for_path)
                 .unwrap_or_else(|| gio::File::for_uri(location.uri_value().unwrap_or_default()));
             let deadline = started + request.time_budget;
-            let finish_truncated =
-                |entries: usize, reason: &'static str, can_trash: Option<bool>| {
-                    tracing::warn!(
-                        request_id = request_id.0,
-                        entries,
-                        elapsed_ms = started.elapsed().as_millis() as u64,
-                        reason,
-                        "directory load truncated"
-                    );
-                    emit(DirectoryEvent::Finished {
-                        request_id,
-                        truncated: true,
-                        can_trash,
-                    });
-                };
+            let finish_truncated = |entries: usize,
+                                    reason: &'static str,
+                                    can_trash: Option<bool>,
+                                    can_delete: Option<bool>| {
+                tracing::warn!(
+                    request_id = request_id.0,
+                    entries,
+                    elapsed_ms = started.elapsed().as_millis() as u64,
+                    reason,
+                    "directory load truncated"
+                );
+                emit(DirectoryEvent::Finished {
+                    request_id,
+                    truncated: true,
+                    can_trash,
+                    can_delete,
+                });
+            };
             let mut can_trash = None;
+            let mut can_delete = None;
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
-                finish_truncated(0, "time budget", can_trash);
+                finish_truncated(0, "time budget", can_trash, can_delete);
                 return;
             }
             let attributes = if request.include_metadata {
@@ -563,7 +578,7 @@ impl FileSource for LocalFileSource {
                     return;
                 }
                 Err(_) => {
-                    finish_truncated(0, "time budget", can_trash);
+                    finish_truncated(0, "time budget", can_trash, can_delete);
                     return;
                 }
             };
@@ -573,7 +588,7 @@ impl FileSource for LocalFileSource {
             loop {
                 let remaining = deadline.saturating_duration_since(Instant::now());
                 if remaining.is_zero() {
-                    finish_truncated(total_entries, "time budget", can_trash);
+                    finish_truncated(total_entries, "time budget", can_trash, can_delete);
                     break;
                 }
                 match glib::future_with_timeout(
@@ -594,12 +609,16 @@ impl FileSource for LocalFileSource {
                             request_id,
                             truncated: false,
                             can_trash,
+                            can_delete,
                         });
                         break;
                     }
                     Ok(Ok(files)) => {
                         if can_trash.is_none() {
                             can_trash = files.iter().find_map(info_can_trash);
+                        }
+                        if can_delete.is_none() {
+                            can_delete = files.iter().find_map(info_can_delete);
                         }
                         let mut entries: Vec<_> = files
                             .into_iter()
@@ -626,7 +645,7 @@ impl FileSource for LocalFileSource {
                             entries,
                         });
                         if entry_budget_exhausted {
-                            finish_truncated(total_entries, "entry budget", can_trash);
+                            finish_truncated(total_entries, "entry budget", can_trash, can_delete);
                             break;
                         }
                     }
@@ -644,7 +663,7 @@ impl FileSource for LocalFileSource {
                         break;
                     }
                     Err(_) => {
-                        finish_truncated(total_entries, "time budget", can_trash);
+                        finish_truncated(total_entries, "time budget", can_trash, can_delete);
                         break;
                     }
                 }

--- a/src/adapters/local_files/tests.rs
+++ b/src/adapters/local_files/tests.rs
@@ -430,6 +430,13 @@ fn finished_can_trash(events: &[DirectoryEvent]) -> Option<Option<bool>> {
     })
 }
 
+fn finished_can_delete(events: &[DirectoryEvent]) -> Option<Option<bool>> {
+    events.iter().find_map(|event| match event {
+        DirectoryEvent::Finished { can_delete, .. } => Some(*can_delete),
+        _ => None,
+    })
+}
+
 #[test]
 fn enumerate_reports_truncated_once_the_entry_budget_is_exceeded() {
     let root = unique_fixture_root("entry-budget");
@@ -487,6 +494,34 @@ fn enumerate_resolves_can_trash_from_a_child_entry() {
     fs::remove_dir_all(&root).expect("the fixture directory should be removed");
 
     assert_eq!(finished_can_trash(&events), Some(Some(expected)));
+}
+
+#[test]
+fn enumerate_resolves_can_delete_from_a_child_entry() {
+    let root = unique_fixture_root("can-delete");
+    fs::create_dir_all(&root).expect("the fixture directory should be created");
+    let child = root.join("child.txt");
+    fs::write(&child, b"content").expect("the fixture file should be written");
+    let expected = gio::File::for_path(&child)
+        .query_info(
+            gio::FILE_ATTRIBUTE_ACCESS_CAN_DELETE,
+            gio::FileQueryInfoFlags::NONE,
+            None::<&gio::Cancellable>,
+        )
+        .expect("the child capability query should succeed")
+        .boolean(gio::FILE_ATTRIBUTE_ACCESS_CAN_DELETE);
+
+    let events = run_enumerate(DirectoryRequest {
+        id: RequestId(1),
+        location: Location::local(&root),
+        batch_size: 64,
+        include_metadata: false,
+        max_entries: 10,
+        time_budget: Duration::from_secs(10),
+    });
+    fs::remove_dir_all(&root).expect("the fixture directory should be removed");
+
+    assert_eq!(finished_can_delete(&events), Some(Some(expected)));
 }
 
 #[test]

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -418,6 +418,7 @@ struct SortPlan {
     retry_metadata: bool,
     truncated: bool,
     can_trash: Option<bool>,
+    can_delete: Option<bool>,
 }
 
 enum PublishTerminal {
@@ -433,6 +434,7 @@ enum RemoteTerminal {
         request_id: RequestId,
         truncated: bool,
         can_trash: Option<bool>,
+        can_delete: Option<bool>,
     },
     Failed {
         request_id: RequestId,
@@ -634,6 +636,10 @@ impl Browser {
 
     pub fn can_trash_at(&self, depth: usize) -> Option<bool> {
         self.state.borrow().can_trash_at(depth)
+    }
+
+    pub fn can_delete_at(&self, depth: usize) -> Option<bool> {
+        self.state.borrow().can_delete_at(depth)
     }
 
     pub fn focus_active(&self) {
@@ -2114,11 +2120,12 @@ impl Browser {
                 request_id,
                 truncated,
                 can_trash,
+                can_delete,
             } => {
                 let finished = self
                     .state
                     .borrow_mut()
-                    .finish(request_id, truncated, can_trash);
+                    .finish(request_id, truncated, can_trash, can_delete);
                 if let Some(depth) = finished {
                     self.emit(BrowserEvent::LoadFinished { depth, truncated });
                     self.ensure_sorted_after_load(depth);
@@ -2159,6 +2166,7 @@ impl Browser {
         request_id: RequestId,
         truncated: bool,
         can_trash: Option<bool>,
+        can_delete: Option<bool>,
     ) {
         let staging = self.staging.borrow_mut().remove(&depth);
         let Some(staging) = staging.filter(|staged| staged.request_id == request_id) else {
@@ -2196,6 +2204,7 @@ impl Browser {
                 retry_metadata,
                 truncated,
                 can_trash,
+                can_delete,
             },
         );
     }
@@ -2238,6 +2247,7 @@ impl Browser {
         let staged_preferences = plan.staged_preferences;
         let truncated = plan.truncated;
         let can_trash = plan.can_trash;
+        let can_delete = plan.can_delete;
         let retry_metadata = plan.retry_metadata;
         let sorting = self.sorting.borrow_mut().remove(&depth);
         let Some(sorting) = sorting.filter(|sorting| sorting.request_id == request_id) else {
@@ -2278,11 +2288,13 @@ impl Browser {
             {
                 self.state
                     .borrow_mut()
-                    .finish(request_id, truncated, can_trash);
+                    .finish(request_id, truncated, can_trash, can_delete);
                 self.emit(BrowserEvent::LoadFinished { depth, truncated });
                 self.ensure_sorted_after_load(depth);
             } else {
-                self.resort_installed_column(depth, request_id, current, truncated, can_trash);
+                self.resort_installed_column(
+                    depth, request_id, current, truncated, can_trash, can_delete,
+                );
             }
             return;
         }
@@ -2302,7 +2314,7 @@ impl Browser {
             .unwrap_or(0);
         self.state
             .borrow_mut()
-            .finish(request_id, truncated, can_trash);
+            .finish(request_id, truncated, can_trash, can_delete);
         self.publish_staged(
             depth,
             request_id,
@@ -2323,6 +2335,7 @@ impl Browser {
         preferences: ViewPreferences,
         truncated: bool,
         can_trash: Option<bool>,
+        can_delete: Option<bool>,
     ) {
         let Some(entries) = self
             .state
@@ -2350,6 +2363,7 @@ impl Browser {
                 retry_metadata: false,
                 truncated,
                 can_trash,
+                can_delete,
             },
         );
     }
@@ -3226,6 +3240,7 @@ impl Browser {
                 request_id,
                 truncated,
                 can_trash,
+                can_delete,
             } => {
                 // Bound to a variable first: an if-let scrutinee borrow would stay live
                 // across the flush and panic inside it.
@@ -3234,7 +3249,9 @@ impl Browser {
                 match (target, open) {
                     (Some((depth, true)), Some(_)) => {
                         self.stage_batch(request_id, depth, Vec::new());
-                        self.finish_staged_load(depth, request_id, truncated, can_trash);
+                        self.finish_staged_load(
+                            depth, request_id, truncated, can_trash, can_delete,
+                        );
                     }
                     (Some((depth, _)), Some(_)) => {
                         self.remote_terminals.borrow_mut().insert(
@@ -3243,6 +3260,7 @@ impl Browser {
                                 request_id,
                                 truncated,
                                 can_trash,
+                                can_delete,
                             },
                         );
                         self.flush_coalesced_capped(Some(depth));

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -111,6 +111,7 @@ impl FileSource for WatchingFileSource {
             request_id: request.id,
             truncated: false,
             can_trash: None,
+            can_delete: None,
         });
         LoadHandle::new(|| {})
     }
@@ -187,6 +188,7 @@ impl FileSource for RetryFileSource {
                 request_id: request.id,
                 truncated: false,
                 can_trash: None,
+                can_delete: None,
             });
         }
         LoadHandle::new(|| {})
@@ -244,6 +246,7 @@ impl FileSource for FilePreviewSource {
             request_id: request.id,
             truncated: false,
             can_trash: None,
+            can_delete: None,
         });
         LoadHandle::new(|| {})
     }
@@ -273,6 +276,7 @@ impl FileSource for RestoredSortingSource {
             request_id: request.id,
             truncated: false,
             can_trash: None,
+            can_delete: None,
         });
         LoadHandle::new(|| {})
     }
@@ -301,6 +305,7 @@ impl FileSource for FakeFileSource {
             request_id: request.id,
             truncated: false,
             can_trash: None,
+            can_delete: None,
         });
         LoadHandle::new(|| {})
     }
@@ -331,6 +336,7 @@ impl FileSource for TrashFileSource {
             request_id: request.id,
             truncated: false,
             can_trash: None,
+            can_delete: None,
         });
         LoadHandle::new(|| {})
     }
@@ -351,6 +357,7 @@ impl FileSource for CountingFileSource {
             request_id: request.id,
             truncated: false,
             can_trash: None,
+            can_delete: None,
         });
         LoadHandle::new(|| {})
     }
@@ -1950,6 +1957,7 @@ impl FileSource for SortFillSource {
             request_id: request.id,
             truncated: false,
             can_trash: None,
+            can_delete: None,
         });
         LoadHandle::new(|| {})
     }
@@ -2088,6 +2096,7 @@ fn load_finish_applies_rows_queued_behind_the_count_threshold() {
         request_id,
         truncated: false,
         can_trash: None,
+        can_delete: None,
     });
 
     let names: Vec<_> = browser.state.borrow().columns[0]
@@ -2136,6 +2145,7 @@ fn remote_load_finishes_only_after_every_queued_row_is_applied() {
         request_id,
         truncated: false,
         can_trash: None,
+        can_delete: None,
     });
 
     assert!(
@@ -2368,6 +2378,7 @@ impl FileSource for ScriptedSource {
             request_id: request.id,
             truncated: false,
             can_trash: None,
+            can_delete: None,
         });
         LoadHandle::new(|| {})
     }
@@ -2781,6 +2792,7 @@ fn refresh_drops_staging_and_its_sort() {
         request_id,
         truncated: false,
         can_trash: None,
+        can_delete: None,
     });
     assert_eq!(replaced_count(&events), 1);
     assert_eq!(
@@ -2818,6 +2830,7 @@ fn close_column_clears_the_truncated_depth() {
         request_id,
         truncated: false,
         can_trash: None,
+        can_delete: None,
     });
 
     browser.descend(0, Location::local("/fixture/sub"));
@@ -2830,6 +2843,7 @@ fn close_column_clears_the_truncated_depth() {
         request_id: sub_id,
         truncated: false,
         can_trash: None,
+        can_delete: None,
     });
     let published = replaced_count(&events);
     assert_eq!(published, 2);
@@ -3151,6 +3165,7 @@ fn native_initial_load_publishes_sorted_once() {
         request_id,
         truncated: false,
         can_trash: None,
+        can_delete: None,
     });
     assert_eq!(replaced_count(&events), 1);
     assert_eq!(
@@ -3176,6 +3191,7 @@ fn empty_native_initial_load_finishes_without_a_batch() {
         request_id,
         truncated: false,
         can_trash: None,
+        can_delete: None,
     });
 
     assert_eq!(replaced_count(&events), 1);
@@ -3216,6 +3232,7 @@ fn incomplete_native_metadata_uses_name_order_until_a_full_retry_finishes() {
         request_id,
         truncated: false,
         can_trash: None,
+        can_delete: None,
     });
 
     assert_eq!(
@@ -3264,6 +3281,7 @@ fn staged_load_reconciles_monitor_deltas_without_resurrection() {
         request_id,
         truncated: false,
         can_trash: None,
+        can_delete: None,
     });
     assert_eq!(
         column_names(&browser, 0),
@@ -3403,6 +3421,7 @@ fn staged_sorts_order_every_key_in_both_directions() {
             request_id,
             truncated: false,
             can_trash: None,
+            can_delete: None,
         });
         assert_eq!(
             column_names(&browser, 0),
@@ -3444,6 +3463,7 @@ fn large_load_streams_prefix_then_tails_with_terminal_last() {
         request_id,
         truncated: false,
         can_trash: None,
+        can_delete: None,
     });
     pump_until(|| {
         events
@@ -3521,6 +3541,7 @@ fn remote_rows_flush_within_the_latency_bound() {
         request_id,
         truncated: false,
         can_trash: None,
+        can_delete: None,
     });
     assert!(
         events
@@ -3566,6 +3587,7 @@ fn resort_after_mid_load_preference_change_republishes() {
             retry_metadata: false,
             truncated: false,
             can_trash: None,
+            can_delete: None,
         },
     );
     assert_eq!(
@@ -3617,6 +3639,7 @@ impl FileSource for MixedPeekFileSource {
             request_id: request.id,
             truncated: false,
             can_trash: None,
+            can_delete: None,
         });
         LoadHandle::new(|| {})
     }

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -47,6 +47,9 @@ pub struct ColumnState {
     /// the first load finishes, for an empty directory, or when the capability
     /// couldn't be answered; treated as "assume trashable" by consumers.
     pub can_trash: Option<bool>,
+    /// Whether entries here can be permanently deleted, resolved the same way
+    /// as `can_trash`. `None` carries the same "assume deletable" meaning.
+    pub can_delete: Option<bool>,
     preferences: ViewPreferences,
     request_id: RequestId,
     select_first_on_load: bool,
@@ -174,6 +177,7 @@ impl NavigationState {
                 load_state: LoadState::Loading,
                 truncated: false,
                 can_trash: None,
+                can_delete: None,
                 preferences,
                 request_id,
                 select_first_on_load: false,
@@ -243,6 +247,7 @@ impl NavigationState {
             load_state: LoadState::Loading,
             truncated: false,
             can_trash: None,
+            can_delete: None,
             preferences: self.preferences,
             request_id,
             select_first_on_load: false,
@@ -485,6 +490,7 @@ impl NavigationState {
         column.load_state = LoadState::Loading;
         column.truncated = false;
         column.can_trash = None;
+        column.can_delete = None;
         column.request_id = request_id;
         Some(column.location.clone())
     }
@@ -587,16 +593,22 @@ impl NavigationState {
         self.columns.get(depth)?.can_trash
     }
 
+    pub fn can_delete_at(&self, depth: usize) -> Option<bool> {
+        self.columns.get(depth)?.can_delete
+    }
+
     pub fn finish(
         &mut self,
         request_id: RequestId,
         truncated: bool,
         can_trash: Option<bool>,
+        can_delete: Option<bool>,
     ) -> Option<usize> {
         let (depth, column) = self.column_for_request_mut(request_id)?;
         column.select_first_on_load = false;
         column.truncated = truncated;
         column.can_trash = can_trash;
+        column.can_delete = can_delete;
         column.load_state = if column.entries.is_empty() {
             LoadState::Empty
         } else {

--- a/src/app/navigation/tests.rs
+++ b/src/app/navigation/tests.rs
@@ -320,7 +320,7 @@ fn empty_is_distinct_from_loading_and_error() {
     state.navigate(location("/empty"), RequestId(1));
     assert_eq!(state.columns[0].load_state, LoadState::Loading);
 
-    assert_eq!(state.finish(RequestId(1), false, None), Some(0));
+    assert_eq!(state.finish(RequestId(1), false, None, None), Some(0));
     assert_eq!(state.columns[0].load_state, LoadState::Empty);
 }
 
@@ -329,7 +329,7 @@ fn truncated_load_state_survives_until_reload() {
     let mut state = NavigationState::default();
     state.navigate(location("/partial"), RequestId(1));
 
-    assert_eq!(state.finish(RequestId(1), true, None), Some(0));
+    assert_eq!(state.finish(RequestId(1), true, None, None), Some(0));
     assert!(state.columns[0].truncated);
 
     state.reload_column(0, RequestId(2));

--- a/src/app/navigation/tests.rs
+++ b/src/app/navigation/tests.rs
@@ -337,6 +337,21 @@ fn truncated_load_state_survives_until_reload() {
 }
 
 #[test]
+fn reload_clears_the_resolved_delete_capability() {
+    let mut state = NavigationState::default();
+    state.navigate(location("/fixture"), RequestId(1));
+
+    assert_eq!(
+        state.finish(RequestId(1), false, None, Some(false)),
+        Some(0)
+    );
+    assert_eq!(state.can_delete_at(0), Some(false));
+
+    state.reload_column(0, RequestId(2));
+    assert_eq!(state.can_delete_at(0), None);
+}
+
+#[test]
 fn navigation_availability_tracks_history_and_parent() {
     let mut state = NavigationState::default();
     assert!(!state.can_go_back());

--- a/src/services/file_source.rs
+++ b/src/services/file_source.rs
@@ -190,6 +190,9 @@ pub enum DirectoryEvent {
         /// couldn't be answered; treated as "assume trashable" by consumers, since that
         /// matches offering Trash and letting the operation itself fail if unsupported.
         can_trash: Option<bool>,
+        /// Whether entries here can be permanently deleted, resolved the same way as
+        /// `can_trash`. `None` carries the same "assume deletable" meaning.
+        can_delete: Option<bool>,
     },
     /// Consumers must not present these partial values as a completed sort.
     MetadataIncomplete { request_id: RequestId },

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -9556,12 +9556,8 @@ fn move_to_trash_is_visible(in_trash: bool, can_trash: Option<bool>) -> bool {
     in_trash || can_trash.unwrap_or(true)
 }
 
-/// Whether the separate "Permanently delete" context-menu option should be
-/// shown. Hidden while browsing Trash, where "Move to Trash" already serves as
-/// permanent delete under a shared label. Otherwise, visible unless the
-/// location's `access::can-delete` check came back a definite `Some(false)`;
-/// `None` defaults to visible, matching `move_to_trash_is_visible`'s
-/// safer-fallback rationale.
+/// Hidden in Trash, where the shared delete action is already permanent, or
+/// when GIO confirms deletion is unsupported.
 fn permanently_delete_is_visible(in_trash: bool, can_delete: Option<bool>) -> bool {
     !in_trash && can_delete.unwrap_or(true)
 }

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -6987,8 +6987,10 @@ pub(super) fn install_item_context_menu(
         let trash_visible = move_to_trash_is_visible(in_trash, state.browser.can_trash_at(depth));
         move_to_trash.set_visible(trash_visible);
         trash_multiple.set_visible(trash_visible);
-        permanent_delete.set_visible(!in_trash);
-        permanent_delete_multiple.set_visible(!in_trash);
+        let permanent_delete_visible =
+            permanently_delete_is_visible(in_trash, state.browser.can_delete_at(depth));
+        permanent_delete.set_visible(permanent_delete_visible);
+        permanent_delete_multiple.set_visible(permanent_delete_visible);
         pin.set_visible(entry.is_directory() && !is_trash_location(&entry.location));
         pin.set_sensitive(
             state
@@ -9444,6 +9446,16 @@ fn is_trash_location(location: &Location) -> bool {
 /// delete option this menu has.
 fn move_to_trash_is_visible(in_trash: bool, can_trash: Option<bool>) -> bool {
     in_trash || can_trash.unwrap_or(true)
+}
+
+/// Whether the separate "Permanently delete" context-menu option should be
+/// shown. Hidden while browsing Trash, where "Move to Trash" already serves as
+/// permanent delete under a shared label. Otherwise, visible unless the
+/// location's `access::can-delete` check came back a definite `Some(false)`;
+/// `None` defaults to visible, matching `move_to_trash_is_visible`'s
+/// safer-fallback rationale.
+fn permanently_delete_is_visible(in_trash: bool, can_delete: Option<bool>) -> bool {
+    !in_trash && can_delete.unwrap_or(true)
 }
 
 fn compact_display_path(location: &Location) -> String {

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1626,8 +1626,6 @@ fn permanently_delete_defaults_to_visible_before_the_check_resolves() {
 
 #[test]
 fn permanently_delete_hides_inside_trash_regardless_of_can_delete() {
-    // Inside Trash, "Move to Trash" already serves as permanent delete under a
-    // shared label, so this separate option would be redundant.
     assert!(!permanently_delete_is_visible(true, Some(true)));
     assert!(!permanently_delete_is_visible(true, None));
 }

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1561,6 +1561,29 @@ fn move_to_trash_stays_visible_inside_trash_regardless_of_can_trash() {
     assert!(move_to_trash_is_visible(true, None));
 }
 
+#[test]
+fn permanently_delete_hides_only_for_a_confirmed_unsupported_location() {
+    assert!(!permanently_delete_is_visible(false, Some(false)));
+}
+
+#[test]
+fn permanently_delete_shows_for_a_confirmed_supported_location() {
+    assert!(permanently_delete_is_visible(false, Some(true)));
+}
+
+#[test]
+fn permanently_delete_defaults_to_visible_before_the_check_resolves() {
+    assert!(permanently_delete_is_visible(false, None));
+}
+
+#[test]
+fn permanently_delete_hides_inside_trash_regardless_of_can_delete() {
+    // Inside Trash, "Move to Trash" already serves as permanent delete under a
+    // shared label, so this separate option would be redundant.
+    assert!(!permanently_delete_is_visible(true, Some(true)));
+    assert!(!permanently_delete_is_visible(true, None));
+}
+
 fn mapped_source(values: &[&str]) -> EntryListModel {
     let owned: Vec<String> = values.iter().map(|value| (*value).to_owned()).collect();
     let model = EntryListModel::new(std::rc::Rc::new(move |position| {


### PR DESCRIPTION
## Description

First slice of #66. "Permanently delete" was always offered in the context menu regardless of backend support, unlike "Move to Trash" which already hides itself when `access::can-trash` reports false (#179/#225).

This extends the same query and plumbing (`DirectoryEvent::Finished`, per-column state, `can_trash_at`) to `access::can-delete`, adding a parallel `can_delete`/`can_delete_at`, and hides "Permanently delete" the same way "Move to Trash" already is, except while already browsing Trash, where "Move to Trash" serves as permanent delete under a shared label.

## Scope

In scope: capability-gating for the "Permanently delete" context-menu action specifically.

Out of scope, left for follow-up PRs against #66: gating create, rename, copy/move, and duplicate; applying gating to keyboard shortcuts, toolbar actions, clipboard paste, and drag/drop (today only the context menu is gated, matching how "Move to Trash" itself was first introduced).

## How to test

1. Create a directory and remove write permission from it (e.g. `chmod 555 some-dir`), so `access::can-delete` and `access::can-trash` both report false for its contents.
2. Right-click a file inside it in Strata.

**Expected result:** neither "Move to Trash" nor "Permanently delete" appear in the context menu.

I verified this exact scenario locally (both options correctly disappear together), plus the existing automated suite (4 new unit tests covering the visibility function directly).

## Related issue

Refs #66