### PR TITLE
fix(file-operations): select and reveal items a copy created

### DIFF
--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -2269,6 +2269,7 @@ impl OperationProvider for LocalOperationProvider {
             let progress = TransferProgressTracker::new(request.id, total_bytes, emit.clone());
             progress.emit();
             let mut completed = Vec::new();
+            let mut created = Vec::new();
             for (index, item) in request.items.iter().enumerate() {
                 if operation_cancellable.is_cancelled() {
                     emit(cancelled_event(
@@ -2374,6 +2375,7 @@ impl OperationProvider for LocalOperationProvider {
                 if let Some(target) = location_for_file(&target) {
                     affected_locations.insert(target);
                 }
+                let created_location = location_for_file(&target);
                 let result = if is_duplicate {
                     copy_new_recursively_with_progress(
                         source,
@@ -2431,11 +2433,15 @@ impl OperationProvider for LocalOperationProvider {
                     return;
                 }
                 completed.push(item.source.clone());
+                if let Some(target) = created_location {
+                    created.push(target);
+                }
                 progress.finish_item(item_started_at, item_sizes[index]);
             }
             emit(OperationEvent::Pasted {
                 request_id: request.id,
                 locations: completed,
+                destinations: created,
             });
         });
         cancellation_handle(cancellable)
@@ -2554,6 +2560,7 @@ impl OperationProvider for LocalOperationProvider {
             emit(OperationEvent::Pasted {
                 request_id: request.id,
                 locations: completed,
+                destinations: Vec::new(),
             });
         });
         cancellation_handle(cancellable)

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -198,7 +198,11 @@ pub enum BrowserEvent {
     ArchiveCompleted {
         select_name: String,
     },
-    TransferCompleted,
+    TransferCompleted {
+        /// Display names of the items the transfer created, so the view can
+        /// select and reveal them.
+        select_names: Vec<String>,
+    },
 }
 
 /// Events dispatch by reference: payloads move once into authoritative state,
@@ -1786,8 +1790,18 @@ impl Browser {
                         select_name: first_name.unwrap_or_default(),
                     });
                 }
-                OperationEvent::Pasted { .. } => {
-                    browser.emit(BrowserEvent::TransferCompleted);
+                OperationEvent::Pasted { destinations, .. } => {
+                    // Only a copy leaves new items to select; a move's
+                    // destination already carries the source's name.
+                    let select_names = if moving == Some(false) {
+                        destinations
+                            .iter()
+                            .map(|location| location.display_name())
+                            .collect()
+                    } else {
+                        Vec::new()
+                    };
+                    browser.emit(BrowserEvent::TransferCompleted { select_names });
                     for location in &refresh_locations {
                         if location.native_path().is_none() {
                             browser.refresh_columns_at(location);

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -558,6 +558,81 @@ fn transfer_failure_reports_moves_completed_before_the_error() {
     )));
 }
 
+#[test]
+fn a_completed_copy_selects_the_created_destination_names() {
+    let browser = Browser::new(Rc::new(FakeFileSource));
+    browser.set_operation_provider(Rc::new(ImmediateOperationProvider));
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let observed = events.clone();
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
+
+    browser.transfer(
+        Location::local("/fixture"),
+        vec![PasteItem {
+            source: Location::local("/elsewhere/report.txt"),
+            conflict: TransferConflict::FailIfExists,
+        }],
+        false,
+    );
+
+    assert!(events.borrow().iter().any(|event| matches!(
+        event,
+        BrowserEvent::TransferCompleted { select_names }
+            if select_names.as_slice() == ["report.txt"]
+    )));
+}
+
+#[test]
+fn a_completed_move_selects_nothing() {
+    let browser = Browser::new(Rc::new(FakeFileSource));
+    browser.set_operation_provider(Rc::new(ImmediateOperationProvider));
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let observed = events.clone();
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
+
+    browser.transfer(
+        Location::local("/fixture/archive"),
+        vec![PasteItem {
+            source: Location::local("/fixture/report.txt"),
+            conflict: TransferConflict::FailIfExists,
+        }],
+        true,
+    );
+
+    assert!(events.borrow().iter().any(|event| matches!(
+        event,
+        BrowserEvent::TransferCompleted { select_names }
+            if select_names.is_empty()
+    )));
+}
+
+#[test]
+fn a_failed_copy_selects_nothing() {
+    let browser = Browser::new(Rc::new(FakeFileSource));
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let observed = events.clone();
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
+    let request_id = browser.begin_operation();
+    browser.transfer_operation.set(Some(false));
+    browser
+        .transfer_destination
+        .replace(Some(Location::local("/fixture")));
+    let emit = browser.operation_callback(request_id, false, HashSet::new());
+
+    emit(OperationEvent::TransferFailed {
+        request_id,
+        completed_locations: Vec::new(),
+        message: "injected failure".to_owned(),
+    });
+
+    assert!(
+        !events
+            .borrow()
+            .iter()
+            .any(|event| matches!(event, BrowserEvent::TransferCompleted { .. }))
+    );
+}
+
 thread_local! {
     static UNDO_MOVE_REQUESTS: RefCell<Vec<Vec<MoveRecord>>> = const { RefCell::new(Vec::new()) };
 }
@@ -597,7 +672,16 @@ impl OperationProvider for ImmediateOperationProvider {
     fn paste(&self, request: PasteRequest, emit: Rc<dyn Fn(OperationEvent)>) -> LoadHandle {
         emit(OperationEvent::Pasted {
             request_id: request.id,
-            locations: request.items.into_iter().map(|item| item.source).collect(),
+            locations: request
+                .items
+                .iter()
+                .map(|item| item.source.clone())
+                .collect(),
+            destinations: request
+                .items
+                .into_iter()
+                .filter_map(|item| item.source.transfer_target(&request.destination))
+                .collect(),
         });
         LoadHandle::new(|| {})
     }
@@ -616,9 +700,10 @@ impl OperationProvider for ImmediateOperationProvider {
             request_id: request.id,
             locations: request
                 .items
-                .into_iter()
-                .map(|item| item.record.current)
+                .iter()
+                .map(|item| item.record.current.clone())
                 .collect(),
+            destinations: Vec::new(),
         });
         LoadHandle::new(|| {})
     }
@@ -1033,6 +1118,7 @@ fn undoing_a_move_leaves_a_pending_cut_untouched() {
     emit(OperationEvent::Pasted {
         request_id,
         locations: vec![record.current.clone()],
+        destinations: Vec::new(),
     });
 
     assert!(events.borrow().iter().any(|event| matches!(

--- a/src/services/operations.rs
+++ b/src/services/operations.rs
@@ -181,6 +181,9 @@ pub enum OperationEvent {
     Pasted {
         request_id: OperationRequestId,
         locations: Vec<Location>,
+        /// Where each completed item actually landed; can differ from
+        /// `locations` for same-folder duplicates and conflict renames.
+        destinations: Vec<Location>,
     },
     TransferFailed {
         request_id: OperationRequestId,

--- a/src/ui/browser/events.rs
+++ b/src/ui/browser/events.rs
@@ -556,15 +556,14 @@ impl ViewState {
                 if !select_name.is_empty() {
                     self.pending_select.borrow_mut().push(select_name.clone());
                 }
-                if let Some(dest) = self.pending_navigate.take() {
-                    self.browser.navigate(dest);
-                } else {
-                    self.browser.reload_active();
-                }
+                self.select_after_transfer();
             }
-            BrowserEvent::TransferCompleted => {
-                if let Some(dest) = self.pending_navigate.take() {
-                    self.browser.navigate(dest);
+            BrowserEvent::TransferCompleted { select_names } => {
+                if !select_names.is_empty() {
+                    self.pending_select
+                        .borrow_mut()
+                        .extend(select_names.iter().cloned());
+                    self.select_after_transfer();
                 }
             }
         }
@@ -572,6 +571,17 @@ impl ViewState {
             self.refresh_active_path_rows();
         }
         self.mode_views.borrow_mut().handle(event);
+    }
+
+    /// Queues the pending selection, then reloads so `LoadFinished` applies
+    /// it once the created items exist. A pending navigation takes precedence:
+    /// it lands on the destination, and `LoadFinished` selects there.
+    fn select_after_transfer(&self) {
+        if let Some(dest) = self.pending_navigate.take() {
+            self.browser.navigate(dest);
+        } else {
+            self.browser.reload_active();
+        }
     }
 
     fn event_refreshes_active_path(event: &BrowserEvent) -> bool {

--- a/src/ui/window/tests.rs
+++ b/src/ui/window/tests.rs
@@ -678,7 +678,9 @@ fn sidebar_sync_runs_only_for_location_changes() {
         }
     ));
     assert!(!SidebarState::event_changes_active_place(
-        &BrowserEvent::TransferCompleted
+        &BrowserEvent::TransferCompleted {
+            select_names: Vec::new(),
+        }
     ));
 }
 


### PR DESCRIPTION
## Description

After a same-folder Ctrl+C/Ctrl+V paste, the new `name (1).ext` appeared but the original stayed selected — the keyboard cursor and preview kept targeting the source, so the next key press acted on the wrong item (#392, split from #354 item 3). The paste event only reported completed sources, so the created destinations (generated duplicate names, conflict-resolved targets) were unknown to the UI; archive completion already selected its new item, copy never did.

What changed:

- `Pasted` now also carries `destinations`: where each item actually landed, including `name (1).ext` duplicates and conflict-renamed targets.
- `TransferCompleted` carries the created display names for copies (moves and no-ops select nothing).
- The view feeds those names through the existing pending-select mechanism (reload active listing, select and reveal on `LoadFinished`), so it works in Columns, Grid, and List.
- Archive and transfer completion share one `select_after_transfer` helper instead of duplicating the navigate-or-reload dance.
- Failed, skipped, and cancelled pastes never change the selection.

## Visual evidence

N/A — selection state, not visuals; covered by automated tests asserting which names are selected (copies), and that moves/failures select nothing.

## How to test

1. In any view, select a file, Ctrl+C, Ctrl+V into the same folder.
2. The new `name (1).txt` appears selected and focused; pressing Down moves from the copy to the next row, not from the original.
3. Copy several files at once: all created copies are selected, the last one focused.
4. Cancel a paste from its progress dialog: selection is unchanged.

**Expected result:** the created item is selected and revealed when its destination is displayed; the source is left alone.

## Related issue

Closes #392