### PR TITLE
chore(agents): lock coding-agent skills with npx skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ packaging/aur/*/*.pkg.tar.zst
 
 /.pytest_cache/
 /tests/e2e/.pytest_cache/
+
+# Restored coding-agent skills (see skills-lock.json)
+/.agents/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,18 @@
 # Agent Instructions
 
+## Agent skills
+
+Restore project skills from the committed `skills-lock.json` after cloning:
+
+```bash
+npx skills experimental_install
+```
+
+That installs them into `.agents/skills/`, which is gitignored. Keep
+`skills-lock.json` in version control. Add or update skills with `npx skills add`
+and `npx skills update`, then commit the lockfile. Do not vendor skill files
+under `.agents/`.
+
 ## Git workflow
 
 - Never commit or push directly to `main`. Work from a GitHub issue and submit changes through a pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,17 @@ installs missing native dependencies (prompting for `sudo`) and installs
 make start-dev
 ```
 
+Project coding-agent skills are listed in `skills-lock.json`. After cloning,
+restore them into the gitignored `.agents/` directory (requires Node.js for
+`npx`):
+
+```bash
+npx skills experimental_install
+```
+
+Commit `skills-lock.json` when adding or updating skills with `npx skills add`
+or `npx skills update`. Do not commit `.agents/`.
+
 ## Branching and pull requests
 
 All changes to `main` go through a pull request. The normal process is:

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "security-review": {
+      "source": "getsentry/skills",
+      "sourceType": "github",
+      "skillPath": "skills/security-review/SKILL.md",
+      "computedHash": "ec9792f5fd065e020c48ab5a57707c83435c286c449ba98dfa726d7b1842c868"
+    }
+  }
+}


### PR DESCRIPTION
## Description

Add a committed `skills-lock.json` so clones restore the same coding-agent skills with `npx skills experimental_install`, instead of vendoring files under `.agents/`. The lock currently includes only Sentry's `security-review` skill, which matches Strata's real review surfaces (archives, sandbox, portal, updates). Restore and update steps are documented in `AGENTS.md` and `CONTRIBUTING.md`; `.agents/` is gitignored.

## Visual evidence

N/A — contributor workflow and lockfile only; no user-visible UI.

## How to test

1. From a clean clone (or after removing `.agents/`), run `npx skills experimental_install`.
2. Confirm `.agents/skills/security-review/SKILL.md` exists and `git status` does not show `.agents/`.
3. Open `skills-lock.json` and confirm it lists only `security-review` from `getsentry/skills`.

**Expected result:** The security-review skill is restored locally, `.agents/` stays untracked, and agents that follow `AGENTS.md` load the same locked skill.

## Related issue

Closes #486