### PR TITLE
fix(updates): refresh opted-in portal after upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Download the matching `strata-<version>-<target>.debug` asset from the same rele
 
 #### 3. Update or uninstall
 
-For a manual installation, use **Settings → Updates** for verified in-app updates, or repeat the download, verification, and `install` steps for a newer release. An in-app update also refreshes an already installed desktop entry and application icon from the new archive; it never creates desktop metadata that was not installed before. Package-managed installations are updated only by their system package manager. To remove a per-user installation:
+For a manual installation, use **Settings → Updates** for verified in-app updates, or repeat the download, verification, and `install` steps for a newer release. An in-app update also refreshes an already installed desktop entry and application icon from the new archive; it never creates desktop metadata that was not installed before. If the user opted into Strata's system file chooser, the update restarts the portal frontend so subsequent dialogs use the newly installed build. Package-managed installations are updated only by their system package manager. To remove a per-user installation:
 
 ```bash
 rm -f ~/.local/bin/strata \

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,9 @@ fn main() -> gtk::glib::ExitCode {
     if let Err(error) = tracing_subscriber::fmt::try_init() {
         eprintln!("Unable to initialize logging: {error}");
     }
+    if let Err(error) = portal_setup::refresh_stale_portal() {
+        tracing::warn!(%error, "could not refresh the stale Strata portal");
+    }
 
     // Timed from here so `window presented` covers the whole launch, the way
     // the field harness measures mapped from process start.

--- a/src/portal_setup.rs
+++ b/src/portal_setup.rs
@@ -6,7 +6,10 @@ mod tests;
 use std::{
     env, fs, io,
     io::Write as _,
-    os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt},
+    os::unix::{
+        ffi::OsStrExt as _,
+        fs::{MetadataExt, OpenOptionsExt, PermissionsExt},
+    },
     path::{Path, PathBuf},
     process::{Command, Stdio},
 };
@@ -20,6 +23,7 @@ const PORTAL_FILE: &str = "strata.portal";
 const SERVICE_FILE: &str = "org.freedesktop.impl.portal.desktop.strata.service";
 const STATE_DIRECTORY: &str = "strata/portal-install";
 const STATE_FILE: &str = "state.toml";
+const PORTAL_BACKEND_UNIT: &str = "dbus-:*-org.freedesktop.impl.portal.desktop.strata@*.service";
 
 pub(crate) fn install() -> Result<String, String> {
     let executable = env::current_exe()
@@ -58,6 +62,95 @@ pub(crate) struct PortalStatus {
 
 pub(crate) fn status() -> Result<PortalStatus, String> {
     status_at(&SetupContext::from_environment()?)
+}
+
+pub(crate) fn refresh_after_in_place_update() -> Result<(), String> {
+    let context = SetupContext::from_environment()?;
+    refresh_configured_portal_at(&context, refresh_portals)
+}
+
+pub(crate) fn refresh_stale_portal() -> Result<(), String> {
+    let context = SetupContext::from_environment()?;
+    let executable = env::current_exe()
+        .map_err(|error| format!("Could not locate the Strata executable: {error}"))?;
+    refresh_stale_portal_at(&context, &executable, Path::new("/proc"), || {
+        refresh_portals()
+    })
+}
+
+fn refresh_stale_portal_at(
+    context: &SetupContext,
+    executable: &Path,
+    proc_root: &Path,
+    refresh: impl FnOnce() -> &'static str,
+) -> Result<(), String> {
+    if !portal_backend_is_stale_at(context, executable, proc_root)? {
+        return Ok(());
+    }
+    refresh_configured_portal_at(context, refresh)
+}
+
+fn refresh_configured_portal_at(
+    context: &SetupContext,
+    refresh: impl FnOnce() -> &'static str,
+) -> Result<(), String> {
+    if !status_at(context)?.configured {
+        return Ok(());
+    }
+    match refresh() {
+        "" => Ok(()),
+        warning => Err(warning.trim().to_owned()),
+    }
+}
+
+fn portal_backend_is_stale_at(
+    context: &SetupContext,
+    executable: &Path,
+    proc_root: &Path,
+) -> Result<bool, String> {
+    if !status_at(context)?.configured {
+        return Ok(false);
+    }
+    let service = context.data_home.join("dbus-1/services").join(SERVICE_FILE);
+    let expected_exec = format!("Exec={} --portal", executable.display());
+    // Do not interfere with a portal explicitly installed from another Strata build.
+    if !read_utf8(&service)?
+        .lines()
+        .any(|line| line == expected_exec)
+    {
+        return Ok(false);
+    }
+    let installed = fs::metadata(executable).map_err(|error| {
+        path_error("inspect the installed Strata executable", executable, error)
+    })?;
+    let entries = fs::read_dir(proc_root)
+        .map_err(|error| path_error("inspect running processes", proc_root, error))?;
+    for entry in entries.flatten() {
+        if entry
+            .file_name()
+            .to_str()
+            .is_none_or(|name| name.parse::<u32>().is_err())
+        {
+            continue;
+        }
+        let Ok(arguments) = fs::read(entry.path().join("cmdline")) else {
+            continue;
+        };
+        let mut arguments = arguments.split(|byte| *byte == 0);
+        if arguments.next() != Some(executable.as_os_str().as_bytes())
+            || arguments.next() != Some(b"--portal")
+        {
+            continue;
+        }
+        let Ok(running) = fs::metadata(entry.path().join("exe")) else {
+            continue;
+        };
+        // Replacing a running executable preserves its old inode under /proc.
+        if (running.dev(), running.ino()) != (installed.dev(), installed.ino()) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 fn status_at(context: &SetupContext) -> Result<PortalStatus, String> {
@@ -571,6 +664,12 @@ fn path_error(action: &str, path: &Path, error: io::Error) -> String {
 }
 
 fn refresh_portals() -> &'static str {
+    let backend_stopped = Command::new("systemctl")
+        .args(["--user", "stop", PORTAL_BACKEND_UNIT])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success());
     let dbus_reloaded = Command::new("gdbus")
         .args([
             "call",
@@ -592,7 +691,7 @@ fn refresh_portals() -> &'static str {
         .stderr(Stdio::null())
         .status()
         .is_ok_and(|status| status.success());
-    if dbus_reloaded && portal_restarted {
+    if backend_stopped && dbus_reloaded && portal_restarted {
         ""
     } else {
         "\nCould not reload every portal service. Ensure xdg-desktop-portal is installed, then log out and back in before testing."

--- a/src/portal_setup/tests.rs
+++ b/src/portal_setup/tests.rs
@@ -1,10 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use std::{fs, os::unix::fs::PermissionsExt as _, path::PathBuf};
+use std::{
+    cell::Cell,
+    fs,
+    os::unix::{ffi::OsStrExt as _, fs::PermissionsExt as _},
+    path::{Path, PathBuf},
+};
 
 use super::{
-    SetupContext, disable_config, enable_config, install_at, secure_executable, trusted_owner,
-    uninstall_at,
+    SetupContext, disable_config, enable_config, install_at, refresh_configured_portal_at,
+    refresh_stale_portal_at, secure_executable, trusted_owner, uninstall_at,
 };
 
 const FILE_CHOOSER: &str = "org.freedesktop.impl.portal.FileChooser";
@@ -26,6 +31,106 @@ fn chooser_preference_preserves_explicit_fallbacks() {
 
     assert!(enabled.contains(&format!("{FILE_CHOOSER}=strata;kde;gtk;")));
     assert_eq!(disable_config(&enabled).expect("disable Strata"), original);
+}
+
+#[test]
+fn update_refreshes_an_opted_in_portal() {
+    let fixture = fixture();
+    let context = context(fixture.path());
+    install_at(&context, &executable(fixture.path())).expect("install portal");
+    let refreshed = Cell::new(false);
+
+    refresh_configured_portal_at(&context, || {
+        refreshed.set(true);
+        ""
+    })
+    .expect("refresh configured portal");
+
+    assert!(refreshed.get());
+}
+
+#[test]
+fn update_leaves_an_unconfigured_portal_alone() {
+    let fixture = fixture();
+    let context = context(fixture.path());
+    let refreshed = Cell::new(false);
+
+    refresh_configured_portal_at(&context, || {
+        refreshed.set(true);
+        ""
+    })
+    .expect("ignore unconfigured portal");
+
+    assert!(!refreshed.get());
+}
+
+#[test]
+fn update_reports_a_configured_portal_refresh_failure() {
+    let fixture = fixture();
+    let context = context(fixture.path());
+    install_at(&context, &executable(fixture.path())).expect("install portal");
+
+    let error = refresh_configured_portal_at(&context, || "\nportal restart failed")
+        .expect_err("report refresh failure");
+
+    assert_eq!(error, "portal restart failed");
+}
+
+#[test]
+fn startup_refreshes_a_configured_portal_running_an_old_executable() {
+    let fixture = fixture();
+    let context = context(fixture.path());
+    let executable = executable(fixture.path());
+    install_at(&context, &executable).expect("install portal");
+    let proc_root = fixture.path().join("proc");
+    portal_process(
+        &proc_root,
+        123,
+        &executable,
+        &fixture.path().join("old-strata"),
+    );
+    let refreshed = Cell::new(false);
+
+    refresh_stale_portal_at(&context, &executable, &proc_root, || {
+        refreshed.set(true);
+        ""
+    })
+    .expect("refresh stale portal");
+
+    assert!(refreshed.get());
+}
+
+#[test]
+fn startup_keeps_a_current_portal_running() {
+    let fixture = fixture();
+    let context = context(fixture.path());
+    let executable = executable(fixture.path());
+    install_at(&context, &executable).expect("install portal");
+    let proc_root = fixture.path().join("proc");
+    portal_process(&proc_root, 123, &executable, &executable);
+    let refreshed = Cell::new(false);
+
+    refresh_stale_portal_at(&context, &executable, &proc_root, || {
+        refreshed.set(true);
+        ""
+    })
+    .expect("keep current portal");
+
+    assert!(!refreshed.get());
+}
+
+fn portal_process(proc_root: &Path, pid: u32, command: &Path, running: &Path) {
+    use std::os::unix::fs::symlink;
+
+    if !running.exists() {
+        fs::write(running, b"old binary").expect("write running executable");
+    }
+    let process = proc_root.join(pid.to_string());
+    fs::create_dir_all(&process).expect("create fake process");
+    let mut cmdline = command.as_os_str().as_bytes().to_vec();
+    cmdline.extend_from_slice(b"\0--portal\0");
+    fs::write(process.join("cmdline"), cmdline).expect("write fake command line");
+    symlink(running, process.join("exe")).expect("link running executable");
 }
 
 #[test]

--- a/src/services/update_install.rs
+++ b/src/services/update_install.rs
@@ -442,6 +442,9 @@ fn try_install(
     if let Some(package_dir) = binary_path.parent() {
         refresh_desktop_metadata(package_dir, current_exe, &glib::user_data_dir());
     }
+    if let Err(error) = crate::portal_setup::refresh_after_in_place_update() {
+        tracing::warn!(%error, "could not refresh the configured Strata portal after updating");
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Description

Refresh an opted-in Strata FileChooser backend after an in-place update so it cannot remain attached to a deleted, outdated executable. A newly launched build also detects an older portal by executable identity and refreshes it, covering the first upgrade from a version that lacks the post-install hook. Portal services remain untouched when Strata is not the configured chooser or belongs to another installation.

## Visual evidence

N/A — process lifecycle fix with no visual changes.

## How to test

1. Opt into Strata as the system file chooser and open a portal dialog to activate the backend.
2. Replace the installed Strata executable with a newer build, then launch that newer build.
3. Open another portal dialog and preview an image.

**Expected result:** The stale backend is stopped, the next dialog runs from the installed executable inode, and its sandboxed image preview succeeds. Users who have not opted into Strata retain their existing portal processes.

## Related issue

Closes #474