### PR TITLE
fix(ui): reflect browser mode in appearance toolbar icon

### DIFF
--- a/data/icons/scalable/actions/strata-list-active.svg
+++ b/data/icons/scalable/actions/strata-list-active.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#22d3ee" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12h.01M3 18h.01M3 6h.01M8 12h13M8 18h13M8 6h13"/></svg>

--- a/data/strata.gresource.xml
+++ b/data/strata.gresource.xml
@@ -32,7 +32,6 @@
     <file>icons/scalable/actions/strata-house.svg</file>
     <file>icons/scalable/actions/strata-image.svg</file>
     <file>icons/scalable/actions/strata-info.svg</file>
-    <file>icons/scalable/actions/strata-list-active.svg</file>
     <file>icons/scalable/actions/strata-list-checks.svg</file>
     <file>icons/scalable/actions/strata-list.svg</file>
     <file>icons/scalable/actions/strata-key.svg</file>

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -44,7 +44,6 @@ pub mod icons {
     pub const ICONS: &str = "strata-icons";
     pub const HOME: &str = "strata-house";
     pub const LIST: &str = "strata-list";
-    pub const LIST_ACTIVE: &str = "strata-list-active";
     pub const LIST_CHECKS: &str = "strata-list-checks";
     pub const KEY: &str = "strata-key";
     pub const KEYBOARD: &str = "strata-keyboard";

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -1394,6 +1394,7 @@ pub(super) fn build_appearance_menu(
     let popover_weak = popover.downgrade();
     append_menu_heading(&content, "VIEW");
     let current_mode = view.view_mode();
+    let button_icon = crate::assets::chrome_icon(browser_mode_icon(current_mode));
     let (columns, columns_check, _) = appearance_option(
         crate::assets::icons::COLUMNS,
         "Columns",
@@ -1457,11 +1458,13 @@ pub(super) fn build_appearance_menu(
         let icons_check = icons_check.clone();
         let list_check = list_check.clone();
         let group_by_type = group_by_type.clone();
+        let button_icon = button_icon.clone();
         view.connect_view_mode_changed(move |mode| {
             columns_check.set_visible(mode == BrowserMode::Columns);
             icons_check.set_visible(mode == BrowserMode::Icons);
             list_check.set_visible(mode == BrowserMode::List);
             group_by_type.set_sensitive(mode.supports_type_grouping());
+            crate::assets::set_primary_icon(&button_icon, browser_mode_icon(mode));
         });
     }
     content.append(&columns);
@@ -1556,20 +1559,17 @@ pub(super) fn build_appearance_menu(
     content.append(&hidden);
 
     popover.set_child(Some(&content));
-    let icon = crate::assets::chrome_icon(crate::assets::icons::LIST);
-    button.set_child(Some(&icon));
+    button.set_child(Some(&button_icon));
     button.add_css_class("header-action");
-    button.connect_active_notify(move |button| {
-        crate::assets::set_primary_icon(
-            &icon,
-            if button.is_active() {
-                crate::assets::icons::LIST_ACTIVE
-            } else {
-                crate::assets::icons::LIST
-            },
-        );
-    });
     button
+}
+
+fn browser_mode_icon(mode: BrowserMode) -> &'static str {
+    match mode {
+        BrowserMode::Columns => crate::assets::icons::COLUMNS,
+        BrowserMode::Icons => crate::assets::icons::ICONS,
+        BrowserMode::List => crate::assets::icons::LIST,
+    }
 }
 
 fn appearance_option(


### PR DESCRIPTION
## Summary
- Appearance toolbar button now shows the icon matching the current browser mode (Columns/Icons/List) instead of a hardcoded List icon
- Updates live on both menu-driven and keyboard-driven (Ctrl+1/2/3) mode changes, alongside the existing popover checkmark
- Removed the no-op `LIST_ACTIVE` icon swap: CSS `:checked` already handles the active state, and the two SVGs were visually identical after theme recoloring. Dropped the dead constant, gresource entry, and SVG file.

Closes #530

#### Manual steps
1. Launch Strata
2. Switch modes via the Appearance menu or `Ctrl+1` / `Ctrl+2` / `Ctrl+3`
3. Observe the Appearance toolbar button icon matches the active view
4. Open the Appearance popover and confirm the active/checked styling still applies

#### Expected result
The toolbar button icon reflects the current browser mode and updates immediately on every mode change.

#### Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`

#### Screenshots

https://github.com/user-attachments/assets/a65a48e6-02f2-40ed-9dff-285565fa5d4a