### PR TITLE
fix(transfer): report live copy and move progress

### DIFF
--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -62,6 +62,175 @@ fn gio_file(location: &Location) -> gio::File {
         .unwrap_or_else(|| gio::File::for_uri(location.uri_value().unwrap_or_default()))
 }
 
+struct TransferProgressTracker {
+    request_id: OperationRequestId,
+    completed_items: Cell<usize>,
+    transferred_bytes: Cell<u64>,
+    total_bytes: Option<u64>,
+    emit: Rc<dyn Fn(OperationEvent)>,
+}
+
+impl TransferProgressTracker {
+    fn new(
+        request_id: OperationRequestId,
+        total_bytes: Option<u64>,
+        emit: Rc<dyn Fn(OperationEvent)>,
+    ) -> Rc<Self> {
+        Rc::new(Self {
+            request_id,
+            completed_items: Cell::new(0),
+            transferred_bytes: Cell::new(0),
+            total_bytes,
+            emit,
+        })
+    }
+
+    fn emit(&self) {
+        (self.emit)(OperationEvent::TransferProgress {
+            request_id: self.request_id,
+            completed_items: self.completed_items.get(),
+            transferred_bytes: self.transferred_bytes.get(),
+            total_bytes: self.total_bytes,
+        });
+    }
+
+    fn add_bytes(&self, bytes: u64) {
+        self.transferred_bytes
+            .set(self.transferred_bytes.get().saturating_add(bytes));
+        self.emit();
+    }
+
+    fn begin_file(self: &Rc<Self>) -> FileTransferProgress {
+        FileTransferProgress {
+            tracker: self.clone(),
+            reported_bytes: Rc::new(Cell::new(0)),
+            reported_total: Rc::new(Cell::new(0)),
+        }
+    }
+
+    fn finish_item(&self, started_at: u64, expected_bytes: Option<u64>) {
+        if let Some(expected_bytes) = expected_bytes {
+            let expected_end = started_at.saturating_add(expected_bytes);
+            if self.transferred_bytes.get() < expected_end {
+                self.transferred_bytes.set(expected_end);
+            }
+        }
+        self.completed_items
+            .set(self.completed_items.get().saturating_add(1));
+        self.emit();
+    }
+}
+
+struct FileTransferProgress {
+    tracker: Rc<TransferProgressTracker>,
+    reported_bytes: Rc<Cell<u64>>,
+    reported_total: Rc<Cell<u64>>,
+}
+
+impl FileTransferProgress {
+    fn callback(&self) -> Box<dyn FnMut(i64, i64)> {
+        let tracker = self.tracker.clone();
+        let reported_bytes = self.reported_bytes.clone();
+        let reported_total = self.reported_total.clone();
+        Box::new(move |current, total| {
+            let current = current.max(0) as u64;
+            let previous = reported_bytes.get();
+            if current > previous {
+                reported_bytes.set(current);
+            }
+            if total >= 0 {
+                reported_total.set(reported_total.get().max(total as u64));
+            }
+            tracker.add_bytes(current.saturating_sub(previous));
+        })
+    }
+
+    fn finish(&self) {
+        let final_bytes = self.reported_total.get().max(self.reported_bytes.get());
+        let missing = final_bytes.saturating_sub(self.reported_bytes.get());
+        if missing > 0 {
+            self.tracker.add_bytes(missing);
+            self.reported_bytes.set(final_bytes);
+        }
+    }
+}
+
+fn transfer_size(
+    file: gio::File,
+    cancellable: gio::Cancellable,
+) -> Pin<Box<dyn Future<Output = Result<Option<u64>, glib::Error>>>> {
+    Box::pin(async move {
+        let info = await_cancellable(&file, &cancellable, |file, cancellable, result| {
+            file.query_info_async(
+                "standard::type,standard::size",
+                gio::FileQueryInfoFlags::NOFOLLOW_SYMLINKS,
+                glib::Priority::DEFAULT,
+                Some(cancellable),
+                move |output| result.resolve(output),
+            );
+        })
+        .await?;
+        if info.file_type() != gio::FileType::Directory {
+            return Ok(info
+                .has_attribute(gio::FILE_ATTRIBUTE_STANDARD_SIZE)
+                .then(|| info.size().max(0) as u64));
+        }
+
+        let enumerator = await_cancellable(&file, &cancellable, |file, cancellable, result| {
+            file.enumerate_children_async(
+                "standard::name",
+                gio::FileQueryInfoFlags::NOFOLLOW_SYMLINKS,
+                glib::Priority::DEFAULT,
+                Some(cancellable),
+                move |output| result.resolve(output),
+            );
+        })
+        .await?;
+        let mut total = Some(0_u64);
+        loop {
+            let children = await_cancellable(
+                &enumerator,
+                &cancellable,
+                |enumerator, cancellable, result| {
+                    enumerator.next_files_async(
+                        64,
+                        glib::Priority::DEFAULT,
+                        Some(cancellable),
+                        move |output| result.resolve(output),
+                    );
+                },
+            )
+            .await?;
+            if children.is_empty() {
+                return Ok(total);
+            }
+            for child in children {
+                let child_size =
+                    transfer_size(file.child(child.name()), cancellable.clone()).await?;
+                total = total.and_then(|total| child_size.and_then(|size| total.checked_add(size)));
+            }
+        }
+    })
+}
+
+async fn transfer_sizes(
+    files: &[gio::File],
+    cancellable: &gio::Cancellable,
+) -> Result<(Vec<Option<u64>>, Option<u64>), glib::Error> {
+    let mut sizes = Vec::with_capacity(files.len());
+    let mut total = Some(0_u64);
+    for file in files {
+        let size = match transfer_size(file.clone(), cancellable.clone()).await {
+            Ok(size) => size,
+            Err(error) if was_cancelled(&error) => return Err(error),
+            Err(_) => None,
+        };
+        total = total.and_then(|total| size.and_then(|size| total.checked_add(size)));
+        sizes.push(size);
+    }
+    Ok((sizes, total))
+}
+
 fn validated_child(parent: &gio::File, name: &str) -> Result<gio::File, &'static str> {
     validate_basename(name)?;
     Ok(parent.child(name))
@@ -295,6 +464,7 @@ fn copy_recursively_local(
     overwrite_existing: bool,
     cancellable: gio::Cancellable,
     created_root: Option<Rc<CreatedCopyRoot>>,
+    progress: Option<Rc<TransferProgressTracker>>,
 ) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>> {
     Box::pin(async move {
         if cancellable.is_cancelled() {
@@ -329,6 +499,8 @@ fn copy_recursively_local(
                     } else {
                         gio::FileCopyFlags::NONE
                     };
+                let file_progress = progress.as_ref().map(TransferProgressTracker::begin_file);
+                let progress_callback = file_progress.as_ref().map(FileTransferProgress::callback);
                 let result = await_cancellable(
                     &source_ref,
                     &cancellable,
@@ -338,12 +510,17 @@ fn copy_recursively_local(
                             flags,
                             glib::Priority::DEFAULT,
                             Some(cancellable),
-                            None,
+                            progress_callback,
                             move |output| result.resolve(output),
                         );
                     },
                 )
                 .await;
+                if result.is_ok()
+                    && let Some(file_progress) = file_progress
+                {
+                    file_progress.finish();
+                }
                 // Keeps `file` open (and its fd number stable) for the
                 // duration of the copy above; only drop it once resolved.
                 drop(file);
@@ -374,6 +551,7 @@ fn copy_recursively_local(
                         overwrite_existing,
                         cancellable.clone(),
                         None,
+                        progress.clone(),
                     )
                     .await?;
                 }
@@ -392,6 +570,7 @@ fn copy_recursively_local_path(
     overwrite_existing: bool,
     cancellable: gio::Cancellable,
     created_root: Option<Rc<CreatedCopyRoot>>,
+    progress: Option<Rc<TransferProgressTracker>>,
 ) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>> {
     Box::pin(async move {
         let Some(parent_path) = source_path.parent().map(Path::to_path_buf) else {
@@ -419,17 +598,19 @@ fn copy_recursively_local_path(
             overwrite_existing,
             cancellable,
             created_root,
+            progress,
         )
         .await
     })
 }
 
-fn copy_recursively(
+fn copy_recursively_with_progress(
     source: gio::File,
     target: gio::File,
     overwrite_existing: bool,
     cancellable: gio::Cancellable,
     created_root: Option<Rc<CreatedCopyRoot>>,
+    progress: Option<Rc<TransferProgressTracker>>,
 ) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>> {
     if source.is_native()
         && target.is_native()
@@ -444,6 +625,7 @@ fn copy_recursively(
             overwrite_existing,
             cancellable,
             created_root,
+            progress,
         );
     }
     Box::pin(async move {
@@ -498,12 +680,13 @@ fn copy_recursively(
                     break;
                 }
                 for child in children {
-                    copy_recursively(
+                    copy_recursively_with_progress(
                         source.child(child.name()),
                         target.child(child.name()),
                         overwrite_existing,
                         cancellable.clone(),
                         None,
+                        progress.clone(),
                     )
                     .await?;
                 }
@@ -517,25 +700,53 @@ fn copy_recursively(
                 } else {
                     gio::FileCopyFlags::NONE
                 };
-            await_cancellable(&source, &cancellable, move |source, cancellable, result| {
-                source.copy_async(
-                    &target,
-                    flags,
-                    glib::Priority::DEFAULT,
-                    Some(cancellable),
-                    None,
-                    move |output| result.resolve(output),
-                );
-            })
-            .await
+            let file_progress = progress.as_ref().map(TransferProgressTracker::begin_file);
+            let progress_callback = file_progress.as_ref().map(FileTransferProgress::callback);
+            let result =
+                await_cancellable(&source, &cancellable, move |source, cancellable, result| {
+                    source.copy_async(
+                        &target,
+                        flags,
+                        glib::Priority::DEFAULT,
+                        Some(cancellable),
+                        progress_callback,
+                        move |output| result.resolve(output),
+                    );
+                })
+                .await;
+            if result.is_ok()
+                && let Some(file_progress) = file_progress
+            {
+                file_progress.finish();
+            }
+            result
         }
     })
 }
 
-async fn copy_new_recursively(
+#[cfg(test)]
+fn copy_recursively(
+    source: gio::File,
+    target: gio::File,
+    overwrite_existing: bool,
+    cancellable: gio::Cancellable,
+    created_root: Option<Rc<CreatedCopyRoot>>,
+) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>> {
+    copy_recursively_with_progress(
+        source,
+        target,
+        overwrite_existing,
+        cancellable,
+        created_root,
+        None,
+    )
+}
+
+async fn copy_new_recursively_with_progress(
     source: gio::File,
     target: gio::File,
     cancellable: gio::Cancellable,
+    progress: Option<Rc<TransferProgressTracker>>,
 ) -> Result<(), glib::Error> {
     if source.is_native()
         && target.is_native()
@@ -558,12 +769,13 @@ async fn copy_new_recursively(
                 .parent()
                 .ok_or_else(|| io_error("The destination has no parent directory"))?;
             let staged = StagedSibling::create(parent, true).map_err(io_error)?;
-            if let Err(error) = copy_recursively(
+            if let Err(error) = copy_recursively_with_progress(
                 source,
                 gio::File::for_path(staged.path()),
                 true,
                 cancellable.clone(),
                 None,
+                progress.clone(),
             )
             .await
             {
@@ -603,12 +815,13 @@ async fn copy_new_recursively(
     }
 
     let created_root = Rc::new(CreatedCopyRoot::new());
-    let result = copy_recursively(
+    let result = copy_recursively_with_progress(
         source,
         target.clone(),
         false,
         cancellable.clone(),
         Some(created_root.clone()),
+        progress,
     )
     .await;
     if result.as_ref().is_err_and(was_cancelled) && created_root.was_created.get() {
@@ -624,6 +837,15 @@ async fn copy_new_recursively(
     result
 }
 
+#[cfg(test)]
+async fn copy_new_recursively(
+    source: gio::File,
+    target: gio::File,
+    cancellable: gio::Cancellable,
+) -> Result<(), glib::Error> {
+    copy_new_recursively_with_progress(source, target, cancellable, None).await
+}
+
 type MoveAttempt = Rc<
     dyn Fn(
         gio::File,
@@ -632,17 +854,24 @@ type MoveAttempt = Rc<
     ) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>>,
 >;
 
-async fn move_local_with(
+async fn move_local_with_progress(
     source: gio::File,
     target: gio::File,
     cancellable: gio::Cancellable,
+    progress: Option<Rc<TransferProgressTracker>>,
     attempt_move: MoveAttempt,
 ) -> Result<(), glib::Error> {
     let source_identity = local_file_identity(&source).await?;
     let result = attempt_move(source.clone(), target.clone(), cancellable.clone()).await;
     match result {
         Err(error) if error.matches(gio::IOErrorEnum::WouldRecurse) => {
-            copy_new_recursively(source.clone(), target, cancellable.clone()).await?;
+            copy_new_recursively_with_progress(
+                source.clone(),
+                target,
+                cancellable.clone(),
+                progress,
+            )
+            .await?;
             permanently_delete_maybe_local_if_unchanged(source, true, source_identity, cancellable)
                 .await
         }
@@ -650,30 +879,52 @@ async fn move_local_with(
     }
 }
 
+#[cfg(test)]
+async fn move_local_with(
+    source: gio::File,
+    target: gio::File,
+    cancellable: gio::Cancellable,
+    attempt_move: MoveAttempt,
+) -> Result<(), glib::Error> {
+    move_local_with_progress(source, target, cancellable, None, attempt_move).await
+}
+
 async fn move_local(
     source: gio::File,
     target: gio::File,
     cancellable: gio::Cancellable,
+    progress: Option<Rc<TransferProgressTracker>>,
 ) -> Result<(), glib::Error> {
-    move_local_with(
+    let fallback_progress = progress.clone();
+    move_local_with_progress(
         source,
         target,
         cancellable,
-        Rc::new(|source, target, cancellable| {
+        fallback_progress,
+        Rc::new(move |source, target, cancellable| {
+            let move_progress = progress.as_ref().map(TransferProgressTracker::begin_file);
+            let progress_callback = move_progress.as_ref().map(FileTransferProgress::callback);
             Box::pin(async move {
                 let flags =
                     gio::FileCopyFlags::ALL_METADATA | gio::FileCopyFlags::NOFOLLOW_SYMLINKS;
-                await_cancellable(&source, &cancellable, move |source, cancellable, result| {
-                    source.move_async(
-                        &target,
-                        flags,
-                        glib::Priority::DEFAULT,
-                        Some(cancellable),
-                        None,
-                        move |output| result.resolve(output),
-                    );
-                })
-                .await
+                let result =
+                    await_cancellable(&source, &cancellable, move |source, cancellable, result| {
+                        source.move_async(
+                            &target,
+                            flags,
+                            glib::Priority::DEFAULT,
+                            Some(cancellable),
+                            progress_callback,
+                            move |output| result.resolve(output),
+                        );
+                    })
+                    .await;
+                if result.is_ok()
+                    && let Some(move_progress) = move_progress
+                {
+                    move_progress.finish();
+                }
+                result
             })
         }),
     )
@@ -856,12 +1107,13 @@ async fn replace_local_with(
     Ok(())
 }
 
-async fn replace_local(
+async fn replace_local_with_progress(
     source: gio::File,
     target: gio::File,
     move_source: bool,
     cancellable: gio::Cancellable,
     affected_locations: Option<&mut HashSet<Location>>,
+    progress: Option<Rc<TransferProgressTracker>>,
 ) -> Result<(), glib::Error> {
     replace_local_with(
         source,
@@ -869,28 +1121,69 @@ async fn replace_local(
         move_source,
         cancellable,
         affected_locations,
-        Rc::new(|source, staged, directory, cancellable| {
+        Rc::new(move |source, staged, directory, cancellable| {
+            let progress = progress.clone();
             Box::pin(async move {
                 if directory {
-                    copy_recursively(source, staged, true, cancellable, None).await
+                    copy_recursively_with_progress(
+                        source,
+                        staged,
+                        true,
+                        cancellable,
+                        None,
+                        progress,
+                    )
+                    .await
                 } else {
                     let flags = gio::FileCopyFlags::ALL_METADATA
                         | gio::FileCopyFlags::NOFOLLOW_SYMLINKS
                         | gio::FileCopyFlags::OVERWRITE;
-                    await_cancellable(&source, &cancellable, move |source, cancellable, result| {
-                        source.copy_async(
-                            &staged,
-                            flags,
-                            glib::Priority::DEFAULT,
-                            Some(cancellable),
-                            None,
-                            move |output| result.resolve(output),
-                        );
-                    })
-                    .await
+                    let file_progress = progress.as_ref().map(TransferProgressTracker::begin_file);
+                    let progress_callback =
+                        file_progress.as_ref().map(FileTransferProgress::callback);
+                    let result = await_cancellable(
+                        &source,
+                        &cancellable,
+                        move |source, cancellable, result| {
+                            source.copy_async(
+                                &staged,
+                                flags,
+                                glib::Priority::DEFAULT,
+                                Some(cancellable),
+                                progress_callback,
+                                move |output| result.resolve(output),
+                            );
+                        },
+                    )
+                    .await;
+                    if result.is_ok()
+                        && let Some(file_progress) = file_progress
+                    {
+                        file_progress.finish();
+                    }
+                    result
                 }
             })
         }),
+    )
+    .await
+}
+
+#[cfg(test)]
+async fn replace_local(
+    source: gio::File,
+    target: gio::File,
+    move_source: bool,
+    cancellable: gio::Cancellable,
+    affected_locations: Option<&mut HashSet<Location>>,
+) -> Result<(), glib::Error> {
+    replace_local_with_progress(
+        source,
+        target,
+        move_source,
+        cancellable,
+        affected_locations,
+        None,
     )
     .await
 }
@@ -1730,7 +2023,39 @@ impl OperationProvider for LocalOperationProvider {
             for parent in request.items.iter().filter_map(|item| item.source.parent()) {
                 affected_locations.insert(parent);
             }
-            let total = request.items.len();
+            let sources = request
+                .items
+                .iter()
+                .map(|item| gio_file(&item.source))
+                .collect::<Vec<_>>();
+            let (item_sizes, total_bytes) =
+                match transfer_sizes(&sources, &operation_cancellable).await {
+                    Ok(sizes) => sizes,
+                    Err(error) if was_cancelled(&error) => {
+                        emit(cancelled_event(
+                            request.id,
+                            Vec::new(),
+                            Vec::new(),
+                            request
+                                .items
+                                .iter()
+                                .map(|item| item.source.clone())
+                                .collect(),
+                            affected_locations,
+                        ));
+                        return;
+                    }
+                    Err(error) => {
+                        emit(OperationEvent::TransferFailed {
+                            request_id: request.id,
+                            completed_locations: Vec::new(),
+                            message: error.to_string(),
+                        });
+                        return;
+                    }
+                };
+            let progress = TransferProgressTracker::new(request.id, total_bytes, emit.clone());
+            progress.emit();
             let mut completed = Vec::new();
             for (index, item) in request.items.iter().enumerate() {
                 if operation_cancellable.is_cancelled() {
@@ -1746,7 +2071,8 @@ impl OperationProvider for LocalOperationProvider {
                     ));
                     return;
                 }
-                let source = gio_file(&item.source);
+                let source = sources[index].clone();
+                let item_started_at = progress.transferred_bytes.get();
                 let Some(name) = source.basename() else {
                     emit(OperationEvent::Failed {
                         request_id: request.id,
@@ -1758,11 +2084,7 @@ impl OperationProvider for LocalOperationProvider {
                 let is_duplicate = !request.move_sources && source.equal(&default_target);
                 if !is_duplicate && transfer_is_noop(&source, &destination, &default_target) {
                     completed.push(item.source.clone());
-                    emit(OperationEvent::TransferProgress {
-                        request_id: request.id,
-                        completed: completed.len(),
-                        total,
-                    });
+                    progress.finish_item(item_started_at, item_sizes[index]);
                     continue;
                 }
                 let target = if is_duplicate {
@@ -1841,20 +2163,39 @@ impl OperationProvider for LocalOperationProvider {
                     affected_locations.insert(target);
                 }
                 let result = if is_duplicate {
-                    copy_new_recursively(source, target, operation_cancellable.clone()).await
+                    copy_new_recursively_with_progress(
+                        source,
+                        target,
+                        operation_cancellable.clone(),
+                        Some(progress.clone()),
+                    )
+                    .await
                 } else if item.conflict == TransferConflict::ReplaceExisting {
-                    replace_local(
+                    replace_local_with_progress(
                         source,
                         target,
                         request.move_sources,
                         operation_cancellable.clone(),
                         Some(&mut affected_locations),
+                        Some(progress.clone()),
                     )
                     .await
                 } else if request.move_sources {
-                    move_local(source, target, operation_cancellable.clone()).await
+                    move_local(
+                        source,
+                        target,
+                        operation_cancellable.clone(),
+                        Some(progress.clone()),
+                    )
+                    .await
                 } else {
-                    copy_new_recursively(source, target, operation_cancellable.clone()).await
+                    copy_new_recursively_with_progress(
+                        source,
+                        target,
+                        operation_cancellable.clone(),
+                        Some(progress.clone()),
+                    )
+                    .await
                 };
                 if let Err(error) = result {
                     if was_cancelled(&error) {
@@ -1878,11 +2219,7 @@ impl OperationProvider for LocalOperationProvider {
                     return;
                 }
                 completed.push(item.source.clone());
-                emit(OperationEvent::TransferProgress {
-                    request_id: request.id,
-                    completed: completed.len(),
-                    total,
-                });
+                progress.finish_item(item_started_at, item_sizes[index]);
             }
             emit(OperationEvent::Pasted {
                 request_id: request.id,
@@ -1896,7 +2233,6 @@ impl OperationProvider for LocalOperationProvider {
         let cancellable = gio::Cancellable::new();
         let operation_cancellable = cancellable.clone();
         let _task = glib::MainContext::default().spawn_local(async move {
-            let total = request.items.len();
             let mut affected_locations = HashSet::new();
             for item in &request.items {
                 for location in [&item.record.current, &item.record.original] {
@@ -1906,6 +2242,39 @@ impl OperationProvider for LocalOperationProvider {
                     }
                 }
             }
+            let sources = request
+                .items
+                .iter()
+                .map(|item| gio_file(&item.record.current))
+                .collect::<Vec<_>>();
+            let (item_sizes, total_bytes) =
+                match transfer_sizes(&sources, &operation_cancellable).await {
+                    Ok(sizes) => sizes,
+                    Err(error) if was_cancelled(&error) => {
+                        emit(cancelled_event(
+                            request.id,
+                            Vec::new(),
+                            Vec::new(),
+                            request
+                                .items
+                                .iter()
+                                .map(|item| item.record.current.clone())
+                                .collect(),
+                            affected_locations,
+                        ));
+                        return;
+                    }
+                    Err(error) => {
+                        emit(OperationEvent::TransferFailed {
+                            request_id: request.id,
+                            completed_locations: Vec::new(),
+                            message: error.to_string(),
+                        });
+                        return;
+                    }
+                };
+            let progress = TransferProgressTracker::new(request.id, total_bytes, emit.clone());
+            progress.emit();
             let mut completed = Vec::new();
             for (index, item) in request.items.iter().enumerate() {
                 let remaining = || {
@@ -1924,19 +2293,27 @@ impl OperationProvider for LocalOperationProvider {
                     ));
                     return;
                 }
-                let source = gio_file(&item.record.current);
+                let source = sources[index].clone();
+                let item_started_at = progress.transferred_bytes.get();
                 let target = gio_file(&item.record.original);
                 let result = if item.conflict == TransferConflict::ReplaceExisting {
-                    replace_local(
+                    replace_local_with_progress(
                         source,
                         target,
                         true,
                         operation_cancellable.clone(),
                         Some(&mut affected_locations),
+                        Some(progress.clone()),
                     )
                     .await
                 } else {
-                    move_local(source, target, operation_cancellable.clone()).await
+                    move_local(
+                        source,
+                        target,
+                        operation_cancellable.clone(),
+                        Some(progress.clone()),
+                    )
+                    .await
                 };
                 if let Err(error) = result {
                     if was_cancelled(&error) {
@@ -1960,11 +2337,7 @@ impl OperationProvider for LocalOperationProvider {
                     return;
                 }
                 completed.push(item.record.current.clone());
-                emit(OperationEvent::TransferProgress {
-                    request_id: request.id,
-                    completed: completed.len(),
-                    total,
-                });
+                progress.finish_item(item_started_at, item_sizes[index]);
             }
             emit(OperationEvent::Pasted {
                 request_id: request.id,
@@ -2157,7 +2530,7 @@ impl OperationProvider for LocalOperationProvider {
                     if let Some(parent) = original_target.parent() {
                         affected_locations.insert(parent);
                     }
-                    move_local(source, target, operation_cancellable.clone()).await
+                    move_local(source, target, operation_cancellable.clone(), None).await
                 } else {
                     match await_cancellable(
                         &source,
@@ -2184,7 +2557,8 @@ impl OperationProvider for LocalOperationProvider {
                                 {
                                     affected_locations.insert(parent);
                                 }
-                                move_local(source, target, operation_cancellable.clone()).await
+                                move_local(source, target, operation_cancellable.clone(), None)
+                                    .await
                             }
                             None => Err(glib::Error::new(
                                 gio::IOErrorEnum::NotFound,

--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -886,7 +886,7 @@ async fn copy_new_recursively_with_progress(
                             move |stage, cancellable, result| {
                                 stage.move_async(
                                     &target,
-                                    gio::FileCopyFlags::NONE,
+                                    gio::FileCopyFlags::NO_FALLBACK_FOR_MOVE,
                                     glib::Priority::DEFAULT,
                                     Some(cancellable),
                                     None,

--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -450,6 +450,103 @@ async fn record_created_copy_root(
     Ok(())
 }
 
+type RemoteFileStageCopy = Rc<
+    dyn Fn(
+        gio::File,
+        gio::File,
+        gio::Cancellable,
+    ) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>>,
+>;
+
+type RemoteFileStageCommit = Rc<
+    dyn Fn(
+        gio::File,
+        gio::File,
+        gio::Cancellable,
+    ) -> Pin<Box<dyn Future<Output = Result<(), glib::Error>>>>,
+>;
+
+async fn discard_incomplete_copy(stage: gio::File) -> Result<(), glib::Error> {
+    match permanently_delete(stage, false, gio::Cancellable::new()).await {
+        Err(error) if error.matches(gio::IOErrorEnum::NotFound) => Ok(()),
+        result => result,
+    }
+}
+
+/// Reserves an unpredictable sibling so a partial remote file is never exposed at the final path.
+async fn create_remote_file_stage(
+    target: &gio::File,
+    cancellable: &gio::Cancellable,
+) -> Result<gio::File, glib::Error> {
+    let parent = target
+        .parent()
+        .ok_or_else(|| io_error("The destination has no parent directory"))?;
+    let stage = parent.child(format!(".strata-copy-{}", glib::uuid_string_random()));
+    let stream = match await_cancellable(&stage, cancellable, |stage, cancellable, result| {
+        stage.create_async(
+            gio::FileCreateFlags::PRIVATE,
+            glib::Priority::DEFAULT,
+            Some(cancellable),
+            move |output| result.resolve(output),
+        );
+    })
+    .await
+    {
+        Ok(stream) => stream,
+        Err(error) if was_cancelled(&error) => {
+            let cleanup = discard_incomplete_copy(stage).await;
+            return Err(copy_failure_after_cleanup(error, cleanup));
+        }
+        Err(error) => return Err(error),
+    };
+    if let Err(error) = await_cancellable(&stream, cancellable, |stream, cancellable, result| {
+        stream.close_async(glib::Priority::DEFAULT, Some(cancellable), move |output| {
+            result.resolve(output)
+        });
+    })
+    .await
+    {
+        let cleanup = discard_incomplete_copy(stage).await;
+        return Err(copy_failure_after_cleanup(error, cleanup));
+    }
+    Ok(stage)
+}
+
+fn copy_failure_after_cleanup(
+    copy_error: glib::Error,
+    cleanup_result: Result<(), glib::Error>,
+) -> glib::Error {
+    match cleanup_result {
+        Ok(()) => copy_error,
+        Err(cleanup_error) => io_error(format!(
+            "{copy_error}; the incomplete copy could not be removed: {cleanup_error}"
+        )),
+    }
+}
+
+async fn copy_new_remote_file_with(
+    source: gio::File,
+    target: gio::File,
+    cancellable: gio::Cancellable,
+    copy_to_stage: RemoteFileStageCopy,
+    commit_stage: RemoteFileStageCommit,
+) -> Result<(), glib::Error> {
+    let stage = create_remote_file_stage(&target, &cancellable).await?;
+    if let Err(error) = copy_to_stage(source, stage.clone(), cancellable.clone()).await {
+        let cleanup = discard_incomplete_copy(stage).await;
+        return Err(copy_failure_after_cleanup(error, cleanup));
+    }
+    if let Err(error) = cancellable.set_error_if_cancelled() {
+        let cleanup = discard_incomplete_copy(stage).await;
+        return Err(copy_failure_after_cleanup(error, cleanup));
+    }
+    if let Err(error) = commit_stage(stage.clone(), target, cancellable).await {
+        let cleanup = discard_incomplete_copy(stage).await;
+        return Err(copy_failure_after_cleanup(error, cleanup));
+    }
+    Ok(())
+}
+
 /// Recursively copies the entry named `name` inside `parent` to `target`,
 /// walking descriptor-relative to each already-open source directory
 /// instead of re-resolving paths, so a component swapped out from under an
@@ -748,6 +845,63 @@ async fn copy_new_recursively_with_progress(
     cancellable: gio::Cancellable,
     progress: Option<Rc<TransferProgressTracker>>,
 ) -> Result<(), glib::Error> {
+    if !target.is_native() {
+        let source_type =
+            await_cancellable(&source, &cancellable, |source, cancellable, result| {
+                source.query_info_async(
+                    "standard::type",
+                    gio::FileQueryInfoFlags::NOFOLLOW_SYMLINKS,
+                    glib::Priority::DEFAULT,
+                    Some(cancellable),
+                    move |output| result.resolve(output),
+                );
+            })
+            .await?
+            .file_type();
+        if source_type != gio::FileType::Directory {
+            let copy_progress = progress.clone();
+            return copy_new_remote_file_with(
+                source,
+                target,
+                cancellable,
+                Rc::new(move |source, stage, cancellable| {
+                    let progress = copy_progress.clone();
+                    Box::pin(async move {
+                        copy_recursively_with_progress(
+                            source,
+                            stage,
+                            true,
+                            cancellable,
+                            None,
+                            progress,
+                        )
+                        .await
+                    })
+                }),
+                Rc::new(|stage, target, cancellable| {
+                    Box::pin(async move {
+                        await_cancellable(
+                            &stage,
+                            &cancellable,
+                            move |stage, cancellable, result| {
+                                stage.move_async(
+                                    &target,
+                                    gio::FileCopyFlags::NONE,
+                                    glib::Priority::DEFAULT,
+                                    Some(cancellable),
+                                    None,
+                                    move |output| result.resolve(output),
+                                );
+                            },
+                        )
+                        .await
+                    })
+                }),
+            )
+            .await;
+        }
+    }
+
     if source.is_native()
         && target.is_native()
         && let Some(target_path) = target.path()
@@ -825,14 +979,14 @@ async fn copy_new_recursively_with_progress(
     )
     .await;
     if result.as_ref().is_err_and(was_cancelled) && created_root.was_created.get() {
-        let cleanup = gio::Cancellable::new();
-        let _cleanup_result = permanently_delete_maybe_local_if_unchanged(
+        let cleanup_result = permanently_delete_maybe_local_if_unchanged(
             target,
             true,
             created_root.identity.get(),
-            cleanup,
+            gio::Cancellable::new(),
         )
         .await;
+        return result.map_err(|error| copy_failure_after_cleanup(error, cleanup_result));
     }
     result
 }

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -1644,6 +1644,61 @@ fn transfer_progress_aggregates_completed_and_in_flight_file_bytes() {
 }
 
 #[test]
+fn copying_a_file_emits_bytes_before_item_completion() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let root = tempfile::tempdir()?;
+    let source = root.path().join("source.bin");
+    let destination = root.path().join("destination");
+    let contents = vec![0x5a; 1024 * 1024];
+    fs::write(&source, &contents)?;
+    fs::create_dir(&destination)?;
+
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let emitted = events.clone();
+    let _operation = LocalOperationProvider.paste(
+        PasteRequest {
+            id: OperationRequestId(25),
+            destination: Location::local(&destination),
+            items: vec![PasteItem {
+                source: Location::local(&source),
+                conflict: TransferConflict::FailIfExists,
+            }],
+            move_sources: false,
+        },
+        Rc::new(move |event| emitted.borrow_mut().push(event)),
+    );
+    while !events.borrow().iter().any(|event| {
+        matches!(
+            event,
+            OperationEvent::Pasted { .. }
+                | OperationEvent::Cancelled { .. }
+                | OperationEvent::TransferFailed { .. }
+                | OperationEvent::Failed { .. }
+        )
+    }) {
+        glib::MainContext::default().iteration(true);
+    }
+
+    assert!(matches!(
+        events.borrow().last(),
+        Some(OperationEvent::Pasted { .. })
+    ));
+    assert!(events.borrow().iter().any(|event| matches!(
+        event,
+        OperationEvent::TransferProgress {
+            completed_items: 0,
+            transferred_bytes,
+            total_bytes: Some(total_bytes),
+            ..
+        } if *transferred_bytes > 0 && *total_bytes == contents.len() as u64
+    )));
+    assert_eq!(fs::read(destination.join("source.bin"))?, contents);
+    Ok(())
+}
+
+#[test]
 fn cancelling_between_moves_reports_completed_and_unattempted_sources() -> Result<(), Box<dyn Error>>
 {
     let _serial = ASYNC_MAIN_CONTEXT_DEFAULT

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -22,8 +22,8 @@ use gtk::{gio, glib, prelude::*};
 use crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT;
 
 use super::{
-    LocalOperationProvider, await_cancellable, copy_new_recursively, copy_recursively,
-    deletion_error_message, deletion_error_summary, duplicate_candidate_name,
+    LocalOperationProvider, TransferProgressTracker, await_cancellable, copy_new_recursively,
+    copy_recursively, deletion_error_message, deletion_error_summary, duplicate_candidate_name,
     extract_7z_from_reader, extract_tar, extract_zip_from_archive, home_trash_entries_at, io_error,
     is_trash_unsupported_failure, move_local_with, operation_error_summary, parse_copy_suffix,
     replace_local, replace_local_with, transfer_is_noop, validated_archive_path, validated_child,
@@ -1603,6 +1603,47 @@ fn cancelling_recursive_delete_leaves_the_unfinished_root_in_place() -> Result<(
 }
 
 #[test]
+fn transfer_progress_aggregates_completed_and_in_flight_file_bytes() {
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let emitted = events.clone();
+    let tracker = TransferProgressTracker::new(
+        OperationRequestId(24),
+        Some(150),
+        Rc::new(move |event| emitted.borrow_mut().push(event)),
+    );
+
+    let first = tracker.begin_file();
+    let mut first_callback = first.callback();
+    first_callback(25, 100);
+    first_callback(100, 100);
+    first.finish();
+    tracker.finish_item(0, Some(100));
+
+    let second = tracker.begin_file();
+    let mut second_callback = second.callback();
+    second_callback(10, 50);
+
+    assert!(events.borrow().iter().any(|event| matches!(
+        event,
+        OperationEvent::TransferProgress {
+            completed_items: 0,
+            transferred_bytes: 25,
+            total_bytes: Some(150),
+            ..
+        }
+    )));
+    assert!(matches!(
+        events.borrow().last(),
+        Some(OperationEvent::TransferProgress {
+            completed_items: 1,
+            transferred_bytes: 110,
+            total_bytes: Some(150),
+            ..
+        })
+    ));
+}
+
+#[test]
 fn cancelling_between_moves_reports_completed_and_unattempted_sources() -> Result<(), Box<dyn Error>>
 {
     let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
@@ -1642,7 +1683,13 @@ fn cancelling_between_moves_reports_completed_and_unattempted_sources() -> Resul
             move_sources: true,
         },
         Rc::new(move |event| {
-            let cancel = matches!(event, OperationEvent::TransferProgress { completed: 1, .. });
+            let cancel = matches!(
+                event,
+                OperationEvent::TransferProgress {
+                    completed_items: 1,
+                    ..
+                }
+            );
             emitted.borrow_mut().push(event);
             if cancel {
                 operation_for_emit.borrow_mut().take();
@@ -1666,6 +1713,15 @@ fn cancelling_between_moves_reports_completed_and_unattempted_sources() -> Resul
             _ => None,
         })
         .expect("terminal cancellation result");
+    assert!(events.borrow().iter().any(|event| matches!(
+        event,
+        OperationEvent::TransferProgress {
+            completed_items: 1,
+            transferred_bytes: 5,
+            total_bytes: Some(11),
+            ..
+        }
+    )));
     assert_eq!(result.completed, [Location::local(&first)]);
     assert!(result.failed.is_empty());
     assert_eq!(result.not_attempted, [Location::local(&second)]);

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -22,12 +22,12 @@ use gtk::{gio, glib, prelude::*};
 use crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT;
 
 use super::{
-    LocalOperationProvider, TransferProgressTracker, await_cancellable, copy_new_recursively,
-    copy_recursively, deletion_error_message, deletion_error_summary, duplicate_candidate_name,
-    extract_7z_from_reader, extract_tar, extract_zip_from_archive, home_trash_entries_at, io_error,
-    is_trash_unsupported_failure, move_local_with, operation_error_summary, parse_copy_suffix,
-    replace_local, replace_local_with, transfer_is_noop, validated_archive_path, validated_child,
-    write_staged_archive,
+    LocalOperationProvider, TransferProgressTracker, await_cancellable, copy_failure_after_cleanup,
+    copy_new_recursively, copy_new_remote_file_with, copy_recursively, deletion_error_message,
+    deletion_error_summary, duplicate_candidate_name, extract_7z_from_reader, extract_tar,
+    extract_zip_from_archive, home_trash_entries_at, io_error, is_trash_unsupported_failure,
+    move_local_with, operation_error_summary, parse_copy_suffix, replace_local, replace_local_with,
+    transfer_is_noop, validated_archive_path, validated_child, write_staged_archive,
 };
 use crate::{
     model::{EntryKind, FileEntry, Location, MetadataValue},
@@ -1325,6 +1325,103 @@ fn every_archive_format_rejects_parent_traversal() -> Result<(), Box<dyn Error>>
         assert!(!root.path().join(marker).exists(), "created {marker}");
     }
     Ok(())
+}
+
+#[test]
+fn cancelling_staged_remote_file_copy_removes_only_the_incomplete_stage()
+-> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let root = tempfile::tempdir()?;
+    let source = root.path().join("source.bin");
+    let target = root.path().join("target.bin");
+    fs::write(&source, b"source contents")?;
+
+    let result = glib::MainContext::default().block_on(copy_new_remote_file_with(
+        gio::File::for_path(&source),
+        gio::File::for_path(&target),
+        gio::Cancellable::new(),
+        Rc::new(|_, stage, _| {
+            Box::pin(async move {
+                fs::write(stage.path().expect("native stage"), b"partial")
+                    .map_err(super::io_error)?;
+                Err(glib::Error::new(
+                    gio::IOErrorEnum::Cancelled,
+                    "injected cancellation",
+                ))
+            })
+        }),
+        Rc::new(|_, _, _| Box::pin(async { panic!("cancelled copy must not commit") })),
+    ));
+
+    assert!(result.is_err_and(|error| error.matches(gio::IOErrorEnum::Cancelled)));
+    assert!(!target.exists());
+    assert_eq!(fs::read(&source)?, b"source contents");
+    assert_eq!(fs::read_dir(root.path())?.count(), 1);
+    Ok(())
+}
+
+#[test]
+fn staged_remote_file_copy_preserves_a_racing_destination() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let root = tempfile::tempdir()?;
+    let source = root.path().join("source.bin");
+    let target = root.path().join("target.bin");
+    fs::write(&source, b"source contents")?;
+
+    let result = glib::MainContext::default().block_on(copy_new_remote_file_with(
+        gio::File::for_path(&source),
+        gio::File::for_path(&target),
+        gio::Cancellable::new(),
+        Rc::new(|source, stage, _| {
+            Box::pin(async move {
+                fs::copy(
+                    source.path().expect("native source"),
+                    stage.path().expect("native stage"),
+                )
+                .map(|_| ())
+                .map_err(super::io_error)
+            })
+        }),
+        Rc::new(|_, target, _| {
+            Box::pin(async move {
+                fs::write(target.path().expect("native target"), b"racing contents")
+                    .map_err(super::io_error)?;
+                Err(glib::Error::new(
+                    gio::IOErrorEnum::Exists,
+                    "injected destination race",
+                ))
+            })
+        }),
+    ));
+
+    assert!(result.is_err_and(|error| error.matches(gio::IOErrorEnum::Exists)));
+    assert_eq!(fs::read(&target)?, b"racing contents");
+    assert_eq!(fs::read(&source)?, b"source contents");
+    assert_eq!(fs::read_dir(root.path())?.count(), 2);
+    Ok(())
+}
+
+#[test]
+fn failed_incomplete_copy_cleanup_is_reported_as_a_failure() {
+    let error = copy_failure_after_cleanup(
+        glib::Error::new(gio::IOErrorEnum::Cancelled, "injected cancellation"),
+        Err(glib::Error::new(
+            gio::IOErrorEnum::PermissionDenied,
+            "injected cleanup failure",
+        )),
+    );
+
+    assert!(!error.matches(gio::IOErrorEnum::Cancelled));
+    assert!(
+        error
+            .to_string()
+            .contains("incomplete copy could not be removed")
+    );
+    assert!(error.to_string().contains("injected cleanup failure"));
 }
 
 #[test]

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -140,8 +140,9 @@ pub enum BrowserEvent {
         moving: bool,
     },
     TransferProgress {
-        completed: usize,
-        total: usize,
+        completed_items: usize,
+        transferred_bytes: u64,
+        total_bytes: Option<u64>,
     },
     TransferFinished {
         moved_locations: Vec<Location>,
@@ -1557,12 +1558,16 @@ impl Browser {
                 return;
             }
             if let OperationEvent::TransferProgress {
-                completed, total, ..
+                completed_items,
+                transferred_bytes,
+                total_bytes,
+                ..
             } = &event
             {
                 browser.emit(BrowserEvent::TransferProgress {
-                    completed: *completed,
-                    total: *total,
+                    completed_items: *completed_items,
+                    transferred_bytes: *transferred_bytes,
+                    total_bytes: *total_bytes,
                 });
                 return;
             }

--- a/src/services/operations.rs
+++ b/src/services/operations.rs
@@ -189,8 +189,9 @@ pub enum OperationEvent {
     },
     TransferProgress {
         request_id: OperationRequestId,
-        completed: usize,
-        total: usize,
+        completed_items: usize,
+        transferred_bytes: u64,
+        total_bytes: Option<u64>,
     },
     DeleteProgress {
         request_id: OperationRequestId,

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -306,6 +306,7 @@ pub(super) struct ViewState {
     delete_progress: RefCell<Option<DeleteProgressView>>,
     pending_file_progress: RefCell<Option<glib::SourceId>>,
     file_operation_progress: Cell<(usize, usize)>,
+    transfer_progress: Cell<Option<(usize, u64, Option<u64>)>>,
     pin_handler: RefCell<Option<PinHandler>>,
     pin_status_handler: RefCell<Option<PinStatusHandler>>,
     print_handler: RefCell<Option<PrintHandler>>,
@@ -468,6 +469,7 @@ impl BrowserView {
             delete_progress: RefCell::new(None),
             pending_file_progress: RefCell::new(None),
             file_operation_progress: Cell::new((0, 0)),
+            transfer_progress: Cell::new(None),
             pin_handler: RefCell::new(None),
             pin_status_handler: RefCell::new(None),
             print_handler: RefCell::new(None),
@@ -2018,8 +2020,36 @@ impl ViewState {
             progress.layer.add_controller(escape);
         }
         cancel.grab_focus();
-        let (completed, total) = self.file_operation_progress.get();
-        self.update_delete_progress(completed, total);
+        if let Some((completed_items, transferred_bytes, total_bytes)) =
+            self.transfer_progress.get()
+        {
+            self.update_transfer_progress(completed_items, transferred_bytes, total_bytes);
+        } else {
+            let (completed, total) = self.file_operation_progress.get();
+            self.update_delete_progress(completed, total);
+        }
+    }
+
+    fn update_transfer_progress(
+        &self,
+        completed_items: usize,
+        transferred_bytes: u64,
+        total_bytes: Option<u64>,
+    ) {
+        self.transfer_progress
+            .set(Some((completed_items, transferred_bytes, total_bytes)));
+        let progress_view = self.delete_progress.borrow();
+        let Some(view) = progress_view.as_ref() else {
+            return;
+        };
+        let (status, fraction) =
+            transfer_progress_status(completed_items, transferred_bytes, total_bytes);
+        view.status.set_text(&status);
+        if let Some(fraction) = fraction {
+            view.progress.set_fraction(fraction);
+        } else {
+            view.progress.pulse();
+        }
     }
 
     fn update_delete_progress(&self, completed: usize, total: usize) {
@@ -2058,6 +2088,7 @@ impl ViewState {
             source.remove();
         }
         self.file_operation_progress.set((0, 0));
+        self.transfer_progress.set(None);
         if let Some(view) = self.delete_progress.take() {
             dismiss_modal_layer(&view.layer, &view.overlay, view.blurred_root.as_ref());
         }
@@ -4243,9 +4274,14 @@ impl ViewState {
                     "Cancelling will not undo completed changes",
                     Rc::new(move || browser.cancel_file_operation()),
                 );
+                self.update_transfer_progress(0, 0, None);
             }
-            BrowserEvent::TransferProgress { completed, total } => {
-                self.update_delete_progress(*completed, *total);
+            BrowserEvent::TransferProgress {
+                completed_items,
+                transferred_bytes,
+                total_bytes,
+            } => {
+                self.update_transfer_progress(*completed_items, *transferred_bytes, *total_bytes);
             }
             BrowserEvent::TransferFinished { moved_locations } => {
                 if !moved_locations.is_empty() {
@@ -5933,6 +5969,42 @@ pub(super) fn format_file_size(bytes: u64) -> String {
     }
     let formatted = format!("{value:.1}");
     format!("{} {}", formatted.trim_end_matches(".0"), UNITS[unit])
+}
+
+fn transfer_progress_status(
+    completed_items: usize,
+    transferred_bytes: u64,
+    total_bytes: Option<u64>,
+) -> (String, Option<f64>) {
+    match total_bytes {
+        Some(0) => ("100%".to_owned(), Some(1.0)),
+        Some(total) => {
+            let fraction = (transferred_bytes as f64 / total as f64).clamp(0.0, 1.0);
+            let percentage = (fraction * 100.0) as usize;
+            let percentage = if transferred_bytes > 0 {
+                percentage.max(1)
+            } else {
+                percentage
+            };
+            (format!("{percentage}%"), Some(fraction))
+        }
+        None if transferred_bytes == 0 && completed_items == 0 => ("Preparing…".to_owned(), None),
+        None if transferred_bytes == 0 => (
+            format!(
+                "{completed_items} {} copied",
+                if completed_items == 1 {
+                    "item"
+                } else {
+                    "items"
+                }
+            ),
+            None,
+        ),
+        None => (
+            format!("{} copied", format_file_size(transferred_bytes)),
+            None,
+        ),
+    }
 }
 
 pub(super) fn metadata_needs_fill(entry: &FileEntry) -> bool {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -108,6 +108,7 @@ struct ActiveNewEntry {
 }
 
 const FILE_PROGRESS_DELAY: Duration = Duration::from_millis(350);
+const INDETERMINATE_PROGRESS_INTERVAL: Duration = Duration::from_millis(100);
 const IMMEDIATE_PROGRESS_ITEM_COUNT: usize = 16;
 
 fn should_show_progress_immediately(total: usize) -> bool {
@@ -120,6 +121,8 @@ struct DeleteProgressView {
     blurred_root: Option<BlurBin>,
     progress: gtk::ProgressBar,
     status: gtk::Label,
+    indeterminate: Rc<Cell<bool>>,
+    pulse_source: Rc<RefCell<Option<glib::SourceId>>>,
 }
 
 struct TrashLoadingView {
@@ -1995,6 +1998,25 @@ impl ViewState {
         let content = layout.content;
         let cancel = layout.confirm;
 
+        let indeterminate = Rc::new(Cell::new(false));
+        let pulse_source = Rc::new(RefCell::new(None));
+        let weak_progress = progress.downgrade();
+        let indeterminate_for_pulse = indeterminate.clone();
+        let source_for_pulse = pulse_source.clone();
+        let source = glib::timeout_add_local(INDETERMINATE_PROGRESS_INTERVAL, move || {
+            if !indeterminate_for_pulse.get() {
+                source_for_pulse.borrow_mut().take();
+                return glib::ControlFlow::Break;
+            }
+            let Some(progress) = weak_progress.upgrade() else {
+                source_for_pulse.borrow_mut().take();
+                return glib::ControlFlow::Break;
+            };
+            progress.pulse();
+            glib::ControlFlow::Continue
+        });
+        pulse_source.replace(Some(source));
+
         let layer = modal_layer(&content, &window_overlay, blurred_root.clone(), None);
         window_overlay.add_overlay(&layer);
         self.delete_progress.replace(Some(DeleteProgressView {
@@ -2003,6 +2025,8 @@ impl ViewState {
             blurred_root,
             progress,
             status,
+            indeterminate,
+            pulse_source,
         }));
         let cancel_action = on_cancel.clone();
         cancel.connect_clicked(move |_| cancel_action());
@@ -2042,13 +2066,13 @@ impl ViewState {
         let Some(view) = progress_view.as_ref() else {
             return;
         };
+        let total_items = self.file_operation_progress.get().1;
         let (status, fraction) =
-            transfer_progress_status(completed_items, transferred_bytes, total_bytes);
+            transfer_progress_status(completed_items, total_items, transferred_bytes, total_bytes);
         view.status.set_text(&status);
+        view.indeterminate.set(fraction.is_none());
         if let Some(fraction) = fraction {
             view.progress.set_fraction(fraction);
-        } else {
-            view.progress.pulse();
         }
     }
 
@@ -2064,6 +2088,7 @@ impl ViewState {
             0
         };
         view.status.set_text(&format!("{pct}%"));
+        view.indeterminate.set(false);
         view.progress
             .set_fraction(completed as f64 / total.max(1) as f64);
     }
@@ -2075,10 +2100,11 @@ impl ViewState {
         };
         if total == 0 {
             view.status.set_text(&format!("{completed} files"));
-            view.progress.pulse();
+            view.indeterminate.set(true);
         } else {
             view.status
                 .set_text(&format!("{completed} / {total} files"));
+            view.indeterminate.set(false);
             view.progress.set_fraction(completed as f64 / total as f64);
         }
     }
@@ -2090,6 +2116,10 @@ impl ViewState {
         self.file_operation_progress.set((0, 0));
         self.transfer_progress.set(None);
         if let Some(view) = self.delete_progress.take() {
+            view.indeterminate.set(false);
+            if let Some(source) = view.pulse_source.take() {
+                source.remove();
+            }
             dismiss_modal_layer(&view.layer, &view.overlay, view.blurred_root.as_ref());
         }
     }
@@ -2114,7 +2144,7 @@ impl ViewState {
         };
         view.status
             .set_text(&format!("{} deleted", item_count_label(processed)));
-        view.progress.pulse();
+        view.indeterminate.set(true);
     }
 
     /// Safe to call more than once: whichever of cancel or completion runs first leaves the
@@ -5973,11 +6003,17 @@ pub(super) fn format_file_size(bytes: u64) -> String {
 
 fn transfer_progress_status(
     completed_items: usize,
+    total_items: usize,
     transferred_bytes: u64,
     total_bytes: Option<u64>,
 ) -> (String, Option<f64>) {
     match total_bytes {
-        Some(0) => ("100%".to_owned(), Some(1.0)),
+        Some(0) if total_items > 0 => {
+            let fraction = (completed_items as f64 / total_items as f64).clamp(0.0, 1.0);
+            let percentage = (fraction * 100.0) as usize;
+            (format!("{percentage}%"), Some(fraction))
+        }
+        Some(0) => ("Preparing…".to_owned(), None),
         Some(total) => {
             let fraction = (transferred_bytes as f64 / total as f64).clamp(0.0, 1.0);
             let percentage = (fraction * 100.0) as usize;

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -111,27 +111,47 @@ fn file_sizes_use_compact_decimal_units() {
 #[test]
 fn transfer_progress_reports_a_byte_fraction_when_the_total_is_known() {
     assert_eq!(
-        transfer_progress_status(0, 750, Some(1_000)),
+        transfer_progress_status(0, 2, 750, Some(1_000)),
         ("75%".to_owned(), Some(0.75))
     );
     assert_eq!(
-        transfer_progress_status(1, 1_500, Some(1_000)),
+        transfer_progress_status(1, 2, 1_500, Some(1_000)),
         ("100%".to_owned(), Some(1.0))
     );
     assert_eq!(
-        transfer_progress_status(0, 1, Some(1_000)),
+        transfer_progress_status(0, 2, 1, Some(1_000)),
         ("1%".to_owned(), Some(0.001))
+    );
+}
+
+#[test]
+fn zero_byte_transfer_progress_tracks_completed_items() {
+    assert_eq!(
+        transfer_progress_status(0, 2, 0, Some(0)),
+        ("0%".to_owned(), Some(0.0))
+    );
+    assert_eq!(
+        transfer_progress_status(1, 2, 0, Some(0)),
+        ("50%".to_owned(), Some(0.5))
+    );
+    assert_eq!(
+        transfer_progress_status(2, 2, 0, Some(0)),
+        ("100%".to_owned(), Some(1.0))
+    );
+    assert_eq!(
+        transfer_progress_status(0, 0, 0, Some(0)),
+        ("Preparing…".to_owned(), None)
     );
 }
 
 #[test]
 fn transfer_progress_is_indeterminate_when_the_total_is_unknown() {
     assert_eq!(
-        transfer_progress_status(0, 0, None),
+        transfer_progress_status(0, 2, 0, None),
         ("Preparing…".to_owned(), None)
     );
     assert_eq!(
-        transfer_progress_status(0, 1_200, None),
+        transfer_progress_status(0, 2, 1_200, None),
         ("1.2 kB copied".to_owned(), None)
     );
 }

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -109,6 +109,34 @@ fn file_sizes_use_compact_decimal_units() {
 }
 
 #[test]
+fn transfer_progress_reports_a_byte_fraction_when_the_total_is_known() {
+    assert_eq!(
+        transfer_progress_status(0, 750, Some(1_000)),
+        ("75%".to_owned(), Some(0.75))
+    );
+    assert_eq!(
+        transfer_progress_status(1, 1_500, Some(1_000)),
+        ("100%".to_owned(), Some(1.0))
+    );
+    assert_eq!(
+        transfer_progress_status(0, 1, Some(1_000)),
+        ("1%".to_owned(), Some(0.001))
+    );
+}
+
+#[test]
+fn transfer_progress_is_indeterminate_when_the_total_is_unknown() {
+    assert_eq!(
+        transfer_progress_status(0, 0, None),
+        ("Preparing…".to_owned(), None)
+    );
+    assert_eq!(
+        transfer_progress_status(0, 1_200, None),
+        ("1.2 kB copied".to_owned(), None)
+    );
+}
+
+#[test]
 fn an_empty_name_is_not_flagged_as_an_error() {
     assert!(basename_field_error("bad/name").is_some());
     assert!(


### PR DESCRIPTION
## Description

Track copy and move progress from GIO byte callbacks instead of advancing only after each item completes. Aggregate bytes across multi-item and recursive transfers, preserve truthful indeterminate progress when totals are unavailable, and keep the preparing animation active while remote trees are sized.

Zero-byte transfers fall back to item progress so an empty tree no longer appears complete before its entries are copied.

Remote file copies are written to a private sibling stage before publication. Cancelling or failing a copy removes the incomplete stage without touching the final destination, and publication fails safely when the backend cannot perform a native move.

## Visual evidence


https://github.com/user-attachments/assets/348f7e04-db10-4a07-a4dc-45df740777db



## How to test

1. Copy a large file to a network share and watch the transfer dialog while bytes are being written.
2. Copy a directory containing multiple files, then copy a tree containing only empty files/directories.
3. Cancel a large file copy to a network share before it finishes, then inspect the destination directory.

**Expected result:** The bar advances during transfers with known byte totals, pulses continuously while a total is unavailable, and does not show 100% for a zero-byte tree until all requested items complete. A cancelled remote file copy leaves neither a partial final file nor a private `.strata-copy-*` stage.

## Related issue

Fixes #249
