### PR TITLE
fix(ui): remove invalid @media rule from GTK CSS

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -3770,4 +3770,3 @@ menubutton.icons-thumbnail-menu > button:focus-visible {
   padding-bottom: 5px;
   padding-top: 5px;
 }
-

--- a/src/style.css
+++ b/src/style.css
@@ -3774,8 +3774,3 @@ menubutton.icons-thumbnail-menu > button:focus-visible {
   padding-top: 5px;
 }
 
-@media (prefers-reduced-motion: reduce) {
-  * {
-    transition-duration: 1ms;
-  }
-}

--- a/src/ui/window/tests.rs
+++ b/src/ui/window/tests.rs
@@ -787,3 +787,27 @@ fn control_digits_select_each_browser_presentation() {
     assert_eq!(browser_mode_for_digit(gtk::gdk::Key::_4), None);
     assert_eq!(browser_mode_for_digit(gtk::gdk::Key::a), None);
 }
+
+#[test]
+fn the_bundled_stylesheet_only_uses_at_rules_gtk_parses() {
+    // GTK's CSS parser rejects anything outside this set with a startup
+    // "Unknown @ rule" warning; `@media` only became valid in GTK 4.20.
+    const SUPPORTED: [&str; 3] = ["define-color", "import", "keyframes"];
+
+    let unsupported: Vec<&str> = include_str!("../../style.css")
+        .lines()
+        .filter_map(|line| line.trim_start().strip_prefix('@'))
+        .map(|rule| {
+            let end = rule
+                .find(|character: char| !character.is_ascii_alphanumeric() && character != '-')
+                .unwrap_or(rule.len());
+            &rule[..end]
+        })
+        .filter(|rule| !SUPPORTED.contains(rule))
+        .collect();
+
+    assert!(
+        unsupported.is_empty(),
+        "the stylesheet uses at-rules GTK 4.12 cannot parse: {unsupported:?}"
+    );
+}


### PR DESCRIPTION
## Description

`src/style.css` ended with an `@media (prefers-reduced-motion: reduce)` block. GTK's CSS parser rejects `@media` before GTK 4.20, so every launch on the supported baseline (GTK 4.12+, e.g. Ubuntu 24.04's 4.14.5) logged `Gtk-WARNING: Theme parser error: <data>:…: Unknown @ rule` and the block never applied.

Tasks from the issue:

- **Removed the invalid `@media` rule.** The block is gone, so the stylesheet no longer contains anything GTK's parser refuses.
- **No invalid CSS at startup.** `src/style.css` now parses with zero `parsing-error` signals; the remaining at-rules are two `@keyframes`, which GTK has always supported.
- **Reduced motion stays with the existing setting.** Settings → Reduce motion still drives `ui::motion::animations_enabled`, which gates the sidebar, column, and preview animations. No new CSS-side mechanism was added.

A unit test now scans the bundled stylesheet and fails on any at-rule outside `@define-color` / `@import` / `@keyframes`, so a future `@media` cannot slip back in unnoticed.

One thing worth flagging for the reviewer: GTK 4.20 and newer *do* parse `@media (prefers-reduced-motion: reduce)` — verified locally against GTK 4.22, where the block loaded without error. So on those versions the rule was live rather than dead, and removing it means the *system* reduced-motion preference no longer shortens CSS transitions. That behaviour was inconsistent anyway (it bypassed Strata's own setting and did nothing at all on GTK 4.12–4.19). If the toggle should also cut CSS transitions, that is worth doing deliberately through the setting rather than through a version-dependent media query.

## Visual evidence

N/A — the change removes a stylesheet block that GTK never applied on the supported baseline. It is log-only, with no rendered difference; the visual baseline scenarios in the end-to-end suite are unchanged.

## How to test

1. Build and launch Strata from a terminal on GTK 4.12–4.19 (Ubuntu 24.04 ships 4.14.5).
2. Watch the terminal output during startup.
3. Open Settings and toggle **Reduce motion**, then switch view modes and open the preview.

**Expected result:** no `Gtk-WARNING: Theme parser error … Unknown @ rule` appears at step 2, and the Reduce motion toggle still suppresses the sidebar, column, and preview animations at step 3.

## Related issue

Closes #436
