### PR TITLE
test(ui): keep mapped windows out of default suite

### DIFF
--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -1680,6 +1680,7 @@ fn notify_filter_query_skips_unchanged_folded_text() {
 }
 
 #[test]
+#[ignore = "requires a mapped GTK window; run this test alone"]
 fn seeded_filter_keeps_first_character_when_typing_continues() {
     const CHILD: &str = "STRATA_SEEDED_FILTER_GTK_CHILD";
     if std::env::var_os(CHILD).is_none() {
@@ -1689,6 +1690,7 @@ fn seeded_filter_keeps_first_character_when_typing_continues() {
         .args([
             "--exact",
             "ui::browser::tests::seeded_filter_keeps_first_character_when_typing_continues",
+            "--ignored",
         ])
         .env(CHILD, "1")
         .status()

--- a/src/ui/browser/tests/focus.rs
+++ b/src/ui/browser/tests/focus.rs
@@ -31,6 +31,7 @@ fn press_column_background(view: &BrowserView, depth: usize) {
 }
 
 #[test]
+#[ignore = "requires a mapped GTK window; run this test alone"]
 fn horizontal_scrollbar_stays_below_destination_hints() {
     const CHILD: &str = "STRATA_DESTINATION_SCROLLBAR_GTK_CHILD";
     if std::env::var_os(CHILD).is_none() {
@@ -40,6 +41,7 @@ fn horizontal_scrollbar_stays_below_destination_hints() {
                 "--exact",
                 "ui::browser::tests::focus::horizontal_scrollbar_stays_below_destination_hints",
                 "--nocapture",
+                "--ignored",
             ])
             .env(CHILD, "1")
             .env("XDG_CONFIG_HOME", sandbox.path().join("config"))
@@ -128,6 +130,7 @@ fn horizontal_scrollbar_stays_below_destination_hints() {
 }
 
 #[test]
+#[ignore = "requires a mapped GTK window; run this test alone"]
 fn pane_ownership_routes_commands_and_preserves_selection() {
     const CHILD: &str = "STRATA_FOCUS_GTK_CHILD";
     if std::env::var_os(CHILD).is_none() {
@@ -137,6 +140,7 @@ fn pane_ownership_routes_commands_and_preserves_selection() {
                 "--exact",
                 "ui::browser::tests::focus::pane_ownership_routes_commands_and_preserves_selection",
                 "--nocapture",
+                "--ignored",
             ])
             .env(CHILD, "1")
             .env("XDG_CONFIG_HOME", sandbox.path().join("config"))

--- a/src/ui/browser/tests/navigate.rs
+++ b/src/ui/browser/tests/navigate.rs
@@ -83,6 +83,7 @@ fn assert_navigate_lands_on_first_item(view: &BrowserView, browser: &crate::app:
 }
 
 #[test]
+#[ignore = "requires a mapped GTK window; run this test alone"]
 fn grid_navigate_focuses_first_item_so_arrows_move_without_left_right() {
     const CHILD: &str = "STRATA_GRID_NAVIGATE_FOCUS_GTK_CHILD";
     if std::env::var_os(CHILD).is_none() {
@@ -92,6 +93,7 @@ fn grid_navigate_focuses_first_item_so_arrows_move_without_left_right() {
                 "--exact",
                 "ui::browser::tests::navigate::grid_navigate_focuses_first_item_so_arrows_move_without_left_right",
                 "--nocapture",
+                "--ignored",
             ])
             .env(CHILD, "1")
             .env("XDG_CONFIG_HOME", sandbox.path().join("config"))
@@ -115,6 +117,7 @@ fn grid_navigate_focuses_first_item_so_arrows_move_without_left_right() {
 }
 
 #[test]
+#[ignore = "requires a mapped GTK window; run this test alone"]
 fn explorer_navigate_focuses_first_item_so_arrows_move() {
     const CHILD: &str = "STRATA_EXPLORER_NAVIGATE_FOCUS_GTK_CHILD";
     if std::env::var_os(CHILD).is_none() {
@@ -124,6 +127,7 @@ fn explorer_navigate_focuses_first_item_so_arrows_move() {
                 "--exact",
                 "ui::browser::tests::navigate::explorer_navigate_focuses_first_item_so_arrows_move",
                 "--nocapture",
+                "--ignored",
             ])
             .env(CHILD, "1")
             .env("XDG_CONFIG_HOME", sandbox.path().join("config"))

--- a/src/ui/browser/tests/sidebar.rs
+++ b/src/ui/browser/tests/sidebar.rs
@@ -28,6 +28,7 @@ fn find_grid(widget: &gtk::Widget) -> Option<gtk::GridView> {
 }
 
 #[test]
+#[ignore = "requires a mapped GTK window; run this test alone"]
 fn sidebar_boundary_tracks_grid_layout_and_empty_views() {
     const CHILD: &str = "STRATA_SIDEBAR_BOUNDARY_GTK_CHILD";
     if std::env::var_os(CHILD).is_none() {
@@ -37,6 +38,7 @@ fn sidebar_boundary_tracks_grid_layout_and_empty_views() {
                 "--exact",
                 "ui::browser::tests::sidebar::sidebar_boundary_tracks_grid_layout_and_empty_views",
                 "--nocapture",
+                "--ignored",
             ])
             .env(CHILD, "1")
             .env("XDG_CONFIG_HOME", sandbox.path().join("config"))

--- a/src/ui/shortcut_footer/tests.rs
+++ b/src/ui/shortcut_footer/tests.rs
@@ -40,6 +40,7 @@ fn navigation_reference_matches_each_mode() {
 }
 
 #[test]
+#[ignore = "requires a mapped GTK window; run this test alone"]
 fn footer_tracks_modes_and_shields_files_while_open() {
     const CHILD: &str = "STRATA_SHORTCUT_FOOTER_GTK_CHILD";
     if std::env::var_os(CHILD).is_none() {
@@ -49,6 +50,7 @@ fn footer_tracks_modes_and_shields_files_while_open() {
                 "--exact",
                 "ui::shortcut_footer::tests::footer_tracks_modes_and_shields_files_while_open",
                 "--nocapture",
+                "--ignored",
             ])
             .env(CHILD, "1")
             .env("XDG_CONFIG_HOME", sandbox.path().join("config"))

--- a/src/ui/top_bar_navigation/tests.rs
+++ b/src/ui/top_bar_navigation/tests.rs
@@ -4,12 +4,13 @@ use super::*;
 use std::cell::Cell;
 
 #[test]
+#[ignore = "requires a mapped GTK window; run this test alone"]
 fn sidebar_top_reaches_navigation_bar_and_restores_focus() {
     const CHILD: &str = "STRATA_TOP_BAR_GTK_CHILD";
     if std::env::var_os(CHILD).is_none() {
         let sandbox = tempfile::tempdir().expect("isolated GTK configuration");
         let status = std::process::Command::new(std::env::current_exe().expect("test executable"))
-            .args(["--exact", "ui::top_bar_navigation::tests::sidebar_top_reaches_navigation_bar_and_restores_focus", "--nocapture"])
+            .args(["--exact", "ui::top_bar_navigation::tests::sidebar_top_reaches_navigation_bar_and_restores_focus", "--nocapture", "--ignored"])
             .env(CHILD, "1")
             .env("XDG_CONFIG_HOME", sandbox.path().join("config"))
             .env("XDG_CACHE_HOME", sandbox.path().join("cache"))


### PR DESCRIPTION
## Description

Mark the six GTK tests that require compositor-mapped windows as explicit, run-alone tests. Their child invocations now retain `--ignored`, so deliberately running one still exercises the complete regression test instead of silently filtering it out. This keeps normal local test runs from flashing transient Strata windows across the desktop.

## Visual evidence

N/A — this changes test execution only; no application UI changes.

## How to test

1. From a graphical desktop session, run the normal test suite and watch the desktop.
2. Deliberately run one mapped test with `cargo test ui::browser::tests::seeded_filter_keeps_first_character_when_typing_continues -- --exact --ignored`.

**Expected result:** The normal suite creates no transient test windows. The explicitly requested mapped test still runs in its child process.

## Related issue

Closes #378