### PR TITLE
ci: skip CI jobs for draft pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
@@ -16,6 +17,7 @@ jobs:
   quality:
     name: Format, lint, and test
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
 
     steps:
       - name: Check out repository
@@ -46,6 +48,7 @@ jobs:
   e2e:
     name: End-to-end GUI suite
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     # A wedged X server or accessibility bus must not hold a pull request open.
     timeout-minutes: 20
 
@@ -91,6 +94,7 @@ jobs:
   release-scripts:
     name: Release workflow scripts
     runs-on: ubuntu-24.04
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
 
     steps:
       - name: Check out repository
@@ -102,6 +106,7 @@ jobs:
   repository-policy:
     name: Dependency and spelling policy
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Description

Draft pull requests no longer burn runner time on the full CI suite. Every job in the CI
workflow is now gated on the pull request not being a draft, and the workflow listens for
`ready_for_review` so the suite runs as soon as a draft is promoted. Pushes to `main` are
unaffected — the guard only applies to `pull_request` events.

## Visual evidence

N/A — workflow-only change with no user-visible surface.

## How to test

1. Open a draft pull request against `main` and check the Actions tab.
2. Mark the pull request ready for review.

**Expected result:** No CI jobs run while the pull request is a draft; marking it ready for
review starts the full suite. Pushing to `main` still runs CI as before.

## Related issue

Closes #500
