### PR TITLE
fix(browser): resolve delete targets from the focused pane

### DIFF
--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -1087,14 +1087,24 @@ impl Browser {
         self.state.borrow().selected_entries()
     }
 
-    pub fn deletion_entries(&self) -> Vec<FileEntry> {
+    /// `depth` should be the pane that actually holds keyboard focus, when the caller
+    /// knows it; the model's own `active_depth` can lag behind it (e.g. a stale
+    /// selection left over in another column), which would otherwise point a
+    /// destructive action away from where the user is actually looking.
+    pub fn deletion_entries(&self, depth: Option<usize>) -> Vec<FileEntry> {
         let state = self.state.borrow();
-        let selected = state.selected_entries();
-        if !selected.is_empty() {
-            return selected;
+        let depth = depth.or_else(|| state.active_depth());
+        if let Some(depth) = depth {
+            let positions = state.selected_positions(depth);
+            if !positions.is_empty() {
+                return positions
+                    .into_iter()
+                    .filter_map(|position| state.entry_at(depth, position))
+                    .collect();
+            }
         }
 
-        let Some(parent_depth) = state.active_depth().and_then(|depth| depth.checked_sub(1)) else {
+        let Some(parent_depth) = depth.and_then(|depth| depth.checked_sub(1)) else {
             return Vec::new();
         };
         let Some(position) = state.active_child_position(parent_depth) else {

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -306,6 +306,39 @@ impl FileSource for FakeFileSource {
     }
 }
 
+/// Unlike `FakeFileSource`, returns a "leaf" entry whose location is derived from the
+/// requested directory, so tests can tell which column's entries they actually got back.
+struct DepthAwareFileSource;
+
+impl FileSource for DepthAwareFileSource {
+    fn validate_location(&self, _location: &Location) -> Result<(), LocationValidationError> {
+        Ok(())
+    }
+
+    fn enumerate(&self, request: DirectoryRequest, emit: Rc<dyn Fn(DirectoryEvent)>) -> LoadHandle {
+        let location = Location::local(format!("{}/leaf", request.location.display_path()));
+        emit(DirectoryEvent::Batch {
+            request_id: request.id,
+            entries: vec![FileEntry {
+                location,
+                native_name: OsString::from("leaf"),
+                display_name: "leaf".into(),
+                kind: EntryKind::File,
+                size: MetadataValue::Unknown,
+                modified_unix_seconds: MetadataValue::Unknown,
+                is_hidden: false,
+                mode: MetadataValue::Unknown,
+            }],
+        });
+        emit(DirectoryEvent::Finished {
+            request_id: request.id,
+            truncated: false,
+            can_trash: None,
+        });
+        LoadHandle::new(|| {})
+    }
+}
+
 struct TrashFileSource;
 
 impl FileSource for TrashFileSource {
@@ -1225,10 +1258,31 @@ fn deletion_targets_the_entered_folder_when_the_child_has_no_selection() {
     browser.select(0, 0);
     browser.descend(0, Location::local("/fixture/child"));
 
-    let entries = browser.deletion_entries();
+    let entries = browser.deletion_entries(None);
 
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0].location, Location::local("/fixture/child"));
+}
+
+#[test]
+fn deletion_entries_prefer_an_explicitly_focused_pane_over_the_model_active_depth() {
+    let browser = Browser::new(Rc::new(DepthAwareFileSource));
+    browser.navigate(Location::local("/fixture"));
+    browser.select(0, 0);
+    browser.descend(0, Location::local("/fixture/child"));
+    browser.select(1, 0);
+
+    // The model's own bookkeeping has moved on to the child column...
+    assert_eq!(
+        browser.deletion_entries(None)[0].location,
+        Location::local("/fixture/child/leaf")
+    );
+    // ...but a caller that knows keyboard focus is still on the parent column must
+    // have its selection there honored instead.
+    assert_eq!(
+        browser.deletion_entries(Some(0))[0].location,
+        Location::local("/fixture/leaf")
+    );
 }
 
 #[test]

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -1039,13 +1039,13 @@ impl BrowserView {
 
     pub fn confirm_delete(&self, permanent: bool) -> bool {
         self.state.sync_mode_selection();
-        let entries = self.state.browser.deletion_entries();
+        let focused_depth = self.state.focused_column_depth();
+        let depth = delete_target_depth(focused_depth, self.state.browser.active_depth());
+        let entries = self.state.browser.deletion_entries(depth);
         if entries.is_empty() {
             return false;
         }
-        let in_trash = self
-            .state
-            .focused_column_depth()
+        let in_trash = focused_depth
             .and_then(|depth| self.state.browser.location_at(depth))
             .or_else(|| self.state.browser.active_location())
             .as_ref()
@@ -8029,6 +8029,13 @@ fn new_folder_destination_depth(
         .filter(|depth| *depth < pane_count)
         .or_else(|| active.filter(|depth| *depth < pane_count))
         .or_else(|| pane_count.checked_sub(1))
+}
+
+/// Delete must act on the pane the keyboard is actually in, not wherever the model's
+/// bookkeeping last landed; falling back to `active` only when nothing is focused
+/// (e.g. a single-pane mode) keeps the destructive command aimed at what the user sees.
+fn delete_target_depth(focused: Option<usize>, active: Option<usize>) -> Option<usize> {
+    focused.or(active)
 }
 
 fn terminal_destination_depth(

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -828,6 +828,13 @@ fn new_folder_prefers_the_focused_pane_then_falls_back_safely() {
 }
 
 #[test]
+fn delete_prefers_the_focused_pane_then_falls_back_to_the_active_depth() {
+    assert_eq!(delete_target_depth(Some(0), Some(1)), Some(0));
+    assert_eq!(delete_target_depth(None, Some(1)), Some(1));
+    assert_eq!(delete_target_depth(None, None), None);
+}
+
+#[test]
 fn open_terminal_prefers_the_hovered_pane_then_falls_back_safely() {
     assert_eq!(
         terminal_destination_depth(Some(1), Some(0), Some(2), 3),


### PR DESCRIPTION
## Description

In Columns mode, `confirm_delete` picked its target column from the model's `active_column` bookkeeping instead of the pane that actually holds GTK keyboard focus. Those two can diverge, and Columns already leaves a breadcrumb-style highlight on the folder row in every ancestor column you drilled through, so several columns can look "selected" at once with no clear signal of which one Delete will act on.

`confirm_delete` now resolves the target depth from real keyboard focus first (`focused_column_depth()`), and only falls back to the model's active depth when nothing is focused (single-pane Explorer/Grid). The existing behavior of falling back to the navigated-into folder when the focused pane has no explicit selection is unchanged, just anchored to the real focused depth instead of the model's.

Per @l0gicgate's note on the issue, the `#291` branch will separately add a guard so an *empty* focused column doesn't fall back to its parent at all — that's out of scope here.

## Visual evidence

N/A — this changes which pane a keyboard shortcut resolves against internally; the dialog that appears looks identical either way. The behavior difference only shows up when the model's bookkeeping and actual keyboard focus disagree, which isn't something a screenshot can distinguish from the correct case.

## How to test

1. Open a folder with at least two subfolders in Columns view.
2. Use the arrow keys to descend into a subfolder (`Right`), then move focus back to the parent column (`Left`) without closing the child column.
3. Press `Delete`.

**Expected result:** the confirmation dialog names the row that has actual keyboard focus in the parent column, not whatever the child column happens to show highlighted.

The regression this guards against is covered directly by two new tests that force the model's active depth and the caller-supplied focused depth to disagree:
- `deletion_entries_prefer_an_explicitly_focused_pane_over_the_model_active_depth` (`src/app/browser/tests.rs`)
- `delete_prefers_the_focused_pane_then_falls_back_to_the_active_depth` (`src/ui/browser/tests.rs`)

## Related issue

Closes #300