### PR TITLE
fix(browser): preserve destination focus after cut-paste

### DIFF
--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -3385,10 +3385,14 @@ impl Browser {
                     take_focus: false,
                 });
             }
-            self.emit(BrowserEvent::FocusChanged {
-                depth,
-                position: selected,
-            });
+            // Monitor updates to an ancestor must not reclaim focus after a
+            // transfer has revealed its destination in a child column.
+            if self.active_depth() == Some(depth) {
+                self.emit(BrowserEvent::FocusChanged {
+                    depth,
+                    position: selected,
+                });
+            }
         }
     }
 

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -1631,6 +1631,12 @@ fn filesystem_notifications_update_the_affected_column_incrementally() {
         mode: MetadataValue::Unknown,
     }));
 
+    assert!(
+        events
+            .borrow()
+            .iter()
+            .any(|event| matches!(event, BrowserEvent::FocusChanged { depth: 0, .. }))
+    );
     assert!(events.borrow().iter().any(|event| matches!(
         event,
         BrowserEvent::EntriesSpliced { depth: 0, splices, .. }
@@ -1649,6 +1655,54 @@ fn filesystem_notifications_update_the_affected_column_incrementally() {
             .borrow()
             .iter()
             .any(|event| matches!(event, BrowserEvent::ColumnReloaded { .. }))
+    );
+}
+
+#[test]
+fn background_directory_removal_does_not_request_focus() {
+    let browser = Browser::new(Rc::new(FakeFileSource));
+    let parent = Location::local("/fixture");
+    browser.navigate(parent.clone());
+    browser.handle_directory_change(0, &parent, DirectoryChange::Upsert(batch_entry("moved")));
+    browser.preview(0, 0);
+    assert_eq!(browser.active_depth(), Some(1));
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let observed = events.clone();
+    browser.observe(move |event| observed.borrow_mut().push(event.clone()));
+
+    browser.handle_directory_change(
+        0,
+        &parent,
+        DirectoryChange::Remove(Location::local("/fixture/moved")),
+    );
+
+    assert_eq!(browser.active_depth(), Some(1));
+    assert_eq!(
+        browser
+            .column_snapshot(0)
+            .expect("parent column")
+            .selected_positions,
+        [0]
+    );
+    assert!(
+        events
+            .borrow()
+            .iter()
+            .any(|event| matches!(event, BrowserEvent::EntriesSpliced { depth: 0, .. }))
+    );
+    assert!(events.borrow().iter().any(|event| matches!(
+        event,
+        BrowserEvent::SelectionSetChanged {
+            depth: 0,
+            take_focus: false,
+            ..
+        }
+    )));
+    assert!(
+        !events
+            .borrow()
+            .iter()
+            .any(|event| matches!(event, BrowserEvent::FocusChanged { .. }))
     );
 }
 


### PR DESCRIPTION
## Description

Only request focus after an incremental directory-monitor update when the affected column is active. Removing cut files from a background parent column must not steal focus from the destination opened by TransferReveal. Background entries and selections still update normally.

Add deterministic regression coverage for background removal and retain coverage of active-column focus updates.

## Visual evidence

Pending before/after capture of the Columns cut-paste sequence below. Keeping this PR in draft until that evidence is attached.

## How to test

1. In Columns view, open a directory containing a destination folder and two files. Leave the destination unopened; populate it with many existing items to make the original race easier to observe.
2. Select the two files and cut with Ctrl+X. Select the destination folder without opening it, then paste with Ctrl+V.
3. Repeat with copy instead of cut, and with the destination already open.

**Expected result:** Files arrive in the destination, its child column remains active, and the pasted files are selected. The parent listing updates without reclaiming focus.

## Related issue

Closes #511
