### PR TITLE
chore(release): exclude skip-changelog PRs from release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,3 +2,4 @@ changelog:
   exclude:
     labels:
       - dependencies
+      - skip-changelog


### PR DESCRIPTION
## Description
Exclude PRs labeled `skip-changelog` from GitHub-generated release notes while preserving the dependency exclusion. Created the repository label and applied it retroactively to internal PRs #481, #484, #487, and #490. Existing published release bodies are unchanged.

## Visual evidence
N/A — release metadata configuration only.

## How to test
1. After merging, generate draft release notes for a range containing the labeled internal PRs and user-facing fixes.
2. Inspect the generated entries.

**Expected result:** PRs labeled `skip-changelog` or `dependencies` are excluded; unlabeled user-facing changes remain.

## Related issue
Closes #512