### PR TITLE
fix(browser): do not insert slash when starting the pane filter

### DIFF
--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -53,7 +53,13 @@ struct TypeToSearch {
 
 impl TypeToSearch {
     fn show(&self, query: char) -> bool {
-        self.preferences.type_to_search() && self.view.show_filter_with_query(&query.to_string())
+        if !self.preferences.type_to_search() {
+            return false;
+        }
+        match type_to_search_seed(query) {
+            Some(seed) => self.view.show_filter_with_query(&seed.to_string()),
+            None => self.view.show_filter(),
+        }
     }
 }
 
@@ -1183,6 +1189,11 @@ fn type_to_search_query(key: gtk::gdk::Key, modifiers: gtk::gdk::ModifierType) -
         return None;
     }
     key.to_unicode().filter(|character| !character.is_control())
+}
+
+fn type_to_search_seed(query: char) -> Option<char> {
+    // `/` activates the pane filter; it is not a query character.
+    (query != '/').then_some(query)
 }
 
 fn is_open_terminal_shortcut(key: gtk::gdk::Key, modifiers: gtk::gdk::ModifierType) -> bool {

--- a/src/ui/window/tests.rs
+++ b/src/ui/window/tests.rs
@@ -16,7 +16,7 @@ use super::{
     parse_pinned_places, pin_status, remove_pinned_place, reorder_pinned_places, reorder_places,
     resolve_place_order, serialize_pinned_places, should_show_standard_place,
     sidebar_accepts_file_drop, sidebar_update_label, standard_place, type_to_search_query,
-    vim_focus_direction, volume_release_action,
+    type_to_search_seed, vim_focus_direction, volume_release_action,
 };
 
 fn release(version: &str, kind: BuildKind) -> ReleaseMetadata {
@@ -289,6 +289,17 @@ fn type_to_search_ignores_shortcuts_and_non_printable_keys() {
         type_to_search_query(gtk::gdk::Key::F5, gtk::gdk::ModifierType::empty()),
         None
     );
+}
+
+#[test]
+fn type_to_search_slash_activates_filter_without_seeding() {
+    assert_eq!(
+        type_to_search_query(gtk::gdk::Key::slash, gtk::gdk::ModifierType::empty()),
+        Some('/')
+    );
+    assert_eq!(type_to_search_seed('/'), None);
+    assert_eq!(type_to_search_seed('n'), Some('n'));
+    assert_eq!(type_to_search_seed('?'), Some('?'));
 }
 
 #[test]


### PR DESCRIPTION
## Description

Pressing `/` with a file view focused opened the pane filter already seeded with `/`, so ordinary names in the current folder did not match. Typing after kept the leading slash (`/n`). Ctrl+F opened the same filter empty and worked.

`/` still activates type-to-search when that preference is on, but it now opens the empty filter field used by Ctrl+F instead of inserting `/` as the first query character. Later keys still seed or type into the filter as before.

## Visual evidence

N/A for this revision: the change is keyboard seeding of an existing filter field, not layout or chrome. Screenshots from Columns / Icons / List can be attached after manual verification.

## How to test

1. Open a folder of ordinary names (for example `LICENSE`, `notes.txt`, `readme.md`) with Settings → General → Type to search enabled.
2. Click a file so the file view has keyboard focus (not the location bar).
3. Press `/`.
4. Confirm the filter field is empty (same as Ctrl+F), and that current-folder names are still listed.
5. Type `n` and confirm `notes.txt` matches. The field should be `n`, not `/n`.
6. Press Escape, then Ctrl+F, then `n` and confirm the same match.
7. Repeat steps 2–6 in Appearance → Icons and Appearance → List.

**Expected result:** `/` opens an empty pane filter; subsequent keys filter by name. Nested paths are no longer matched only because `/` appears in `search_path`.

## Related issue

Closes #418