### PR TITLE
fix(dialogs): submit modal forms with Enter

### DIFF
--- a/src/ui/browser/archive.rs
+++ b/src/ui/browser/archive.rs
@@ -14,7 +14,9 @@ use crate::ui::controls::{
     ModalTone, form_entry, form_label, form_password_entry, message_dialog_description,
     message_dialog_layout, modal_layout, segmented_control,
 };
-use crate::ui::modal::{ModalHost, dismiss_modal_layer, modal_layer, show_error_dialog};
+use crate::ui::modal::{
+    ModalHost, dismiss_modal_layer, modal_layer, show_error_dialog, submit_on_enter,
+};
 use gtk::prelude::*;
 use gtk::{gio, glib};
 use std::cell::Cell;
@@ -344,6 +346,7 @@ impl ViewState {
                 );
             }
         });
+        submit_on_enter(&body, &confirm);
         name_entry.grab_focus();
     }
 
@@ -460,6 +463,7 @@ impl ViewState {
             dismiss_for_confirm();
         });
 
+        submit_on_enter(&body, &confirm);
         field.grab_focus();
     }
 
@@ -491,6 +495,7 @@ impl ViewState {
             dismiss_for_confirm();
             browser.extract(entry.clone(), destination.clone(), password);
         });
+        submit_on_enter(&body, &confirm);
         password_entry.grab_focus();
     }
 }

--- a/src/ui/browser/location.rs
+++ b/src/ui/browser/location.rs
@@ -11,7 +11,9 @@ use crate::ui::browser::{BrowserView, ViewState};
 use crate::ui::controls::{
     form_entry, form_label, form_password_entry, modal_layout, segmented_control, wrap_dialog_text,
 };
-use crate::ui::modal::{ModalHost, dismiss_modal_layer, modal_layer, show_error_dialog};
+use crate::ui::modal::{
+    ModalHost, dismiss_modal_layer, modal_layer, show_error_dialog, submit_on_enter,
+};
 use gtk::prelude::*;
 use gtk::{gio, glib};
 use std::cell::{Cell, RefCell};
@@ -254,12 +256,7 @@ fn show_authentication_dialog(
         }
     });
 
-    for entry in [&username, &domain] {
-        let submit = connect.clone();
-        entry.connect_activate(move |_| submit.emit_clicked());
-    }
-    let submit = connect.clone();
-    password.connect_activate(move |_| submit.emit_clicked());
+    submit_on_enter(&layout.body, &connect);
 
     let escape = gtk::EventControllerKey::new();
     let escape_operation = operation.cloned();

--- a/src/ui/browser/transfer.rs
+++ b/src/ui/browser/transfer.rs
@@ -13,7 +13,7 @@ use crate::ui::controls::{
     ModalTone, form_check_button, form_entry, form_label, message_dialog_description,
     message_dialog_layout, modal_layout,
 };
-use crate::ui::modal::{ModalHost, dismiss_modal_layer, modal_layer};
+use crate::ui::modal::{ModalHost, dismiss_modal_layer, modal_layer, submit_on_enter};
 use gtk::prelude::*;
 use gtk::{gio, glib};
 use std::cell::{Cell, RefCell};
@@ -577,8 +577,7 @@ impl ViewState {
                 }
             });
         });
-        let activate_confirm = confirm.clone();
-        field.connect_activate(move |_| activate_confirm.emit_clicked());
+        submit_on_enter(&layout.body, &confirm);
         let escape = gtk::EventControllerKey::new();
         let escape_layer = layer.clone();
         let escape_overlay = window_overlay;

--- a/src/ui/modal.rs
+++ b/src/ui/modal.rs
@@ -109,6 +109,32 @@ pub(super) fn modal_layer(
     layer
 }
 
+/// The modal equivalent of a window's default widget: Enter in any single-line field under
+/// `fields` invokes `confirm`, matching a click on it. Multi-line inputs are left alone so they
+/// keep their newline, and an insensitive primary action stays inert. Call this once the form's
+/// fields are in place, since it wires the fields present at that moment.
+pub(super) fn submit_on_enter(fields: &impl IsA<gtk::Widget>, confirm: &gtk::Button) {
+    let mut child = fields.as_ref().first_child();
+    while let Some(widget) = child {
+        child = widget.next_sibling();
+        if let Some(entry) = widget.downcast_ref::<gtk::Entry>() {
+            let confirm = confirm.clone();
+            entry.connect_activate(move |_| activate_primary(&confirm));
+        } else if let Some(entry) = widget.downcast_ref::<gtk::PasswordEntry>() {
+            let confirm = confirm.clone();
+            entry.connect_activate(move |_| activate_primary(&confirm));
+        } else {
+            submit_on_enter(&widget, confirm);
+        }
+    }
+}
+
+fn activate_primary(confirm: &gtk::Button) {
+    if confirm.is_sensitive() {
+        confirm.emit_clicked();
+    }
+}
+
 pub(super) fn animate_in(layer: &gtk::Box) {
     layer.remove_css_class("dismissing");
     layer.set_sensitive(true);

--- a/src/ui/modal.rs
+++ b/src/ui/modal.rs
@@ -109,10 +109,6 @@ pub(super) fn modal_layer(
     layer
 }
 
-/// The modal equivalent of a window's default widget: Enter in any single-line field under
-/// `fields` invokes `confirm`, matching a click on it. Multi-line inputs are left alone so they
-/// keep their newline, and an insensitive primary action stays inert. Call this once the form's
-/// fields are in place, since it wires the fields present at that moment.
 pub(super) fn submit_on_enter(fields: &impl IsA<gtk::Widget>, confirm: &gtk::Button) {
     let mut child = fields.as_ref().first_child();
     while let Some(widget) = child {

--- a/src/ui/modal/tests.rs
+++ b/src/ui/modal/tests.rs
@@ -47,6 +47,38 @@ fn modal_hosts_preserve_nested_blur_and_support_plain_overlays() {
     );
 }
 
+#[test]
+fn enter_in_a_single_line_field_invokes_the_primary_action() {
+    crate::test_support::gtk_test(
+        "ui::modal::tests::enter_in_a_single_line_field_invokes_the_primary_action",
+        || {
+            let body = gtk::Box::new(gtk::Orientation::Vertical, 0);
+            let nested = gtk::Box::new(gtk::Orientation::Vertical, 0);
+            let name = gtk::Entry::new();
+            let password = gtk::PasswordEntry::new();
+            nested.append(&password);
+            nested.append(&gtk::TextView::new());
+            body.append(&name);
+            body.append(&nested);
+
+            let confirm = gtk::Button::with_label("Compress");
+            let clicks = Rc::new(Cell::new(0_usize));
+            let counted = clicks.clone();
+            confirm.connect_clicked(move |_| counted.set(counted.get() + 1));
+            submit_on_enter(&body, &confirm);
+
+            name.emit_by_name::<()>("activate", &[]);
+            assert_eq!(clicks.get(), 1, "a text field should submit the form");
+            password.emit_by_name::<()>("activate", &[]);
+            assert_eq!(clicks.get(), 2, "a nested password field should submit too");
+
+            confirm.set_sensitive(false);
+            name.emit_by_name::<()>("activate", &[]);
+            assert_eq!(clicks.get(), 2, "a disabled primary action stays inert");
+        },
+    );
+}
+
 fn wait_until(condition: impl Fn() -> bool) {
     let deadline = Instant::now() + Duration::from_secs(5);
     while !condition() {

--- a/tests/e2e/scenarios/test_dialogs_and_menus.py
+++ b/tests/e2e/scenarios/test_dialogs_and_menus.py
@@ -151,3 +151,87 @@ def test_the_shortcut_reference_opens_and_closes(strata):
         lambda: strata.window.find(role="label", name="Keyboard shortcuts") is None,
         "Escape to close the shortcut reference",
     )
+
+
+def compress_from_the_context_menu(strata, entry_name, archive_name):
+    strata.open_context_menu(entry_name)
+    strata.choose_menu_item("Compress…")
+    field = strata.editable_field()
+    strata.keyboard.press("ctrl+a")
+    strata.keyboard.type_text(archive_name)
+    strata.wait(
+        lambda: field.text == archive_name, f"{archive_name!r} to reach the name field"
+    )
+    return field
+
+
+def test_enter_submits_the_compress_dialog(strata):
+    compress_from_the_context_menu(strata, "readme.md", "bundle")
+
+    strata.keyboard.press("Return")
+
+    strata.wait(lambda: strata.dialog() is None, "the dialog to close")
+    strata.wait(
+        lambda: strata.fixture.path("bundle.zip").exists(),
+        "Enter to create the archive",
+    )
+
+
+def test_an_invalid_archive_name_keeps_the_compress_dialog_open(strata):
+    compress_from_the_context_menu(strata, "readme.md", "../escape")
+
+    strata.keyboard.press("Return")
+
+    dialog = strata.wait_for_dialog()
+    assert dialog.name == "Compress 1 item", (
+        f"an invalid name must keep the dialog open, got {dialog.name!r}"
+    )
+    assert not strata.fixture.path("escape.zip").exists(), (
+        "an invalid name must not produce an archive"
+    )
+    strata.keyboard.press("Escape")
+
+
+def test_enter_submits_the_extract_to_dialog(strata):
+    compress_from_the_context_menu(strata, "readme.md", "bundle")
+    strata.keyboard.press("Return")
+    strata.wait(
+        lambda: strata.fixture.path("bundle.zip").exists(), "the archive to be created"
+    )
+
+    destination = strata.fixture.path("unpacked")
+    strata.open_context_menu("bundle.zip")
+    strata.choose_menu_item("Extract to…")
+    field = strata.editable_field()
+    strata.keyboard.press("ctrl+a")
+    strata.keyboard.type_text(str(destination))
+    strata.wait(
+        lambda: field.text == str(destination), "the destination to reach the field"
+    )
+
+    strata.keyboard.press("Return")
+
+    strata.wait(
+        lambda: (destination / "readme.md").exists(),
+        "Enter to extract into the destination",
+    )
+
+
+def test_enter_submits_the_copy_to_dialog(strata):
+    destination = strata.fixture.path("documents")
+
+    strata.open_context_menu("todo.txt")
+    strata.choose_menu_item("Copy to…")
+    field = strata.editable_field()
+    strata.keyboard.press("ctrl+a")
+    strata.keyboard.type_text(str(destination))
+    strata.wait(
+        lambda: field.text == str(destination), "the destination to reach the field"
+    )
+
+    strata.keyboard.press("Return")
+
+    strata.wait(
+        lambda: (destination / "todo.txt").exists(),
+        "Enter to copy into the destination",
+    )


### PR DESCRIPTION
## Description

Enter in a single-line modal field did not reliably invoke the form's primary action. The archive dialogs built by `build_archive_modal` connected the confirm button with `connect_clicked` only and never touched their entries, so Enter fell through to `focus_navigation`, which skips activation while an editable has focus. `Copy to…` and the mount authentication dialog each worked around this separately with their own per-field `connect_activate` handlers.

Rather than patch the compression field, this adds one default-action pattern in `src/ui/modal.rs` and routes every modal form through it:

- `submit_on_enter(fields, confirm)` walks a form's widget tree and connects `activate` on each single-line field (`gtk::Entry`, `gtk::PasswordEntry`) to the primary action, the way a `GtkWindow`'s default widget behaves. The overlay modals are not `GtkWindow`s, so `set_default_widget` is not available to them.
- Multi-line inputs are not descended into as fields, so a `GtkTextView` keeps its newline.
- The action fires only while it is sensitive, so a form mid-operation (for example "Creating folder…") stays inert.
- Validation is untouched: an invalid form still keeps the dialog open and shows its existing error state.

Dialogs covered by the shared pattern:

| Dialog | Before | After |
| --- | --- | --- |
| Compress (name, password, confirm password) | Enter did nothing | Enter runs **Compress** |
| Extract to (destination) | Enter did nothing | Enter runs **Extract here** |
| Extract password (password) | Enter did nothing | Enter runs **Extract** |
| Copy to / Move to (destination) | worked via an ad-hoc handler | same behavior, now the shared pattern, and inert while the folder is being created |
| Mount authentication (username, domain, password) | worked via three ad-hoc handlers | same behavior, now the shared pattern |

Coverage added rather than just the one field:

- Unit test for the pattern itself: a nested password field submits, a `GtkTextView` is not treated as a field, and a disabled primary action stays inert.
- End-to-end scenarios driving real keys: Enter submits Compress, Enter submits Extract to, Enter submits Copy to (regression guard for the dialog that already worked), and an invalid archive name keeps the Compress dialog open without producing an archive.

## Visual evidence

N/A — keyboard interaction only; no pixels change. The behavior is asserted by the end-to-end scenarios listed above.

## How to test

1. Right-click a file → **Compress…**, type a valid archive name, press Enter. The archive is created and the dialog closes.
2. Repeat with an invalid name such as `../escape` and press Enter. The dialog stays open and the field shows its validation state; no archive is written.
3. Right-click that archive → **Extract to…**, type a destination folder, press Enter. The archive is extracted there.
4. Right-click a file → **Copy to…**, type a destination folder, press Enter. The file is copied.
5. Open a password-protected archive so the password prompt appears, type the password, press Enter.

**Expected result:** Enter in each single-line field does exactly what clicking that dialog's primary button does; invalid forms stay open with their validation state intact.

## Related issue

Closes #439