### PR TITLE
fix(terminal): name the missing terminal helper in the error

### DIFF
--- a/src/ui/browser/desktop.rs
+++ b/src/ui/browser/desktop.rs
@@ -4,11 +4,11 @@ use crate::adapters::gio_file_for_location;
 use crate::model::{FileEntry, Location};
 use crate::ui::browser::paths::is_trash_location;
 use crate::ui::modal::show_error_dialog;
+use crate::ui::terminal;
 use gtk::gio;
 use gtk::prelude::*;
 use std::ffi::OsString;
 use std::path::Path;
-use std::process::{Command, Stdio};
 
 pub(in crate::ui) fn open_location(location: &Location, parent: &impl IsA<gtk::Widget>) {
     let file = gio_file_for_location(location);
@@ -67,15 +67,16 @@ pub(in crate::ui) fn launch_terminal(location: &Location, parent: &impl IsA<gtk:
         location = %location.diagnostic_path(),
         "opening terminal"
     );
-    let result = Command::new("xdg-terminal-exec")
+    let result = terminal::command()
         .arg(terminal_directory_argument(&path))
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
         .spawn();
     if let Err(error) = result {
-        tracing::warn!(%error, "unable to launch terminal");
-        show_error_dialog(parent, "Unable to open terminal", &error.to_string());
+        tracing::warn!(%error, launcher = terminal::LAUNCHER, "unable to launch terminal");
+        show_error_dialog(
+            parent,
+            "Unable to open terminal",
+            &terminal::launch_failure(&error),
+        );
     }
 }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -20,6 +20,7 @@ mod scrolling;
 mod search;
 mod settings;
 mod shortcut_footer;
+mod terminal;
 mod theme;
 mod thumbnail;
 mod thumbnail_cache;

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -2,7 +2,7 @@
 
 use std::{
     cell::{Cell, RefCell},
-    process::{Command, Stdio},
+    process::Command,
     rc::Rc,
     sync::{OnceLock, mpsc::TryRecvError},
     time::{Duration, Instant},
@@ -27,6 +27,7 @@ use super::{
     browser::{BrowserView, dismiss_modal_layer, modal_layer},
     browser_modes::{BrowserMode, ClickActivation, ClickCount},
     controls::{form_entry, menu_option, modal_layout, segmented_control},
+    terminal,
     theme::{TextSize, Theme, ThemeManager, ThemeTokens},
 };
 
@@ -2101,12 +2102,8 @@ fn aur_update_action_label() -> &'static str {
 }
 
 fn aur_update_command(helper: &str, package: &str) -> Command {
-    let mut command = Command::new("xdg-terminal-exec");
-    command
-        .args(["--", helper, "-Syu", package])
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
+    let mut command = terminal::command();
+    command.args(["--", helper, "-Syu", package]);
     command
 }
 
@@ -2118,7 +2115,7 @@ fn launch_aur_update() -> Result<&'static str, String> {
         return aur_update_command(helper, package)
             .spawn()
             .map(|_child| "AUR update opened in your terminal.")
-            .map_err(|error| error.to_string());
+            .map_err(|error| terminal::launch_failure(&error));
     }
     let package = managed
         .package()
@@ -2130,12 +2127,8 @@ fn launch_aur_update() -> Result<&'static str, String> {
 }
 
 fn omarchy_update_command() -> Command {
-    let mut command = Command::new("xdg-terminal-exec");
-    command
-        .args(["--", "omarchy", "update"])
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
+    let mut command = terminal::command();
+    command.args(["--", "omarchy", "update"]);
     command
 }
 
@@ -2143,7 +2136,7 @@ fn launch_omarchy_update() -> Result<(), String> {
     omarchy_update_command()
         .spawn()
         .map(|_child| ())
-        .map_err(|error| error.to_string())
+        .map_err(|error| terminal::launch_failure(&error))
 }
 
 /// Renders `release`'s channel, tag, source commit, and publication date as

--- a/src/ui/terminal.rs
+++ b/src/ui/terminal.rs
@@ -3,10 +3,8 @@
 use std::io::ErrorKind;
 use std::process::{Command, Stdio};
 
-/// The XDG helper every "open a terminal" path spawns.
 pub(super) const LAUNCHER: &str = "xdg-terminal-exec";
 
-/// The launcher with its standard streams detached, so the terminal outlives Strata.
 pub(super) fn command() -> Command {
     let mut command = Command::new(LAUNCHER);
     command
@@ -16,8 +14,6 @@ pub(super) fn command() -> Command {
     command
 }
 
-/// Names the launcher in the failure. A bare "No such file or directory" leaves no clue
-/// which program is missing or how to supply it.
 pub(super) fn launch_failure(error: &std::io::Error) -> String {
     if error.kind() == ErrorKind::NotFound {
         return format!("Terminal launcher “{LAUNCHER}” was not found on your PATH");

--- a/src/ui/terminal.rs
+++ b/src/ui/terminal.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::io::ErrorKind;
+use std::process::{Command, Stdio};
+
+/// The XDG helper every "open a terminal" path spawns.
+pub(super) const LAUNCHER: &str = "xdg-terminal-exec";
+
+/// The launcher with its standard streams detached, so the terminal outlives Strata.
+pub(super) fn command() -> Command {
+    let mut command = Command::new(LAUNCHER);
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    command
+}
+
+/// Names the launcher in the failure. A bare "No such file or directory" leaves no clue
+/// which program is missing or how to supply it.
+pub(super) fn launch_failure(error: &std::io::Error) -> String {
+    if error.kind() == ErrorKind::NotFound {
+        return format!("Terminal launcher “{LAUNCHER}” was not found on your PATH");
+    }
+    format!("Terminal launcher “{LAUNCHER}” could not be started: {error}")
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/ui/terminal/tests.rs
+++ b/src/ui/terminal/tests.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use super::*;
+
+#[test]
+fn a_missing_launcher_is_named_in_the_failure() {
+    let message = launch_failure(&std::io::Error::from(ErrorKind::NotFound));
+
+    assert_eq!(
+        message,
+        "Terminal launcher “xdg-terminal-exec” was not found on your PATH"
+    );
+}
+
+#[test]
+fn other_launch_failures_name_the_launcher_and_keep_the_cause() {
+    let error = std::io::Error::from(ErrorKind::PermissionDenied);
+    let message = launch_failure(&error);
+
+    assert!(
+        message.starts_with("Terminal launcher “xdg-terminal-exec” could not be started: "),
+        "unexpected message: {message}"
+    );
+    assert!(
+        message.ends_with(&error.to_string()),
+        "the cause is dropped: {message}"
+    );
+}
+
+#[test]
+fn the_launcher_command_runs_the_xdg_helper() {
+    assert_eq!(command().get_program(), LAUNCHER);
+}

--- a/tests/e2e/scenarios/test_terminal.py
+++ b/tests/e2e/scenarios/test_terminal.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Opening a terminal, and what is reported when the launcher is missing."""
+
+from __future__ import annotations
+
+import pytest
+
+from harness import environment as harness_environment
+
+LAUNCHER = "xdg-terminal-exec"
+
+
+@pytest.fixture
+def test_environment():
+    """A HOME whose PATH holds no terminal launcher.
+
+    The whole module covers what Strata reports when the helper is absent, so
+    the search path is emptied rather than depending on what the host installs.
+    """
+
+    environment = harness_environment.TestEnvironment()
+    inherited = environment.variables
+    empty_path = environment.root / "empty-path"
+    empty_path.mkdir()
+
+    def variables():
+        return {**inherited(), "PATH": str(empty_path)}
+
+    environment.variables = variables
+    try:
+        yield environment
+    finally:
+        environment.cleanup()
+
+
+def test_a_missing_terminal_launcher_is_named_in_the_error(strata):
+    strata.keyboard.press("ctrl+t")
+
+    dialog = strata.wait_for_dialog()
+    assert dialog.name == "Unable to open terminal", (
+        f"unexpected dialog {dialog.name!r}"
+    )
+    assert any(LAUNCHER in node.name for node in dialog.find_all(role="label")), (
+        f"the error should name the missing launcher\n{dialog.dump()}"
+    )
+
+    strata.pointer.click(strata.dialog_button("Close"))
+    strata.wait(lambda: strata.dialog() is None, "the dialog to close")

--- a/tests/e2e/scenarios/test_terminal.py
+++ b/tests/e2e/scenarios/test_terminal.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-"""Opening a terminal, and what is reported when the launcher is missing."""
 
 from __future__ import annotations
 
@@ -12,11 +11,7 @@ LAUNCHER = "xdg-terminal-exec"
 
 @pytest.fixture
 def test_environment():
-    """A HOME whose PATH holds no terminal launcher.
-
-    The whole module covers what Strata reports when the helper is absent, so
-    the search path is emptied rather than depending on what the host installs.
-    """
+    """Empty PATH so launcher availability does not depend on the host."""
 
     environment = harness_environment.TestEnvironment()
     inherited = environment.variables


### PR DESCRIPTION
## Description

`launch_terminal` spawned `xdg-terminal-exec` and, on failure, put `error.to_string()` straight into the dialog. With the helper absent that reads "No such file or directory (os error 2)" — it names neither the program that is missing nor where Strata looked for it, so there is nothing for the user to act on.

The same helper is spawned from two more places (the AUR update and Omarchy update rows in Settings), each with its own inline `Command::new("xdg-terminal-exec")` and the same bare error text.

What changed:

- New `src/ui/terminal.rs` owns the launcher: its name (`LAUNCHER`), the detached-stdio `command()` every caller was building by hand, and `launch_failure()`.
- `launch_failure()` names the helper. A missing binary now reports `Terminal launcher “xdg-terminal-exec” was not found on your PATH`; any other spawn failure reports `Terminal launcher “xdg-terminal-exec” could not be started: <cause>`, keeping the underlying error.
- Ctrl+T / **Open in Terminal**, the AUR update row, and the Omarchy update row all go through it, so the three copies of the command builder collapse into one and none of them can report an anonymous error again.
- The tracing warning carries the launcher name too.

Coverage:

- Unit tests for the message: a missing launcher is named, other failures are named and keep their cause, and the command runs the XDG helper.
- An end-to-end scenario presses Ctrl+T with an emptied `PATH` and asserts the dialog names `xdg-terminal-exec`. Emptying `PATH` rather than depending on what the host installs keeps it deterministic.

## Visual evidence

Ctrl+T on a system with no terminal launcher on `PATH`:

**Before** — "No such file or directory (os error 2)"

**After** — "Terminal launcher “xdg-terminal-exec” was not found on your PATH"

Screenshots of both dialogs are attached to this PR.

## How to test

1. Start Strata with a `PATH` that has no `xdg-terminal-exec` on it, for example `env PATH=/var/empty strata ~`.
2. Press Ctrl+T (or right-click a folder → **Open in Terminal**).
3. Read the error dialog.

**Expected result:** the dialog says `Terminal launcher “xdg-terminal-exec” was not found on your PATH` instead of `No such file or directory (os error 2)`. With the helper installed, Ctrl+T opens a terminal in the current folder as before.

## Related issue

Closes #437