### PR TITLE
fix(archives): cap extraction size, ratio, and entry count

### DIFF
--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -3042,14 +3042,18 @@ impl OperationProvider for LocalOperationProvider {
             let result = gio::spawn_blocking(move || match format {
                 Some(ArchiveFormat::Zip) => {
                     let file = std::fs::File::open(&archive_path).map_err(|e| e.to_string())?;
+                    let compressed_size =
+                        file.metadata().map(|metadata| metadata.len()).unwrap_or(0);
                     let mut archive = zip::ZipArchive::new(file).map_err(|e| e.to_string())?;
                     work_total.store(archive.len(), Ordering::Relaxed);
-                    extract_zip_from_archive(
+                    extract_zip_from_archive_with_limits(
                         &mut archive,
                         &dest_dir,
                         password.as_deref(),
                         &work_progress,
                         &work_cancelled,
+                        ExtractLimits::production(),
+                        compressed_size,
                     )
                 }
                 Some(ArchiveFormat::SevenZ) => {
@@ -3396,6 +3400,22 @@ impl ExtractionDestination {
         Ok(Self { root })
     }
 
+    fn filesystem_resources(&self) -> (Option<u64>, Option<u64>) {
+        match rustix::fs::fstatvfs(&self.root) {
+            Ok(stat) => {
+                let block = if stat.f_frsize > 0 {
+                    stat.f_frsize
+                } else {
+                    stat.f_bsize.max(1)
+                };
+                let bytes = stat.f_bavail.saturating_mul(block);
+                let inodes = (stat.f_favail > 0).then_some(stat.f_favail);
+                (Some(bytes), inodes)
+            }
+            Err(_) => (None, None),
+        }
+    }
+
     fn available_name<Fd: AsFd>(&self, directory: &Fd, name: &OsStr) -> Result<OsString, String> {
         for index in 1.. {
             let candidate = if index == 1 {
@@ -3508,6 +3528,148 @@ fn count_archive_files(entries: &[PathBuf], cancelled: &AtomicBool) -> Result<us
 
 const COPY_BUF: usize = 1 << 20; // 1 MiB
 const ARCHIVE_CANCELLED: &str = "Operation cancelled";
+const EXTRACT_MAX_UNCOMPRESSED_BYTES: u64 = 1 << 40;
+const EXTRACT_MAX_ENTRIES: u64 = 1_000_000;
+const EXTRACT_MAX_COMPRESSION_RATIO: u64 = 100;
+const EXTRACT_RATIO_MIN_UNCOMPRESSED_BYTES: u64 = 64 * 1024 * 1024;
+
+#[derive(Clone, Copy, Debug)]
+struct ExtractLimits {
+    max_uncompressed_bytes: u64,
+    max_entries: u64,
+    max_compression_ratio: u64,
+    ratio_min_uncompressed_bytes: u64,
+}
+
+impl ExtractLimits {
+    fn production() -> Self {
+        Self {
+            max_uncompressed_bytes: EXTRACT_MAX_UNCOMPRESSED_BYTES,
+            max_entries: EXTRACT_MAX_ENTRIES,
+            max_compression_ratio: EXTRACT_MAX_COMPRESSION_RATIO,
+            ratio_min_uncompressed_bytes: EXTRACT_RATIO_MIN_UNCOMPRESSED_BYTES,
+        }
+    }
+}
+
+struct ExtractBudget {
+    compressed_size: u64,
+    uncompressed_written: u64,
+    entries: u64,
+    absolute_max: u64,
+    disk_available: Option<u64>,
+    max_entries: u64,
+    max_compression_ratio: u64,
+    ratio_min_uncompressed_bytes: u64,
+}
+
+impl ExtractBudget {
+    fn new(
+        destination: &ExtractionDestination,
+        compressed_size: u64,
+        limits: ExtractLimits,
+    ) -> Self {
+        let (available_bytes, available_inodes) = destination.filesystem_resources();
+        let max_entries = match available_inodes {
+            Some(inodes) => limits.max_entries.min(inodes),
+            None => limits.max_entries,
+        };
+        Self {
+            compressed_size,
+            uncompressed_written: 0,
+            entries: 0,
+            absolute_max: limits.max_uncompressed_bytes,
+            disk_available: available_bytes,
+            max_entries,
+            max_compression_ratio: limits.max_compression_ratio,
+            ratio_min_uncompressed_bytes: limits.ratio_min_uncompressed_bytes,
+        }
+    }
+
+    #[cfg(test)]
+    fn from_limits(compressed_size: u64, limits: ExtractLimits) -> Self {
+        Self {
+            compressed_size,
+            uncompressed_written: 0,
+            entries: 0,
+            absolute_max: limits.max_uncompressed_bytes,
+            disk_available: None,
+            max_entries: limits.max_entries,
+            max_compression_ratio: limits.max_compression_ratio,
+            ratio_min_uncompressed_bytes: limits.ratio_min_uncompressed_bytes,
+        }
+    }
+
+    fn reject_entry_count(&self, count: u64) -> Result<(), ArchiveError> {
+        if count > self.max_entries {
+            Err(self.entry_count_error(count))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn account_entry(&mut self) -> Result<(), ArchiveError> {
+        let count = self.entries.saturating_add(1);
+        self.reject_entry_count(count)?;
+        self.entries = count;
+        Ok(())
+    }
+
+    fn reject_claimed_total(&self, claimed: u128) -> Result<(), ArchiveError> {
+        self.check_total(claimed)
+    }
+
+    fn reject_additional(&self, claimed: u64) -> Result<(), ArchiveError> {
+        self.check_total(u128::from(self.uncompressed_written).saturating_add(claimed.into()))
+    }
+
+    fn account_bytes(&mut self, n: u64) -> Result<(), ArchiveError> {
+        let total = u128::from(self.uncompressed_written).saturating_add(n.into());
+        self.check_total(total)?;
+        self.uncompressed_written = self.uncompressed_written.saturating_add(n);
+        Ok(())
+    }
+
+    fn check_total(&self, total: u128) -> Result<(), ArchiveError> {
+        if let Some(available) = self.disk_available
+            && total > u128::from(available)
+        {
+            return Err(archive_failed(format!(
+                "Extraction aborted: archive would expand beyond the {available} bytes of free space at the destination"
+            )));
+        }
+        if total > u128::from(self.absolute_max) {
+            return Err(archive_failed(format!(
+                "Extraction aborted: uncompressed size exceeds the {} byte limit",
+                self.absolute_max
+            )));
+        }
+        if total >= u128::from(self.ratio_min_uncompressed_bytes) && self.ratio_exceeded(total) {
+            return Err(archive_failed(format!(
+                "Extraction aborted: compression ratio exceeds {}:1; refusing to expand the archive",
+                self.max_compression_ratio
+            )));
+        }
+        Ok(())
+    }
+
+    fn ratio_exceeded(&self, uncompressed: u128) -> bool {
+        if self.compressed_size == 0 || self.max_compression_ratio == 0 {
+            return false;
+        }
+        match u128::from(self.compressed_size).checked_mul(self.max_compression_ratio.into()) {
+            Some(limit) => uncompressed > limit,
+            None => false,
+        }
+    }
+
+    fn entry_count_error(&self, count: u64) -> ArchiveError {
+        archive_failed(format!(
+            "Extraction aborted: archive has {count} entries, which exceeds the {} entry limit",
+            self.max_entries
+        ))
+    }
+}
 
 #[derive(Debug, PartialEq, Eq)]
 enum ArchiveError {
@@ -3654,9 +3816,27 @@ fn cancelled_extract_after_partial_write(
 }
 
 fn copy_with_big_buf(
+    reader: impl std::io::Read,
+    writer: &mut (impl std::io::Write + ?Sized),
+    cancelled: &AtomicBool,
+) -> Result<u64, ArchiveError> {
+    copy_with_extract_budget(reader, writer, cancelled, None)
+}
+
+fn copy_extracted_with_budget(
+    reader: impl std::io::Read,
+    writer: &mut (impl std::io::Write + ?Sized),
+    cancelled: &AtomicBool,
+    budget: &mut ExtractBudget,
+) -> Result<u64, ArchiveError> {
+    copy_with_extract_budget(reader, writer, cancelled, Some(budget))
+}
+
+fn copy_with_extract_budget(
     mut reader: impl std::io::Read,
     writer: &mut (impl std::io::Write + ?Sized),
     cancelled: &AtomicBool,
+    mut budget: Option<&mut ExtractBudget>,
 ) -> Result<u64, ArchiveError> {
     let mut buf = vec![0u8; COPY_BUF];
     let mut total = 0;
@@ -3666,8 +3846,12 @@ fn copy_with_big_buf(
         if n == 0 {
             break;
         }
+        let n64 = n as u64;
+        if let Some(budget) = budget.as_mut() {
+            budget.account_bytes(n64)?;
+        }
         writer.write_all(&buf[..n]).map_err(archive_failed)?;
-        total += n as u64;
+        total += n64;
     }
     Ok(total)
 }
@@ -3756,6 +3940,7 @@ impl ExtractNameResolver {
     }
 }
 
+#[cfg(test)]
 fn extract_zip_from_archive(
     archive: &mut zip::ZipArchive<std::fs::File>,
     dest_dir: &Path,
@@ -3763,7 +3948,32 @@ fn extract_zip_from_archive(
     progress: &Arc<AtomicUsize>,
     cancelled: &AtomicBool,
 ) -> Result<ArchiveOutcome<Option<String>>, ArchiveError> {
+    extract_zip_from_archive_with_limits(
+        archive,
+        dest_dir,
+        password,
+        progress,
+        cancelled,
+        ExtractLimits::production(),
+        0,
+    )
+}
+
+fn extract_zip_from_archive_with_limits(
+    archive: &mut zip::ZipArchive<std::fs::File>,
+    dest_dir: &Path,
+    password: Option<&str>,
+    progress: &Arc<AtomicUsize>,
+    cancelled: &AtomicBool,
+    limits: ExtractLimits,
+    compressed_size: u64,
+) -> Result<ArchiveOutcome<Option<String>>, ArchiveError> {
     let destination = ExtractionDestination::open(dest_dir)?;
+    let mut budget = ExtractBudget::new(&destination, compressed_size, limits);
+    budget.reject_entry_count(archive.len() as u64)?;
+    if let Some(claimed) = archive.decompressed_size() {
+        budget.reject_claimed_total(claimed)?;
+    }
     let pw_bytes = password.map(|p| p.as_bytes());
     let mut resolver = ExtractNameResolver::new();
     let mut first_name = None;
@@ -3792,11 +4002,15 @@ fn extract_zip_from_archive(
                 .next()
                 .map(|c| c.as_os_str().to_string_lossy().to_string());
         }
+        budget.account_entry()?;
         if entry.is_dir() {
             destination.create_directories(&outpath)?;
         } else {
+            budget.reject_additional(entry.size())?;
             let (mut outfile, created) = destination.create_file(&outpath)?;
-            if let Err(error) = copy_with_big_buf(&mut entry, &mut outfile, cancelled) {
+            if let Err(error) =
+                copy_extracted_with_budget(&mut entry, &mut outfile, cancelled, &mut budget)
+            {
                 drop(outfile);
                 drop(entry);
                 let removed = destination.remove_file(&created);
@@ -3825,7 +4039,29 @@ fn extract_tar(
     progress: &Arc<AtomicUsize>,
     cancelled: &AtomicBool,
 ) -> Result<ArchiveOutcome<Option<String>>, ArchiveError> {
+    extract_tar_with_limits(
+        archive_path,
+        dest_dir,
+        gzip,
+        progress,
+        cancelled,
+        ExtractLimits::production(),
+    )
+}
+
+fn extract_tar_with_limits(
+    archive_path: &Path,
+    dest_dir: &Path,
+    gzip: bool,
+    progress: &Arc<AtomicUsize>,
+    cancelled: &AtomicBool,
+    limits: ExtractLimits,
+) -> Result<ArchiveOutcome<Option<String>>, ArchiveError> {
     let destination = ExtractionDestination::open(dest_dir)?;
+    let compressed_size = std::fs::metadata(archive_path)
+        .map(|metadata| metadata.len())
+        .unwrap_or(0);
+    let mut budget = ExtractBudget::new(&destination, compressed_size, limits);
     let file = std::fs::File::open(archive_path).map_err(archive_failed)?;
     let reader: Box<dyn std::io::Read> = if gzip {
         Box::new(flate2::read::GzDecoder::new(file))
@@ -3860,11 +4096,15 @@ fn extract_tar(
                 .next()
                 .map(|c| c.as_os_str().to_string_lossy().to_string());
         }
+        budget.account_entry()?;
         if entry.header().entry_type().is_dir() {
             destination.create_directories(&outpath)?;
         } else {
+            budget.reject_additional(entry.size())?;
             let (mut outfile, created) = destination.create_file(&outpath)?;
-            if let Err(error) = copy_with_big_buf(&mut entry, &mut outfile, cancelled) {
+            if let Err(error) =
+                copy_extracted_with_budget(&mut entry, &mut outfile, cancelled, &mut budget)
+            {
                 drop(outfile);
                 drop(entry);
                 let removed = destination.remove_file(&created);
@@ -3967,7 +4207,29 @@ fn extract_7z_from_reader(
     progress: &Arc<AtomicUsize>,
     cancelled: &AtomicBool,
 ) -> Result<ArchiveOutcome<Option<String>>, ArchiveError> {
+    extract_7z_from_reader_with_limits(
+        reader,
+        dest_dir,
+        password,
+        progress,
+        cancelled,
+        ExtractLimits::production(),
+    )
+}
+
+fn extract_7z_from_reader_with_limits(
+    reader: std::fs::File,
+    dest_dir: &Path,
+    password: sevenz_rust2::Password,
+    progress: &Arc<AtomicUsize>,
+    cancelled: &AtomicBool,
+    limits: ExtractLimits,
+) -> Result<ArchiveOutcome<Option<String>>, ArchiveError> {
     let destination = ExtractionDestination::open(dest_dir)?;
+    let compressed_size = reader
+        .metadata()
+        .map(|metadata| metadata.len())
+        .unwrap_or(0);
     let mut archive = sevenz_rust2::ArchiveReader::new(reader, password).map_err(archive_failed)?;
     let entry_names: Vec<String> = archive
         .archive()
@@ -3975,6 +4237,14 @@ fn extract_7z_from_reader(
         .iter()
         .map(|entry| entry.name.clone())
         .collect();
+    let claimed = archive.archive().files.iter().fold(0u128, |total, entry| {
+        total.saturating_add(entry.size.into())
+    });
+    let budget = RefCell::new(ExtractBudget::new(&destination, compressed_size, limits));
+    budget
+        .borrow()
+        .reject_entry_count(entry_names.len() as u64)?;
+    budget.borrow().reject_claimed_total(claimed)?;
     let resolver = RefCell::new(ExtractNameResolver::new());
     let first_name = RefCell::new(None::<String>);
     let completed = RefCell::new(Vec::new());
@@ -4000,15 +4270,25 @@ fn extract_7z_from_reader(
                 .next()
                 .map(|c| c.as_os_str().to_string_lossy().to_string());
         }
+        budget
+            .borrow_mut()
+            .account_entry()
+            .map_err(sevenz_extract_error)?;
         if entry.is_directory {
             destination
                 .create_directories(&outpath)
                 .map_err(|error| sevenz_rust2::Error::Other(error.into()))?;
         } else {
+            budget
+                .borrow()
+                .reject_additional(entry.size)
+                .map_err(sevenz_extract_error)?;
             let (mut file, created) = destination
                 .create_file(&outpath)
                 .map_err(|error| sevenz_rust2::Error::Other(error.into()))?;
-            if let Err(error) = copy_with_big_buf(reader, &mut file, cancelled) {
+            if let Err(error) =
+                copy_extracted_with_budget(reader, &mut file, cancelled, &mut budget.borrow_mut())
+            {
                 drop(file);
                 let removed = destination.remove_file(&created);
                 return match error {
@@ -4051,5 +4331,12 @@ fn extract_7z_from_reader(
             not_attempted: not_attempted.into_inner(),
         }),
         Err(error) => Err(archive_failed(error)),
+    }
+}
+
+fn sevenz_extract_error(error: ArchiveError) -> sevenz_rust2::Error {
+    match error {
+        ArchiveError::Cancelled => sevenz_cancelled(),
+        ArchiveError::Failed(message) => sevenz_rust2::Error::Other(message.into()),
     }
 }

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -22,14 +22,16 @@ use gtk::{gio, glib, prelude::*};
 use crate::test_support::ASYNC_MAIN_CONTEXT_DEFAULT;
 
 use super::{
-    ArchiveError, ArchiveOutcome, LocalOperationProvider, TransferProgressTracker,
-    await_cancellable, compress_7z, compress_tar, compress_zip, copy_failure_after_cleanup,
-    copy_new_recursively, copy_new_remote_file_with, copy_recursively, copy_with_big_buf,
-    count_archive_files, deletion_error_message, deletion_error_summary, duplicate_candidate_name,
-    extract_7z_from_reader, extract_tar, extract_zip_from_archive, home_trash_entries_at, io_error,
-    is_trash_unsupported_failure, move_local, move_local_with, operation_error_summary,
-    parse_copy_suffix, process_umask, replace_local, replace_local_with, transfer_is_noop,
-    validated_archive_path, validated_child, write_staged_archive,
+    ArchiveError, ArchiveOutcome, ExtractBudget, ExtractLimits, LocalOperationProvider,
+    TransferProgressTracker, await_cancellable, compress_7z, compress_tar, compress_zip,
+    copy_extracted_with_budget, copy_failure_after_cleanup, copy_new_recursively,
+    copy_new_remote_file_with, copy_recursively, copy_with_big_buf, count_archive_files,
+    deletion_error_message, deletion_error_summary, duplicate_candidate_name,
+    extract_7z_from_reader, extract_7z_from_reader_with_limits, extract_tar,
+    extract_tar_with_limits, extract_zip_from_archive, extract_zip_from_archive_with_limits,
+    home_trash_entries_at, io_error, is_trash_unsupported_failure, move_local, move_local_with,
+    operation_error_summary, parse_copy_suffix, process_umask, replace_local, replace_local_with,
+    transfer_is_noop, validated_archive_path, validated_child, write_staged_archive,
 };
 use crate::{
     model::{EntryKind, FileEntry, Location, MetadataValue},
@@ -2951,6 +2953,315 @@ fn copy_with_big_buf_stops_when_cancelled() {
         .expect_err("cancelled copy must stop");
     assert!(matches!(error, ArchiveError::Cancelled));
     assert!(destination.is_empty());
+}
+
+fn extract_size_limits(max_uncompressed_bytes: u64) -> ExtractLimits {
+    ExtractLimits {
+        max_uncompressed_bytes,
+        ..ExtractLimits::production()
+    }
+}
+
+fn extract_entry_limits(max_entries: u64) -> ExtractLimits {
+    ExtractLimits {
+        max_entries,
+        ..ExtractLimits::production()
+    }
+}
+
+fn extract_ratio_limits(
+    max_compression_ratio: u64,
+    ratio_min_uncompressed_bytes: u64,
+) -> ExtractLimits {
+    ExtractLimits {
+        max_compression_ratio,
+        ratio_min_uncompressed_bytes,
+        ..ExtractLimits::production()
+    }
+}
+
+fn extract_must_fail(
+    result: Result<ArchiveOutcome<Option<String>>, ArchiveError>,
+    context: &str,
+) -> ArchiveError {
+    match result {
+        Err(error) => error,
+        Ok(_) => panic!("{context}"),
+    }
+}
+
+fn extract_failed_message(error: ArchiveError) -> String {
+    match error {
+        ArchiveError::Failed(message) => message,
+        ArchiveError::Cancelled => panic!("expected a limit failure, not cancellation"),
+    }
+}
+
+fn destination_is_empty(path: &Path) -> Result<bool, Box<dyn Error>> {
+    Ok(path.read_dir()?.next().is_none())
+}
+
+fn extract_zip_with_limits(
+    path: &Path,
+    destination: &Path,
+    limits: ExtractLimits,
+) -> Result<ArchiveOutcome<Option<String>>, ArchiveError> {
+    let compressed_size = fs::metadata(path)
+        .map(|metadata| metadata.len())
+        .unwrap_or(0);
+    let file = fs::File::open(path).map_err(archive_io)?;
+    let mut archive =
+        zip::ZipArchive::new(file).map_err(|error| ArchiveError::Failed(error.to_string()))?;
+    extract_zip_from_archive_with_limits(
+        &mut archive,
+        destination,
+        None,
+        &Arc::new(AtomicUsize::new(0)),
+        &never_cancelled(),
+        limits,
+        compressed_size,
+    )
+}
+
+fn archive_io(error: std::io::Error) -> ArchiveError {
+    ArchiveError::Failed(error.to_string())
+}
+
+#[test]
+fn extract_budget_rejects_uncompressed_size_disk_space_ratio_and_entry_count() {
+    let mut budget = ExtractBudget::from_limits(0, extract_size_limits(100));
+    assert!(budget.account_bytes(50).is_ok());
+    let size_error = extract_failed_message(budget.account_bytes(60).expect_err("size limit"));
+    assert!(size_error.contains("uncompressed size exceeds the 100 byte limit"));
+
+    let mut disk_budget = ExtractBudget::from_limits(0, extract_size_limits(1_000_000));
+    disk_budget.disk_available = Some(32);
+    let disk_error = extract_failed_message(disk_budget.account_bytes(40).expect_err("disk limit"));
+    assert!(disk_error.contains("32 bytes of free space"));
+
+    let mut ratio_budget = ExtractBudget::from_limits(8, extract_ratio_limits(4, 16));
+    assert!(ratio_budget.account_bytes(16).is_ok());
+    let ratio_error =
+        extract_failed_message(ratio_budget.account_bytes(17).expect_err("ratio limit"));
+    assert!(ratio_error.contains("compression ratio exceeds 4:1"));
+
+    let mut entries = ExtractBudget::from_limits(0, extract_entry_limits(2));
+    assert!(entries.account_entry().is_ok());
+    assert!(entries.account_entry().is_ok());
+    let entry_error = extract_failed_message(entries.account_entry().expect_err("entry limit"));
+    assert!(entry_error.contains("exceeds the 2 entry limit"));
+}
+
+#[test]
+fn extract_budget_ignores_ratio_until_the_configured_floor() {
+    let mut budget = ExtractBudget::from_limits(1, extract_ratio_limits(2, 32));
+    assert!(budget.account_bytes(31).is_ok());
+}
+
+#[test]
+fn extract_budget_skips_ratio_when_compressed_size_is_unknown() {
+    let mut budget = ExtractBudget::from_limits(0, extract_ratio_limits(1, 1));
+    assert!(budget.account_bytes(1_000).is_ok());
+}
+
+#[test]
+fn copy_extracted_with_budget_does_not_write_past_the_size_limit() {
+    let mut budget = ExtractBudget::from_limits(0, extract_size_limits(4));
+    let mut destination = Vec::new();
+    let error = copy_extracted_with_budget(
+        &b"0123456789"[..],
+        &mut destination,
+        &never_cancelled(),
+        &mut budget,
+    )
+    .expect_err("bounded copy must stop");
+    assert!(extract_failed_message(error).contains("uncompressed size"));
+    assert!(destination.is_empty());
+}
+
+#[test]
+fn zip_extraction_aborts_before_writing_when_claimed_size_exceeds_the_limit()
+-> Result<(), Box<dyn Error>> {
+    let root = tempfile::tempdir()?;
+    let destination = root.path().join("destination");
+    fs::create_dir(&destination)?;
+    let archive_path = root.path().join("payload.zip");
+    write_zip(&archive_path, &[("payload.bin", &[0u8; 256][..])])?;
+
+    let error = extract_must_fail(
+        extract_zip_with_limits(&archive_path, &destination, extract_size_limits(64)),
+        "zip extract must honor the size ceiling",
+    );
+    assert!(extract_failed_message(error).contains("uncompressed size"));
+    assert!(destination_is_empty(&destination)?);
+    Ok(())
+}
+
+#[test]
+fn tar_and_7z_extraction_abort_when_uncompressed_size_exceeds_the_limit()
+-> Result<(), Box<dyn Error>> {
+    let root = tempfile::tempdir()?;
+    let destination = root.path().join("destination");
+    fs::create_dir(&destination)?;
+    let tar_path = root.path().join("payload.tar");
+    let seven_z_path = root.path().join("payload.7z");
+    write_tar(&tar_path, "payload.bin", &[7u8; 256], false)?;
+    write_7z(&seven_z_path, "payload.bin", &[7u8; 256])?;
+
+    let tar_error = extract_must_fail(
+        extract_tar_with_limits(
+            &tar_path,
+            &destination,
+            false,
+            &Arc::new(AtomicUsize::new(0)),
+            &never_cancelled(),
+            extract_size_limits(64),
+        ),
+        "tar extract must honor the size ceiling",
+    );
+    assert!(extract_failed_message(tar_error).contains("uncompressed size"));
+    assert!(destination_is_empty(&destination)?);
+
+    let seven_z_error = extract_must_fail(
+        extract_7z_from_reader_with_limits(
+            fs::File::open(&seven_z_path)?,
+            &destination,
+            sevenz_rust2::Password::empty(),
+            &Arc::new(AtomicUsize::new(0)),
+            &never_cancelled(),
+            extract_size_limits(64),
+        ),
+        "7z extract must honor the size ceiling",
+    );
+    assert!(extract_failed_message(seven_z_error).contains("uncompressed size"));
+    assert!(destination_is_empty(&destination)?);
+    Ok(())
+}
+
+#[test]
+fn extraction_aborts_when_entry_count_exceeds_the_limit() -> Result<(), Box<dyn Error>> {
+    let root = tempfile::tempdir()?;
+    let zip_destination = root.path().join("zip");
+    let tar_destination = root.path().join("tar");
+    let seven_z_destination = root.path().join("seven-z");
+    fs::create_dir(&zip_destination)?;
+    fs::create_dir(&tar_destination)?;
+    fs::create_dir(&seven_z_destination)?;
+    let entries = [
+        ("one.txt", b"a".as_slice()),
+        ("two.txt", b"b".as_slice()),
+        ("three.txt", b"c".as_slice()),
+    ];
+    let zip_path = root.path().join("files.zip");
+    let tar_path = root.path().join("files.tar");
+    let seven_z_path = root.path().join("files.7z");
+    write_zip(&zip_path, &entries)?;
+    write_tar_entries(&tar_path, &entries, false)?;
+    write_7z_entries(&seven_z_path, &entries)?;
+    let limits = extract_entry_limits(2);
+
+    let zip_error = extract_must_fail(
+        extract_zip_with_limits(&zip_path, &zip_destination, limits),
+        "zip extract must honor the entry ceiling",
+    );
+    assert!(extract_failed_message(zip_error).contains("entry limit"));
+    assert!(destination_is_empty(&zip_destination)?);
+
+    let tar_error = extract_must_fail(
+        extract_tar_with_limits(
+            &tar_path,
+            &tar_destination,
+            false,
+            &Arc::new(AtomicUsize::new(0)),
+            &never_cancelled(),
+            limits,
+        ),
+        "tar extract must honor the entry ceiling",
+    );
+    assert!(extract_failed_message(tar_error).contains("entry limit"));
+    assert_eq!(tar_destination.read_dir()?.count(), 2);
+
+    let seven_z_error = extract_must_fail(
+        extract_7z_from_reader_with_limits(
+            fs::File::open(&seven_z_path)?,
+            &seven_z_destination,
+            sevenz_rust2::Password::empty(),
+            &Arc::new(AtomicUsize::new(0)),
+            &never_cancelled(),
+            limits,
+        ),
+        "7z extract must honor the entry ceiling",
+    );
+    assert!(extract_failed_message(seven_z_error).contains("entry limit"));
+    assert!(destination_is_empty(&seven_z_destination)?);
+    Ok(())
+}
+
+#[test]
+fn extraction_aborts_when_compression_ratio_exceeds_the_limit() -> Result<(), Box<dyn Error>> {
+    let root = tempfile::tempdir()?;
+    let destination = root.path().join("destination");
+    fs::create_dir(&destination)?;
+    let zeros = vec![0u8; 4096];
+    let zip_path = root.path().join("zeros.zip");
+    let tar_gz_path = root.path().join("zeros.tar.gz");
+    let seven_z_path = root.path().join("zeros.7z");
+    write_zip(&zip_path, &[("zeros.bin", zeros.as_slice())])?;
+    write_tar(&tar_gz_path, "zeros.bin", &zeros, true)?;
+    write_7z(&seven_z_path, "zeros.bin", &zeros)?;
+    let limits = extract_ratio_limits(2, 16);
+
+    let zip_error = extract_must_fail(
+        extract_zip_with_limits(&zip_path, &destination, limits),
+        "zip extract must honor the ratio ceiling",
+    );
+    assert!(extract_failed_message(zip_error).contains("compression ratio"));
+    assert!(destination_is_empty(&destination)?);
+
+    let tar_error = extract_must_fail(
+        extract_tar_with_limits(
+            &tar_gz_path,
+            &destination,
+            true,
+            &Arc::new(AtomicUsize::new(0)),
+            &never_cancelled(),
+            limits,
+        ),
+        "tar.gz extract must honor the ratio ceiling",
+    );
+    assert!(extract_failed_message(tar_error).contains("compression ratio"));
+    assert!(destination_is_empty(&destination)?);
+
+    let seven_z_error = extract_must_fail(
+        extract_7z_from_reader_with_limits(
+            fs::File::open(&seven_z_path)?,
+            &destination,
+            sevenz_rust2::Password::empty(),
+            &Arc::new(AtomicUsize::new(0)),
+            &never_cancelled(),
+            limits,
+        ),
+        "7z extract must honor the ratio ceiling",
+    );
+    assert!(extract_failed_message(seven_z_error).contains("compression ratio"));
+    assert!(destination_is_empty(&destination)?);
+    Ok(())
+}
+
+#[test]
+fn zip_extraction_still_extracts_a_normal_archive_under_production_limits()
+-> Result<(), Box<dyn Error>> {
+    let root = tempfile::tempdir()?;
+    let destination = root.path().join("destination");
+    fs::create_dir(&destination)?;
+    let archive_path = root.path().join("normal.zip");
+    write_zip(&archive_path, &[("hello.txt", b"hello world")])?;
+    assert_eq!(
+        extract_zip(&archive_path, &destination)?.as_deref(),
+        Some("hello.txt")
+    );
+    assert_eq!(fs::read(destination.join("hello.txt"))?, b"hello world");
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Archive extraction previously copied decompressed bytes until EOF with no cap on uncompressed size, compression ratio, entry count, or destination free space. A small zip bomb could fill the disk.

This first-pass fix introduces a shared `ExtractBudget` used by the zip, tar, and 7z extract paths (not the compression copy helper). Extraction now:

- Tracks cumulative uncompressed bytes and aborts at 1 TiB or at the free space reported by `fstatvfs` on the destination
- Rejects archives with more than 1,000,000 entries (also capped by free inodes when known)
- Rejects expansion beyond a 100:1 ratio once at least 64 MiB has been written
- Uses claimed sizes from zip/7z/tar headers to fail before writing when the archive already advertises a violation
- Removes the incomplete current file and returns a clear error instead of continuing until ENOSPC

Normal archives remain within these limits.

## Visual evidence

N/A — extraction limit enforcement is not a user-visible layout change; failures surface as existing extract error messages.

## How to test

1. Extract a normal zip, tar/tar.gz, and 7z archive with **Extract here** / **Extract to…**. Contents should extract as before.
2. The new `local_operations` tests cover size, free-space, ratio, and entry-count aborts for zip, tar, and 7z, plus a normal zip still extracting under production limits.
3. Optional: extract a highly compressible archive of zeros with a tiny test limit (or a crafted zip bomb) and confirm extraction stops with an “Extraction aborted…” error rather than filling the disk.

**Expected result:** Legitimate archives extract. Oversized / high-ratio / high-entry archives fail closed with a clear error and without writing unbounded output.

Local validation on this branch: `cargo fmt --all --check` and `cargo clippy --all-targets --all-features -- -D warnings` passed. The new extract-limit tests and existing archive extract/cancel/path-traversal tests passed. The full suite was 907 passed / 2 failed; the two failures are unrelated asset rasterization tests (`folder_emoji_renders_at_high_resolution`, `primary_icons_rasterize_at_high_resolution`) that need icon/font rendering this environment does not provide.

## Related issue

Closes #479

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6d69032-55b5-41c2-a00d-748e959044bb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6d69032-55b5-41c2-a00d-748e959044bb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

