### PR TITLE
fix(browser): focus first item after grid navigate

### DIFF
--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -648,6 +648,10 @@ impl Browser {
         self.state.borrow_mut().focus_column(depth);
     }
 
+    pub fn select_first_on_load(&self, depth: usize) {
+        self.state.borrow_mut().select_first_on_load(depth);
+    }
+
     pub fn focus_active(&self) {
         let focus = self.state.borrow().active_focus();
         if let Some((depth, position)) = focus {

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -1710,6 +1710,21 @@ fn activating_an_open_list_item_closes_its_child_column() {
 }
 
 #[test]
+fn requesting_first_selection_during_navigate_selects_the_first_entry() {
+    let browser = Browser::new(Rc::new(FakeFileSource));
+    let loader = browser.clone();
+    browser.observe(move |event| {
+        if matches!(event, BrowserEvent::ColumnAdded { depth: 0, .. }) {
+            loader.select_first_on_load(0);
+        }
+    });
+
+    browser.navigate(Location::local("/fixture"));
+
+    assert_eq!(browser.selected_positions(0), [0]);
+}
+
+#[test]
 fn explorer_activation_replaces_the_directory_instead_of_adding_a_column() {
     let browser = Browser::new(Rc::new(FakeFileSource));
     let events = Rc::new(RefCell::new(Vec::new()));

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -6441,8 +6441,24 @@ pub(crate) const FILTER_DEBOUNCE_DELAY: Duration = Duration::from_millis(200);
 /// `scroll_to` before the view has a real height leaves ListView/GridView with a
 /// one-row widget pool, so scrolling after a mode switch stays janky.
 pub(crate) fn scroll_collection_when_allocated(view: &gtk::Widget, position: u32) {
+    scroll_collection_when_allocated_with(view, position, gtk::ListScrollFlags::FOCUS);
+}
+
+pub(crate) fn focus_collection_item_when_allocated(view: &gtk::Widget, position: u32) {
+    scroll_collection_when_allocated_with(
+        view,
+        position,
+        gtk::ListScrollFlags::FOCUS | gtk::ListScrollFlags::SELECT,
+    );
+}
+
+fn scroll_collection_when_allocated_with(
+    view: &gtk::Widget,
+    position: u32,
+    flags: gtk::ListScrollFlags,
+) {
     if view.height() > 1 {
-        apply_collection_scroll(view, position);
+        apply_collection_scroll(view, position, flags);
         return;
     }
     // ponytail: a few frames is enough for the first layout. Upgrade: a real
@@ -6450,7 +6466,12 @@ pub(crate) fn scroll_collection_when_allocated(view: &gtk::Widget, position: u32
     let frames = Cell::new(0u8);
     view.add_tick_callback(move |view, _| {
         if view.height() > 1 {
-            apply_collection_scroll(view, position);
+            if flags.intersects(gtk::ListScrollFlags::FOCUS | gtk::ListScrollFlags::SELECT)
+                && !collection_view_holds_focus(view)
+            {
+                return glib::ControlFlow::Break;
+            }
+            apply_collection_scroll(view, position, flags);
             return glib::ControlFlow::Break;
         }
         let waited = frames.get().saturating_add(1);
@@ -6463,17 +6484,24 @@ pub(crate) fn scroll_collection_when_allocated(view: &gtk::Widget, position: u32
     });
 }
 
-fn apply_collection_scroll(view: &gtk::Widget, position: u32) {
+fn collection_view_holds_focus(view: &gtk::Widget) -> bool {
+    let Some(focused) = view.root().and_then(|root| root.focus()) else {
+        return false;
+    };
+    view.has_focus() || focused == *view || view.is_ancestor(&focused) || focused.is_ancestor(view)
+}
+
+fn apply_collection_scroll(view: &gtk::Widget, position: u32, flags: gtk::ListScrollFlags) {
     if let Ok(list) = view.clone().downcast::<gtk::ListView>() {
         if position < list.model().map_or(0, |model| model.n_items()) {
-            list.scroll_to(position, gtk::ListScrollFlags::FOCUS, None);
+            list.scroll_to(position, flags, None);
         }
         return;
     }
     if let Ok(grid) = view.clone().downcast::<gtk::GridView>()
         && position < grid.model().map_or(0, |model| model.n_items())
     {
-        grid.scroll_to(position, gtk::ListScrollFlags::FOCUS, None);
+        grid.scroll_to(position, flags, None);
     }
 }
 

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 mod focus;
+mod navigate;
 mod sidebar;
 
 use super::*;

--- a/src/ui/browser/tests/navigate.rs
+++ b/src/ui/browser/tests/navigate.rs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use super::*;
+use std::time::{Duration, Instant};
+
+fn settle() {
+    let deadline = Instant::now() + Duration::from_millis(120);
+    while Instant::now() < deadline {
+        while glib::MainContext::default().iteration(false) {}
+        std::thread::sleep(Duration::from_millis(2));
+    }
+}
+
+fn wait_until(condition: impl Fn() -> bool) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !condition() {
+        assert!(Instant::now() < deadline, "browser did not settle");
+        glib::MainContext::default().iteration(false);
+        std::thread::sleep(Duration::from_millis(2));
+    }
+}
+
+fn present_single_pane(
+    mode: BrowserMode,
+) -> (
+    BrowserView,
+    Rc<crate::app::Browser>,
+    gtk::Window,
+    tempfile::TempDir,
+    tempfile::TempDir,
+) {
+    let home = tempfile::tempdir().expect("home fixture");
+    let place = tempfile::tempdir().expect("place fixture");
+    for index in 0..6 {
+        std::fs::write(place.path().join(format!("file-{index:02}.txt")), "fixture")
+            .expect("fixture file");
+    }
+    let view = BrowserView::new(
+        Rc::new(crate::adapters::LocalFileSource),
+        PeekBehavior::default(),
+    );
+    let browser = view.browser();
+    view.set_view_mode(mode);
+    let window = gtk::Window::builder()
+        .child(&view.widget())
+        .default_width(1000)
+        .default_height(650)
+        .build();
+    window.present();
+    browser.navigate(Location::local(home.path()));
+    wait_until(|| {
+        browser
+            .column_snapshot(0)
+            .is_some_and(|snapshot| !snapshot.loading)
+    });
+    settle();
+    (view, browser, window, home, place)
+}
+
+fn assert_navigate_lands_on_first_item(view: &BrowserView, browser: &crate::app::Browser) {
+    wait_until(|| {
+        browser
+            .column_snapshot(0)
+            .is_some_and(|snapshot| !snapshot.loading)
+            && browser.selected_positions(0) == [0]
+    });
+    settle();
+    assert_eq!(
+        browser
+            .focused_entry()
+            .expect("first item after navigate")
+            .display_name,
+        "file-00.txt"
+    );
+    assert!(
+        view.item_view_has_focus(),
+        "navigate must leave keyboard focus in the file view"
+    );
+    assert!(
+        view.at_left_edge(),
+        "the first item must be a usable cursor so Right stays in the listing"
+    );
+}
+
+#[test]
+fn grid_navigate_focuses_first_item_so_arrows_move_without_left_right() {
+    const CHILD: &str = "STRATA_GRID_NAVIGATE_FOCUS_GTK_CHILD";
+    if std::env::var_os(CHILD).is_none() {
+        let sandbox = tempfile::tempdir().expect("isolated settings");
+        let status = std::process::Command::new(std::env::current_exe().expect("test executable"))
+            .args([
+                "--exact",
+                "ui::browser::tests::navigate::grid_navigate_focuses_first_item_so_arrows_move_without_left_right",
+                "--nocapture",
+            ])
+            .env(CHILD, "1")
+            .env("XDG_CONFIG_HOME", sandbox.path().join("config"))
+            .env("XDG_CACHE_HOME", sandbox.path().join("cache"))
+            .env("XDG_DATA_HOME", sandbox.path().join("data"))
+            .status()
+            .expect("GTK test starts");
+        assert!(status.success());
+        return;
+    }
+    if gtk::init().is_err() {
+        return;
+    }
+    crate::assets::prepare().expect("assets");
+    crate::assets::register_icon_theme();
+    let (view, browser, window, _home, place) = present_single_pane(BrowserMode::Grid);
+    browser.navigate(Location::local(place.path()));
+    assert_navigate_lands_on_first_item(&view, &browser);
+    window.destroy();
+    browser.clear_observer();
+}
+
+#[test]
+fn explorer_navigate_focuses_first_item_so_arrows_move() {
+    const CHILD: &str = "STRATA_EXPLORER_NAVIGATE_FOCUS_GTK_CHILD";
+    if std::env::var_os(CHILD).is_none() {
+        let sandbox = tempfile::tempdir().expect("isolated settings");
+        let status = std::process::Command::new(std::env::current_exe().expect("test executable"))
+            .args([
+                "--exact",
+                "ui::browser::tests::navigate::explorer_navigate_focuses_first_item_so_arrows_move",
+                "--nocapture",
+            ])
+            .env(CHILD, "1")
+            .env("XDG_CONFIG_HOME", sandbox.path().join("config"))
+            .env("XDG_CACHE_HOME", sandbox.path().join("cache"))
+            .env("XDG_DATA_HOME", sandbox.path().join("data"))
+            .status()
+            .expect("GTK test starts");
+        assert!(status.success());
+        return;
+    }
+    if gtk::init().is_err() {
+        return;
+    }
+    crate::assets::prepare().expect("assets");
+    crate::assets::register_icon_theme();
+    let (view, browser, window, _home, place) = present_single_pane(BrowserMode::Explorer);
+    browser.navigate(Location::local(place.path()));
+    assert_navigate_lands_on_first_item(&view, &browser);
+    window.destroy();
+    browser.clear_observer();
+}

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -953,8 +953,14 @@ impl ModeViews {
             {
                 match self.mode {
                     BrowserMode::Columns => {}
-                    BrowserMode::Grid => self.rebuild_grid(),
-                    BrowserMode::Explorer => self.rebuild_explorer(),
+                    BrowserMode::Grid => {
+                        self.browser.select_first_on_load(*depth);
+                        self.rebuild_grid();
+                    }
+                    BrowserMode::Explorer => {
+                        self.browser.select_first_on_load(*depth);
+                        self.rebuild_explorer();
+                    }
                 }
             }
             BrowserEvent::ColumnAdded { .. } => {}
@@ -1095,10 +1101,14 @@ impl ModeViews {
                 take_focus,
                 ..
             } => {
+                let view_has_focus = self
+                    .panes_at(*depth)
+                    .iter()
+                    .any(|pane| pane_holds_keyboard_focus(pane));
                 for pane in self.panes_at(*depth) {
                     set_selections(pane, positions);
                 }
-                if *take_focus {
+                if *take_focus || view_has_focus {
                     self.focus_visible_pane(*depth);
                 }
             }
@@ -1325,6 +1335,9 @@ impl ModeViews {
             }
             return;
         }
+        if let Some(position) = position {
+            focus_collection_item(&view, position);
+        }
         let view = view.downgrade();
         glib::idle_add_local_once(move || {
             if let Some(view) = view.upgrade()
@@ -1340,9 +1353,10 @@ impl ModeViews {
                 {
                     return;
                 }
-                view.grab_focus();
                 if let Some(position) = position {
-                    scroll_collection_to(&view, position);
+                    focus_collection_item(&view, position);
+                } else {
+                    view.grab_focus();
                 }
             }
         });
@@ -1496,6 +1510,15 @@ fn widget_has_focus(widget: &impl IsA<gtk::Widget>, focused: Option<&gtk::Widget
         || focused.is_some_and(|focused| {
             focused == widget.as_ref() || focused.is_ancestor(widget.as_ref())
         })
+}
+
+fn pane_holds_keyboard_focus(pane: &Pane) -> bool {
+    let focused = pane.stack.root().and_then(|root| root.focus());
+    widget_has_focus(&pane.stack, focused.as_ref())
+        || pane
+            .item_sections()
+            .iter()
+            .any(|section| widget_has_focus(&section.view, focused.as_ref()))
 }
 
 #[derive(Clone)]
@@ -3941,6 +3964,10 @@ fn scroll_pane_to_source(pane: &Pane, source_position: usize) {
 
 fn scroll_collection_to(view: &gtk::Widget, position: u32) {
     super::browser::scroll_collection_when_allocated(view, position);
+}
+
+fn focus_collection_item(view: &gtk::Widget, position: u32) {
+    super::browser::focus_collection_item_when_allocated(view, position);
 }
 
 fn set_mode_cut_style(widget: &impl IsA<gtk::Widget>, cut: bool) {


### PR DESCRIPTION
## Description

Keyboard focus was staying on the sidebar (or otherwise leaving the file pane) after opening a folder in grid/explorer. Navigate now requests the first entry when a column finishes loading, scrolls with FOCUS|SELECT, and refocuses the visible pane so Enter/arrow keys operate on files.

## Visual evidence

N/A — this is a keyboard/focus behavior change, not a layout or visual styling change.

## How to test

1. Open a folder in grid view with the sidebar visible and the file pane focused.
2. Press Enter on a directory (or otherwise navigate into it).
3. Repeat in explorer/column view.
4. After the destination loads, press an arrow key or Enter without clicking the file list.

**Expected result:** The first item in the opened folder is selected, the file pane keeps keyboard focus, and further keys act on that view instead of the sidebar.

## Related issue

Closes #374