### PR TITLE
fix(browser): paste into a single selected folder

### DIFF
--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -871,6 +871,16 @@ impl BrowserView {
     }
 
     pub fn paste(&self) {
+        // A single selected directory receives the paste itself; otherwise
+        // the paste targets the destination column.
+        self.state.sync_mode_selection();
+        let selected = self.state.browser.selected_entries();
+        if let [folder] = selected.as_slice()
+            && folder.is_directory()
+        {
+            self.state.paste_into(folder.location.clone());
+            return;
+        }
         let depth = self.state.destination_depth();
         if let Some(location) = depth.and_then(|depth| self.state.browser.location_at(depth)) {
             self.state.paste_into(location);

--- a/src/ui/browser/events.rs
+++ b/src/ui/browser/events.rs
@@ -42,6 +42,16 @@ impl ViewState {
                 self.set_location(location);
                 if self.mode_views.borrow().mode() == BrowserMode::Columns {
                     self.append_column(*depth, location);
+                    // A pointer click that opens a folder leaves the mouse on
+                    // the parent column, so paste would target the folder's
+                    // parent instead of the folder itself. Follow the newly
+                    // opened column while the pointer owns navigation.
+                    if self.input_ownership.borrow().last_navigation
+                        == super::super::input_ownership::NavigationInput::Pointer
+                    {
+                        self.hovered_column.set(Some(*depth));
+                        self.refresh_destination_style();
+                    }
                 }
             }
             BrowserEvent::EntriesInserted { depth, insertions } => {


### PR DESCRIPTION
## Description

Selecting a folder and pressing Ctrl+V pasted into the visible column instead of the selected folder — the selection highlighted a destination the paste ignored (#449).

When exactly one directory is selected, paste now targets it. Files selected, multiple items, or no selection keep pasting into the destination column. A pointer click that opens a child column also moves the paste destination to that column (the mouse stays parked on the parent while the pointer owns navigation, so the hover used to keep the target stuck one column up).

This deliberately diverges from Nautilus/Thunar/Finder, where Ctrl+V always pastes into the current view; here the single-folder selection is the destination.

## Visual evidence

https://github.com/user-attachments/assets/f2227980-ba5a-4cf5-979b-693c55c7528c

## How to test

1. Create `source.txt` and an empty folder `inside/`.
2. Select `source.txt`, Ctrl+C.
3. Single-click `inside/` so it is highlighted (do not descend into it).
4. Ctrl+V.

**Expected result:** `source.txt` appears inside `inside/`. Repeat with a file selected, multiple items, or nothing selected — the paste lands in the current column. Click a folder to open its child column, then Ctrl+V without moving the mouse — the paste lands in the opened column, not its parent.

## Related issue

Closes #449