### PR TITLE
fix(file-operations): make copy participate in latest-operation undo

### DIFF
--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -2269,6 +2269,7 @@ impl OperationProvider for LocalOperationProvider {
             let progress = TransferProgressTracker::new(request.id, total_bytes, emit.clone());
             progress.emit();
             let mut completed = Vec::new();
+            let mut created = Vec::new();
             for (index, item) in request.items.iter().enumerate() {
                 if operation_cancellable.is_cancelled() {
                     emit(cancelled_event(
@@ -2374,6 +2375,7 @@ impl OperationProvider for LocalOperationProvider {
                 if let Some(target) = location_for_file(&target) {
                     affected_locations.insert(target);
                 }
+                let created_location = location_for_file(&target);
                 let result = if is_duplicate {
                     copy_new_recursively_with_progress(
                         source,
@@ -2431,11 +2433,15 @@ impl OperationProvider for LocalOperationProvider {
                     return;
                 }
                 completed.push(item.source.clone());
+                if let Some(target) = created_location {
+                    created.push(target);
+                }
                 progress.finish_item(item_started_at, item_sizes[index]);
             }
             emit(OperationEvent::Pasted {
                 request_id: request.id,
                 locations: completed,
+                destinations: created,
             });
         });
         cancellation_handle(cancellable)
@@ -2554,6 +2560,7 @@ impl OperationProvider for LocalOperationProvider {
             emit(OperationEvent::Pasted {
                 request_id: request.id,
                 locations: completed,
+                destinations: Vec::new(),
             });
         });
         cancellation_handle(cancellable)

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -10,7 +10,9 @@ use std::{
 
 use crate::{
     app::navigation::{EntryInsertion, EntrySplice, NavigationPath, NavigationState, sort_entries},
-    model::{FileEntry, Location, SortDirection, SortKey, ViewPreferences},
+    model::{
+        EntryKind, FileEntry, Location, MetadataValue, SortDirection, SortKey, ViewPreferences,
+    },
     services::{
         ArchiveFormat, CompressRequest, CreateDirectoryRequest, CreateFileRequest, DeleteRequest,
         DirectoryChange, DirectoryEvent, DirectoryRequest, ExtractRequest, FileSource, LoadHandle,
@@ -210,17 +212,19 @@ type PreferencesObserver = Rc<dyn Fn(ViewPreferences)>;
 const MAX_INCREMENTAL_OPERATION_UPDATES: usize = 64;
 
 /// The latest reversible operation. Trash entries restore from Trash; moved
-/// entries transfer back to the location they started from.
+/// entries transfer back to the location they started from; copy entries
+/// remove the copies a paste created, leaving the originals untouched.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum UndoEntry {
     Trash(Vec<Location>),
     Move(Vec<MoveRecord>),
+    Copy(Vec<Location>),
 }
 
 impl UndoEntry {
     fn is_empty(&self) -> bool {
         match self {
-            Self::Trash(locations) => locations.is_empty(),
+            Self::Trash(locations) | Self::Copy(locations) => locations.is_empty(),
             Self::Move(records) => records.is_empty(),
         }
     }
@@ -230,6 +234,9 @@ impl UndoEntry {
 struct UndoState {
     generation: u64,
     entry: Option<UndoEntry>,
+    /// The entry displaced when the current one was recorded, restored after
+    /// the current one is undone so Ctrl+Z walks back through operations.
+    previous: Option<UndoEntry>,
     claimed: bool,
 }
 
@@ -244,9 +251,11 @@ fn replace_pending_undo(entry: UndoEntry) {
     }
     PENDING_UNDO.with(|pending| {
         let generation = pending.borrow().generation.saturating_add(1);
+        let previous = pending.borrow_mut().entry.take();
         pending.replace(UndoState {
             generation,
             entry: Some(entry),
+            previous,
             claimed: false,
         });
     });
@@ -285,7 +294,7 @@ fn mark_undo_item_completed(generation: u64, location: &Location) {
             return;
         }
         match pending.entry.as_mut() {
-            Some(UndoEntry::Trash(locations)) => {
+            Some(UndoEntry::Trash(locations)) | Some(UndoEntry::Copy(locations)) => {
                 locations.retain(|candidate| candidate != location);
             }
             Some(UndoEntry::Move(records)) => {
@@ -301,7 +310,7 @@ fn finish_undo(generation: u64, completed: bool) {
         let mut pending = pending.borrow_mut();
         if pending.generation == generation {
             if completed {
-                pending.entry = None;
+                pending.entry = pending.previous.take();
             }
             pending.claimed = false;
         }
@@ -1342,7 +1351,7 @@ impl Browser {
         }
         match peek_pending_undo()? {
             (generation, UndoEntry::Move(records)) => Some((generation, records)),
-            (_, UndoEntry::Trash(_)) => None,
+            _ => None,
         }
     }
 
@@ -1427,6 +1436,83 @@ impl Browser {
             UndoMoveRequest {
                 id: request_id,
                 items,
+            },
+            self.operation_callback(request_id, false, refresh_locations),
+        );
+        self.operation_load.replace(Some(load));
+        true
+    }
+
+    /// The pending copy undo, if the latest reversible operation was a copy.
+    pub fn pending_undo_copy(&self) -> Option<(u64, Vec<Location>)> {
+        if self.current_operation.get().is_some() {
+            return None;
+        }
+        match peek_pending_undo()? {
+            (generation, UndoEntry::Copy(locations)) => Some((generation, locations)),
+            _ => None,
+        }
+    }
+
+    /// Removes the copies a completed paste created, leaving the originals.
+    /// The copies are Strata's own generated duplicates, so they go straight
+    /// to permanent deletion rather than through the Trash.
+    pub fn undo_copy(self: &Rc<Self>, generation: u64, locations: Vec<Location>) -> bool {
+        if locations.is_empty() || self.current_operation.get().is_some() {
+            return false;
+        }
+        let Some((generation, entry)) = claim_pending_undo(Some(generation)) else {
+            return false;
+        };
+        let UndoEntry::Copy(pending_locations) = entry else {
+            finish_undo(generation, false);
+            return false;
+        };
+        let Some(provider) = self.operation_provider.borrow().clone() else {
+            finish_undo(generation, false);
+            return false;
+        };
+        // Keep only the copies this undo will actually delete, so a partial
+        // failure leaves the rest for the next Ctrl+Z.
+        for location in &locations {
+            mark_undo_item_completed(generation, location);
+        }
+        let entries: Vec<_> = locations
+            .iter()
+            .map(|location| FileEntry {
+                kind: if location.native_path().is_some_and(|path| path.is_dir()) {
+                    EntryKind::Directory
+                } else {
+                    EntryKind::File
+                },
+                location: location.clone(),
+                native_name: location.file_name().unwrap_or_default(),
+                thumbnail_path: None,
+                display_name: location.display_name(),
+                size: MetadataValue::Unknown,
+                modified_unix_seconds: MetadataValue::Unknown,
+                is_hidden: false,
+                mode: MetadataValue::Unknown,
+            })
+            .collect();
+        let total = entries.len();
+        let mut refresh_locations = HashSet::new();
+        for location in &locations {
+            if let Some(parent) = location.parent() {
+                refresh_locations.insert(parent);
+            }
+        }
+        let request_id = self.begin_operation();
+        self.deletion_operation.set(true);
+        self.deletion_permanent.set(true);
+        self.undo_claim
+            .replace(Some((generation, UndoEntry::Copy(pending_locations))));
+        self.emit(BrowserEvent::DeletionStarted { total });
+        let load = provider.delete(
+            DeleteRequest {
+                id: request_id,
+                entries,
+                permanent: true,
             },
             self.operation_callback(request_id, false, refresh_locations),
         );
@@ -1647,6 +1733,10 @@ impl Browser {
                     (UndoEntry::Move(_), OperationEvent::Cancelled { result, .. }) => {
                         result.completed.clone()
                     }
+                    (UndoEntry::Copy(_), OperationEvent::Deleted { locations, .. }) => {
+                        locations.clone()
+                    }
+                    (UndoEntry::Copy(_), _) => Vec::new(),
                     (UndoEntry::Move(_), _) => Vec::new(),
                 };
                 for location in &completed {
@@ -1659,6 +1749,7 @@ impl Browser {
                             matches!(&event, OperationEvent::Restored { .. })
                         }
                         UndoEntry::Move(_) => matches!(&event, OperationEvent::Pasted { .. }),
+                        UndoEntry::Copy(_) => matches!(&event, OperationEvent::Deleted { .. }),
                     },
                 );
             }
@@ -1690,10 +1781,14 @@ impl Browser {
                 if undoing.is_none()
                     && let Some(destination) = destination.as_ref()
                 {
-                    replace_pending_undo(UndoEntry::Move(move_records(
-                        &moved_locations,
-                        destination,
-                    )));
+                    if moving == Some(true) {
+                        replace_pending_undo(UndoEntry::Move(move_records(
+                            &moved_locations,
+                            destination,
+                        )));
+                    } else if let OperationEvent::Pasted { destinations, .. } = &event {
+                        replace_pending_undo(UndoEntry::Copy(destinations.clone()));
+                    }
                 }
                 browser.emit(BrowserEvent::TransferFinished {
                     moved_locations: if undoing.is_some() {

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -597,7 +597,17 @@ impl OperationProvider for ImmediateOperationProvider {
     fn paste(&self, request: PasteRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle {
         emit(OperationEvent::Pasted {
             request_id: request.id,
-            locations: request.items.into_iter().map(|item| item.source).collect(),
+            locations: request
+                .items
+                .iter()
+                .map(|item| item.source.clone())
+                .collect(),
+            destinations: request
+                .items
+                .iter()
+                .map(|item| item.source.transfer_target(&request.destination))
+                .collect::<Option<Vec<_>>>()
+                .unwrap_or_default(),
         });
         LoadHandle::new(|| {})
     }
@@ -616,8 +626,13 @@ impl OperationProvider for ImmediateOperationProvider {
             request_id: request.id,
             locations: request
                 .items
+                .iter()
+                .map(|item| item.record.current.clone())
+                .collect(),
+            destinations: request
+                .items
                 .into_iter()
-                .map(|item| item.record.current)
+                .map(|item| item.record.original)
                 .collect(),
         });
         LoadHandle::new(|| {})
@@ -814,6 +829,59 @@ fn a_completed_trash_operation_can_be_undone_once() {
 }
 
 #[test]
+fn undo_walks_back_through_copy_then_trash() {
+    let browser = Browser::new(Rc::new(FakeFileSource));
+    browser.set_operation_provider(Rc::new(ImmediateOperationProvider));
+    let entry = FileEntry {
+        location: Location::local("/fixture/deleted.txt"),
+        thumbnail_path: None,
+        native_name: OsString::from("deleted.txt"),
+        display_name: "deleted.txt".into(),
+        kind: EntryKind::File,
+        size: MetadataValue::Unknown,
+        modified_unix_seconds: MetadataValue::Unknown,
+        is_hidden: false,
+        mode: MetadataValue::Unknown,
+    };
+
+    browser.delete(vec![entry], false);
+    assert_eq!(
+        pending_undo_entry(),
+        Some(UndoEntry::Trash(vec![Location::local(
+            "/fixture/deleted.txt"
+        )]))
+    );
+
+    browser.transfer(
+        Location::local("/fixture"),
+        vec![PasteItem {
+            source: Location::local("/fixture/deleted.txt"),
+            conflict: TransferConflict::FailIfExists,
+        }],
+        false,
+    );
+    assert_eq!(
+        pending_undo_entry(),
+        Some(UndoEntry::Copy(vec![Location::local(
+            "/fixture/deleted.txt"
+        )]))
+    );
+
+    let (generation, locations) = browser.pending_undo_copy().expect("pending copy undo");
+    assert!(browser.undo_copy(generation, locations));
+    assert_eq!(
+        pending_undo_entry(),
+        Some(UndoEntry::Trash(vec![Location::local(
+            "/fixture/deleted.txt"
+        )]))
+    );
+
+    assert!(browser.undo_last_trash());
+    assert_eq!(pending_undo_entry(), None);
+    assert!(!browser.undo_last_trash());
+}
+
+#[test]
 fn another_browser_can_undo_the_latest_trash_operation() {
     let deleting_browser = Browser::new(Rc::new(FakeFileSource));
     deleting_browser.set_operation_provider(Rc::new(ImmediateOperationProvider));
@@ -861,9 +929,12 @@ fn a_completed_move_records_where_each_item_landed() {
 }
 
 #[test]
-fn a_copy_records_no_undo() {
+fn a_completed_copy_becomes_the_latest_undo_and_displaces_an_older_trash_undo() {
     let browser = Browser::new(Rc::new(FakeFileSource));
     browser.set_operation_provider(Rc::new(ImmediateOperationProvider));
+    replace_pending_undo(UndoEntry::Trash(vec![Location::local(
+        "/fixture/deleted.txt",
+    )]));
 
     browser.transfer(
         Location::local("/fixture/archive"),
@@ -874,7 +945,43 @@ fn a_copy_records_no_undo() {
         false,
     );
 
-    assert_eq!(pending_undo_entry(), None);
+    assert_eq!(
+        pending_undo_entry(),
+        Some(UndoEntry::Copy(vec![Location::local(
+            "/fixture/archive/report.txt"
+        )]))
+    );
+}
+
+#[test]
+fn undoing_a_copy_removes_only_the_created_copies_and_restores_the_previous_undo() {
+    let browser = Browser::new(Rc::new(FakeFileSource));
+    browser.set_operation_provider(Rc::new(ImmediateOperationProvider));
+    replace_pending_undo(UndoEntry::Trash(vec![Location::local(
+        "/fixture/deleted.txt",
+    )]));
+    browser.transfer(
+        Location::local("/fixture/archive"),
+        vec![PasteItem {
+            source: Location::local("/fixture/report.txt"),
+            conflict: TransferConflict::FailIfExists,
+        }],
+        false,
+    );
+
+    let (generation, locations) = browser.pending_undo_copy().expect("pending copy undo");
+    assert_eq!(
+        locations,
+        vec![Location::local("/fixture/archive/report.txt")]
+    );
+    assert!(browser.undo_copy(generation, locations));
+
+    assert_eq!(
+        pending_undo_entry(),
+        Some(UndoEntry::Trash(vec![Location::local(
+            "/fixture/deleted.txt"
+        )]))
+    );
 }
 
 #[test]
@@ -1033,6 +1140,7 @@ fn undoing_a_move_leaves_a_pending_cut_untouched() {
     emit(OperationEvent::Pasted {
         request_id,
         locations: vec![record.current.clone()],
+        destinations: vec![record.original.clone()],
     });
 
     assert!(events.borrow().iter().any(|event| matches!(

--- a/src/services/operations.rs
+++ b/src/services/operations.rs
@@ -181,6 +181,9 @@ pub enum OperationEvent {
     Pasted {
         request_id: OperationRequestId,
         locations: Vec<Location>,
+        /// Where each completed item actually landed, which can differ from
+        /// `locations` for same-folder duplicates and conflict renames.
+        destinations: Vec<Location>,
     },
     TransferFailed {
         request_id: OperationRequestId,

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -1027,6 +1027,9 @@ impl BrowserView {
         if let Some((generation, records)) = self.state.browser.pending_undo_move() {
             return self.state.undo_move(generation, records);
         }
+        if let Some((generation, locations)) = self.state.browser.pending_undo_copy() {
+            return self.state.browser.undo_copy(generation, locations);
+        }
         self.state.browser.undo_last_trash()
     }
 


### PR DESCRIPTION
## Description

A completed copy never replaced the single pending undo entry, so after delete → copy → Ctrl+Z, Strata restored the previously deleted files instead of removing the copies (#390, split from #354 item 2). There was no `Copy` undo variant, and the paste event only reported completed *sources*, so the created destinations (`name (1).ext`, conflict-resolved names) were unknown to the undo layer.

What changed:

- `Pasted` now also carries `destinations`: where each item actually landed, including same-folder generated duplicate names and conflict-resolved targets. `locations` (sources) is unchanged for the cut-clipboard pruning.
- New `UndoEntry::Copy(created destinations)` recorded when a copy-paste completes, displacing an older trash/move undo as the latest Ctrl+Z target.
- The undo state keeps the displaced entry: after the copy undo completes, the previous reversible operation (e.g. the trash restore) is available again, so Ctrl+Z walks back through operations.
- `undo_copy` permanently deletes only the copies that operation created; originals and unrelated items are untouched. Copies Strata itself generated skip the Trash.
- Ctrl+Z routing in the browser view: move → copy → trash.

## Visual evidence

<img width="960" height="540" alt="screenrecording-2026-09-06_16-56-33" src="https://github.com/user-attachments/assets/b4333978-0914-43e8-8098-2631dd21b98a" />

## How to test

1. In a writable folder create `deleted.txt` and `copied.txt`.
2. Select `deleted.txt`, press Delete (goes to Trash).
3. Select `copied.txt`, Ctrl+C, Ctrl+V — `copied (1).txt` appears.
4. Press Ctrl+Z — the duplicate disappears; `deleted.txt` stays in Trash and `copied.txt` is untouched.
5. Press Ctrl+Z again — `deleted.txt` is restored from Trash (the previous undo came back).

**Expected result:** undo targets the most recent completed operation: the copy first, then the older trash. No-op pastes (copying a folder into its own subfolder) record no undo.

## Related issue

Closes #390