### PR TITLE
fix(browser): restore column rows when the miller filter is cleared

### DIFF
--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -5107,20 +5107,19 @@ impl ViewState {
             if query.is_empty() {
                 search_gen_for_changed.set(search_gen_for_changed.get().saturating_add(1));
                 search_handle_for_changed.borrow_mut().take();
-                search_results_for_changed.borrow_mut().clear();
-                search_model_for_changed.splice(0, search_model_for_changed.n_items(), &[]);
-                if filtered_model_for_search.model().as_ref()
-                    != Some(model_for_search.upcast_ref::<gio::ListModel>())
-                {
-                    filtered_model_for_search.set_model(Some(&model_for_search));
-                }
+                deactivate_recursive_search(
+                    &search_active_for_changed,
+                    &search_results_for_changed,
+                    &search_model_for_changed,
+                    &filtered_model_for_search,
+                    &model_for_search,
+                );
                 apply_filter_query(
                     &filtered_model_for_search,
                     &filter,
                     &filter_query,
                     text.to_lowercase(),
                 );
-                search_active_for_changed.set(false);
                 return;
             }
             *filter_query.borrow_mut() = text.to_lowercase();
@@ -6650,6 +6649,28 @@ pub(crate) fn notify_filter_query(
     let change = filter_change_for(&previous, &settled);
     *query.borrow_mut() = settled;
     filter.changed(change);
+}
+
+/// Restores a miller column to its directory listing after its recursive search filter is cleared.
+///
+/// The flag must drop before the model swap: GTK binds the visible rows synchronously inside
+/// `set_model`, and the row factory reads it to decide whether to source entries from the
+/// search results or the directory. Clearing it afterwards binds every visible row against the
+/// already-emptied results, so they keep fallback icons and no hover size until an unrelated
+/// rebuild.
+pub(crate) fn deactivate_recursive_search(
+    search_active: &Cell<bool>,
+    search_results: &RefCell<Vec<crate::services::SearchItem>>,
+    search_model: &gtk::StringList,
+    filtered_model: &gtk::FilterListModel,
+    directory_model: &EntryListModel,
+) {
+    search_active.set(false);
+    search_results.borrow_mut().clear();
+    search_model.splice(0, search_model.n_items(), &[]);
+    if filtered_model.model().as_ref() != Some(directory_model.upcast_ref::<gio::ListModel>()) {
+        filtered_model.set_model(Some(directory_model));
+    }
 }
 
 pub(crate) fn apply_filter_query(

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -2,6 +2,7 @@
 
 mod focus;
 mod navigate;
+mod recursive_search;
 mod sidebar;
 
 use super::*;

--- a/src/ui/browser/tests/recursive_search.rs
+++ b/src/ui/browser/tests/recursive_search.rs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use super::*;
+
+#[test]
+fn clearing_recursive_search_deactivates_before_rows_rebind() {
+    const CHILD: &str = "STRATA_RECURSIVE_SEARCH_TEST_CHILD";
+    if std::env::var_os(CHILD).is_none() {
+        let status = std::process::Command::new(std::env::current_exe().expect("test executable"))
+            .args([
+                "--exact",
+                "ui::browser::tests::recursive_search::clearing_recursive_search_deactivates_before_rows_rebind",
+            ])
+            .env(CHILD, "1")
+            .status()
+            .expect("isolated GTK test should start");
+        assert!(status.success());
+        return;
+    }
+    if gtk::init().is_err() {
+        return;
+    }
+
+    let directory_model = EntryListModel::new(Rc::new(|position| {
+        (position < 3).then(|| format!("entry-{position}"))
+    }));
+    directory_model.replace(3);
+    let search_model = gtk::StringList::new(&["hit-a", "hit-b"]);
+    let filtered_model =
+        gtk::FilterListModel::new(Some(search_model.clone()), None::<gtk::CustomFilter>);
+    let search_active = Rc::new(Cell::new(true));
+    let search_results = Rc::new(RefCell::new(Vec::new()));
+
+    let active_during_rebind: Rc<RefCell<Vec<bool>>> = Rc::new(RefCell::new(Vec::new()));
+    let observed = active_during_rebind.clone();
+    let flag = search_active.clone();
+    filtered_model.connect_items_changed(move |_, _, _, added| {
+        if added > 0 {
+            observed.borrow_mut().push(flag.get());
+        }
+    });
+
+    deactivate_recursive_search(
+        &search_active,
+        &search_results,
+        &search_model,
+        &filtered_model,
+        &directory_model,
+    );
+
+    assert!(!search_active.get());
+    assert_eq!(filtered_model.n_items(), 3);
+    assert!(
+        !active_during_rebind.borrow().is_empty(),
+        "swapping back to the directory model should have re-added rows"
+    );
+    assert!(
+        active_during_rebind.borrow().iter().all(|active| !active),
+        "rows rebound while recursive search still looked active"
+    );
+}


### PR DESCRIPTION
## Description

In Column (Miller) view, clearing a settled recursive-search filter left the column's rows with generic fallback icons, no folder chevrons, and no hover file-size overlay until an unrelated listing rebuild.

The empty-query branch of the column filter handler swapped the `FilterListModel` back to the directory listing *before* clearing `recursive_search_active`. GTK binds the visible rows synchronously inside `set_model`, so the row factory still believed search was active, looked up the already-emptied `search_results`, and took its missing-entry path — fallback icon, hidden chevron, and an empty `.file-size` label for hover CSS to fade in. Scroll and resize do not rebind rows that stay on screen, so the state persisted until something rebuilt the model (sort change, folders-first toggle, reload, navigating away and back).

The reset now lives in `deactivate_recursive_search`, which drops the flag before the model swap so those rows rebind against the directory entries. A regression test asserts the flag is already clear when the filtered model announces the re-added rows; it fails on the previous ordering.

## Visual evidence

N/A — the fix restores the thumbnails and hover sizes shown in the issue's video; there is no new or changed UI.

## How to test

1. Open Strata in Column (Miller) view and enter a folder that shows image thumbnails.
2. Hover a file and confirm the size overlay appears.
3. Focus the column, open its filter (`Ctrl+F`), type a query, and wait ~200ms for the subfolder search to settle.
4. Backspace until the filter is empty.
5. Hover files and scroll the column.

**Expected result:** thumbnails and hover file sizes come back immediately when the filter empties, with no need to change the sort order or reload the column.

## Related issue

Closes #377