### PR TITLE
fix(navigation): move right into existing column

### DIFF
--- a/docs/keyboard-navigation.md
+++ b/docs/keyboard-navigation.md
@@ -60,7 +60,7 @@ From the sidebar, Right returns to the item you left (or the current file view i
 
 [Before: sidebar Home](screenshots/291/sidebar-top-bar-before.png) · [After Up: top navigation bar](screenshots/291/sidebar-top-bar.png)
 
-**Alt+Left / Alt+Right / Alt+Up** remain Back / Forward / Parent in every mode. List/Columns retain Miller-column navigation: **Right enters folders only**. On a focused file, Right does not open or preview it. **Enter** opens files; the existing Vim `l` activation shortcut is unchanged. Backspace and the existing Vim directory shortcuts remain available.
+**Alt+Left / Alt+Right / Alt+Up** remain Back / Forward / Parent in every mode. List/Columns retain Miller-column navigation: **Right enters folders or moves into an existing pane to the right**. On a focused file with no pane to the right, Right does nothing; it never opens or previews the file. **Enter** opens files; the existing Vim `l` activation shortcut is unchanged. Backspace and the existing Vim directory shortcuts remain available.
 
 [Right-arrow demo: files stay selected; folders open in a child column](screenshots/291/right-folder-only.mp4).
 

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -1942,11 +1942,9 @@ impl Browser {
     }
 
     pub fn enter_focused_directory(self: &Rc<Self>) {
-        if self
-            .focused_entry()
-            .is_none_or(|entry| entry.is_directory())
-        {
-            self.activate_focused();
+        match self.focused_entry() {
+            Some(entry) if !entry.is_directory() => self.focus_child(),
+            _ => self.activate_focused(),
         }
     }
 

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -66,6 +66,8 @@ struct RestoredSortingSource;
 
 struct FilePreviewSource;
 
+struct OpenChildBesideFileSource;
+
 struct RejectingFileSource;
 
 struct NotMountedFileSource;
@@ -241,6 +243,52 @@ impl FileSource for FilePreviewSource {
                 is_hidden: false,
                 mode: MetadataValue::Unknown,
             }],
+        });
+        emit(DirectoryEvent::Finished {
+            request_id: request.id,
+            truncated: false,
+            can_trash: None,
+            can_delete: None,
+        });
+        LoadHandle::new(|| {})
+    }
+}
+
+impl FileSource for OpenChildBesideFileSource {
+    fn validate_location(&self, _location: &Location) -> Result<(), LocationValidationError> {
+        Ok(())
+    }
+
+    fn enumerate(&self, request: DirectoryRequest, emit: Rc<dyn Fn(DirectoryEvent)>) -> LoadHandle {
+        let entries = if request.location == Location::local("/fixture") {
+            vec![
+                FileEntry {
+                    location: Location::local("/fixture/child"),
+                    native_name: OsString::from("child"),
+                    display_name: "child".into(),
+                    kind: EntryKind::Directory,
+                    size: MetadataValue::Unknown,
+                    modified_unix_seconds: MetadataValue::Unknown,
+                    is_hidden: false,
+                    mode: MetadataValue::Unknown,
+                },
+                FileEntry {
+                    location: Location::local("/fixture/example.conf"),
+                    native_name: OsString::from("example.conf"),
+                    display_name: "example.conf".into(),
+                    kind: EntryKind::File,
+                    size: MetadataValue::Known(12),
+                    modified_unix_seconds: MetadataValue::Known(1),
+                    is_hidden: false,
+                    mode: MetadataValue::Unknown,
+                },
+            ]
+        } else {
+            Vec::new()
+        };
+        emit(DirectoryEvent::Batch {
+            request_id: request.id,
+            entries,
         });
         emit(DirectoryEvent::Finished {
             request_id: request.id,
@@ -1816,6 +1864,26 @@ fn directory_navigation_does_not_open_or_preview_files() {
         BrowserEvent::OpenRequested { location }
             if location == &Location::local("/fixture/example.conf")
     )));
+}
+
+#[test]
+fn directory_navigation_moves_right_from_a_file_into_an_open_column() {
+    let browser = Browser::new(Rc::new(OpenChildBesideFileSource));
+    browser.navigate(Location::local("/fixture"));
+    browser.select(0, 0);
+    browser.enter_focused_directory();
+    assert_eq!(browser.active_depth(), Some(1));
+
+    browser.focus_parent();
+    browser.select(0, 1);
+    browser.enter_focused_directory();
+    assert_eq!(browser.active_depth(), Some(1));
+
+    browser.focus_parent();
+    browser.close_column(1);
+    browser.enter_focused_directory();
+    assert_eq!(browser.active_depth(), Some(0));
+    assert!(browser.location_at(1).is_none());
 }
 
 #[test]

--- a/src/ui/chooser.rs
+++ b/src/ui/chooser.rs
@@ -38,6 +38,7 @@ use crate::{
 use super::{
     blur::BlurBin,
     browser::{BrowserView, dismiss_modal_layer, entry_supports_quick_preview, modal_layer},
+    browser_modes::BrowserMode,
     controls::{
         ModalTone, form_check_button, form_entry, form_label, menu_option, message_dialog_layout,
     },
@@ -1548,13 +1549,12 @@ fn install_shortcuts(
                 sidebar_state.focus_active_place();
             }
             (gtk::gdk::Key::h | gtk::gdk::Key::Left, false) => state.view.navigate_left(),
-            (
-                gtk::gdk::Key::l
-                | gtk::gdk::Key::Right
-                | gtk::gdk::Key::Return
-                | gtk::gdk::Key::KP_Enter,
-                false,
-            ) => state.view.activate_focused(),
+            (gtk::gdk::Key::Right, false) if state.view.view_mode() == BrowserMode::Columns => {
+                browser.enter_focused_directory();
+            }
+            (gtk::gdk::Key::l | gtk::gdk::Key::Return | gtk::gdk::Key::KP_Enter, false) => {
+                state.view.activate_focused()
+            }
             _ => return glib::Propagation::Proceed,
         }
         glib::Propagation::Stop


### PR DESCRIPTION
## Description

Make Right in Miller column mode focus an already-open child pane when the current item is a file. The file remains unopened, and Right remains a no-op when there is no pane to the right. The portal chooser now uses the same directory-only Right-arrow behavior as the main window.

## Visual evidence

N/A — this changes keyboard focus behavior without changing the interface.

## How to test

1. Open a child folder in Columns mode, then return focus to its parent pane without closing the child.
2. Focus a regular file in the parent and press Right.
3. Repeat after closing the child pane.

**Expected result:** Right focuses the open child pane in step 2, does not open the file, and does nothing when no child pane exists.

## Related issue

Closes #381
