### PR TITLE
fix(sidebar): offer Unpin from Properties

### DIFF
--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -75,6 +75,7 @@ pub(super) use crate::ui::modal::{
 };
 
 type PinHandler = Rc<dyn Fn(Location, String)>;
+type UnpinHandler = Rc<dyn Fn(&Location)>;
 type PinStatusHandler = Rc<dyn Fn(&Location) -> PinStatus>;
 type PrintHandler = Rc<dyn Fn(FileEntry)>;
 
@@ -153,6 +154,7 @@ pub(super) struct ViewState {
     file_operation_progress: Cell<(usize, usize)>,
     transfer_progress: Cell<Option<(usize, u64, Option<u64>)>>,
     pin_handler: RefCell<Option<PinHandler>>,
+    unpin_handler: RefCell<Option<UnpinHandler>>,
     pin_status_handler: RefCell<Option<PinStatusHandler>>,
     print_handler: RefCell<Option<PrintHandler>>,
     pending_select: RefCell<Vec<String>>,
@@ -334,6 +336,7 @@ impl BrowserView {
             file_operation_progress: Cell::new((0, 0)),
             transfer_progress: Cell::new(None),
             pin_handler: RefCell::new(None),
+            unpin_handler: RefCell::new(None),
             pin_status_handler: RefCell::new(None),
             print_handler: RefCell::new(None),
             pending_select: RefCell::new(Vec::new()),
@@ -457,8 +460,14 @@ impl BrowserView {
         self.state.browser.clone()
     }
 
-    pub(super) fn set_pin_handlers(&self, handler: PinHandler, status_handler: PinStatusHandler) {
+    pub(super) fn set_pin_handlers(
+        &self,
+        handler: PinHandler,
+        unpin_handler: UnpinHandler,
+        status_handler: PinStatusHandler,
+    ) {
         self.state.pin_handler.replace(Some(handler));
+        self.state.unpin_handler.replace(Some(unpin_handler));
         self.state.pin_status_handler.replace(Some(status_handler));
     }
 

--- a/src/ui/browser/paths.rs
+++ b/src/ui/browser/paths.rs
@@ -9,6 +9,38 @@ pub(super) fn can_pin_entry(entry: &FileEntry, status: PinStatus) -> bool {
     entry.is_directory() && !is_trash_location(&entry.location) && status == PinStatus::Available
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum PinAction {
+    Pin,
+    Unpin,
+}
+
+impl PinAction {
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            Self::Pin => "Pin",
+            Self::Unpin => "Unpin",
+        }
+    }
+}
+
+/// `None` means the location can never be pinned, so the control is hidden
+/// rather than shown in an insensitive state some themes render unreadably.
+pub(super) fn pin_action_for(
+    location: &Location,
+    is_directory: bool,
+    status: PinStatus,
+) -> Option<PinAction> {
+    if !is_directory || is_trash_location(location) {
+        return None;
+    }
+    match status {
+        PinStatus::Available => Some(PinAction::Pin),
+        PinStatus::Pinned => Some(PinAction::Unpin),
+        PinStatus::Unavailable => None,
+    }
+}
+
 pub(in crate::ui) fn is_trash_root(location: &Location) -> bool {
     location.uri_value() == Some("trash:///")
 }

--- a/src/ui/browser/paths/tests.rs
+++ b/src/ui/browser/paths/tests.rs
@@ -70,3 +70,35 @@ fn pinning_requires_an_available_non_trash_directory() {
     assert!(!can_pin_entry(&file, PinStatus::Available));
     assert!(!can_pin_entry(&trash_directory, PinStatus::Available));
 }
+
+#[test]
+fn properties_offers_unpin_for_an_already_pinned_directory() {
+    let folder = Location::local("/fixture/folder");
+
+    assert_eq!(
+        pin_action_for(&folder, true, PinStatus::Available),
+        Some(PinAction::Pin)
+    );
+    assert_eq!(
+        pin_action_for(&folder, true, PinStatus::Pinned),
+        Some(PinAction::Unpin)
+    );
+    assert_eq!(PinAction::Pin.label(), "Pin");
+    assert_eq!(PinAction::Unpin.label(), "Unpin");
+}
+
+#[test]
+fn properties_hides_the_pin_control_where_pinning_is_impossible() {
+    let folder = Location::local("/fixture/folder");
+
+    assert_eq!(pin_action_for(&folder, true, PinStatus::Unavailable), None);
+    assert_eq!(pin_action_for(&folder, false, PinStatus::Available), None);
+    assert_eq!(
+        pin_action_for(
+            &Location::uri("trash:///folder"),
+            true,
+            PinStatus::Available
+        ),
+        None
+    );
+}

--- a/src/ui/browser/properties.rs
+++ b/src/ui/browser/properties.rs
@@ -6,7 +6,7 @@ use crate::model::{FileEntry, Location};
 use crate::ui::browser::clipboard::copy_path_text;
 use crate::ui::browser::desktop::open_location;
 use crate::ui::browser::entry::{entry_icon, format_file_size, item_count_label};
-use crate::ui::browser::paths::{compact_display_path, is_trash_location, is_trash_root};
+use crate::ui::browser::paths::{PinAction, compact_display_path, is_trash_root, pin_action_for};
 use crate::ui::browser::{PinStatus, ViewState};
 use crate::ui::controls::{form_check_button, modal_layout};
 use crate::ui::modal::{ModalHost, dismiss_modal_layer, modal_layer, show_error_dialog};
@@ -317,15 +317,15 @@ impl ViewState {
             entry.is_some() && (self.interactive || self.browser.selected_entries().len() == 1),
         );
         open.set_visible(self.interactive);
-        let pin = properties_action(crate::assets::icons::PIN, "Pin");
-        pin.set_visible(self.interactive);
         let pin_handler = self.pin_handler.borrow().clone();
-        pin.set_sensitive(
-            is_directory
-                && !is_trash_location(&location)
-                && pin_handler.is_some()
-                && pin_status == PinStatus::Available,
+        let unpin_handler = self.unpin_handler.borrow().clone();
+        let pin_action = pin_action_for(&location, is_directory, pin_status)
+            .filter(|_| pin_handler.is_some() && unpin_handler.is_some());
+        let pin = properties_action(
+            crate::assets::icons::PIN,
+            pin_action.unwrap_or(PinAction::Pin).label(),
         );
+        pin.set_visible(self.interactive && pin_action.is_some());
         let copy_path = properties_action(crate::assets::icons::COPY, "Copy path");
         layout.actions.prepend(&copy_path);
         layout.actions.prepend(&pin);
@@ -419,8 +419,18 @@ impl ViewState {
         let pinning_location = location.clone();
         let pinning_name = name.clone();
         pin.connect_clicked(move |_| {
-            if let Some(handler) = pin_handler.as_ref() {
-                handler(pinning_location.clone(), pinning_name.clone());
+            match pin_action {
+                Some(PinAction::Pin) => {
+                    if let Some(handler) = pin_handler.as_ref() {
+                        handler(pinning_location.clone(), pinning_name.clone());
+                    }
+                }
+                Some(PinAction::Unpin) => {
+                    if let Some(handler) = unpin_handler.as_ref() {
+                        handler(&pinning_location);
+                    }
+                }
+                None => {}
             }
             dismiss_modal_layer(&pinning_layer, &pinning_overlay, pinning_root.as_ref());
         });

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -201,11 +201,17 @@ fn present_target(
     content.set_vexpand(true);
     let sidebar = build_sidebar(browser.clone(), theme_manager.clone(), false);
     let weak_sidebar = Rc::downgrade(&sidebar.state);
+    let weak_unpin_sidebar = Rc::downgrade(&sidebar.state);
     let pinned_places = sidebar.state.pinned_places.clone();
     browser.set_pin_handlers(
         Rc::new(move |location, name| {
             if let Some(sidebar) = weak_sidebar.upgrade() {
                 sidebar.pin_location(location, name);
+            }
+        }),
+        Rc::new(move |location| {
+            if let Some(sidebar) = weak_unpin_sidebar.upgrade() {
+                sidebar.unpin_location(location);
             }
         }),
         Rc::new(move |location| pin_status(&pinned_places.borrow(), location)),

--- a/tests/e2e/scenarios/test_dialogs_and_menus.py
+++ b/tests/e2e/scenarios/test_dialogs_and_menus.py
@@ -52,12 +52,53 @@ def test_the_pane_context_menu_offers_directory_actions(strata):
     strata.dismiss_menu()
 
 
-def test_properties_opens_and_closes(strata):
-    strata.open_context_menu("readme.md")
+def _open_properties(strata, name):
+    strata.open_context_menu(name)
     strata.choose_menu_item("Properties")
+    return strata.wait_for_dialog()
 
-    dialog = strata.wait_for_dialog()
+
+def test_properties_opens_and_closes(strata):
+    dialog = _open_properties(strata, "readme.md")
     assert "readme.md" in dialog.dump(), "the dialog should describe the file"
+
+    strata.keyboard.press("Escape")
+    strata.wait(lambda: strata.dialog() is None, "Escape to close the dialog")
+
+
+def test_properties_pins_a_folder_and_offers_unpin_afterwards(strata):
+    dialog = _open_properties(strata, "documents")
+    pin = dialog.find(role="button", name="Pin")
+    assert pin is not None, dialog.dump()
+    assert "sensitive" in pin.states
+    strata.pointer.click(pin)
+    strata.wait(lambda: strata.dialog() is None, "the dialog to close after pinning")
+    strata.wait(
+        lambda: strata.window.find(role="button", name="documents"),
+        "the pinned sidebar row",
+    )
+
+    dialog = _open_properties(strata, "documents")
+    unpin = dialog.find(role="button", name="Unpin")
+    assert unpin is not None, (
+        f"Properties must offer Unpin for a pinned folder\n{dialog.dump()}"
+    )
+    assert "sensitive" in unpin.states, "the Unpin control must stay readable"
+    assert dialog.find(role="button", name="Pin") is None
+
+    strata.pointer.click(unpin)
+    strata.wait(lambda: strata.dialog() is None, "the dialog to close after unpinning")
+    strata.wait(
+        lambda: strata.window.find(role="button", name="documents") is None,
+        "the sidebar row to disappear",
+    )
+
+
+def test_properties_hides_the_pin_control_for_a_file(strata):
+    dialog = _open_properties(strata, "readme.md")
+
+    assert dialog.find(role="button", name="Pin") is None, dialog.dump()
+    assert dialog.find(role="button", name="Unpin") is None, dialog.dump()
 
     strata.keyboard.press("Escape")
     strata.wait(lambda: strata.dialog() is None, "Escape to close the dialog")


### PR DESCRIPTION
## Description

Properties left the Pin control insensitive once a location was already pinned, so unpinning looked impossible from that dialog. Themes that dim insensitive labels heavily (Azure Glow, per the report) rendered the label nearly unreadable.

Tasks from the issue:

- **Properties now offers Unpin for a pinned location.** The action switches its label to `Unpin` and removes the location from the sidebar, matching what the pinned sidebar row's context menu already did.
- **The control is readable.** It is a normal sensitive button in both states, so no theme renders it as a dimmed, unreadable label.
- **No insensitive Pin control is left behind.** Where pinning can never apply — files, trash, and the standard places that are always in the sidebar — the control is hidden outright instead of being shown insensitive. This mirrors how the entry context menu already hides "Pin to sidebar" for non-directories.

The pin/unpin decision lives in one pure helper (`pin_action_for`) with unit tests, and the flow is covered end to end by the headless GUI suite.

## Visual evidence

Properties for a folder that is already pinned:

| Before | After |
| --- | --- |
| ![Properties for a pinned folder before the fix](https://raw.githubusercontent.com/spandan11106/strata/7c3e2e6a47bcb4e3ad156fd99c0143d3f2ddae72/properties-pin-before.png) | ![Properties for a pinned folder after the fix](https://raw.githubusercontent.com/spandan11106/strata/7c3e2e6a47bcb4e3ad156fd99c0143d3f2ddae72/properties-pin-after.png) |
| The action reads `Pin` and is insensitive — dimmed icon and label, no way to unpin. | The action reads `Unpin`, fully sensitive, and unpins on click. |

Both captured with the headless end-to-end harness.

## How to test

1. Start Strata in any directory that contains a subfolder.
2. Right-click the subfolder and choose **Properties**, then click **Pin**. The folder appears in the sidebar.
3. Right-click the same subfolder and choose **Properties** again.
4. Click **Unpin**.
5. Open **Properties** for a plain file.

**Expected result:** step 3 shows a readable, sensitive **Unpin** action instead of an insensitive **Pin**; step 4 removes the folder from the sidebar and closes the dialog; step 5 shows no pin control at all rather than a dimmed one.

## Related issue

Closes #438
