### PR TITLE
fix(trash): restore on filesystems without renameat2 flags and guard the shared trash tree

### DIFF
--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -1118,23 +1118,53 @@ fn move_restore_path(
 
         let display_name = source_name.to_string_lossy().into_owned();
         gio::spawn_blocking(move || {
-            rustix::fs::renameat_with(
-                &source_parent,
-                &source_name,
-                &target_parent,
-                &target_name,
-                rustix::fs::RenameFlags::NOREPLACE,
-            )
+            rename_without_replacing(&target_parent, &target_name, |flags| {
+                rustix::fs::renameat_with(
+                    &source_parent,
+                    &source_name,
+                    &target_parent,
+                    &target_name,
+                    flags,
+                )
+            })
         })
         .await
         .map_err(|_| io_error("Restore task panicked"))?
         .map_err(|error| match error {
-            rustix::io::Errno::XDEV | rustix::io::Errno::INVAL => {
+            rustix::io::Errno::XDEV => {
                 io_error(format!("Could not restore {display_name} across volumes"))
             }
+            rustix::io::Errno::EXIST => io_error(format!(
+                "Could not restore {display_name}: something already exists at the destination"
+            )),
             error => io_error(format!("Could not restore {display_name}: {error}")),
         })
     })
+}
+
+/// Filesystems without `renameat2` flag support (NFS, libfuse2 daemons such as
+/// ntfs-3g) refuse `RENAME_NOREPLACE` with `EINVAL`. Emulate it there with an
+/// existence check through the already pinned target parent before a plain
+/// rename; the destination has been validated and confirmed by then.
+fn rename_without_replacing(
+    target_parent: &OwnedFd,
+    target_name: &OsStr,
+    rename: impl Fn(rustix::fs::RenameFlags) -> rustix::io::Result<()>,
+) -> rustix::io::Result<()> {
+    match rename(rustix::fs::RenameFlags::NOREPLACE) {
+        Err(rustix::io::Errno::INVAL | rustix::io::Errno::NOSYS) => {
+            match rustix::fs::statat(
+                target_parent,
+                target_name,
+                rustix::fs::AtFlags::SYMLINK_NOFOLLOW,
+            ) {
+                Ok(_) => Err(rustix::io::Errno::EXIST),
+                Err(rustix::io::Errno::NOENT) => rename(rustix::fs::RenameFlags::empty()),
+                Err(error) => Err(error),
+            }
+        }
+        result => result,
+    }
 }
 
 async fn move_restore(

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -3547,6 +3547,64 @@ fn restore_uses_the_trash_entry_target_path_as_the_physical_source() -> Result<(
     Ok(())
 }
 
+#[test]
+fn restore_rename_emulates_noreplace_when_the_filesystem_rejects_the_flag()
+-> Result<(), Box<dyn Error>> {
+    use rustix::fs::RenameFlags;
+    use rustix::io::Errno;
+
+    let fixture = tempfile::tempdir()?;
+    fs::write(fixture.path().join("a.txt"), b"a")?;
+    fs::write(fixture.path().join("taken.txt"), b"taken")?;
+    let parent = super::open_local_parent_directory(fixture.path())?;
+    let attempts = RefCell::new(Vec::new());
+    let rejecting_flags = |target: &str, flags: RenameFlags| {
+        attempts.borrow_mut().push(flags);
+        if flags.contains(RenameFlags::NOREPLACE) {
+            return Err(Errno::INVAL);
+        }
+        rustix::fs::renameat(&parent, "a.txt", &parent, target)
+    };
+
+    let result = super::rename_without_replacing(&parent, OsStr::new("taken.txt"), |flags| {
+        rejecting_flags("taken.txt", flags)
+    });
+    assert_eq!(result, Err(Errno::EXIST));
+    assert_eq!(*attempts.borrow(), vec![RenameFlags::NOREPLACE]);
+    assert_eq!(fs::read(fixture.path().join("taken.txt"))?, b"taken");
+    assert!(fixture.path().join("a.txt").exists());
+
+    attempts.borrow_mut().clear();
+    super::rename_without_replacing(&parent, OsStr::new("b.txt"), |flags| {
+        rejecting_flags("b.txt", flags)
+    })?;
+    assert_eq!(
+        *attempts.borrow(),
+        vec![RenameFlags::NOREPLACE, RenameFlags::empty()]
+    );
+    assert_eq!(fs::read(fixture.path().join("b.txt"))?, b"a");
+    assert!(!fixture.path().join("a.txt").exists());
+    Ok(())
+}
+
+#[test]
+fn restore_rename_keeps_the_kernel_result_when_noreplace_is_supported() -> Result<(), Box<dyn Error>>
+{
+    use rustix::fs::RenameFlags;
+    use rustix::io::Errno;
+
+    let fixture = tempfile::tempdir()?;
+    let parent = super::open_local_parent_directory(fixture.path())?;
+    let attempts = RefCell::new(Vec::new());
+    let result = super::rename_without_replacing(&parent, OsStr::new("missing"), |flags| {
+        attempts.borrow_mut().push(flags);
+        Err(Errno::EXIST)
+    });
+    assert_eq!(result, Err(Errno::EXIST));
+    assert_eq!(*attempts.borrow(), vec![RenameFlags::NOREPLACE]);
+    Ok(())
+}
+
 fn distinct_restore_devices() -> Option<(tempfile::TempDir, tempfile::TempDir)> {
     use std::os::unix::fs::MetadataExt;
     let first = tempfile::tempdir().ok()?;

--- a/src/adapters/trash_restore.rs
+++ b/src/adapters/trash_restore.rs
@@ -116,15 +116,16 @@ pub(crate) fn plan_restore_from_known_paths(
     if !destination.starts_with(&allowed_root) {
         return Err(escaped_restore_error());
     }
-    if path_is_within(&destination, trash_root) {
+    let trash_tree = trash_tree_root(trash_root);
+    if path_is_within(&destination, &trash_tree) {
         return Err(RestoreTargetError::new(
             "The original location must not be inside the trash directory",
         ));
     }
-    let trash_root = trash_root
+    let trash_tree = trash_tree
         .canonicalize()
-        .unwrap_or_else(|_| trash_root.to_path_buf());
-    if path_is_within(&destination, &trash_root) {
+        .unwrap_or_else(|_| trash_tree.clone());
+    if path_is_within(&destination, &trash_tree) {
         return Err(RestoreTargetError::new(
             "The original location must not be inside the trash directory",
         ));
@@ -252,8 +253,7 @@ fn resolve_restore_destination(
     let absolute = if orig_path.is_absolute() {
         orig_path.to_path_buf()
     } else {
-        trash_root
-            .parent()
+        trash_topdir(trash_root)
             .ok_or_else(|| RestoreTargetError::new("The original location is invalid"))?
             .join(orig_path)
     };
@@ -425,9 +425,7 @@ fn find_trash_item_by_orig_path(
 ) -> Option<DiscoveredTrashItem> {
     let info_root = trash_root.join("info");
     let files_root = trash_root.join("files");
-    // A relative `Path=` is relative to the directory holding the trash
-    // directory, which is how GVfs reports `trash::orig-path`.
-    let topdir = trash_root.parent()?;
+    let topdir = trash_topdir(trash_root)?;
     let infos = std::fs::read_dir(info_root).ok()?;
     for info in infos.flatten() {
         let info_path = info.path();
@@ -489,6 +487,42 @@ fn valid_shared_trash_dir(mount: &Path, uid: u32) -> Option<PathBuf> {
         return None;
     }
     Some(trash.join(uid.to_string()))
+}
+
+/// The shared layout nests the per-user directory one level deeper than
+/// `$topdir/.Trash-$uid`, so its trash root is `$topdir/.Trash/$uid`.
+fn is_shared_trash_root(trash_root: &Path) -> bool {
+    trash_root
+        .file_name()
+        .and_then(OsStr::to_str)
+        .is_some_and(|name| name.parse::<u32>().is_ok())
+        && trash_root
+            .parent()
+            .and_then(Path::file_name)
+            .is_some_and(|name| name == ".Trash")
+}
+
+/// Directory a relative `Path=` is resolved against: the mount point for
+/// volume trash directories and `$XDG_DATA_HOME` for the home trash, matching
+/// how GVfs reports `trash::orig-path`.
+fn trash_topdir(trash_root: &Path) -> Option<&Path> {
+    let parent = trash_root.parent()?;
+    if is_shared_trash_root(trash_root) {
+        parent.parent()
+    } else {
+        Some(parent)
+    }
+}
+
+/// Outermost directory that belongs to the trash: the shared `.Trash` dir for
+/// the shared layout, otherwise the trash root itself.
+fn trash_tree_root(trash_root: &Path) -> PathBuf {
+    if is_shared_trash_root(trash_root)
+        && let Some(shared) = trash_root.parent()
+    {
+        return shared.to_path_buf();
+    }
+    trash_root.to_path_buf()
 }
 
 pub(crate) fn trash_root_from_files_path(path: &Path) -> Option<PathBuf> {

--- a/src/adapters/trash_restore/tests.rs
+++ b/src/adapters/trash_restore/tests.rs
@@ -25,6 +25,16 @@ fn volume_trash(root: &Path, uid: u32) -> PathBuf {
     trash
 }
 
+fn shared_volume_trash(root: &Path, uid: u32) -> PathBuf {
+    let shared = root.join(".Trash");
+    fs::create_dir(&shared).expect("shared trash");
+    fs::set_permissions(&shared, PermissionsExt::from_mode(0o1777)).expect("sticky");
+    let trash = shared.join(uid.to_string());
+    fs::create_dir_all(trash.join("files")).expect("files");
+    fs::create_dir_all(trash.join("info")).expect("info");
+    trash
+}
+
 fn distinct_device_dirs() -> Option<(tempfile::TempDir, tempfile::TempDir)> {
     let first = tempfile::tempdir().ok()?;
     let shm = Path::new("/dev/shm");
@@ -101,6 +111,99 @@ fn relative_orig_path_in_home_trash_is_joined_to_xdg_data_home() {
             .canonicalize()
             .expect("canonical mount")
             .join("Documents/report.txt")
+    );
+}
+
+#[test]
+fn relative_orig_path_in_shared_trash_is_joined_to_the_mount_point() {
+    let fixture = tempfile::tempdir().expect("fixture");
+    let uid = 1000;
+    let trash = shared_volume_trash(fixture.path(), uid);
+    let source = trash.join("files/report.txt");
+    fs::write(&source, b"ok").expect("source");
+    fs::create_dir_all(fixture.path().join("Documents")).expect("documents");
+    let context = context_for(&fixture.path().join("home-trash"), uid, fixture.path());
+
+    let plan = plan_restore_from_known_paths(
+        &source,
+        Path::new("Documents/report.txt"),
+        &trash,
+        None,
+        &context,
+    )
+    .expect("shared-trash relative path");
+
+    let mount = fixture.path().canonicalize().expect("canonical mount");
+    assert_eq!(plan.destination, mount.join("Documents/report.txt"));
+    assert_eq!(plan.allowed_root, mount);
+}
+
+#[test]
+fn shared_trash_item_is_found_by_its_relative_orig_path() {
+    let fixture = tempfile::tempdir().expect("fixture");
+    let trash = shared_volume_trash(fixture.path(), 1000);
+    fs::write(trash.join("files/report.txt"), b"ok").expect("source");
+    fs::write(
+        trash.join("info/report.txt.trashinfo"),
+        "[Trash Info]\nPath=Documents/report.txt\n",
+    )
+    .expect("info");
+
+    let found = find_trash_item_by_orig_path(&trash, &fixture.path().join("Documents/report.txt"))
+        .expect("resolved against the mount point, not .Trash");
+
+    assert_eq!(found.source_path, trash.join("files/report.txt"));
+    assert!(
+        find_trash_item_by_orig_path(&trash, &fixture.path().join(".Trash/Documents/report.txt"))
+            .is_none()
+    );
+}
+
+#[test]
+fn destination_inside_the_shared_trash_directory_is_rejected() {
+    let fixture = tempfile::tempdir().expect("fixture");
+    let uid = 1000;
+    let trash = shared_volume_trash(fixture.path(), uid);
+    let source = trash.join("files/report.txt");
+    fs::write(&source, b"ok").expect("source");
+    let context = context_for(&fixture.path().join("home-trash"), uid, fixture.path());
+
+    for orig in [
+        fixture.path().join(".Trash/Documents/report.txt"),
+        fixture.path().join(".Trash/1000/files/report.txt"),
+        fixture.path().join(".Trash/2000/files/report.txt"),
+    ] {
+        let error = plan_restore_from_known_paths(&source, &orig, &trash, None, &context)
+            .expect_err("inside the shared trash tree");
+        assert!(
+            error.message().contains("inside the trash directory"),
+            "{orig:?}: {}",
+            error.message()
+        );
+    }
+}
+
+#[test]
+fn trash_topdir_matches_the_freedesktop_layouts() {
+    assert_eq!(
+        trash_topdir(Path::new("/media/usb/.Trash-1000")),
+        Some(Path::new("/media/usb"))
+    );
+    assert_eq!(
+        trash_topdir(Path::new("/media/usb/.Trash/1000")),
+        Some(Path::new("/media/usb"))
+    );
+    assert_eq!(
+        trash_topdir(Path::new("/home/user/.local/share/Trash")),
+        Some(Path::new("/home/user/.local/share"))
+    );
+    assert_eq!(
+        trash_tree_root(Path::new("/media/usb/.Trash/1000")),
+        Path::new("/media/usb/.Trash")
+    );
+    assert_eq!(
+        trash_tree_root(Path::new("/media/usb/.Trash-1000")),
+        Path::new("/media/usb/.Trash-1000")
     );
 }
 

--- a/src/services/transfer_action.rs
+++ b/src/services/transfer_action.rs
@@ -72,7 +72,12 @@ pub(crate) enum TransferKind {
 pub(crate) enum DropCommit {
     Copy,
     Move,
-    Ask { default: TransferKind },
+    /// `volume` is `Unknown` when the lookup had not resolved (or timed out) at
+    /// drop time, so the prompt must not claim the destination is another device.
+    Ask {
+        default: TransferKind,
+        volume: VolumeRelation,
+    },
     Forbidden,
 }
 
@@ -81,7 +86,7 @@ impl DropCommit {
         match self {
             Self::Copy => TransferKind::Copy,
             Self::Move => TransferKind::Move,
-            Self::Ask { default } => default,
+            Self::Ask { default, .. } => default,
             Self::Forbidden => TransferKind::Forbidden,
         }
     }
@@ -160,6 +165,7 @@ fn cross_volume_commit(input: DropActionInput) -> DropCommit {
     if input.strategy == CrossVolumeDropStrategy::Ask && input.can_copy && input.can_move {
         DropCommit::Ask {
             default: TransferKind::Copy,
+            volume: input.volume,
         }
     } else {
         match preferred {

--- a/src/services/transfer_action/tests.rs
+++ b/src/services/transfer_action/tests.rs
@@ -178,6 +178,11 @@ fn drop_commit_follows_cross_volume_strategy() {
     let neither = (false, false);
     let ask_copy = DropCommit::Ask {
         default: TransferKind::Copy,
+        volume: Different,
+    };
+    let ask_copy_unknown = DropCommit::Ask {
+        default: TransferKind::Copy,
+        volume: Unknown,
     };
 
     let cases = [
@@ -185,7 +190,7 @@ fn drop_commit_follows_cross_volume_strategy() {
         (both, Same, None, Copy, DropCommit::Move),
         (both, Same, None, Move, DropCommit::Move),
         (both, Different, None, Ask, ask_copy),
-        (both, Unknown, None, Ask, ask_copy),
+        (both, Unknown, None, Ask, ask_copy_unknown),
         (both, Different, None, Copy, DropCommit::Copy),
         (both, Unknown, None, Copy, DropCommit::Copy),
         (both, Different, None, Move, DropCommit::Move),

--- a/src/ui/browser/clipboard/tests.rs
+++ b/src/ui/browser/clipboard/tests.rs
@@ -164,6 +164,7 @@ fn file_drop_action_hover_matches_cross_volume_strategy() {
         ),
         crate::services::DropCommit::Ask {
             default: crate::services::TransferKind::Copy,
+            volume: different,
         }
     );
     assert_eq!(

--- a/src/ui/browser/transfer.rs
+++ b/src/ui/browser/transfer.rs
@@ -3,7 +3,7 @@
 use crate::adapters::gio_file_for_location;
 use crate::model::{FileEntry, Location};
 use crate::services::{
-    DropCommit, MoveRecord, PasteItem, TransferConflict, TransferKind, UndoMoveItem,
+    DropCommit, MoveRecord, PasteItem, TransferConflict, TransferKind, UndoMoveItem, VolumeRelation,
 };
 use crate::ui::browser::ViewState;
 use crate::ui::browser::destination::{
@@ -50,6 +50,15 @@ fn transfer_has_collision(source: &Location, destination: &Location) -> bool {
     target.query_exists(None::<&gio::Cancellable>)
 }
 
+fn cross_volume_drop_description(volume: VolumeRelation) -> &'static str {
+    match volume {
+        VolumeRelation::Different => "The destination is on a different device.",
+        VolumeRelation::Same | VolumeRelation::Unknown => {
+            "Strata could not determine whether the destination is on the same device."
+        }
+    }
+}
+
 pub(super) fn duplicate_transfer(entries: &[FileEntry]) -> Option<(Location, Vec<Location>)> {
     let destination = entries.first()?.location.parent()?;
     if is_trash_location(&destination)
@@ -73,8 +82,8 @@ impl ViewState {
         match commit {
             DropCommit::Copy => self.start_transfer(destination, sources, false),
             DropCommit::Move => self.start_transfer(destination, sources, true),
-            DropCommit::Ask { default } => {
-                self.confirm_cross_volume_drop(destination, sources, default);
+            DropCommit::Ask { default, volume } => {
+                self.confirm_cross_volume_drop(destination, sources, default, volume);
             }
             DropCommit::Forbidden => {}
         }
@@ -85,6 +94,7 @@ impl ViewState {
         destination: Location,
         sources: Vec<Location>,
         default: TransferKind,
+        volume: VolumeRelation,
     ) {
         let Some(ModalHost {
             overlay: window_overlay,
@@ -108,9 +118,11 @@ impl ViewState {
             "Copy",
             ModalTone::Accent,
         );
-        layout.body.append(&message_dialog_description(
-            "The destination is on a different device.",
-        ));
+        layout
+            .body
+            .append(&message_dialog_description(cross_volume_drop_description(
+                volume,
+            )));
         let move_button = gtk::Button::with_label("Move");
         move_button.add_css_class("action-dialog-cancel");
         layout

--- a/src/ui/browser/transfer/tests.rs
+++ b/src/ui/browser/transfer/tests.rs
@@ -34,9 +34,22 @@ fn commit_file_drop_routes_copy_move_ask_and_forbidden() {
     assert_eq!(
         DropCommit::Ask {
             default: TransferKind::Copy,
+            volume: VolumeRelation::Different,
         }
         .transfer_kind(),
         TransferKind::Copy
+    );
+}
+
+#[test]
+fn cross_volume_prompt_only_claims_another_device_when_the_lookup_resolved() {
+    assert_eq!(
+        cross_volume_drop_description(VolumeRelation::Different),
+        "The destination is on a different device."
+    );
+    assert_eq!(
+        cross_volume_drop_description(VolumeRelation::Unknown),
+        "Strata could not determine whether the destination is on the same device."
     );
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Follow-ups to #502 on top of `667291d`, which already resolves shared `.Trash/$uid` relative paths against the mount point. This branch merges that commit and adds what it left open:

- **`RENAME_NOREPLACE` emulation.** NFS returns `EINVAL` for every `renameat2` flag and FUSE does the same when the daemon lacks `RENAME2` (libfuse2 daemons such as ntfs-3g), so `667291d` still fails every restore there, only with a clearer message. `main` restored these through GVfs. `move_restore_path` now checks the destination through the already pinned target parent and retries with a plain rename; an occupied destination is still refused. Verified on a FUSE (bindfs) mount: the item restores, an occupied destination is refused, nothing is overwritten.
- **Shared trash tree guard.** The "inside the trash directory" check compared against `$topdir/.Trash/$uid` only, so a destination elsewhere under `$topdir/.Trash` passed. It now rejects anything inside the shared `.Trash` directory.
- **Honest copy-or-move prompt.** `DropCommit::Ask` is reached for `VolumeRelation::Unknown` as well as `Different`; it now carries the relation and the dialog no longer states "The destination is on a different device." when the lookup was unresolved.

Verified live against gvfsd-trash 1.54 on a loop-mounted ext4 volume with a sticky `.Trash/1000`: the dialog shows `/media/usb/Documents/report.txt` (matching GVfs's `trash::orig-path`), the file lands there, and nothing is created under `/media/usb/.Trash/`.

## Visual evidence

N/A — the only UI change is one sentence in the copy-or-move prompt for the unresolved case.

## How to test

1. On a FUSE-mounted directory (`bindfs src dst`, or an ntfs-3g stick), create `dst/.Trash-$UID/files/report.txt` and `info/report.txt.trashinfo` with `Path=Documents/report.txt`, open Trash in Strata, restore it.
2. On an ext4 volume, create a sticky `.Trash/` at the mount root with `.Trash/$UID/files/report.txt` and a relative `Path=Documents/report.txt`; restore from the Trash view.
3. Drag files onto a folder reached through a symlink and drop immediately with the drop strategy set to Ask.

**Expected result:** (1) the file returns to `dst/Documents/report.txt` and its `.trashinfo` is removed; a file already at the destination is refused with "something already exists at the destination". (2) The confirmation shows `<mount>/Documents/report.txt` and the file lands there, not under `.Trash/`. (3) If the prompt appears before the lookup resolved, it says Strata could not determine whether the destination is on the same device.

## Related issue

Refs #478 (follow-up to #502)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-732efdf5-5b59-4386-b8df-b1c2ca96e00d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-732efdf5-5b59-4386-b8df-b1c2ca96e00d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

