### PR TITLE
fix(archives): keep compression staging files private

### DIFF
--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -1769,7 +1769,7 @@ async fn write_staged_archive<F>(
 where
     F: FnOnce(std::fs::File) -> Result<(), String> + Send + 'static,
 {
-    let existing_permissions = if conflict == TransferConflict::ReplaceExisting {
+    let published_permissions = if conflict == TransferConflict::ReplaceExisting {
         match std::fs::symlink_metadata(archive_path) {
             Ok(metadata) if metadata.file_type().is_file() => Some(metadata.permissions()),
             Ok(_) => None,
@@ -1778,11 +1778,12 @@ where
         }
     } else {
         None
-    };
+    }
+    .unwrap_or_else(umask_adjusted_file_permissions);
     let mut builder = tempfile::Builder::new();
     builder
         .prefix(".strata-compression-")
-        .permissions(std::fs::Permissions::from_mode(0o666));
+        .permissions(std::fs::Permissions::from_mode(0o600));
     let staged = builder
         .tempfile_in(destination)
         .map_err(|error| error.to_string())?;
@@ -1790,18 +1791,33 @@ where
     gio::spawn_blocking(move || write_archive(file))
         .await
         .map_err(|_| "Compression task panicked".to_owned())??;
-    if let Some(permissions) = existing_permissions {
-        staged
-            .as_file()
-            .set_permissions(permissions)
-            .map_err(|error| error.to_string())?;
-    }
+    staged
+        .as_file()
+        .set_permissions(published_permissions)
+        .map_err(|error| error.to_string())?;
     match conflict {
         TransferConflict::FailIfExists => staged.persist_noclobber(archive_path),
         TransferConflict::ReplaceExisting => staged.persist(archive_path),
     }
     .map(|_| ())
     .map_err(|error| error.to_string())
+}
+
+fn umask_adjusted_file_permissions() -> std::fs::Permissions {
+    std::fs::Permissions::from_mode(0o666 & !process_umask())
+}
+
+fn process_umask() -> u32 {
+    // /proc avoids the process-global umask(2) set-and-restore race in a GUI.
+    std::fs::read_to_string("/proc/self/status")
+        .ok()
+        .and_then(|status| {
+            status.lines().find_map(|line| {
+                line.strip_prefix("Umask:")
+                    .and_then(|value| u32::from_str_radix(value.trim(), 8).ok())
+            })
+        })
+        .unwrap_or(0o022)
 }
 
 fn deletion_error_summary(errors: &[String]) -> String {

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -26,8 +26,8 @@ use super::{
     copy_new_recursively, copy_new_remote_file_with, copy_recursively, deletion_error_message,
     deletion_error_summary, duplicate_candidate_name, extract_7z_from_reader, extract_tar,
     extract_zip_from_archive, home_trash_entries_at, io_error, is_trash_unsupported_failure,
-    move_local, move_local_with, operation_error_summary, parse_copy_suffix, replace_local,
-    replace_local_with, transfer_is_noop, validated_archive_path, validated_child,
+    move_local, move_local_with, operation_error_summary, parse_copy_suffix, process_umask,
+    replace_local, replace_local_with, transfer_is_noop, validated_archive_path, validated_child,
     write_staged_archive,
 };
 use crate::{
@@ -1071,6 +1071,31 @@ fn compression_stages(destination: &Path) -> Result<Vec<OsString>, Box<dyn Error
         .collect())
 }
 
+fn compression_stage_mode(destination: &Path) -> Result<u32, Box<dyn Error>> {
+    let mut stages = compression_stages(destination)?;
+    let name = stages.pop().ok_or("no compression staging file")?;
+    if !stages.is_empty() {
+        return Err("expected a single compression staging file".into());
+    }
+    Ok(fs::metadata(destination.join(name))?.permissions().mode() & 0o777)
+}
+
+struct UmaskGuard(rustix::fs::Mode);
+
+impl UmaskGuard {
+    fn set(mask: u32) -> Self {
+        Self(rustix::process::umask(
+            rustix::fs::Mode::from_bits_truncate(mask),
+        ))
+    }
+}
+
+impl Drop for UmaskGuard {
+    fn drop(&mut self) {
+        rustix::process::umask(self.0);
+    }
+}
+
 #[test]
 fn compression_provider_rejects_escaping_archive_names() -> Result<(), Box<dyn Error>> {
     let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
@@ -1144,6 +1169,104 @@ fn compression_conflict_choices_preserve_or_replace_the_destination() -> Result<
         Some("source.txt".to_owned())
     );
     assert_eq!(fs::metadata(&archive)?.permissions().mode() & 0o777, 0o640);
+    assert!(compression_stages(&destination)?.is_empty());
+    Ok(())
+}
+
+#[test]
+fn compression_staging_stays_private_while_encoding() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let _umask = UmaskGuard::set(0o022);
+    assert_eq!(process_umask(), 0o022);
+    let root = tempfile::tempdir()?;
+    let destination = root.path().to_path_buf();
+    let archive = destination.join("existing.zip");
+    fs::write(&archive, b"original")?;
+    fs::set_permissions(&archive, fs::Permissions::from_mode(0o640))?;
+    let started = Arc::new(AtomicBool::new(false));
+    let release = Arc::new(AtomicBool::new(false));
+    let worker_started = started.clone();
+    let worker_release = release.clone();
+    let worker_destination = destination.clone();
+    let worker_archive = archive.clone();
+    let task = glib::MainContext::default().spawn_local(async move {
+        write_staged_archive(
+            &worker_destination,
+            &worker_archive,
+            TransferConflict::ReplaceExisting,
+            move |mut file| {
+                file.write_all(b"replacement")
+                    .map_err(|error| error.to_string())?;
+                worker_started.store(true, Ordering::Release);
+                while !worker_release.load(Ordering::Acquire) {
+                    std::thread::yield_now();
+                }
+                Ok(())
+            },
+        )
+        .await
+    });
+    let context = glib::MainContext::default();
+    while !started.load(Ordering::Acquire) {
+        context.iteration(false);
+        std::thread::yield_now();
+    }
+    assert_eq!(compression_stage_mode(&destination)?, 0o600);
+
+    release.store(true, Ordering::Release);
+    assert_eq!(context.block_on(task)?, Ok(()));
+    assert_eq!(fs::read(&archive)?, b"replacement");
+    assert_eq!(fs::metadata(&archive)?.permissions().mode() & 0o777, 0o640);
+    assert!(compression_stages(&destination)?.is_empty());
+    Ok(())
+}
+
+#[test]
+fn new_archive_staging_stays_private_until_publish() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let _umask = UmaskGuard::set(0o022);
+    assert_eq!(process_umask(), 0o022);
+    let root = tempfile::tempdir()?;
+    let destination = root.path().to_path_buf();
+    let archive = destination.join("created.zip");
+    let started = Arc::new(AtomicBool::new(false));
+    let release = Arc::new(AtomicBool::new(false));
+    let worker_started = started.clone();
+    let worker_release = release.clone();
+    let worker_destination = destination.clone();
+    let worker_archive = archive.clone();
+    let task = glib::MainContext::default().spawn_local(async move {
+        write_staged_archive(
+            &worker_destination,
+            &worker_archive,
+            TransferConflict::FailIfExists,
+            move |mut file| {
+                file.write_all(b"created")
+                    .map_err(|error| error.to_string())?;
+                worker_started.store(true, Ordering::Release);
+                while !worker_release.load(Ordering::Acquire) {
+                    std::thread::yield_now();
+                }
+                Ok(())
+            },
+        )
+        .await
+    });
+    let context = glib::MainContext::default();
+    while !started.load(Ordering::Acquire) {
+        context.iteration(false);
+        std::thread::yield_now();
+    }
+    assert_eq!(compression_stage_mode(&destination)?, 0o600);
+
+    release.store(true, Ordering::Release);
+    assert_eq!(context.block_on(task)?, Ok(()));
+    assert_eq!(fs::read(&archive)?, b"created");
+    assert_eq!(fs::metadata(&archive)?.permissions().mode() & 0o777, 0o644);
     assert!(compression_stages(&destination)?.is_empty());
     Ok(())
 }

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -1224,7 +1224,7 @@ fn compression_staging_stays_private_while_encoding() -> Result<(), Box<dyn Erro
 }
 
 #[test]
-fn new_archive_staging_stays_private_until_publish() -> Result<(), Box<dyn Error>> {
+fn compression_new_archive_staging_stays_private_until_publish() -> Result<(), Box<dyn Error>> {
     let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
         .lock()
         .map_err(|error| error.to_string())?;


### PR DESCRIPTION
## Description

Compression used to create the sibling staging file with mode `0666` (subject to umask) and only restore the existing archive's permissions after encoding finished. In a shared directory that made the temp archive more widely readable than the file being replaced.

Staging files are now created with mode `0600`. Intended permissions are applied only after compression succeeds, immediately before persist. Replacing an archive still copies the original mode onto the published result; new archives still receive the usual umask-adjusted `0666` creation mode.

## Visual evidence

N/A — this is a file-mode change with no user-visible UI.

## How to test

1. Create a destination directory that other users can traverse, and an archive in it with mode `0640`.
2. Compress a replacement into that archive (Replace) and pause or inspect `.strata-compression-*` while encoding is in progress.
3. Confirm the staging file is `0600` during encoding, then that the published archive is `0640`.
4. Compress a new archive into the same directory and confirm the published mode matches a normal `File::create` (typically `0644` with umask `022`).

**Expected result:** Staging stays owner-only while encoding. Replacement preserves the original archive mode. New archives keep umask-based defaults.

## Related issue

Closes #404
