### PR TITLE
fix(trash): resolve volume trash items through GVfs target-uri

### DIFF
--- a/src/adapters/trash_restore.rs
+++ b/src/adapters/trash_restore.rs
@@ -137,12 +137,29 @@ pub(crate) async fn plan_restore_for_location(
     trash_info: Option<&Path>,
     context: &RestoreContext,
 ) -> Result<RestorePlan, RestoreTargetError> {
+    // GVfs names volume items after their escaped physical path and resolves
+    // relative `Path=` values itself, so ask it for the physical entry rather
+    // than guessing from the `trash:///` basename.
+    let gio_item = if source.native_path().is_none() && trash_info.is_none() {
+        Some(query_gio_trash_item(source).await?)
+    } else {
+        None
+    };
     let orig_path = if let Some(path) = original_target.and_then(Location::native_path) {
         path.to_path_buf()
+    } else if let Some(item) = &gio_item {
+        item.orig_path.clone()
     } else {
         orig_path_for_location(source, trash_info).await?
     };
-    let discovered = discover_trash_item(source, trash_info, Some(&orig_path), context)?;
+    let discovered = match gio_item
+        .as_ref()
+        .and_then(|item| item.target_path.as_deref())
+        .and_then(trash_item_from_files_path)
+    {
+        Some(discovered) => discovered,
+        None => discover_trash_item(source, trash_info, Some(&orig_path), context)?,
+    };
     plan_restore_from_known_paths(
         &discovered.source_path,
         &orig_path,
@@ -223,14 +240,8 @@ fn discover_trash_item(
             trash_info: Some(info.to_path_buf()),
         });
     }
-    if let Some(path) = source.native_path()
-        && let Some(trash_root) = trash_root_from_files_path(path)
-    {
-        return Ok(DiscoveredTrashItem {
-            trash_info: info_path_for_files_path(path),
-            trash_root,
-            source_path: path.to_path_buf(),
-        });
+    if let Some(discovered) = source.native_path().and_then(trash_item_from_files_path) {
+        return Ok(discovered);
     }
 
     let name = source.file_name().ok_or_else(|| {
@@ -283,14 +294,19 @@ async fn orig_path_for_location(
     {
         return Ok(orig);
     }
-    query_gio_orig_path(location).await
+    Ok(query_gio_trash_item(location).await?.orig_path)
 }
 
-async fn query_gio_orig_path(location: &Location) -> Result<PathBuf, RestoreTargetError> {
+struct GioTrashItem {
+    orig_path: PathBuf,
+    target_path: Option<PathBuf>,
+}
+
+async fn query_gio_trash_item(location: &Location) -> Result<GioTrashItem, RestoreTargetError> {
     let file = gio_file_for_location(location);
     let info = file
         .query_info_future(
-            "trash::orig-path",
+            "trash::orig-path,standard::target-uri",
             gio::FileQueryInfoFlags::NOFOLLOW_SYMLINKS,
             glib::Priority::DEFAULT,
         )
@@ -301,13 +317,35 @@ async fn query_gio_orig_path(location: &Location) -> Result<PathBuf, RestoreTarg
             "The original location is unavailable",
         ));
     };
-    let path = PathBuf::from(original.as_str());
-    if path.as_os_str().is_empty() {
+    let orig_path = PathBuf::from(original.as_str());
+    if orig_path.as_os_str().is_empty() {
         return Err(RestoreTargetError::new(
             "The original location is unavailable",
         ));
     }
-    Ok(path)
+    let target_path = info
+        .attribute_string(gio::FILE_ATTRIBUTE_STANDARD_TARGET_URI)
+        .and_then(|target| glib::filename_from_uri(&target).ok())
+        .and_then(|(path, hostname)| {
+            hostname
+                .is_none_or(|host| host.eq_ignore_ascii_case("localhost"))
+                .then_some(path)
+        });
+    Ok(GioTrashItem {
+        orig_path,
+        target_path,
+    })
+}
+
+/// Accepts only a `<trash root>/files/<name>` entry so a reported target that
+/// is not shaped like a trash item never becomes the restore source.
+fn trash_item_from_files_path(path: &Path) -> Option<DiscoveredTrashItem> {
+    let trash_root = trash_root_from_files_path(path)?;
+    Some(DiscoveredTrashItem {
+        trash_info: info_path_for_files_path(path),
+        trash_root,
+        source_path: path.to_path_buf(),
+    })
 }
 
 fn orig_path_from_trashinfo(info_path: &Path) -> Option<PathBuf> {
@@ -324,6 +362,9 @@ fn find_trash_item_by_orig_path(
 ) -> Option<DiscoveredTrashItem> {
     let info_root = trash_root.join("info");
     let files_root = trash_root.join("files");
+    // A relative `Path=` is relative to the directory holding the trash
+    // directory, which is how GVfs reports `trash::orig-path`.
+    let topdir = trash_root.parent()?;
     let infos = std::fs::read_dir(info_root).ok()?;
     for info in infos.flatten() {
         let info_path = info.path();
@@ -335,6 +376,11 @@ fn find_trash_item_by_orig_path(
         };
         let Some(path) = orig_path_from_trashinfo(&info_path) else {
             continue;
+        };
+        let path = if path.is_absolute() {
+            path
+        } else {
+            topdir.join(path)
         };
         if path != orig_path {
             continue;

--- a/src/adapters/trash_restore/tests.rs
+++ b/src/adapters/trash_restore/tests.rs
@@ -255,6 +255,80 @@ fn lexical_normalize_collapses_dot_and_dotdot() {
 }
 
 #[test]
+fn relative_trashinfo_path_matches_the_topdir_resolved_orig_path() {
+    let fixture = tempfile::tempdir().expect("fixture");
+    let trash = volume_trash(fixture.path(), 1000);
+    fs::write(trash.join("files/report.txt"), b"ok").expect("source");
+    fs::write(
+        trash.join("info/report.txt.trashinfo"),
+        "[Trash Info]\nPath=Documents/report.txt\nDeletionDate=2026-01-01T00:00:00\n",
+    )
+    .expect("info");
+
+    let found = find_trash_item_by_orig_path(&trash, &fixture.path().join("Documents/report.txt"))
+        .expect("relative Path= resolves against the topdir");
+
+    assert_eq!(found.source_path, trash.join("files/report.txt"));
+    assert_eq!(found.trash_root, trash);
+    assert!(
+        find_trash_item_by_orig_path(&trash, Path::new("/elsewhere/Documents/report.txt"))
+            .is_none()
+    );
+}
+
+#[test]
+fn gvfs_named_volume_item_is_discovered_from_its_relative_trashinfo() {
+    let fixture = tempfile::tempdir().expect("fixture");
+    let uid = 1000;
+    let trash = volume_trash(fixture.path(), uid);
+    fs::write(trash.join("files/report.txt"), b"ok").expect("source");
+    fs::write(
+        trash.join("info/report.txt.trashinfo"),
+        "[Trash Info]\nPath=Documents/report.txt\nDeletionDate=2026-01-01T00:00:00\n",
+    )
+    .expect("info");
+    let context = context_for(&fixture.path().join("home-trash"), uid, fixture.path());
+    let escaped = format!(
+        "trash:///{}",
+        glib::Uri::escape_string(
+            &format!("{}/.Trash-{uid}/files/report.txt", fixture.path().display())
+                .replace('/', "\\"),
+            None,
+            false,
+        )
+    );
+
+    let discovered = discover_trash_item(
+        &Location::uri(escaped),
+        None,
+        Some(&fixture.path().join("Documents/report.txt")),
+        &context,
+    )
+    .expect("volume item found through its orig path");
+
+    assert_eq!(discovered.source_path, trash.join("files/report.txt"));
+    assert_eq!(
+        discovered.trash_info.as_deref(),
+        Some(trash.join("info/report.txt.trashinfo").as_path())
+    );
+}
+
+#[test]
+fn trash_item_from_files_path_requires_a_files_entry() {
+    let item = trash_item_from_files_path(Path::new("/media/usb/.Trash-1000/files/report.txt"))
+        .expect("files entry");
+    assert_eq!(item.trash_root, Path::new("/media/usb/.Trash-1000"));
+    assert_eq!(
+        item.trash_info.as_deref(),
+        Some(Path::new(
+            "/media/usb/.Trash-1000/info/report.txt.trashinfo"
+        ))
+    );
+    assert!(trash_item_from_files_path(Path::new("/media/usb/Documents/report.txt")).is_none());
+    assert!(trash_item_from_files_path(Path::new("/media/usb/.Trash-1000/info/x")).is_none());
+}
+
+#[test]
 fn trash_root_is_derived_from_the_files_entry() {
     let path = Path::new("/media/usb/.Trash-1000/files/report.txt");
     assert_eq!(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Follow-up to #502 found while reviewing it against #478. The new restore planner located the physical `files/` entry of a `trash:///` item by guessing from the `trash:///` basename or by an exact match on the `.trashinfo` `Path=` value. Verified against a live gvfsd-trash (1.54) on a loop-mounted ext4 volume, that breaks legitimate restores:

- GVfs names items in volume trash directories after their escaped physical path (`\media\usb\.Trash-1000\files\report.txt`), so the basename lookup never matches.
- GIO writes `Path=` **relative to the topdir** for `.Trash-$uid` directories and GVfs resolves it before reporting `trash::orig-path` (`/media/usb/Documents/report.txt`), so the exact `Path=` comparison never matches either.
- Result: every item trashed on removable media failed with "Unable to determine where this item was deleted from" (Trash view Restore and undo-of-trash). A basename collision between a home-trash item and a volume-trash item also bound the home item to the volume entry and rejected the restore.

This change uses `standard::target-uri` (the physical entry GVfs itself moves on restore, which Strata already reads for thumbnails) as the primary source for `trash:///` items, and resolves relative `Path=` values against the topdir in the scan fallback. Destination validation (mount root, filesystem identity, `openat2` `RESOLVE_BENEATH`, `RENAME_NOREPLACE`) is unchanged; the planted-payload case from #478 is still rejected.

## Visual evidence

N/A — no UI change; the restore confirmation dialog and its contents are unchanged.

## How to test

1. On a mounted volume (a loop-mounted ext4 image works: `mkfs.ext4 usb.img && sudo mount -o loop usb.img /media/usb`), trash a file from `/media/usb/Documents/report.txt` with `gio trash`, or create `.Trash-$UID/files/report.txt` plus `info/report.txt.trashinfo` containing `Path=Documents/report.txt`.
2. Open Trash in Strata, select the item, choose Restore, and confirm.
3. Also plant `.Trash-$UID/files/payload.desktop` with `Path=/home/$USER/.config/autostart/payload.desktop` and try to restore it.

**Expected result:** `report.txt` is restored to `/media/usb/Documents/report.txt` and its `.trashinfo` is removed. The planted item is refused with "outside the trash volume" and nothing is created under `~/.config/autostart`. Home-trash restores are unaffected, including when a same-named file exists in a volume trash.

## Related issue

Refs #478 (follow-up to #502)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-732efdf5-5b59-4386-b8df-b1c2ca96e00d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-732efdf5-5b59-4386-b8df-b1c2ca96e00d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

