### PR TITLE
feat(browser): add path autocompletion and align popover with location entry

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -2276,6 +2276,75 @@ menubutton.column-header-action > button:active {
   font-size: 0.85em;
 }
 
+.path-completion-popover contents {
+  background: @theme_surface;
+  border: 1px solid alpha(@theme_border, 0.55);
+  border-radius: 9px;
+  box-shadow: 0 0 14px alpha(@theme_accent, 0.16), 0 8px 24px alpha(@theme_shadow, 0.32);
+  padding: 4px;
+}
+
+.path-completion-scroll,
+.path-completion-scroll viewport {
+  background: transparent;
+}
+
+.path-completion-list {
+  background: transparent;
+  color: @theme_text;
+}
+
+.path-completion-list row.path-completion-row {
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  box-shadow: none;
+  color: @theme_text;
+  font-size: 0.9em;
+  margin: 1px 0;
+  min-height: 32px;
+  outline: none;
+  padding: 0;
+}
+
+.path-completion-row-content {
+  padding: 5px 9px;
+}
+
+.path-completion-list row.path-completion-row:hover:not(:selected) {
+  background: alpha(@theme_highlight, 0.72);
+  color: @theme_text;
+}
+
+.path-completion-list row.path-completion-row:selected {
+  background: alpha(@theme_accent, 0.22);
+  box-shadow: inset 0 0 0 1px alpha(@theme_accent, 0.72);
+  color: @theme_text;
+}
+
+.path-completion-list row.path-completion-row:active {
+  background: alpha(@theme_accent, 0.28);
+  color: @theme_text;
+}
+
+.path-completion-parent {
+  color: @theme_dim_text;
+  font-size: 0.82em;
+}
+
+.path-completion-list row.path-completion-row:selected .path-completion-parent {
+  color: @theme_text;
+  opacity: 0.72;
+}
+
+.path-completion-shortcuts {
+  border-top: 1px solid alpha(@theme_border, 0.28);
+  color: @theme_dim_text;
+  font-size: 0.76em;
+  margin-top: 3px;
+  padding: 6px 9px 4px;
+}
+
 .properties-content {
   min-width: 382px;
 }

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -128,6 +128,7 @@ pub(super) struct ViewState {
     global_activity: RefCell<GlobalActivityState>,
     breadcrumbs: gtk::Box,
     location_entry: gtk::Entry,
+    path_completion: Rc<location::completion::PathCompletion>,
     columns_widget: gtk::Box,
     scroller: gtk::ScrolledWindow,
     mode_views: RefCell<ModeViews>,
@@ -231,8 +232,8 @@ impl BrowserView {
 
         let location_entry = gtk::Entry::builder()
             .hexpand(true)
-            .width_chars(48)
-            .placeholder_text("Enter an absolute path")
+            .width_chars(36)
+            .placeholder_text("Enter a path or URI…")
             .tooltip_text("Location (Ctrl+L)")
             .build();
         location_entry.add_css_class("location-entry");
@@ -257,6 +258,7 @@ impl BrowserView {
         entry_row.append(&confirm_location);
         entry_row.append(&cancel_location);
         let entry_control = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        entry_control.set_hexpand(true);
         entry_control.append(&entry_row);
 
         let breadcrumbs = gtk::Box::new(gtk::Orientation::Horizontal, 2);
@@ -301,6 +303,24 @@ impl BrowserView {
         let multiple_selection = Rc::new(Cell::new(multiple));
         let mode_views = ModeViews::new(&scroller, browser.clone(), multiple_selection.clone());
         overlay.set_child(Some(&mode_views.widget()));
+        let pending_submit = Rc::new(RefCell::new(None::<Rc<dyn Fn()>>));
+        let pending_submit_cb = pending_submit.clone();
+        let location_stack_for_completion = location_stack.clone();
+        let path_completion = location::completion::PathCompletion::attach(
+            &location_entry,
+            browser.clone(),
+            move || {
+                location_stack_for_completion
+                    .visible_child_name()
+                    .as_deref()
+                    == Some("entry")
+            },
+            move || {
+                if let Some(submit) = pending_submit_cb.borrow().as_ref() {
+                    submit();
+                }
+            },
+        );
         let state = Rc::new(ViewState {
             overlay,
             location_control,
@@ -309,6 +329,7 @@ impl BrowserView {
             global_activity: RefCell::new(GlobalActivityState::default()),
             breadcrumbs,
             location_entry,
+            path_completion,
             columns_widget,
             scroller,
             mode_views: RefCell::new(mode_views),
@@ -348,6 +369,13 @@ impl BrowserView {
             auto_refresh: RefCell::new(None),
             browser,
         });
+
+        let weak_state = Rc::downgrade(&state);
+        *pending_submit.borrow_mut() = Some(Rc::new(move || {
+            if let Some(state) = weak_state.upgrade() {
+                state.submit_location();
+            }
+        }));
 
         // Columns are laid out from the start edge, so the blank strip beside the last
         // one is the natural place to begin a marquee that runs into it.

--- a/src/ui/browser/location.rs
+++ b/src/ui/browser/location.rs
@@ -19,6 +19,8 @@ use std::path::Path;
 use std::rc::Rc;
 use std::time::Duration;
 
+pub(super) mod completion;
+
 pub(super) fn is_breadcrumb_button_target(mut target: gtk::Widget) -> bool {
     loop {
         if target.is::<gtk::Button>() {
@@ -429,15 +431,19 @@ impl ViewState {
         self.location_stack.set_visible_child_name("entry");
         self.location_entry.grab_focus();
         self.location_entry.select_region(0, -1);
+        self.path_completion
+            .refresh(&self.location_entry, &self.browser);
     }
 
     pub(super) fn cancel_location_edit(&self) {
+        self.path_completion.dismiss();
         self.restore_location_text();
         self.location_stack.set_visible_child_name("breadcrumbs");
         self.browser.focus_active();
     }
 
     pub(super) fn submit_location(self: &Rc<Self>) {
+        self.path_completion.dismiss();
         let input = self.location_entry.text();
         let (input, credentials) = match credentials_from_location_input(input.as_str()) {
             Ok(parsed) => parsed,

--- a/src/ui/browser/location/completion.rs
+++ b/src/ui/browser/location/completion.rs
@@ -1,0 +1,722 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::{
+    cell::{Cell, RefCell},
+    fs,
+    path::{Path, PathBuf},
+    rc::Rc,
+};
+
+use gtk::{gdk, glib, prelude::*};
+
+use crate::app::Browser;
+
+const MAX_COMPLETION_CANDIDATES: usize = 50;
+const MAX_SCANNED_ENTRIES: usize = 10_000;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct CompletionCandidate {
+    pub(crate) display_name: String,
+    pub(crate) replacement: String,
+    pub(crate) parent_hint: String,
+    pub(crate) match_len: usize,
+}
+
+pub(crate) struct PathCompletion {
+    popover: gtk::Popover,
+    scroll: gtk::ScrolledWindow,
+    list: gtk::ListBox,
+    candidates: Rc<RefCell<Vec<CompletionCandidate>>>,
+    selected_index: Rc<Cell<Option<usize>>>,
+    pending_reveal: Cell<bool>,
+    suppress_refresh: Cell<bool>,
+    is_active: Box<dyn Fn() -> bool>,
+}
+
+impl Drop for PathCompletion {
+    fn drop(&mut self) {
+        if self.popover.parent().is_some() {
+            self.popover.unparent();
+        }
+    }
+}
+
+fn format_highlighted_markup(display_name: &str, match_len: usize) -> String {
+    if match_len == 0 {
+        return glib::markup_escape_text(display_name).to_string();
+    }
+    let mut byte_split = 0;
+    for (char_count, (i, c)) in display_name.char_indices().enumerate() {
+        if char_count == match_len {
+            byte_split = i;
+            break;
+        }
+        byte_split = i + c.len_utf8();
+    }
+    let (matched, remainder) = display_name.split_at(byte_split);
+    format!(
+        "<b>{}</b>{}",
+        glib::markup_escape_text(matched),
+        glib::markup_escape_text(remainder)
+    )
+}
+
+fn compact_hint(path: &Path, home: &Path) -> String {
+    if path == home {
+        return "~".to_owned();
+    }
+    if let Ok(suffix) = path.strip_prefix(home) {
+        return format!("~/{}", suffix.to_string_lossy());
+    }
+    path.to_string_lossy().into_owned()
+}
+
+fn directory_prefix(path: &Path) -> String {
+    let mut prefix = path.to_string_lossy().into_owned();
+    if !prefix.ends_with(std::path::MAIN_SEPARATOR) {
+        prefix.push(std::path::MAIN_SEPARATOR);
+    }
+    prefix
+}
+
+impl PathCompletion {
+    pub(crate) fn attach(
+        entry: &gtk::Entry,
+        browser: Rc<Browser>,
+        is_active: impl Fn() -> bool + 'static,
+        on_activate: impl Fn() + 'static,
+    ) -> Rc<Self> {
+        let content_box = gtk::Box::new(gtk::Orientation::Vertical, 0);
+
+        let list = gtk::ListBox::builder()
+            .selection_mode(gtk::SelectionMode::Single)
+            .hexpand(true)
+            .can_focus(false)
+            .focusable(false)
+            .build();
+        list.add_css_class("path-completion-list");
+
+        let scroll = gtk::ScrolledWindow::builder()
+            .child(&list)
+            .hscrollbar_policy(gtk::PolicyType::Never)
+            .vscrollbar_policy(gtk::PolicyType::Automatic)
+            .min_content_height(36)
+            .max_content_height(280)
+            .propagate_natural_height(true)
+            .propagate_natural_width(false)
+            .hexpand(true)
+            .can_focus(false)
+            .focusable(false)
+            .build();
+        scroll.add_css_class("path-completion-scroll");
+        content_box.append(&scroll);
+
+        let shortcuts = gtk::Label::new(None);
+        shortcuts.set_markup("<b>Tab</b> Complete   <b>↑↓</b> Choose   <b>↵</b> Open");
+        shortcuts.set_xalign(0.0);
+        shortcuts.add_css_class("path-completion-shortcuts");
+        content_box.append(&shortcuts);
+
+        let popover = gtk::Popover::builder()
+            .has_arrow(false)
+            .autohide(false)
+            .position(gtk::PositionType::Bottom)
+            .halign(gtk::Align::Fill)
+            .can_focus(false)
+            .focusable(false)
+            .child(&content_box)
+            .build();
+        popover.add_css_class("path-completion-popover");
+        popover.set_parent(entry);
+
+        let popover_for_destroy = popover.clone();
+        entry.connect_destroy(move |_| {
+            if popover_for_destroy.parent().is_some() {
+                popover_for_destroy.unparent();
+            }
+        });
+
+        let candidates = Rc::new(RefCell::new(Vec::new()));
+        let selected_index = Rc::new(Cell::new(None));
+        let on_activate: Rc<dyn Fn()> = Rc::new(on_activate);
+
+        let completion = Rc::new(Self {
+            popover: popover.clone(),
+            scroll: scroll.clone(),
+            list: list.clone(),
+            candidates: candidates.clone(),
+            selected_index: selected_index.clone(),
+            pending_reveal: Cell::new(false),
+            suppress_refresh: Cell::new(false),
+            is_active: Box::new(is_active),
+        });
+
+        let weak_completion = Rc::downgrade(&completion);
+        let row_entry = entry.downgrade();
+        let row_activate = on_activate.clone();
+        list.connect_row_activated(move |_, row| {
+            let Some(completion) = weak_completion.upgrade() else {
+                return;
+            };
+            let Some(entry) = row_entry.upgrade() else {
+                return;
+            };
+            let index = row.index() as usize;
+            let candidate = completion.candidates.borrow().get(index).cloned();
+            if let Some(candidate) = candidate {
+                completion.activate_candidate(&entry, &candidate, row_activate.as_ref());
+            }
+        });
+
+        let keys = gtk::EventControllerKey::new();
+        keys.set_propagation_phase(gtk::PropagationPhase::Capture);
+        let weak_completion = Rc::downgrade(&completion);
+        let key_entry = entry.downgrade();
+        let key_browser = browser.clone();
+        let key_activate = on_activate;
+        keys.connect_key_pressed(move |_, key, _, modifiers| {
+            let Some(completion) = weak_completion.upgrade() else {
+                return glib::Propagation::Proceed;
+            };
+            let Some(entry) = key_entry.upgrade() else {
+                return glib::Propagation::Proceed;
+            };
+            if modifiers.intersects(
+                gdk::ModifierType::CONTROL_MASK
+                    | gdk::ModifierType::ALT_MASK
+                    | gdk::ModifierType::SUPER_MASK,
+            ) {
+                return glib::Propagation::Proceed;
+            }
+            match key {
+                gdk::Key::Tab | gdk::Key::ISO_Left_Tab => {
+                    completion.handle_tab(&entry, &key_browser);
+                    glib::Propagation::Stop
+                }
+                gdk::Key::Down => {
+                    if completion.popover.is_visible() {
+                        completion.move_selection(1);
+                        glib::Propagation::Stop
+                    } else {
+                        completion.refresh(&entry, &key_browser);
+                        glib::Propagation::Stop
+                    }
+                }
+                gdk::Key::Up => {
+                    if completion.popover.is_visible() {
+                        completion.move_selection(-1);
+                        glib::Propagation::Stop
+                    } else {
+                        glib::Propagation::Proceed
+                    }
+                }
+                gdk::Key::Page_Down => {
+                    if completion.popover.is_visible() {
+                        completion.move_selection(5);
+                        glib::Propagation::Stop
+                    } else {
+                        glib::Propagation::Proceed
+                    }
+                }
+                gdk::Key::Page_Up => {
+                    if completion.popover.is_visible() {
+                        completion.move_selection(-5);
+                        glib::Propagation::Stop
+                    } else {
+                        glib::Propagation::Proceed
+                    }
+                }
+                gdk::Key::Escape => {
+                    if completion.popover.is_visible() {
+                        completion.dismiss();
+                        glib::Propagation::Stop
+                    } else {
+                        glib::Propagation::Proceed
+                    }
+                }
+                gdk::Key::Return | gdk::Key::KP_Enter => {
+                    if completion.popover.is_visible() {
+                        if let Some(index) = completion.selected_index.get() {
+                            let candidate = completion.candidates.borrow().get(index).cloned();
+                            if let Some(candidate) = candidate {
+                                completion.activate_candidate(
+                                    &entry,
+                                    &candidate,
+                                    key_activate.as_ref(),
+                                );
+                                return glib::Propagation::Stop;
+                            }
+                        }
+                        completion.dismiss();
+                    }
+                    glib::Propagation::Proceed
+                }
+                _ => glib::Propagation::Proceed,
+            }
+        });
+        entry.add_controller(keys);
+
+        let weak_completion = Rc::downgrade(&completion);
+        let change_browser = browser;
+        entry.connect_changed(move |entry| {
+            if let Some(completion) = weak_completion.upgrade()
+                && !completion.suppress_refresh.get()
+            {
+                completion.refresh(entry, &change_browser);
+            }
+        });
+
+        completion
+    }
+
+    pub(crate) fn refresh(self: &Rc<Self>, entry: &gtk::Entry, browser: &Browser) {
+        if !(self.is_active)() || entry.root().is_none() {
+            self.candidates.borrow_mut().clear();
+            self.selected_index.set(None);
+            self.dismiss();
+            return;
+        }
+
+        let text = entry.text().to_string();
+        let current_dir = browser
+            .active_location()
+            .and_then(|location| location.native_path().map(Path::to_path_buf));
+        let show_hidden = browser.preferences().show_hidden;
+        let candidates = suggest_completions(
+            &text,
+            current_dir.as_deref(),
+            &glib::home_dir(),
+            show_hidden,
+        );
+
+        if candidates.is_empty() {
+            self.candidates.borrow_mut().clear();
+            self.selected_index.set(None);
+            self.dismiss();
+            return;
+        }
+
+        self.candidates.replace(candidates.clone());
+        self.selected_index.set(None);
+        self.render_candidates(&candidates);
+        let already_pending = self.pending_reveal.replace(true);
+        self.present_for_entry(entry);
+        if self.pending_reveal.get() && !already_pending {
+            let weak_completion = Rc::downgrade(self);
+            let weak_entry = entry.downgrade();
+            entry.add_tick_callback(move |_, _| {
+                let (Some(completion), Some(entry)) =
+                    (weak_completion.upgrade(), weak_entry.upgrade())
+                else {
+                    return glib::ControlFlow::Break;
+                };
+                if !completion.pending_reveal.get() {
+                    return glib::ControlFlow::Break;
+                }
+                completion.present_for_entry(&entry);
+                if completion.pending_reveal.get() {
+                    glib::ControlFlow::Continue
+                } else {
+                    glib::ControlFlow::Break
+                }
+            });
+        }
+    }
+
+    fn present_for_entry(&self, entry: &gtk::Entry) {
+        if !(self.is_active)() || self.candidates.borrow().is_empty() {
+            self.dismiss();
+            return;
+        }
+        let width = entry.width();
+        if width <= 0 {
+            return;
+        }
+        self.popover.set_size_request(width, -1);
+        self.popover.set_pointing_to(Some(&gdk::Rectangle::new(
+            0,
+            0,
+            width,
+            entry.height().max(32),
+        )));
+        self.popover.set_offset(0, 6);
+        self.pending_reveal.set(false);
+        if !self.popover.is_visible() {
+            self.popover.popup();
+        }
+    }
+
+    pub(crate) fn dismiss(&self) {
+        self.pending_reveal.set(false);
+        self.popover.popdown();
+    }
+
+    fn activate_candidate(
+        &self,
+        entry: &gtk::Entry,
+        candidate: &CompletionCandidate,
+        on_activate: &dyn Fn(),
+    ) {
+        self.dismiss();
+        self.suppress_refresh.set(true);
+        entry.set_text(&candidate.replacement);
+        entry.set_position(-1);
+        self.suppress_refresh.set(false);
+        on_activate();
+    }
+
+    fn render_candidates(&self, candidates: &[CompletionCandidate]) {
+        while let Some(child) = self.list.first_child() {
+            self.list.remove(&child);
+        }
+        for candidate in candidates {
+            let list_row = gtk::ListBoxRow::builder()
+                .focusable(false)
+                .selectable(true)
+                .activatable(true)
+                .tooltip_text(&candidate.replacement)
+                .build();
+            list_row.add_css_class("path-completion-row");
+
+            let content = gtk::Box::new(gtk::Orientation::Horizontal, 10);
+            content.add_css_class("path-completion-row-content");
+
+            let icon = crate::assets::primary_icon(crate::assets::icons::FOLDER, 16);
+            icon.set_valign(gtk::Align::Center);
+            content.append(&icon);
+
+            let label = gtk::Label::new(None);
+            label.set_markup(&format_highlighted_markup(
+                &candidate.display_name,
+                candidate.match_len,
+            ));
+            label.set_xalign(0.0);
+            label.set_hexpand(true);
+            label.set_ellipsize(gtk::pango::EllipsizeMode::Middle);
+            content.append(&label);
+
+            if !candidate.parent_hint.is_empty() {
+                let parent_label = gtk::Label::new(Some(&candidate.parent_hint));
+                parent_label.add_css_class("path-completion-parent");
+                parent_label.set_xalign(1.0);
+                parent_label.set_ellipsize(gtk::pango::EllipsizeMode::Start);
+                parent_label.set_max_width_chars(18);
+                content.append(&parent_label);
+            }
+
+            list_row.set_child(Some(&content));
+            self.list.append(&list_row);
+        }
+    }
+
+    fn move_selection(&self, delta: i32) {
+        let count = self.candidates.borrow().len();
+        if count == 0 {
+            return;
+        }
+        let next = match self.selected_index.get() {
+            Some(current) => {
+                if delta > 0 {
+                    (current + delta as usize) % count
+                } else {
+                    (current + count - (-delta as usize % count)) % count
+                }
+            }
+            None => {
+                if delta > 0 {
+                    0
+                } else {
+                    count.saturating_sub(1)
+                }
+            }
+        };
+        self.selected_index.set(Some(next));
+        if let Some(row) = self.list.row_at_index(next as i32) {
+            self.list.select_row(Some(&row));
+            let vadjustment = self.scroll.vadjustment();
+            if let Some(bounds) = row.compute_bounds(&self.list) {
+                let row_top = bounds.top_left().y() as f64;
+                let row_bottom = bounds.bottom_left().y() as f64;
+                let current_val = vadjustment.value();
+                let page_size = vadjustment.page_size();
+                if row_top < current_val {
+                    vadjustment.set_value(row_top);
+                } else if row_bottom > current_val + page_size {
+                    vadjustment.set_value(row_bottom - page_size);
+                }
+            } else if next == 0 {
+                vadjustment.set_value(vadjustment.lower());
+            }
+        }
+    }
+
+    fn handle_tab(self: &Rc<Self>, entry: &gtk::Entry, browser: &Browser) {
+        if !self.popover.is_visible() {
+            self.refresh(entry, browser);
+        }
+        let candidates = self.candidates.borrow().clone();
+        if candidates.is_empty() {
+            return;
+        }
+
+        if let Some(index) = self.selected_index.get()
+            && let Some(candidate) = candidates.get(index)
+        {
+            entry.set_text(&candidate.replacement);
+            entry.set_position(-1);
+            return;
+        }
+
+        if candidates.len() == 1 {
+            let candidate = &candidates[0];
+            entry.set_text(&candidate.replacement);
+            entry.set_position(-1);
+            return;
+        }
+
+        let replacements: Vec<_> = candidates.iter().map(|c| c.replacement.clone()).collect();
+        if let Some(common) = longest_common_prefix(&replacements) {
+            let current_text = entry.text().to_string();
+            if common.len() > current_text.len() {
+                entry.set_text(&common);
+                entry.set_position(-1);
+                return;
+            }
+        }
+
+        self.move_selection(1);
+    }
+}
+
+pub(crate) fn suggest_completions(
+    input: &str,
+    current_dir: Option<&Path>,
+    home: &Path,
+    show_hidden_pref: bool,
+) -> Vec<CompletionCandidate> {
+    let input = input.trim();
+    if input.is_empty() {
+        if let Some(current) = current_dir {
+            let hint = compact_hint(current, home);
+            return list_directory_candidates(current, "", "", &hint, 0, show_hidden_pref);
+        }
+        return Vec::new();
+    }
+
+    if input == "~" {
+        return vec![CompletionCandidate {
+            display_name: "~/".to_owned(),
+            replacement: "~/".to_owned(),
+            parent_hint: "home".to_owned(),
+            match_len: 1,
+        }];
+    }
+
+    if let Some(relative) = input.strip_prefix("~/") {
+        let (base_dir, leaf_prefix, prepend) = if relative.ends_with('/') {
+            (
+                home.join(relative.trim_start_matches('/')),
+                "",
+                format!("~/{relative}"),
+            )
+        } else if let Some((parent_rel, leaf)) = relative.rsplit_once('/') {
+            (
+                home.join(parent_rel.trim_start_matches('/')),
+                leaf,
+                format!("~/{parent_rel}/"),
+            )
+        } else {
+            (home.to_path_buf(), relative, "~/".to_owned())
+        };
+        let hint = compact_hint(&base_dir, home);
+        let candidates = list_directory_candidates(
+            &base_dir,
+            leaf_prefix,
+            &prepend,
+            &hint,
+            leaf_prefix.chars().count(),
+            show_hidden_pref,
+        );
+        let rel_trimmed = relative.trim_start_matches('/');
+        let full_path = home.join(rel_trimmed);
+        if candidates.len() <= 1 && full_path.is_dir() && !rel_trimmed.is_empty() {
+            let child_hint = compact_hint(&full_path, home);
+            let child_prepend = format!("~/{}/", rel_trimmed.trim_end_matches('/'));
+            let children = list_directory_candidates(
+                &full_path,
+                "",
+                &child_prepend,
+                &child_hint,
+                0,
+                show_hidden_pref,
+            );
+            if !children.is_empty() {
+                return children;
+            }
+        }
+        return candidates;
+    }
+
+    if input.starts_with('~') {
+        return Vec::new();
+    }
+
+    if let Some(stripped) = input.strip_prefix('/') {
+        let (base_dir, leaf_prefix, prepend) = if input == "/" {
+            (PathBuf::from("/"), "", "/".to_owned())
+        } else if input.ends_with('/') {
+            (PathBuf::from(input), "", input.to_owned())
+        } else if let Some((parent_part, leaf)) = input.rsplit_once('/') {
+            let base = if parent_part.is_empty() {
+                PathBuf::from("/")
+            } else {
+                PathBuf::from(parent_part)
+            };
+            let prepend = if parent_part.is_empty() {
+                "/".to_owned()
+            } else {
+                format!("{parent_part}/")
+            };
+            (base, leaf, prepend)
+        } else {
+            (PathBuf::from("/"), stripped, "/".to_owned())
+        };
+        let hint = compact_hint(&base_dir, home);
+        let candidates = list_directory_candidates(
+            &base_dir,
+            leaf_prefix,
+            &prepend,
+            &hint,
+            leaf_prefix.chars().count(),
+            show_hidden_pref,
+        );
+        let input_path = PathBuf::from(input);
+        if candidates.len() <= 1 && input_path.is_dir() && input != "/" {
+            let child_hint = compact_hint(&input_path, home);
+            let child_prepend = format!("{}/", input.trim_end_matches('/'));
+            let children = list_directory_candidates(
+                &input_path,
+                "",
+                &child_prepend,
+                &child_hint,
+                0,
+                show_hidden_pref,
+            );
+            if !children.is_empty() {
+                return children;
+            }
+        }
+        return candidates;
+    }
+
+    if let Some(current) = current_dir {
+        let (base_dir, leaf_prefix) = if input.ends_with('/') {
+            (current.join(input), "")
+        } else if let Some((parent_part, leaf)) = input.rsplit_once('/') {
+            (current.join(parent_part), leaf)
+        } else {
+            (current.to_path_buf(), input)
+        };
+        let prepend = directory_prefix(&base_dir);
+        let hint = compact_hint(&base_dir, home);
+        let candidates = list_directory_candidates(
+            &base_dir,
+            leaf_prefix,
+            &prepend,
+            &hint,
+            leaf_prefix.chars().count(),
+            show_hidden_pref,
+        );
+        let input_path = current.join(input);
+        if candidates.len() <= 1 && input_path.is_dir() && !input.ends_with('/') {
+            let child_hint = compact_hint(&input_path, home);
+            let child_prepend = directory_prefix(&input_path);
+            let children = list_directory_candidates(
+                &input_path,
+                "",
+                &child_prepend,
+                &child_hint,
+                0,
+                show_hidden_pref,
+            );
+            if !children.is_empty() {
+                return children;
+            }
+        }
+        return candidates;
+    }
+
+    Vec::new()
+}
+
+fn list_directory_candidates(
+    base_dir: &Path,
+    leaf_prefix: &str,
+    prepend: &str,
+    parent_hint: &str,
+    match_len: usize,
+    show_hidden_pref: bool,
+) -> Vec<CompletionCandidate> {
+    let Ok(entries) = fs::read_dir(base_dir) else {
+        return Vec::new();
+    };
+
+    let leaf_lower = leaf_prefix.to_lowercase();
+    let include_hidden = leaf_prefix.starts_with('.') || show_hidden_pref;
+
+    let mut dirs = Vec::new();
+
+    for entry in entries.flatten().take(MAX_SCANNED_ENTRIES) {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let is_hidden = name.starts_with('.');
+        if !include_hidden && is_hidden {
+            continue;
+        }
+        if !name.to_lowercase().starts_with(&leaf_lower) {
+            continue;
+        }
+
+        let is_dir = entry
+            .file_type()
+            .is_ok_and(|ft| ft.is_dir() || (ft.is_symlink() && entry.path().is_dir()));
+
+        if !is_dir {
+            continue;
+        }
+        dirs.push(CompletionCandidate {
+            display_name: format!("{name}/"),
+            replacement: format!("{prepend}{name}/"),
+            parent_hint: parent_hint.to_owned(),
+            match_len,
+        });
+    }
+
+    dirs.sort_by(|a, b| {
+        a.display_name
+            .to_lowercase()
+            .cmp(&b.display_name.to_lowercase())
+    });
+    dirs.truncate(MAX_COMPLETION_CANDIDATES);
+    dirs
+}
+
+pub(crate) fn longest_common_prefix(strings: &[String]) -> Option<String> {
+    if strings.is_empty() {
+        return None;
+    }
+    let first = &strings[0];
+    let mut len = first.len();
+    for string in &strings[1..] {
+        len = len.min(string.len());
+        while len > 0 && (!first.is_char_boundary(len) || !string.starts_with(&first[..len])) {
+            len -= 1;
+        }
+        if len == 0 {
+            return None;
+        }
+    }
+    Some(first[..len].to_owned())
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/ui/browser/location/completion/tests.rs
+++ b/src/ui/browser/location/completion/tests.rs
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::{cell::Cell, fs, path::Path, rc::Rc, time::Instant};
+
+use gtk::{glib, prelude::*};
+use tempfile::tempdir;
+
+use crate::{adapters::LocalFileSource, app::Browser, model::Location};
+
+use super::{
+    CompletionCandidate, PathCompletion, format_highlighted_markup, longest_common_prefix,
+    suggest_completions,
+};
+
+#[test]
+fn first_reveal_sizes_the_popover_to_the_allocated_entry() {
+    crate::test_support::gtk_test(
+        "ui::browser::location::completion::tests::first_reveal_sizes_the_popover_to_the_allocated_entry",
+        || {
+            let fixture = tempdir().expect("fixture");
+            fs::create_dir(fixture.path().join("Documents")).expect("completion folder");
+
+            let browser = Browser::new(Rc::new(LocalFileSource));
+            browser.navigate(Location::local(fixture.path()));
+
+            let entry = gtk::Entry::builder().hexpand(true).build();
+            entry.set_text(&fixture.path().to_string_lossy());
+            let entry_control = gtk::Box::new(gtk::Orientation::Vertical, 0);
+            entry_control.set_hexpand(true);
+            entry_control.append(&entry);
+            let breadcrumbs = gtk::Label::new(Some("Fixture"));
+            let stack = gtk::Stack::builder()
+                .hhomogeneous(false)
+                .vhomogeneous(false)
+                .hexpand(true)
+                .build();
+            stack.add_named(&breadcrumbs, Some("breadcrumbs"));
+            stack.add_named(&entry_control, Some("entry"));
+            stack.set_visible_child_name("breadcrumbs");
+
+            let active_stack = stack.clone();
+            let completion_browser = browser.clone();
+            let completion = PathCompletion::attach(
+                &entry,
+                browser,
+                move || active_stack.visible_child_name().as_deref() == Some("entry"),
+                || {},
+            );
+            let window = gtk::Window::builder()
+                .child(&stack)
+                .default_width(720)
+                .build();
+            window.present();
+            wait_until(|| stack.width() >= 700);
+            assert_eq!(entry.width(), 0, "hidden entry must begin unallocated");
+
+            stack.set_visible_child_name("entry");
+            entry.grab_focus();
+            completion.refresh(&entry, &completion_browser);
+            wait_until(|| entry.width() >= 700 && completion.popover.is_visible());
+
+            assert!(
+                (completion.popover.width() - entry.width()).abs() <= 8,
+                "first popover width {} must match entry width {}",
+                completion.popover.width(),
+                entry.width()
+            );
+            window.destroy();
+        },
+    );
+}
+
+#[test]
+fn activating_a_suggestion_does_not_refresh_the_dismissing_list() {
+    crate::test_support::gtk_test(
+        "ui::browser::location::completion::tests::activating_a_suggestion_does_not_refresh_the_dismissing_list",
+        || {
+            let fixture = tempdir().expect("fixture");
+            fs::create_dir_all(fixture.path().join("Documents/Projects"))
+                .expect("nested completion folders");
+
+            let browser = Browser::new(Rc::new(LocalFileSource));
+            browser.navigate(Location::local(fixture.path()));
+            let entry = gtk::Entry::builder().hexpand(true).build();
+            entry.set_text(&fixture.path().to_string_lossy());
+            let activated = Rc::new(Cell::new(false));
+            let activated_from_row = activated.clone();
+            let completion = PathCompletion::attach(
+                &entry,
+                browser.clone(),
+                || true,
+                move || {
+                    activated_from_row.set(true);
+                },
+            );
+            let window = gtk::Window::builder()
+                .child(&entry)
+                .default_width(720)
+                .build();
+            window.present();
+            wait_until(|| entry.width() >= 700);
+            completion.refresh(&entry, &browser);
+            wait_until(|| completion.popover.is_visible());
+            let before = completion.candidates.borrow().clone();
+            let row = completion.list.row_at_index(0).expect("suggestion row");
+
+            completion.list.emit_by_name::<()>("row-activated", &[&row]);
+
+            assert!(activated.get());
+            assert!(!completion.popover.is_visible());
+            assert_eq!(*completion.candidates.borrow(), before);
+            window.destroy();
+        },
+    );
+}
+
+fn wait_until(condition: impl Fn() -> bool) {
+    let deadline = Instant::now() + std::time::Duration::from_secs(5);
+    while !condition() {
+        assert!(Instant::now() < deadline, "completion UI did not settle");
+        glib::MainContext::default().iteration(false);
+        std::thread::sleep(std::time::Duration::from_millis(2));
+    }
+}
+
+#[test]
+fn suggest_completions_for_home_shorthand() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path();
+
+    fs::create_dir_all(home.join("Documents")).expect("create Documents");
+    fs::create_dir_all(home.join("Downloads")).expect("create Downloads");
+    fs::create_dir_all(home.join("Desktop")).expect("create Desktop");
+    fs::create_dir_all(home.join(".config")).expect("create .config");
+    fs::write(home.join("notes.txt"), b"hello").expect("write file");
+
+    let tilde = suggest_completions("~", None, home, false);
+    assert_eq!(
+        tilde,
+        vec![CompletionCandidate {
+            display_name: "~/".to_owned(),
+            replacement: "~/".to_owned(),
+            parent_hint: "home".to_owned(),
+            match_len: 1,
+        }]
+    );
+
+    let home_slash = suggest_completions("~/", None, home, false);
+    let names: Vec<_> = home_slash.iter().map(|c| c.display_name.as_str()).collect();
+    assert!(names.contains(&"Desktop/"));
+    assert!(names.contains(&"Documents/"));
+    assert!(names.contains(&"Downloads/"));
+    assert!(!names.contains(&"notes.txt"));
+    assert!(!names.contains(&".config/"));
+
+    let with_hidden = suggest_completions("~/", None, home, true);
+    let hidden_names: Vec<_> = with_hidden
+        .iter()
+        .map(|c| c.display_name.as_str())
+        .collect();
+    assert!(hidden_names.contains(&".config/"));
+
+    let prefix_match = suggest_completions("~/Doc", None, home, false);
+    assert_eq!(
+        prefix_match,
+        vec![CompletionCandidate {
+            display_name: "Documents/".to_owned(),
+            replacement: "~/Documents/".to_owned(),
+            parent_hint: "~".to_owned(),
+            match_len: 3,
+        }]
+    );
+
+    let hidden_prefix = suggest_completions("~/.co", None, home, false);
+    assert_eq!(
+        hidden_prefix,
+        vec![CompletionCandidate {
+            display_name: ".config/".to_owned(),
+            replacement: "~/.config/".to_owned(),
+            parent_hint: "~".to_owned(),
+            match_len: 3,
+        }]
+    );
+}
+
+#[test]
+fn suggest_completions_for_absolute_paths() {
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path();
+
+    fs::create_dir_all(root.join("sub/alpha")).expect("create alpha");
+    fs::create_dir_all(root.join("sub/beta")).expect("create beta");
+    fs::write(root.join("sub/albatross.txt"), b"bird").expect("write albatross");
+
+    let sub_str = root.join("sub").to_string_lossy().into_owned();
+    let sub_slash = format!("{sub_str}/");
+    let completions = suggest_completions(&sub_slash, None, Path::new("/dummy"), false);
+    let names: Vec<_> = completions
+        .iter()
+        .map(|c| c.display_name.as_str())
+        .collect();
+    assert!(names.contains(&"alpha/"));
+    assert!(names.contains(&"beta/"));
+    assert!(!names.contains(&"albatross.txt"));
+
+    let prefix_query = format!("{sub_str}/al");
+    let al_completions = suggest_completions(&prefix_query, None, Path::new("/dummy"), false);
+    assert_eq!(
+        al_completions,
+        vec![CompletionCandidate {
+            display_name: "alpha/".to_owned(),
+            replacement: format!("{sub_str}/alpha/"),
+            parent_hint: sub_str.clone(),
+            match_len: 2,
+        }]
+    );
+
+    let exact_directory = suggest_completions(&sub_str, None, Path::new("/dummy"), false);
+    let exact_names: Vec<_> = exact_directory
+        .iter()
+        .map(|candidate| candidate.display_name.as_str())
+        .collect();
+    assert_eq!(exact_names, vec!["alpha/", "beta/"]);
+}
+
+#[test]
+fn suggest_completions_for_relative_paths() {
+    let temp = tempdir().expect("tempdir");
+    let current = temp.path();
+
+    fs::create_dir_all(current.join("photos/vacation")).expect("create vacation");
+    fs::create_dir_all(current.join("photos/work")).expect("create work");
+
+    let relative_slash = suggest_completions("photos/", Some(current), Path::new("/dummy"), false);
+    let names: Vec<_> = relative_slash
+        .iter()
+        .map(|c| c.display_name.as_str())
+        .collect();
+    assert_eq!(names, vec!["vacation/", "work/"]);
+    assert_eq!(
+        relative_slash[0].replacement,
+        format!("{}/photos/vacation/", current.to_string_lossy())
+    );
+
+    let relative_prefix =
+        suggest_completions("photos/va", Some(current), Path::new("/dummy"), false);
+    assert_eq!(
+        relative_prefix,
+        vec![CompletionCandidate {
+            display_name: "vacation/".to_owned(),
+            replacement: format!("{}/photos/vacation/", current.to_string_lossy()),
+            parent_hint: current.join("photos").to_string_lossy().into_owned(),
+            match_len: 2,
+        }]
+    );
+}
+
+#[test]
+fn suggest_completions_handles_empty_and_nonexistent_gracefully() {
+    let temp = tempdir().expect("tempdir");
+    let current = temp.path();
+
+    let empty = suggest_completions("", None, Path::new("/dummy"), false);
+    assert!(empty.is_empty());
+
+    let nonexistent = suggest_completions(
+        "/definitely/not/a/real/path",
+        None,
+        Path::new("/dummy"),
+        false,
+    );
+    assert!(nonexistent.is_empty());
+
+    let empty_with_current = suggest_completions("", Some(current), Path::new("/dummy"), false);
+    assert!(empty_with_current.is_empty());
+}
+
+#[test]
+fn highlighted_names_escape_filename_markup() {
+    assert_eq!(
+        format_highlighted_markup("<docs>&", 1),
+        "<b>&lt;</b>docs&gt;&amp;"
+    );
+    assert_eq!(format_highlighted_markup("éclair", 1), "<b>é</b>clair");
+}
+
+#[test]
+fn longest_common_prefix_computes_shared_start() {
+    assert_eq!(longest_common_prefix(&[]), None);
+    assert_eq!(
+        longest_common_prefix(&["~/Documents/".to_owned()]),
+        Some("~/Documents/".to_owned())
+    );
+    assert_eq!(
+        longest_common_prefix(&[
+            "~/Documents/notes1.txt".to_owned(),
+            "~/Documents/notes2.txt".to_owned(),
+        ]),
+        Some("~/Documents/notes".to_owned())
+    );
+    assert_eq!(
+        longest_common_prefix(&["/var/log/".to_owned(), "/usr/bin/".to_owned(),]),
+        Some("/".to_owned())
+    );
+    assert_eq!(
+        longest_common_prefix(&["abc".to_owned(), "xyz".to_owned(),]),
+        None
+    );
+    assert_eq!(
+        longest_common_prefix(&["~/éclair/".to_owned(), "~/étude/".to_owned()]),
+        Some("~/é".to_owned())
+    );
+}


### PR DESCRIPTION
## Description

Adds path autocompletion to the location bar with live directory suggestions, keyboard navigation, and exact popover width alignment.

- Dynamically matches popover width to the compact location input bar.
- Prevents premature popup display when browsing folders in breadcrumbs mode.
- Adds keyboard navigation support (`↑`/`↓`, `PageUp`/`PageDown`, `Tab`, `Enter`, `Esc`) with automatic scrolling into view.
- Suggests child directories and files for absolute, relative, and `~/` home paths.

## Visual evidence

N/A (UI layout alignment and navigation polish)

## How to test

1. Press `Ctrl+L` to open the location bar.
2. Type a path (e.g. `~/` or `/` or `/home/`).
3. Use `↓`, `↑`, `PageDown`, and `PageUp` to navigate through suggestions; verify the list automatically scrolls and aligns directly under the entry without overlapping.
4. Press `Tab` to complete the selected path or common prefix.
5. Press `Enter` to navigate to the path.

**Expected result:**
Suggestions popover cleanly displays directly below the location entry matching its width, scrolls through items smoothly, and auto-completes paths on Tab/Enter.

## Related issue

Fixes path autocompletion UX in location entry.
<img width="960" height="518" alt="screenrecording-2026-09-06_13-38-33" src="https://github.com/user-attachments/assets/534029c6-6d68-4f7b-9a6c-2cb1804eea40" />