### PR TITLE
fix(appearance): snap scaled text to whole pixels

### DIFF
--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -60,6 +60,8 @@ fn notify_live<T>(listeners: Vec<T>, is_live: impl Fn(&T) -> bool, run: impl Fn(
 }
 
 const THEME_CATALOG: &str = include_str!("../../data/themes/catalog.toml");
+const GTK_DEFAULT_DPI: f64 = 96.0;
+const GTK_DPI_UNITS: f64 = 1024.0;
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ThemeTokens {
@@ -367,6 +369,7 @@ impl ThemeManager {
         });
         manager.install_provider();
         manager.apply_selected();
+        manager.monitor_text_scaling();
         manager.monitor_omarchy();
         manager
     }
@@ -894,7 +897,8 @@ impl ThemeManager {
     }
 
     fn apply_tokens(&self, tokens: &ThemeTokens) {
-        let root_font_px = self.text_size().root_font_px();
+        let root_font_px =
+            snapped_root_font_px(self.text_size().root_font_px(), desktop_text_scale_factor());
         self.provider
             .load_from_string(&tokens_css(tokens, root_font_px));
         apply_interface_font(root_font_px);
@@ -917,6 +921,21 @@ impl ThemeManager {
         if let Err(error) = result {
             tracing::warn!(%error, "unable to save theme preference");
         }
+    }
+
+    fn monitor_text_scaling(self: &Rc<Self>) {
+        let Some(settings) = gtk::Settings::default() else {
+            return;
+        };
+        let weak = Rc::downgrade(self);
+        settings.connect_gtk_xft_dpi_notify(move |_| {
+            let Some(manager) = weak.upgrade() else {
+                return;
+            };
+            if !manager.previewing.get() {
+                manager.apply_selected();
+            }
+        });
     }
 
     fn monitor_omarchy(self: &Rc<Self>) {
@@ -1257,19 +1276,40 @@ fn source_style_scheme_xml(tokens: &ThemeTokens) -> String {
 
 const INTERFACE_FONT_FAMILY: &str = "JetBrains Mono";
 
-fn interface_font_name(root_font_px: u32) -> String {
-    format!("{INTERFACE_FONT_FAMILY} {root_font_px}px")
+fn interface_font_name(root_font_px: f64) -> String {
+    format!("{INTERFACE_FONT_FAMILY} {root_font_px:.6}px")
 }
 
-fn apply_interface_font(root_font_px: u32) {
+fn apply_interface_font(root_font_px: f64) {
     if let Some(settings) = gtk::Settings::default() {
         settings.set_gtk_font_name(Some(&interface_font_name(root_font_px)));
     }
 }
 
-fn tokens_css(tokens: &ThemeTokens, root_font_px: u32) -> String {
+fn desktop_text_scale_factor() -> f64 {
+    gtk::Settings::default()
+        .map(|settings| text_scale_factor_from_xft_dpi(settings.gtk_xft_dpi()))
+        .unwrap_or(1.0)
+}
+
+fn text_scale_factor_from_xft_dpi(xft_dpi: i32) -> f64 {
+    if xft_dpi <= 0 {
+        return 1.0;
+    }
+    f64::from(xft_dpi) / (GTK_DEFAULT_DPI * GTK_DPI_UNITS)
+}
+
+fn snapped_root_font_px(root_font_px: u32, scale_factor: f64) -> f64 {
+    if !scale_factor.is_finite() || scale_factor <= 0.0 {
+        return f64::from(root_font_px);
+    }
+    // Fractional effective pixels can lose hinted glyph rows in GTK's text renderer.
+    (f64::from(root_font_px) * scale_factor).round() / scale_factor
+}
+
+fn tokens_css(tokens: &ThemeTokens, root_font_px: f64) -> String {
     format!(
-        "@define-color theme_bg {};\n@define-color theme_surface {};\n@define-color theme_text {};\n@define-color theme_accent {};\n@define-color theme_danger {};\n@define-color theme_muted {};\n@define-color theme_highlight {};\n@define-color theme_border {};\n@define-color theme_dim_text {};\nwindow, popover, popover.background {{ font-size: {root_font_px}px; }}\n",
+        "@define-color theme_bg {};\n@define-color theme_surface {};\n@define-color theme_text {};\n@define-color theme_accent {};\n@define-color theme_danger {};\n@define-color theme_muted {};\n@define-color theme_highlight {};\n@define-color theme_border {};\n@define-color theme_dim_text {};\nwindow, popover, popover.background {{ font-size: {root_font_px:.6}px; }}\n",
         tokens.background,
         tokens.surface,
         tokens.text,

--- a/src/ui/theme/tests.rs
+++ b/src/ui/theme/tests.rs
@@ -5,8 +5,9 @@ use std::{cell::RefCell, collections::HashSet};
 use super::{
     Preferences, TextSize, Theme, azure_tokens, blend, browser_mode_from_stored, builtins,
     configured_hardware_acceleration, configured_video_preview_backend, is_omarchy_theme_event,
-    merge_builtin_and_custom_themes, notify_live, slugify, sort_preferences, stored_browser_mode,
-    title_case_slug, tokens_from_quattro, validate_tokens,
+    merge_builtin_and_custom_themes, notify_live, slugify, snapped_root_font_px, sort_preferences,
+    stored_browser_mode, text_scale_factor_from_xft_dpi, title_case_slug, tokens_from_quattro,
+    validate_tokens,
 };
 use crate::{
     model::{SortDirection, SortKey, ViewPreferences},
@@ -427,6 +428,39 @@ fn text_sizes_map_to_a_strictly_increasing_root_font_size() {
     assert!(small < medium);
     assert!(medium < large);
     assert_eq!(medium, 13, "medium should match the unscaled base size");
+}
+
+#[test]
+fn root_font_size_snaps_to_a_whole_effective_pixel() {
+    let scale_factor = 13.0 / 11.0;
+    let root_font_px = snapped_root_font_px(TextSize::Large.root_font_px(), scale_factor);
+
+    assert!((root_font_px - 15.230_769).abs() < 0.000_001);
+    assert!((root_font_px * scale_factor - 18.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn root_font_size_is_unchanged_without_desktop_scaling() {
+    for size in [TextSize::Small, TextSize::Medium, TextSize::Large] {
+        assert_eq!(
+            snapped_root_font_px(size.root_font_px(), 1.0),
+            f64::from(size.root_font_px())
+        );
+    }
+}
+
+#[test]
+fn invalid_scaling_values_leave_the_root_font_size_unchanged() {
+    for scale_factor in [0.0, -1.0, f64::NAN] {
+        assert_eq!(snapped_root_font_px(15, scale_factor), 15.0);
+    }
+}
+
+#[test]
+fn xft_dpi_converts_to_desktop_text_scale() {
+    assert_eq!(text_scale_factor_from_xft_dpi(-1), 1.0);
+    assert_eq!(text_scale_factor_from_xft_dpi(96 * 1024), 1.0);
+    assert!((text_scale_factor_from_xft_dpi(115_200) - 1.171_875).abs() < f64::EPSILON);
 }
 
 #[test]


### PR DESCRIPTION
## Description

Snap each text-size preset so GTK's desktop-scaled font size lands on a whole effective pixel, avoiding clipped hinted glyphs at fractional sizes. Reapply the selected theme when GTK's text-scaling DPI changes so the correction updates live.

## Visual evidence

Before/after from the issue reporter using desktop text size 13 and Strata's Large preset:

![Before and after scaled text rendering](https://raw.githubusercontent.com/salemsayed/strata/64051326aed9d8b4414180de4fbb222f6dca734c/before-after-zoom.png)

## How to test

1. Set `org.gnome.desktop.interface text-scaling-factor` to `1.1818` (or run `omarchy display text size 13`) with font hinting set to `slight`.
2. Open Strata and choose **Settings → Theme & appearance → Text size → Large**.
3. Inspect capital letters in file labels, then change the desktop text size while Strata remains open.

**Expected result:** Capital glyphs render without a clipped top row, and remain intact after live desktop text-size changes.

## Related issue

Closes #442
