### PR TITLE
feat(settings): enable type-to-search by default

### DIFF
--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -109,7 +109,7 @@ struct Preferences {
     video_preview_backend: String,
     #[serde(default)]
     search_open_files_directly: bool,
-    #[serde(default)]
+    #[serde(default = "default_enabled")]
     type_to_search: bool,
     #[serde(default = "default_enabled")]
     show_keybinding_hints: bool,
@@ -171,7 +171,7 @@ impl Default for Preferences {
             hardware_accelerated_video_previews: None,
             video_preview_backend: default_video_preview_backend(),
             search_open_files_directly: false,
-            type_to_search: false,
+            type_to_search: true,
             show_keybinding_hints: true,
             reduce_motion: false,
             browser_mode: default_browser_mode(),

--- a/src/ui/theme/tests.rs
+++ b/src/ui/theme/tests.rs
@@ -177,7 +177,8 @@ theme = "azure-glow"
         MediaPreviewBackend::Automatic
     );
     assert!(!preferences.search_open_files_directly);
-    assert!(!preferences.type_to_search);
+    assert!(preferences.type_to_search);
+    assert!(Preferences::default().type_to_search);
     assert!(preferences.show_keybinding_hints);
     assert!(Preferences::default().show_keybinding_hints);
     assert!(!preferences.reduce_motion);
@@ -267,7 +268,7 @@ fn general_preferences_round_trip() {
         folder_peeking: false,
         single_click_previews: false,
         search_open_files_directly: true,
-        type_to_search: true,
+        type_to_search: false,
         show_keybinding_hints: false,
         reduce_motion: true,
         columns_file_clicks: 1,
@@ -286,7 +287,7 @@ fn general_preferences_round_trip() {
     assert!(!restored.folder_peeking);
     assert!(!restored.single_click_previews);
     assert!(restored.search_open_files_directly);
-    assert!(restored.type_to_search);
+    assert!(!restored.type_to_search);
     assert!(!restored.show_keybinding_hints);
     assert!(restored.reduce_motion);
     assert_eq!(restored.columns_file_clicks, 1);


### PR DESCRIPTION
## Description

Enable Type to search for new and legacy preference files that do not contain an explicit value. Explicitly disabling the setting remains persisted and respected.

## Visual evidence

N/A — this changes the default behavior of an existing setting without changing its UI.

## How to test

1. Launch Strata with a fresh preferences file and open a folder containing files.
2. Type a printable character and confirm the browser opens its filter with that character.
3. Disable **Type to search** in Settings, restart Strata, and confirm typing no longer opens the filter.

**Expected result:** Type-to-search is enabled unless the user explicitly disables it.

## Related issue

Closes #386