### PR TITLE
fix(file-operations): make the conflict dialog X button cancel

### DIFF
--- a/src/ui/browser/transfer.rs
+++ b/src/ui/browser/transfer.rs
@@ -249,8 +249,14 @@ impl ViewState {
         let cancel_layer = layer.clone();
         let cancel_overlay = window_overlay.clone();
         let cancel_root = blurred_root.clone();
+        let dismiss_layer = cancel_layer.clone();
+        let dismiss_overlay = cancel_overlay.clone();
+        let dismiss_root = cancel_root.clone();
         cancel.connect_clicked(move |_| {
             dismiss_modal_layer(&cancel_layer, &cancel_overlay, cancel_root.as_ref());
+        });
+        layout.close.connect_clicked(move |_| {
+            dismiss_modal_layer(&dismiss_layer, &dismiss_overlay, dismiss_root.as_ref());
         });
 
         for (button, choice) in [


### PR DESCRIPTION
## Description

The "File already exists" conflict dialog wired Cancel, Skip, Replace, and Escape, but never its header X button — clicking X did nothing and the paste hung in place (#391, split from #354 item 4). The shared `confirm_replace_conflict` helper is used by both paste collisions and undo-move collisions, so both were affected; other dialogs (Empty Trash, archive-exists, delete-confirm, error dialogs) already wired their X, which is why only the conflict dialog looked broken.

The X now dismisses the dialog exactly like Cancel: the whole conflict flow is abandoned and no files are overwritten, renamed, or created.

## Visual evidence

https://github.com/user-attachments/assets/d7f35921-90f5-42db-ad16-9f1554435b5a

## How to test

1. In a folder, create `report.txt` (content `new`) and `sub/report.txt` (content `old`).
2. Copy `report.txt`, navigate into `sub/`, paste — the "File already exists" dialog appears.
3. Click the header X.
4. The dialog closes; `sub/report.txt` still contains `old`.

Repeat with Cancel and Escape to confirm all three dismiss identically, and Replace/Skip to confirm choices are unchanged. Same check on the undo-move collision prompt (move a file over its old name, press Ctrl+Z).

**Expected result:** X, Cancel, and Escape all cancel the conflict flow; Replace and Skip keep their meaning.

## Related issue

Closes #391