### PR TITLE
perf(e2e): parallelize scenarios with hardware-aware workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Run the canonical end-to-end container
+      - name: Run the hardware-aware end-to-end container
+        env:
+          STRATA_E2E_WORKERS: auto
         run: ./scripts/e2e.sh -p no:cacheprovider
 
       - name: Upload failure artifacts

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -32,6 +32,41 @@ For explicit host-toolkit debugging only, `./scripts/e2e-native.sh` accepts
 `STRATA_BINARY` and `STRATA_E2E_VENV`. It is not the pre-push E2E gate; a native
 pass does not replace `./scripts/e2e.sh`.
 
+### Hardware-aware parallelism
+
+The canonical container and native debugging runner default to isolated
+`pytest-xdist` workers. Each worker owns its Xvfb server, private session and
+accessibility buses, and input connection; scenarios within a worker run
+serially. The application is built once before workers start.
+
+Auto mode chooses the smallest of:
+
+- half the available logical CPUs (rounded down), respecting CPU affinity and
+  cgroup v1/v2 quotas, including visible ancestor limits;
+- one worker per 2 GiB of available memory after reserving 1 GiB, respecting
+  host `MemAvailable` and remaining cgroup memory;
+- 16 workers.
+
+At least one worker runs, including when memory availability is unknown. The
+budget is detected **inside the container, after compilation**, and printed at
+startup. It is a conservative resource budget, not a promise of linear speedup.
+
+```bash
+STRATA_E2E_WORKERS=auto ./scripts/e2e.sh  # default, locally and in CI
+STRATA_E2E_WORKERS=8 ./scripts/e2e.sh     # explicit budget
+STRATA_E2E_WORKERS=1 ./scripts/e2e.sh     # serial scenarios
+./scripts/e2e.sh -n 0                   # no worker subprocess, for debugging
+```
+
+A positive override bypasses the automatic resource caps. Explicit numeric
+pytest `-n` options take precedence over the environment variable. Parallel runs require
+`--dist=loadgroup`: all visual-baseline scenarios share one scheduling group so
+their fixed fixture directory is never claimed concurrently. Other scenarios
+are distributed individually. Worker crashes fail the run without automatic
+replacement or assertion retries. Baseline updates use the same grouping.
+Compare worker budgets with a warm build cache; xdist does not speed up image
+setup or Rust compilation.
+
 ### Keep Rust test windows off the local desktop
 
 Some Rust tests also create GTK windows when a display is available. Run the
@@ -62,7 +97,7 @@ them on the host.
 | Screen capture | `imagemagick` | `imagemagick` |
 | Font | `cantarell-fonts` | `fonts-cantarell` |
 
-`pytest` and Pillow are installed into the virtual environment from
+`pytest`, `pytest-xdist`, and Pillow are installed into the virtual environment from
 `tests/e2e/requirements.txt`. The environment is created with
 `--system-site-packages` because PyGObject is a system package.
 
@@ -160,7 +195,8 @@ rather than relying on GTK 4.14 to export `SELECTABLE` for unselected rows.
 
 ## Failure artifacts
 
-A failing scenario writes a directory under `target/e2e-artifacts/<test name>`
+A failing scenario writes a directory under `target/e2e-artifacts/<worker>/<test name>`
+(the worker component is omitted with `-n 0`)
 containing a screenshot, the accessibility tree, the application log, the
 fixture tree listing, and the Xvfb, D-Bus, and AT-SPI logs. The path is printed
 in the test output, and CI uploads the whole directory. Pass
@@ -176,8 +212,9 @@ versions do not have separate baselines; native baseline runs fail rather than
 silently accepting a different renderer.
 These scenarios exclusively claim `/tmp/strata-e2e-baseline`, because the
 breadcrumb and context menu render the full path. An existing directory or
-symlink is a setup error, never deleted or reused; concurrent baseline runs
-must use separate containers.
+symlink is a setup error, never deleted or reused. Within a run, baseline
+scenarios stay on one worker; independent concurrent runs must use separate
+containers.
 
 A capture matches when no more than 0.5% of pixels differ by more than 24 in
 any channel, which absorbs the subpixel antialiasing that software rendering
@@ -216,5 +253,7 @@ a workflow that does not have a mutation yet.
 
 The `e2e` job in `.github/workflows/ci.yml` invokes `./scripts/e2e.sh`, just
 like a local run. It does not separately install GTK or build a host binary.
-The suite runs serially with a per-test and a whole-job timeout. The infrastructure start-up is retried once;
+The suite uses the same hardware-aware worker budget as local runs (normally
+2 workers on the 4-vCPU runner), with a per-test and a whole-job timeout.
+The infrastructure start-up is retried once;
 a failed interaction assertion never is. Artifacts are uploaded on failure.

--- a/scripts/e2e-mutation-check.sh
+++ b/scripts/e2e-mutation-check.sh
@@ -67,7 +67,9 @@ for name in "${selected[@]}"; do
   report="$reports/$name.xml"
   rm -f "$report"
   result=0
-  "$repository/scripts/e2e.sh" -q -x --junitxml="$report" "$scenario" \
+  # xdist's fail-fast shutdown exits as an interruption, not a test failure.
+  # Finish the selected scenarios so detection still requires exit status 1.
+  "$repository/scripts/e2e.sh" -q --maxfail=0 --junitxml="$report" "$scenario" \
     >"$reports/$name.log" 2>&1 || result=$?
   if python3 "$repository/scripts/e2e_mutation_result.py" "$report" "$result"; then
     echo "   detected"

--- a/scripts/e2e-native.sh
+++ b/scripts/e2e-native.sh
@@ -21,16 +21,22 @@ if ((${#missing[@]})); then
   exit 1
 fi
 
-# PyGObject comes from the system; only pytest and Pillow are installed here.
+# PyGObject comes from the system; Python-only dependencies live in the venv.
 if [[ ! -x "$venv/bin/python" ]]; then
   echo "Creating the end-to-end virtual environment in $venv"
   python3 -m venv --system-site-packages "$venv"
+fi
+if ! cmp -s "$suite/requirements.txt" "$venv/strata-requirements.txt"; then
   "$venv/bin/pip" install --quiet --requirement "$suite/requirements.txt"
+  cp "$suite/requirements.txt" "$venv/strata-requirements.txt"
 fi
 
 if [[ -z "${STRATA_BINARY:-}" ]]; then
   cargo build --manifest-path "$repository/Cargo.toml" --bin strata
+  STRATA_BINARY="$(realpath "${CARGO_TARGET_DIR:-$repository/target}/debug/strata")"
+  export STRATA_BINARY
 fi
 
 cd "$repository"
-exec "$venv/bin/python" -m pytest -c "$suite/pytest.ini" --rootdir "$repository" "$@"
+exec "$venv/bin/python" -m pytest -c "$suite/pytest.ini" --rootdir "$repository" \
+  -n auto --dist=loadgroup --max-worker-restart=0 "$@"

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -31,6 +31,7 @@ exec "$engine" run "${options[@]}" \
   --env CARGO_HOME=/workspace/target/e2e-container/cargo \
   --env CARGO_TARGET_DIR=/workspace/target/e2e-container/build \
   --env "STRATA_E2E_UPDATE_BASELINES=${STRATA_E2E_UPDATE_BASELINES:-0}" \
+  --env "STRATA_E2E_WORKERS=${STRATA_E2E_WORKERS:-auto}" \
   "$image" bash -euc '
     mkdir -p "$HOME" "$CARGO_HOME"
     printf "GTK: "; pkg-config --modversion gtk4

--- a/scripts/test_e2e_mutation_result.py
+++ b/scripts/test_e2e_mutation_result.py
@@ -1,10 +1,47 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import os
+import shutil
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
 from e2e_mutation_result import detected
+
+
+class MutationRunnerTests(unittest.TestCase):
+    def test_parallel_mutation_runs_finish_without_fail_fast_interruption(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            scripts = root / "scripts"
+            scripts.mkdir()
+            for name in ("e2e-mutation-check.sh", "e2e_mutation_result.py"):
+                shutil.copyfile(Path(__file__).with_name(name), scripts / name)
+            mutations = root / "tests/e2e/mutations"
+            mutations.mkdir(parents=True)
+            (mutations / "click-modes.patch").touch()
+            tools = root / "bin"
+            tools.mkdir()
+            git = tools / "git"
+            git.write_text("#!/bin/sh\nexit 0\n")
+            git.chmod(0o755)
+            runner = scripts / "e2e.sh"
+            runner.write_text(
+                f"#!{sys.executable}\nimport sys\nfrom pathlib import Path\n"
+                "for arg in sys.argv[1:]:\n"
+                "    if arg.startswith('--junitxml='):\n"
+                "        Path(arg.split('=', 1)[1]).write_text('<testsuite><testcase><failure/></testcase></testsuite>')\n"
+                "        sys.exit(1 if '--maxfail=0' in sys.argv and '-x' not in sys.argv else 2)\n"
+            )
+            runner.chmod(0o755)
+            environment = {**os.environ, "PATH": f"{tools}:{os.environ.get('PATH', os.defpath)}"}
+            environment.pop("STRATA_BINARY", None)
+            result = subprocess.run(["bash", str(scripts / "e2e-mutation-check.sh"), "click-modes"],
+                                    env=environment, capture_output=True, text=True)
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("every mutation was detected", result.stdout)
 
 
 class MutationResultTests(unittest.TestCase):

--- a/scripts/test_e2e_resources.py
+++ b/scripts/test_e2e_resources.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SPEC = importlib.util.spec_from_file_location(
+    "e2e_resources", Path(__file__).resolve().parents[1] / "tests/e2e/harness/resources.py"
+)
+RESOURCES = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(RESOURCES)
+GIB = RESOURCES.GIB
+
+
+class WorkerCountTests(unittest.TestCase):
+    def test_cpu_memory_and_safety_cap(self):
+        for cpus, memory, expected in ((32, 38, 16), (4, 15, 2), (128, 256, 16),
+                                       (32, 7, 3), (1, 1, 1), (0.5, 0, 1)):
+            with self.subTest(cpus=cpus, memory=memory):
+                self.assertEqual(RESOURCES.worker_count(cpus, memory * GIB), expected)
+
+    def test_manual_override_and_serial(self):
+        self.assertEqual(RESOURCES.worker_count(4, GIB, "8"), 8)
+        self.assertEqual(RESOURCES.worker_count(32, 60 * GIB, "1"), 1)
+
+    def test_invalid_overrides(self):
+        for value in ("", "0", "-1", "1.5", "all", " auto", "²"):
+            with self.subTest(value=value), self.assertRaisesRegex(ValueError, "positive integer"):
+                RESOURCES.worker_count(32, 60 * GIB, value)
+
+
+class ResourceDetectionTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        self.proc = self.root / "proc"
+        (self.proc / "self").mkdir(parents=True)
+        (self.proc / "meminfo").write_text(f"MemAvailable: {40 * GIB // 1024} kB\n")
+        self.mount = self.root / "cgroup"
+        self.mount.mkdir()
+        affinity = patch.object(RESOURCES.os, "sched_getaffinity", return_value=set(range(32)))
+        affinity.start()
+        self.addCleanup(affinity.stop)
+
+    def mount_cgroup(self, membership="/job/worker", root="/", version=2):
+        controllers = "" if version == 2 else "cpu,memory"
+        filesystem = "cgroup2 cgroup rw" if version == 2 else "cgroup cgroup rw,cpu,memory"
+        (self.proc / "self/cgroup").write_text(f"0:{controllers}:{membership}\n")
+        (self.proc / "self/mountinfo").write_text(
+            f"1 0 0:1 {root} {self.mount} rw - {filesystem}\n"
+        )
+
+    def limits(self, path, **files):
+        path.mkdir(parents=True, exist_ok=True)
+        for name, contents in files.items():
+            (path / name).write_text(str(contents))
+
+    def test_v2_ancestor_quota_and_remaining_memory(self):
+        self.mount_cgroup()
+        self.limits(self.mount, **{"cpu.max": "800000 100000", "memory.max": 10 * GIB,
+                                  "memory.current": 3 * GIB})
+        self.limits(self.mount / "job", **{"cpu.max": "350000 100000"})
+        self.limits(self.mount / "job/worker", **{"cpu.max": "max 100000", "memory.max": "max"})
+        self.assertEqual(RESOURCES.available_resources(self.proc), (3.5, 7 * GIB))
+
+    def test_v1_limits(self):
+        self.mount_cgroup(membership="/", version=1)
+        self.limits(self.mount, **{"cpu.cfs_quota_us": 200000, "cpu.cfs_period_us": 100000,
+                                  "memory.limit_in_bytes": 8 * GIB, "memory.usage_in_bytes": 2 * GIB})
+        self.assertEqual(RESOURCES.available_resources(self.proc), (2, 6 * GIB))
+
+    def test_mount_root_and_namespace_relative_membership(self):
+        for membership, root in (("/host/job/worker", "/host/job"), ("/", "/host/job"),
+                                 ("/../../host/job", "/")):
+            with self.subTest(membership=membership):
+                self.mount_cgroup(membership, root)
+                self.limits(self.mount, **{"cpu.max": "100000 100000"})
+                self.assertEqual(RESOURCES.available_resources(self.proc)[0], 1)
+                self.assertTrue(all(p.is_relative_to(self.mount) for p in RESOURCES.cgroup_directories(self.proc)))
+
+    def test_affinity_and_host_memory_are_upper_bounds(self):
+        self.mount_cgroup(membership="/")
+        self.limits(self.mount, **{"cpu.max": "6400000 100000", "memory.max": 100 * GIB,
+                                  "memory.current": GIB})
+        self.assertEqual(RESOURCES.available_resources(self.proc), (32, 40 * GIB))
+
+    def test_missing_or_invalid_limits_and_cpu_fallback(self):
+        self.mount_cgroup(membership="/")
+        self.limits(self.mount, **{"cpu.max": "garbage", "memory.max": "max"})
+        with patch.object(RESOURCES.os, "sched_getaffinity", side_effect=OSError), \
+             patch.object(RESOURCES.os, "cpu_count", return_value=None):
+            self.assertEqual(RESOURCES.available_resources(self.proc), (1, 40 * GIB))
+        (self.proc / "meminfo").unlink()
+        self.assertEqual(RESOURCES.available_resources(self.proc)[1], 0)
+
+    def test_memory_pressure_never_selects_zero_workers(self):
+        self.mount_cgroup(membership="/")
+        self.limits(self.mount, **{"memory.max": GIB, "memory.current": 2 * GIB})
+        cpus, memory = RESOURCES.available_resources(self.proc)
+        self.assertEqual(memory, 0)
+        self.assertEqual(RESOURCES.worker_count(cpus, memory), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_e2e_runner.py
+++ b/scripts/test_e2e_runner.py
@@ -11,7 +11,7 @@ REPOSITORY = Path(__file__).resolve().parents[1]
 
 
 class ContainerRunnerTests(unittest.TestCase):
-    def run_runner(self, engine_name="docker", binary=None, uid=None):
+    def run_runner(self, engine_name="docker", binary=None, uid=None, workers="auto"):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             engine = root / engine_name
@@ -34,6 +34,7 @@ class ContainerRunnerTests(unittest.TestCase):
                 "WAYLAND_DISPLAY": "wayland-0",
                 "NOTIFY_SOCKET": "/run/user/1000/systemd/notify",
                 "STRATA_E2E_UPDATE_BASELINES": "1",
+                "STRATA_E2E_WORKERS": workers,
             }
             if uid is not None:
                 identity = root / "id"
@@ -70,6 +71,13 @@ class ContainerRunnerTests(unittest.TestCase):
             self.assertIsNone(call["display"])
             self.assertIsNone(call["wayland"])
             self.assertIsNone(call["notify"])
+
+    def test_worker_budget_is_forwarded_into_container(self):
+        for workers in ("auto", "1", "8"):
+            with self.subTest(workers=workers):
+                result, calls = self.run_runner(workers=workers)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn(f"STRATA_E2E_WORKERS={workers}", calls[1]["args"])
 
     def test_rootless_podman_preserves_checkout_ownership(self):
         result, calls = self.run_runner("podman")
@@ -124,6 +132,72 @@ class ContainerRunnerTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("e2e-native.sh", result.stderr)
         self.assertEqual(calls, [])
+
+
+class NativeRunnerTests(unittest.TestCase):
+    def run_runner(self, *, current_requirements=True, binary=None, arguments=()):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            scripts = root / "scripts"
+            scripts.mkdir()
+            runner = scripts / "e2e-native.sh"
+            runner.write_text((REPOSITORY / "scripts/e2e-native.sh").read_text())
+            suite = root / "tests/e2e"
+            suite.mkdir(parents=True)
+            (suite / "requirements.txt").write_text("pytest-xdist==3.8.0\n")
+            venv = root / "venv"
+            tools = venv / "bin"
+            tools.mkdir(parents=True)
+            (root / "target/debug").mkdir(parents=True)
+            if current_requirements:
+                (venv / "strata-requirements.txt").write_text((suite / "requirements.txt").read_text())
+            for name in ("Xvfb", "dbus-daemon", "dbus-send", "import", "python3"):
+                tool = tools / name
+                tool.write_text("#!/bin/sh\nexit 0\n")
+                tool.chmod(0o755)
+            log = root / "calls.jsonl"
+            for name in ("python", "pip", "cargo"):
+                tool = tools / name
+                tool.write_text(
+                    f"#!{sys.executable}\nimport json, os, sys\n"
+                    f"with open({str(log)!r}, 'a') as stream:\n"
+                    "    stream.write(json.dumps({'tool': os.path.basename(sys.argv[0]), "
+                    "'args': sys.argv[1:], 'binary': os.environ.get('STRATA_BINARY'), "
+                    "'display': os.environ.get('DISPLAY'), 'wayland': os.environ.get('WAYLAND_DISPLAY')}) + '\\n')\n"
+                )
+                tool.chmod(0o755)
+            environment = {**os.environ, "PATH": f"{tools}:{os.defpath}",
+                           "STRATA_E2E_VENV": str(venv), "DISPLAY": ":0", "WAYLAND_DISPLAY": "wayland-0"}
+            environment.pop("STRATA_BINARY", None)
+            environment.pop("CARGO_TARGET_DIR", None)
+            if binary:
+                environment["STRATA_BINARY"] = binary
+            result = subprocess.run(["bash", str(runner), *arguments], cwd=root,
+                                    env=environment, capture_output=True, text=True)
+            calls = [json.loads(line) for line in log.read_text().splitlines()]
+            return result, calls, root
+
+    def test_default_builds_once_before_parallel_pytest(self):
+        result, calls, root = self.run_runner()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual([call["tool"] for call in calls], ["cargo", "python"])
+        invocation = calls[-1]
+        self.assertEqual(invocation["binary"], str(root / "target/debug/strata"))
+        self.assertEqual(invocation["args"][-4:], ["-n", "auto", "--dist=loadgroup", "--max-worker-restart=0"])
+        self.assertIsNone(invocation["display"])
+        self.assertIsNone(invocation["wayland"])
+
+    def test_explicit_pytest_options_follow_defaults_and_binary_skips_build(self):
+        result, calls, _ = self.run_runner(binary="/provided/strata", arguments=("-n", "0", "-k", "baseline"))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual([call["tool"] for call in calls], ["python"])
+        self.assertEqual(calls[0]["args"][-4:], ["-n", "0", "-k", "baseline"])
+        self.assertEqual(calls[0]["binary"], "/provided/strata")
+
+    def test_existing_venv_is_updated_when_requirements_change(self):
+        result, calls, _ = self.run_runner(current_requirements=False)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual([call["tool"] for call in calls], ["pip", "cargo", "python"])
 
 
 if __name__ == "__main__":

--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -25,7 +25,8 @@ RUN rustup toolchain install 1.98.1 --no-self-update --profile minimal --compone
 
 COPY requirements.txt /opt/e2e-requirements.txt
 RUN python3 -m venv --system-site-packages /opt/e2e-venv \
-    && /opt/e2e-venv/bin/pip install --no-cache-dir -r /opt/e2e-requirements.txt
+    && /opt/e2e-venv/bin/pip install --no-cache-dir -r /opt/e2e-requirements.txt \
+    && cp /opt/e2e-requirements.txt /opt/e2e-venv/strata-requirements.txt
 
 # D-Bus requires an account entry even when the runtime accepts a numeric UID.
 ARG E2E_UID=1000

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -12,7 +12,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from harness import screenshots, tree  # noqa: E402
+from harness import resources, screenshots, tree  # noqa: E402
 from harness.application import Application, build_binary  # noqa: E402
 from harness.artifacts import ArtifactCollector  # noqa: E402
 from harness.browser import Strata  # noqa: E402
@@ -32,6 +32,23 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         action="store_true",
         help="write the failure artifact bundle for passing scenarios too",
     )
+
+
+def pytest_xdist_auto_num_workers(config: pytest.Config) -> int:
+    cpus, memory = resources.available_resources()
+    try:
+        workers = resources.worker_count(cpus, memory, os.environ.get("STRATA_E2E_WORKERS", "auto"))
+    except ValueError as error:
+        raise pytest.UsageError(str(error)) from error
+    print(f"E2E resources: {cpus:g} CPUs, {memory / resources.GIB:.1f} GiB available; {workers} workers")
+    return workers
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    for item in items:
+        if item.get_closest_marker("baseline"):
+            item.add_marker(pytest.mark.xdist_group("visual-baselines"))
 
 
 @pytest.fixture(scope="session")
@@ -186,6 +203,8 @@ def pytest_unconfigure(config: pytest.Config) -> None:
 
 
 def pytest_configure(config: pytest.Config) -> None:
+    if config.getoption("numprocesses", 0) and config.getoption("dist", "no") != "loadgroup":
+        raise pytest.UsageError("Parallel E2E requires --dist=loadgroup to isolate visual baselines")
     config.stash[_TERMINATION_HANDLER_KEY] = signal.signal(signal.SIGTERM, _terminate_session)
     config.addinivalue_line(
         "markers", "preferences(**values): seed Strata preferences for a scenario"

--- a/tests/e2e/harness/artifacts.py
+++ b/tests/e2e/harness/artifacts.py
@@ -15,6 +15,9 @@ from . import screenshots
 def artifact_root() -> Path:
     configured = os.environ.get("STRATA_E2E_ARTIFACTS")
     base = Path(configured) if configured else _default_root()
+    worker = os.environ.get("PYTEST_XDIST_WORKER")
+    if worker:
+        base = base / worker
     base.mkdir(parents=True, exist_ok=True)
     return base
 

--- a/tests/e2e/harness/display.py
+++ b/tests/e2e/harness/display.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import select
 import shutil
 import subprocess
 import tempfile
@@ -23,7 +24,7 @@ MAX_RUNTIME_DIR_LENGTH = 60
 
 # Well clear of the session display and of the numbers Xephyr and friends take.
 FIRST_DISPLAY_NUMBER = 90
-DISPLAY_TRIES = 30
+DISPLAY_TRIES = 256
 XVFB_START_TIMEOUT = 15.0
 
 BUS_LAUNCHER_CANDIDATES = (
@@ -130,9 +131,9 @@ class HeadlessDisplay:
         return managed
 
     def _start_xvfb(self) -> None:
-        # `-displayfd` always searches upwards from :0, which on a developer
-        # machine means the real session display. Claim a high number instead
-        # and move on when the server refuses it.
+        # An explicit display keeps -displayfd away from the desktop's low
+        # numbers. The readiness pipe confirms ownership, not just a socket
+        # another concurrently starting worker may have created.
         for number in range(FIRST_DISPLAY_NUMBER, FIRST_DISPLAY_NUMBER + DISPLAY_TRIES):
             if self._display_is_taken(number):
                 continue
@@ -152,11 +153,21 @@ class HeadlessDisplay:
         )
 
     def _try_display(self, number: int) -> bool:
+        read_fd, write_fd = os.pipe()
+        try:
+            return self._start_display(number, read_fd, write_fd)
+        finally:
+            os.close(read_fd)
+            os.close(write_fd)
+
+    def _start_display(self, number: int, read_fd: int, write_fd: int) -> bool:
         server = self._spawn(
             f"xvfb-{number}",
             [
                 "Xvfb",
                 f":{number}",
+                "-displayfd",
+                str(write_fd),
                 "-screen",
                 "0",
                 f"{self.width}x{self.height}x{self.depth}",
@@ -167,16 +178,19 @@ class HeadlessDisplay:
                 "-noreset",
                 "-ac",
             ],
+            pass_fds=(write_fd,),
         )
-        socket = Path(f"/tmp/.X11-unix/X{number}")
         deadline = time.monotonic() + XVFB_START_TIMEOUT
         while time.monotonic() < deadline:
-            if socket.exists():
-                return True
             if server.exited():
                 self._processes.remove(server)
                 return False
-            time.sleep(0.05)
+            ready, _, _ = select.select([read_fd], [], [], 0.05)
+            if ready:
+                advertised = os.read(read_fd, 64).strip()
+                if advertised == str(number).encode():
+                    return True
+                break
         terminate(server.popen)
         self._processes.remove(server)
         return False

--- a/tests/e2e/harness/resources.py
+++ b/tests/e2e/harness/resources.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Conservative GUI concurrency from resources available to this process."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+GIB = 1024**3
+MAX_AUTO_WORKERS = 16
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text().strip()
+    except OSError:
+        return ""
+
+
+def cgroup_directories(proc: Path = Path("/proc")) -> list[Path]:
+    """Resolve v1/v2 mounts, including namespace roots and ancestor limits."""
+    memberships = {}
+    for line in _read(proc / "self/cgroup").splitlines():
+        _, controllers, location = line.split(":", 2)
+        for controller in controllers.split(","):
+            memberships[controller] = location
+    directories = set()
+    for line in _read(proc / "self/mountinfo").splitlines():
+        before, after = line.split(" - ", 1)
+        fields, filesystem = before.split(), after.split()
+        if filesystem[0] not in ("cgroup", "cgroup2"):
+            continue
+        root, mount = Path(fields[3]), Path(fields[4])
+        controllers = [""] if filesystem[0] == "cgroup2" else filesystem[2].split(",")
+        for controller in controllers:
+            if controller not in memberships:
+                continue
+            location = Path(memberships[controller])
+            # A namespace can hide the membership's host-side prefix. Its mount
+            # root still exposes the applicable limit; never escape that mount.
+            if ".." in location.parts or not location.is_relative_to(root):
+                current = mount
+            else:
+                current = mount / location.relative_to(root)
+            while True:
+                directories.add(current)
+                if current == mount:
+                    break
+                current = current.parent
+    return sorted(directories)
+
+
+def available_resources(proc: Path = Path("/proc")) -> tuple[float, int]:
+    try:
+        cpus = float(len(os.sched_getaffinity(0)))
+    except (AttributeError, OSError):
+        cpus = float(os.cpu_count() or 1)
+    memory = 0
+    for line in _read(proc / "meminfo").splitlines():
+        if line.startswith("MemAvailable:"):
+            memory = int(line.split()[1]) * 1024
+    for directory in cgroup_directories(proc):
+        quota = _read(directory / "cpu.max").split()
+        if not quota:
+            quota = [_read(directory / "cpu.cfs_quota_us"),
+                     _read(directory / "cpu.cfs_period_us")]
+        try:
+            limit, period = map(int, quota)
+            if limit > 0 and period > 0:
+                cpus = min(cpus, limit / period)
+        except ValueError:
+            pass
+        for maximum, usage in (("memory.max", "memory.current"),
+                               ("memory.limit_in_bytes", "memory.usage_in_bytes")):
+            try:
+                remaining = max(0, int(_read(directory / maximum)) - int(_read(directory / usage)))
+                memory = min(memory, remaining)
+            except ValueError:
+                pass
+    return cpus, memory
+
+
+def worker_count(cpus: float, memory: int, override: str = "auto") -> int:
+    if override != "auto":
+        if not override.isdecimal() or int(override) < 1:
+            raise ValueError("STRATA_E2E_WORKERS must be 'auto' or a positive integer")
+        return int(override)
+    # Leave memory for the controller and infrastructure. Each worker runs
+    # Strata, Xvfb, and two buses; CPU oversubscription destabilizes GUI timing.
+    return max(1, min(MAX_AUTO_WORKERS, int(cpus / 2), (memory - GIB) // (2 * GIB)))

--- a/tests/e2e/mutations/clipboard.patch
+++ b/tests/e2e/mutations/clipboard.patch
@@ -2,13 +2,13 @@ diff --git a/src/ui/browser.rs b/src/ui/browser.rs
 index 11f9f7b..26b2f24 100644
 --- a/src/ui/browser.rs
 +++ b/src/ui/browser.rs
-@@ -1055,6 +1055,9 @@ impl BrowserView {
+@@ -890,6 +890,9 @@ impl BrowserView {
      }
  
      pub fn paste(&self) {
 +        if true {
 +            return;
 +        }
-         let depth = self.state.destination_depth();
-         if let Some(location) = depth.and_then(|depth| self.state.browser.location_at(depth)) {
-             self.state.paste_into(location);
+         self.state.sync_mode_selection();
+         let selected = self.state.browser.selected_entries();
+         let column = self

--- a/tests/e2e/requirements.txt
+++ b/tests/e2e/requirements.txt
@@ -6,4 +6,6 @@ pluggy==1.6.0
 pygments==2.21.0
 pytest==9.1.1
 pytest-timeout==2.5.0
+pytest-xdist==3.8.0
+execnet==2.1.2
 pillow==12.3.0

--- a/tests/e2e/unit/test_parallel.py
+++ b/tests/e2e/unit/test_parallel.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import Mock
+
+import pytest
+
+from harness.artifacts import ArtifactCollector
+from harness.display import HeadlessDisplay
+
+
+def test_artifacts_are_separated_by_worker(tmp_path, monkeypatch):
+    monkeypatch.setenv("STRATA_E2E_ARTIFACTS", str(tmp_path))
+    paths = []
+    for worker in ("gw0", "gw1"):
+        monkeypatch.setenv("PYTEST_XDIST_WORKER", worker)
+        paths.append(ArtifactCollector("infrastructure").write("startup-error.txt", worker))
+    assert paths[0] != paths[1]
+    assert [p.read_text() for p in paths] == ["gw0", "gw1"]
+
+
+def test_concurrent_displays_have_private_servers_and_buses():
+    displays = [HeadlessDisplay() for _ in range(4)]
+    try:
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            list(executor.map(lambda display: display.start(), displays))
+        for attribute in ("display", "runtime_dir", "session_bus_address", "accessibility_bus_address"):
+            assert len({getattr(display, attribute) for display in displays}) == len(displays)
+        assert all(not process.exited() for display in displays for process in display._processes)
+    finally:
+        for display in displays:
+            display.stop()
+    assert all(not display.runtime_dir.exists() for display in displays)
+
+
+def test_display_does_not_accept_another_workers_socket(monkeypatch):
+    display = HeadlessDisplay()
+    server = Mock(exited=lambda: True)
+    monkeypatch.setattr(display, "_spawn", lambda *args, **kwargs: server)
+    monkeypatch.setattr("harness.display.Path.exists", lambda _: True)
+    display._processes.append(server)
+    assert not display._try_display(1999)
+    assert not display._processes
+
+
+def test_baselines_are_grouped_before_xdist_scheduling():
+    from conftest import pytest_collection_modifyitems
+
+    baseline, ordinary = Mock(), Mock()
+    ordinary.get_closest_marker.return_value = None
+    pytest_collection_modifyitems([baseline, ordinary])
+    assert baseline.add_marker.call_args.args[0].args == ("visual-baselines",)
+    ordinary.add_marker.assert_not_called()
+
+
+def test_unsafe_scheduler_is_rejected():
+    from conftest import pytest_configure
+
+    config = Mock(getoption=lambda name, default: {"numprocesses": 2, "dist": "load"}[name])
+    with pytest.raises(pytest.UsageError, match="loadgroup"):
+        pytest_configure(config)


### PR DESCRIPTION
## Description

Run E2E scenarios in hardware-aware pytest workers, using the same defaults locally and in CI. Respect CPU affinity, cgroup CPU/memory limits, and available RAM; allow explicit worker budgets or serial debugging. Keep displays, buses, input, and artifacts isolated, group visual baselines together, and build the binary once. Adapt mutation checks without accepting interrupted runs, and refresh the stale clipboard mutation context.

On the requested 32-thread machine, all 260 tests passed at 1/2/4/8/16 workers. The warm full command fell from **357s to 69s** (scenario/test phase: **328s to 40s**). [Benchmark details](https://github.com/lgse/strata/issues/525#issuecomment-5566748143).

## Visual evidence

N/A — test infrastructure only; application appearance is unchanged.

## How to test

Use the container engine configured per `docs/e2e-testing.md` (`STRATA_CONTAINER_ENGINE=podman` for rootless Podman).

1. Run `./scripts/e2e.sh` and inspect the reported CPU, memory, and worker budget.
2. Compare with `STRATA_E2E_WORKERS=1 ./scripts/e2e.sh` or an explicit budget such as `STRATA_E2E_WORKERS=4`.
3. Run `./scripts/e2e.sh -n 0 -k baseline` to exercise debugging without worker subprocesses.

**Expected result:** The same scenarios pass with each budget. Auto mode stays within its CPU/memory caps, baseline scenarios do not collide, and parallel failure evidence is separated by worker under `target/e2e-artifacts`.

## Related issue

Closes #525
