### PR TITLE
feat(selection): clear the active selection with Escape

### DIFF
--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -891,8 +891,22 @@ impl Browser {
         closed
     }
 
+    pub fn clear_active_selection(&self) -> bool {
+        let cleared = self.state.borrow_mut().clear_active_selection();
+        if let Some((depth, focused)) = cleared {
+            self.emit(BrowserEvent::SelectionSetChanged {
+                depth,
+                positions: Vec::new(),
+                focused,
+                take_focus: false,
+            });
+            return true;
+        }
+        false
+    }
+
     pub fn escape(self: &Rc<Self>) {
-        if self.close_peek() {
+        if self.close_peek() || self.clear_active_selection() {
             return;
         }
 

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -2513,7 +2513,7 @@ fn keyboard_selection_and_activation_descend_without_the_ui() {
 }
 
 #[test]
-fn escape_closes_a_peek_before_the_deepest_column() {
+fn escape_closes_a_peek_before_clearing_selection_and_closing_the_deepest_column() {
     let browser = Browser::new(Rc::new(FakeFileSource));
     let events = Rc::new(RefCell::new(Vec::new()));
     let observed = events.clone();
@@ -2539,6 +2539,16 @@ fn escape_closes_a_peek_before_the_deepest_column() {
     );
 
     events.borrow_mut().clear();
+    let location = browser.active_location();
+    browser.escape();
+    assert!(browser.selected_positions(1).is_empty());
+    assert_eq!(browser.active_location(), location);
+    assert!(events.borrow().iter().any(|event| matches!(
+        event,
+        BrowserEvent::SelectionSetChanged { depth: 1, positions, .. } if positions.is_empty()
+    )));
+
+    events.borrow_mut().clear();
     browser.escape();
     assert!(
         events
@@ -2546,6 +2556,38 @@ fn escape_closes_a_peek_before_the_deepest_column() {
             .iter()
             .any(|event| matches!(event, BrowserEvent::ColumnsTruncated { len: 1 }))
     );
+}
+
+#[test]
+fn escape_clears_only_the_active_selection_and_preserves_the_cursor() {
+    for multiple in [false, true] {
+        let mut source = ScriptedSource::scripted(vec!["a.txt", "b.txt"], Vec::new());
+        source.dirs = vec!["child"];
+        let browser = Browser::new(Rc::new(source));
+        browser.navigate(Location::local("/fixture"));
+        browser.move_selection(1);
+        browser.activate_focused();
+        if multiple {
+            browser.select_all(1);
+        }
+        let parent_selection = browser.selected_positions(0);
+        let focused = browser.focused_item();
+        let location = browser.active_location();
+        assert_eq!(
+            browser.selected_positions(1).len(),
+            if multiple { 3 } else { 1 }
+        );
+
+        browser.escape();
+
+        assert!(browser.selected_positions(1).is_empty());
+        assert_eq!(browser.selected_positions(0), parent_selection);
+        assert_eq!(browser.focused_item(), focused);
+        assert_eq!(browser.active_location(), location);
+        assert!(!browser.selection_is_load_cursor());
+        browser.move_selection(1);
+        assert!(!browser.selected_positions(1).is_empty());
+    }
 }
 
 type CapturedLoad = Rc<RefCell<Option<(RequestId, Rc<dyn Fn(DirectoryEvent)>)>>>;

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -726,7 +726,7 @@ impl NavigationState {
             .collect();
         let commit = std::mem::take(&mut self.selection_commit);
         adopt_selected_locations(column, locations, commit);
-        column.selected = focused.filter(|position| positions.contains(position));
+        column.selected = focused.or(column.selected);
         if column.selection_anchor.is_none() {
             column.selection_anchor = column
                 .selected

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -737,6 +737,17 @@ impl NavigationState {
         true
     }
 
+    pub fn clear_active_selection(&mut self) -> Option<(usize, usize)> {
+        let depth = self.active_depth()?;
+        let column = self.columns.get_mut(depth)?;
+        if column.selected_locations.is_empty() {
+            return None;
+        }
+        let focused = column.selected.unwrap_or(0);
+        adopt_selected_locations(column, HashSet::new(), true);
+        Some((depth, focused))
+    }
+
     pub fn extend_selection(&mut self, direction: i32) -> Option<(usize, usize, Vec<usize>)> {
         let depth = self
             .active_column

--- a/src/app/navigation/tests.rs
+++ b/src/app/navigation/tests.rs
@@ -77,6 +77,31 @@ fn focusing_a_column_preserves_selection_and_descendants() {
 }
 
 #[test]
+fn empty_selection_sync_preserves_the_keyboard_cursor() {
+    let mut state = NavigationState::default();
+    state.navigate(location("/fixture"), RequestId(1));
+    state.apply_batch(
+        RequestId(1),
+        vec![
+            named_entry("/fixture/alpha", "alpha"),
+            named_entry("/fixture/bravo", "bravo"),
+            named_entry("/fixture/charlie", "charlie"),
+        ],
+    );
+    state.select(0, 1);
+    assert_eq!(state.clear_active_selection(), Some((0, 1)));
+    assert!(state.set_selection(0, &[], None));
+    assert!(state.selected_positions(0).is_empty());
+    assert_eq!(state.active_focus(), Some((0, Some(1))));
+    assert_eq!(state.move_selection(1), Some((0, 2)));
+
+    assert!(state.set_selection(0, &[], Some(1)));
+    assert!(state.selected_positions(0).is_empty());
+    assert_eq!(state.active_focus(), Some((0, Some(1))));
+    assert_eq!(state.move_selection(-1), Some((0, 0)));
+}
+
+#[test]
 fn multi_selection_tracks_entries_and_replaces_cleanly() {
     let mut state = NavigationState::default();
     state.navigate(location("/fixture"), RequestId(1));

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -609,6 +609,10 @@ impl BrowserView {
         self.state.browser.commit_selection();
     }
 
+    pub fn resume_native_selection(&self) {
+        self.state.mode_views.borrow().resume_native_selection();
+    }
+
     pub fn navigate_left(&self) {
         if self.view_mode() != BrowserMode::Columns {
             self.state.browser.parent();
@@ -1263,7 +1267,13 @@ impl ViewState {
         let Some((depth, positions)) = self.mode_views.borrow().selected_positions() else {
             return;
         };
-        let focused = positions.last().copied();
+        let focused = self
+            .mode_views
+            .borrow()
+            .focused_position()
+            .filter(|(focused_depth, _)| *focused_depth == depth)
+            .map(|(_, position)| position)
+            .or_else(|| positions.last().copied());
         self.browser.set_selection(depth, &positions, focused);
     }
 

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -1029,7 +1029,7 @@ impl ModeViews {
                 for pane in self.panes_at(*depth) {
                     set_selections(pane, positions);
                 }
-                if *take_focus || view_has_focus {
+                if *take_focus || (view_has_focus && !positions.is_empty()) {
                     self.focus_visible_pane(*depth);
                 }
             }
@@ -1060,6 +1060,21 @@ impl ModeViews {
             BrowserMode::Icons => self.icons_panes.iter().collect(),
             BrowserMode::List => self.list_pane.iter().collect(),
         }
+    }
+
+    pub fn resume_native_selection(&self) {
+        let Some((depth, focused, _)) = self.browser.focused_item() else {
+            return;
+        };
+        if !self.browser.selected_positions(depth).is_empty() {
+            return;
+        }
+        // Seed GTK's empty selection before the arrow moves it, without scheduling
+        // a focus restore that would undo the native move after key dispatch.
+        for pane in self.panes_at(depth) {
+            set_selections(pane, &[focused]);
+        }
+        self.browser.set_selection(depth, &[focused], Some(focused));
     }
 
     pub fn focused_position(&self) -> Option<(usize, usize)> {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -1012,6 +1012,21 @@ fn install_keyboard_navigation(
         if key == gtk::gdk::Key::Delete && !view.filter_has_focus() && view.confirm_delete(shift) {
             return glib::Propagation::Stop;
         }
+        if key == gtk::gdk::Key::Escape
+            && !control
+            && !alt
+            && !modifiers.contains(gtk::gdk::ModifierType::SUPER_MASK)
+            && !text_has_focus
+        {
+            if preview.is_open() {
+                preview.close();
+                return glib::Propagation::Stop;
+            }
+            // Transient surfaces may return focus to pane chrome rather than an item.
+            if browser.close_peek() || browser.clear_active_selection() {
+                return glib::Propagation::Stop;
+            }
+        }
         if !control && !alt && !view.item_view_has_focus() && !header_left_boundary {
             return glib::Propagation::Proceed;
         }
@@ -1081,10 +1096,6 @@ fn install_keyboard_navigation(
         }
         if key == gtk::gdk::Key::space && !alt && !control {
             preview.toggle(preview_target(browser.focused_entry()));
-            return glib::Propagation::Stop;
-        }
-        if key == gtk::gdk::Key::Escape && preview.is_open() {
-            preview.close();
             return glib::Propagation::Stop;
         }
         if key == gtk::gdk::Key::BackSpace && !control && !alt {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -1054,6 +1054,9 @@ fn install_keyboard_navigation(
                         return glib::Propagation::Stop;
                     }
                     view.commit_selection();
+                    if !control {
+                        view.resume_native_selection();
+                    }
                     if !control
                         && !shift
                         && let Some(direction) = sidebar_focus_direction(key)

--- a/tests/e2e/scenarios/test_escape_selection.py
+++ b/tests/e2e/scenarios/test_escape_selection.py
@@ -3,18 +3,21 @@
 
 import pytest
 
-from harness.modes import ALL_MODES, PREVIOUS_ENTRY_KEY
+from harness.modes import ALL_MODES, NEXT_ENTRY_KEY, PREVIOUS_ENTRY_KEY
 
 
 @pytest.mark.parametrize("mode", ALL_MODES)
 @pytest.mark.parametrize("multiple", [False, True])
+@pytest.mark.parametrize("direction", ["previous", "next"])
 @pytest.mark.preferences(single_click_previews=False)
-def test_escape_clears_selection_without_navigation(strata, mode, multiple):
+def test_escape_clears_selection_without_navigation(strata, mode, multiple, direction):
     root = strata.fixture.root.name
-    strata.select_entry("readme.md", root)
     if multiple:
-        strata.click_entry_with("todo.txt", ["ctrl"], root)
-    focused = "todo.txt" if multiple else "readme.md"
+        strata.select_entry("todo.txt", root)
+        strata.click_entry_with("readme.md", ["ctrl"], root)
+    else:
+        strata.select_entry("readme.md", root)
+    focused = "readme.md"
     strata.wait_for_selection(["readme.md", "todo.txt"] if multiple else [focused], root)
     panes = strata.pane_names()
 
@@ -23,8 +26,27 @@ def test_escape_clears_selection_without_navigation(strata, mode, multiple):
     strata.wait_for_selection([], root)
     strata.wait_for_focused_entry(focused)
     assert strata.pane_names() == panes
-    strata.keyboard.press(PREVIOUS_ENTRY_KEY[mode])
-    strata.wait(lambda: bool(strata.selected_names(root)), "keyboard navigation to resume")
+    key = PREVIOUS_ENTRY_KEY[mode] if direction == "previous" else NEXT_ENTRY_KEY[mode]
+    expected = "pictures" if direction == "previous" else "todo.txt"
+    strata.keyboard.press(key)
+    strata.wait_for_selection([expected], root)
+    strata.wait_for_focused_entry(expected)
+
+
+@pytest.mark.parametrize("mode", ALL_MODES)
+@pytest.mark.preferences(single_click_previews=False)
+def test_enter_after_escape_opens_the_focused_folder(strata, mode):
+    root = strata.fixture.root.name
+    strata.select_entry_with_keyboard("documents")
+    strata.wait_for_focused_entry("documents")
+    strata.keyboard.press("Escape")
+    strata.wait_for_selection([], root)
+    strata.wait_for_focused_entry("documents")
+
+    strata.keyboard.press("Return")
+
+    strata.wait_for_directory("documents")
+    strata.wait_for_entries(["notes.txt", "report.md", "spreadsheet.csv"], "documents")
 
 
 @pytest.mark.preferences(browser_mode="columns", single_click_previews=False)

--- a/tests/e2e/scenarios/test_escape_selection.py
+++ b/tests/e2e/scenarios/test_escape_selection.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Escape dismisses transient UI before clearing the active pane selection."""
+
+import pytest
+
+from harness.modes import ALL_MODES, PREVIOUS_ENTRY_KEY
+
+
+@pytest.mark.parametrize("mode", ALL_MODES)
+@pytest.mark.parametrize("multiple", [False, True])
+@pytest.mark.preferences(single_click_previews=False)
+def test_escape_clears_selection_without_navigation(strata, mode, multiple):
+    root = strata.fixture.root.name
+    strata.select_entry("readme.md", root)
+    if multiple:
+        strata.click_entry_with("todo.txt", ["ctrl"], root)
+    focused = "todo.txt" if multiple else "readme.md"
+    strata.wait_for_selection(["readme.md", "todo.txt"] if multiple else [focused], root)
+    panes = strata.pane_names()
+
+    strata.keyboard.press("Escape")
+
+    strata.wait_for_selection([], root)
+    strata.wait_for_focused_entry(focused)
+    assert strata.pane_names() == panes
+    strata.keyboard.press(PREVIOUS_ENTRY_KEY[mode])
+    strata.wait(lambda: bool(strata.selected_names(root)), "keyboard navigation to resume")
+
+
+@pytest.mark.preferences(browser_mode="columns", single_click_previews=False)
+def test_escape_only_clears_the_active_column(strata):
+    root = strata.fixture.root.name
+    strata.open_directory("documents", directory=root)
+    strata.select_entry("notes.txt", "documents")
+    parent_selection = strata.selected_names(root)
+    strata.keyboard.press("Escape")
+    strata.wait_for_selection([], "documents")
+    assert strata.selected_names(root) == parent_selection
+    assert strata.pane_names() == [root, "documents"]
+    strata.wait_for_focused_entry("notes.txt")
+
+
+@pytest.mark.parametrize("mode", ALL_MODES)
+@pytest.mark.parametrize("surface", ["menu", "properties", "rename", "new-folder", "location", "filter", "preview"])
+@pytest.mark.preferences(single_click_previews=False)
+def test_escape_dismisses_transient_before_selection(strata, mode, surface):
+    root = strata.fixture.root.name
+    strata.select_entry("readme.md", root)
+    if surface in ("menu", "properties"):
+        strata.open_context_menu("readme.md", root)
+        if surface == "properties":
+            strata.choose_menu_item("Properties")
+            strata.wait_for_dialog()
+    elif surface == "preview":
+        strata.keyboard.press("space")
+        strata.wait(strata.preview, "preview to open")
+    else:
+        shortcut = {"rename": "F2", "new-folder": "ctrl+shift+n", "location": "ctrl+l", "filter": "ctrl+f"}[surface]
+        strata.keyboard.press(shortcut)
+        strata.editable_field()
+
+    strata.keyboard.press("Escape")
+
+    if surface == "menu":
+        strata.wait_for_menu_closed()
+    elif surface == "properties":
+        strata.wait(lambda: strata.dialog() is None, "properties to close")
+    elif surface == "preview":
+        strata.wait(lambda: strata.preview() is None, "preview to close")
+    strata.wait_for_selection(["readme.md"], root)
+    strata.keyboard.press("Escape")
+    strata.wait_for_selection([], root)
+    assert strata.pane_names() == [root]


### PR DESCRIPTION
## Description

Clear the active pane’s selection with Escape in Columns, Icons, and List, retaining its keyboard cursor and current directory. Menus, dialogs, inline editors, filters, and previews still dismiss first; a subsequent Escape clears the selection even when dismissal returns focus to pane controls.

## Visual evidence

N/A — keyboard-only interaction; no layout or styling changes.

## How to test

1. In each view, select one file, then multiple files, and press Escape. Press an arrow key: selection and focus should move to the adjacent item on the first press.
2. In Columns, open a child folder and select entries there. Press Escape and verify the parent selection and both columns remain unchanged.
3. With a file selected, open a context menu, Properties, rename/new-folder editor, location editor, filter, or quick preview. Press Escape twice.
4. Focus a folder with the keyboard, press Escape, then Enter. The focused folder should open without jumping to the first entry.

**Expected result:** Escape clears only the active selection without moving focus or navigating. Transient UI dismisses on the first Escape, leaving selection intact; the next Escape clears it.

## Related issue

Closes #528
