### PR TITLE
fix(devices): defer sidebar mount visibility to the volume-monitor backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,12 +157,16 @@ On Arch Linux or Omarchy:
 
 ```bash
 sudo pacman -S --needed bubblewrap ffmpeg ffmpegthumbnailer fontconfig \
-  gst-libav gst-plugins-good gtk4 gtksourceview5 poppler-glib
+  gst-libav gst-plugins-good gtk4 gtksourceview5 gvfs poppler-glib
 # Optional SMB and broader camera RAW support:
 sudo pacman -S --needed gvfs-smb imagemagick libraw dcraw
 ```
 
 GTK **4.12 or newer** and glibc **2.39 or newer** are required. Other glibc-based distributions may work when they provide equivalent runtime libraries, but their package names and binary compatibility vary. Systems with an older glibc must [build Strata from source](#development-and-documentation).
+
+Device discovery requires the GVfs UDisks2 volume monitor (`gvfs` on Arch and
+Fedora; `gvfs-daemons` on Debian/Ubuntu). Without that backend, removable drives
+may be absent from Devices. SMB support remains optional.
 
 #### 2. Download and verify
 
@@ -385,7 +389,7 @@ Build requirements are the latest stable Rust toolchain, a C toolchain, `pkg-con
 
 ```bash
 sudo pacman -S --needed base-devel rust bubblewrap ffmpeg ffmpegthumbnailer fontconfig \
-  gst-libav gst-plugins-good gtk4 gtksourceview5 poppler-glib
+  gst-libav gst-plugins-good gtk4 gtksourceview5 gvfs poppler-glib
 make start-dev        # rebuild and restart as files change
 make run-dev          # build and launch the main app once
 make run-chooser-dev  # build and open an isolated Save chooser with choices

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ APP_ID="io.github.lgse.Strata"
 MIN_GLIBC="2.39"
 REQUIRED_PACKAGES=(
   bubblewrap desktop-file-utils ffmpeg ffmpegthumbnailer fontconfig gst-libav
-  gst-plugins-good gtk4 gtksourceview5 poppler-glib github-cli xdg-utils
+  gst-plugins-good gtk4 gtksourceview5 gvfs poppler-glib github-cli xdg-utils
 )
 RAW_PREVIEW_PACKAGES=(imagemagick libraw dcraw)
 
@@ -422,7 +422,8 @@ main() {
     fi
   else
     printf '\nStrata needs GTK 4.12+, GtkSourceView 5, Poppler GLib, Fontconfig, Bubblewrap,\n'
-    printf 'FFmpeg, ffmpegthumbnailer, and GStreamer runtime plugins.\n'
+    printf 'FFmpeg, ffmpegthumbnailer, GStreamer plugins, and the GVfs UDisks2 volume monitor.\n'
+    printf 'For the volume monitor, install gvfs-daemons on Debian/Ubuntu or gvfs on Fedora.\n'
     if [[ $NON_INTERACTIVE == yes ]]; then
       die "Non-interactive dependency installation currently supports Arch-based systems only."
     fi

--- a/packaging/aur/PKGBUILD.in
+++ b/packaging/aur/PKGBUILD.in
@@ -15,6 +15,7 @@ depends=(
   'glibc>=2.39'
   'gtk4>=4.12'
   'gtksourceview5'
+  'gvfs'
   'poppler-glib'
 )
 optdepends=(

--- a/packaging/aur/strata-bin/.SRCINFO
+++ b/packaging/aur/strata-bin/.SRCINFO
@@ -11,6 +11,7 @@ pkgbase = strata-bin
 	depends = glibc>=2.39
 	depends = gtk4>=4.12
 	depends = gtksourceview5
+	depends = gvfs
 	depends = poppler-glib
 	optdepends = ffmpeg: video previews
 	optdepends = ffmpegthumbnailer: video thumbnails

--- a/packaging/aur/strata-bin/PKGBUILD
+++ b/packaging/aur/strata-bin/PKGBUILD
@@ -15,6 +15,7 @@ depends=(
   'glibc>=2.39'
   'gtk4>=4.12'
   'gtksourceview5'
+  'gvfs'
   'poppler-glib'
 )
 optdepends=(

--- a/packaging/aur/strata-rc-bin/.SRCINFO
+++ b/packaging/aur/strata-rc-bin/.SRCINFO
@@ -11,6 +11,7 @@ pkgbase = strata-rc-bin
 	depends = glibc>=2.39
 	depends = gtk4>=4.12
 	depends = gtksourceview5
+	depends = gvfs
 	depends = poppler-glib
 	optdepends = ffmpeg: video previews
 	optdepends = ffmpegthumbnailer: video thumbnails

--- a/packaging/aur/strata-rc-bin/PKGBUILD
+++ b/packaging/aur/strata-rc-bin/PKGBUILD
@@ -15,6 +15,7 @@ depends=(
   'glibc>=2.39'
   'gtk4>=4.12'
   'gtksourceview5'
+  'gvfs'
   'poppler-glib'
 )
 optdepends=(

--- a/scripts/test_installer.py
+++ b/scripts/test_installer.py
@@ -32,6 +32,12 @@ class InstallerTests(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 0, result.stderr)
 
+    def test_volume_monitor_is_required_but_smb_is_optional(self) -> None:
+        result = bash('printf "%s\\n" "${REQUIRED_PACKAGES[@]}"')
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("gvfs", result.stdout.splitlines())
+        self.assertNotIn("gvfs-smb", result.stdout.splitlines())
+
     def test_banner_remains_readable_without_terminal_color(self) -> None:
         result = bash("show_banner", env={"NO_COLOR": "1"})
         self.assertEqual(result.returncode, 0, result.stderr)

--- a/src/sandbox_helper.rs
+++ b/src/sandbox_helper.rs
@@ -122,12 +122,12 @@ fn render_simple_dcraw(path: &Path, size: i32) -> Result<Vec<u8>, String> {
     use std::os::unix::fs::symlink;
 
     // Writes `<file>.thumb.jpg` next to the input, which is a read-only bind.
-    let staging = Path::new("/tmp/raw-thumb");
-    let _ = fs::remove_file(staging);
-    symlink(path, staging).map_err(|error| error.to_string())?;
+    let directory = tempfile::tempdir().map_err(|error| error.to_string())?;
+    let staging = directory.path().join("raw-thumb");
+    symlink(path, &staging).map_err(|error| error.to_string())?;
     let status = Command::new("simple_dcraw")
         .arg("-e")
-        .arg(staging)
+        .arg(&staging)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -136,8 +136,8 @@ fn render_simple_dcraw(path: &Path, size: i32) -> Result<Vec<u8>, String> {
     if !status.success() {
         return Err("simple_dcraw failed".to_owned());
     }
-    for thumb in ["/tmp/raw-thumb.thumb.jpg", "/tmp/raw-thumb.thumb.ppm"] {
-        let Ok(file) = fs::File::open(thumb) else {
+    for thumb in ["raw-thumb.thumb.jpg", "raw-thumb.thumb.ppm"] {
+        let Ok(file) = fs::File::open(directory.path().join(thumb)) else {
             continue;
         };
         let Ok(data) = read_limited(file, MAX_OUTPUT_BYTES) else {

--- a/src/sandbox_helper/tests.rs
+++ b/src/sandbox_helper/tests.rs
@@ -11,7 +11,7 @@ use gdk_pixbuf::prelude::*;
 use super::{
     MediaBackend, bounded_output, bounded_output_with_timeout, bounded_surface_dimensions,
     media_backends, media_command, read_limited, render_pixbuf, render_raw, render_raw_thumbnail,
-    run, run_media_backends, scale_embedded_thumbnail,
+    render_simple_dcraw, run, run_media_backends, scale_embedded_thumbnail,
 };
 use crate::sandbox::MediaPreviewBackend;
 
@@ -295,6 +295,23 @@ fn preview_image_uses_raw_fallbacks() {
             assert_eq!(preview.expect_err("stub should fail RAW fallbacks"), raw);
         }
     }
+}
+
+#[test]
+fn concurrent_raw_fallbacks_do_not_share_staging_files() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let input = directory.path().join("photo.ARW");
+    std::fs::write(&input, b"not a camera file").expect("write stub");
+    let expected = render_simple_dcraw(&input, 256).expect_err("invalid RAW file");
+
+    std::thread::scope(|scope| {
+        let workers: Vec<_> = (0..8)
+            .map(|_| scope.spawn(|| render_simple_dcraw(&input, 256)))
+            .collect();
+        for worker in workers {
+            assert_eq!(worker.join().expect("worker"), Err(expected.clone()));
+        }
+    });
 }
 
 #[test]

--- a/src/ui/browser/collection.rs
+++ b/src/ui/browser/collection.rs
@@ -12,6 +12,20 @@ use std::time::Duration;
 
 pub(crate) const FILTER_DEBOUNCE_DELAY: Duration = Duration::from_millis(40);
 
+thread_local! {
+    static PENDING_SCROLLS: RefCell<Vec<(glib::WeakRef<gtk::Widget>, gtk::TickCallbackId)>> = const { RefCell::new(Vec::new()) };
+}
+
+fn take_pending_scroll(view: &gtk::Widget) -> Option<gtk::TickCallbackId> {
+    PENDING_SCROLLS.with_borrow_mut(|pending| {
+        pending.retain(|(view, _)| view.upgrade().is_some());
+        let index = pending
+            .iter()
+            .position(|(candidate, _)| candidate.upgrade().as_ref() == Some(view))?;
+        Some(pending.swap_remove(index).1)
+    })
+}
+
 /// `scroll_to` before the view has a real height leaves ListView/GridView with a
 /// one-row widget pool, so scrolling after a mode switch stays janky.
 pub(crate) fn scroll_collection_when_allocated(view: &gtk::Widget, position: u32) {
@@ -28,15 +42,17 @@ fn scroll_collection_when_allocated_with(
     position: u32,
     flags: gtk::ListScrollFlags,
 ) {
+    if let Some(pending) = take_pending_scroll(view) {
+        pending.remove();
+    }
     if view.height() > 1 {
         apply_collection_scroll(view, position, flags);
         return;
     }
-    // ponytail: a few frames is enough for the first layout. Upgrade: a real
-    // allocate listener if GTK grows one that is safe to scroll from.
     let frames = Cell::new(0u8);
-    view.add_tick_callback(move |view, _| {
+    let callback = view.add_tick_callback(move |view, _| {
         if view.height() > 1 {
+            take_pending_scroll(view);
             if flags.intersects(gtk::ListScrollFlags::FOCUS | gtk::ListScrollFlags::SELECT)
                 && !collection_view_holds_focus(view)
             {
@@ -48,11 +64,13 @@ fn scroll_collection_when_allocated_with(
         let waited = frames.get().saturating_add(1);
         frames.set(waited);
         if waited >= 8 {
+            take_pending_scroll(view);
             glib::ControlFlow::Break
         } else {
             glib::ControlFlow::Continue
         }
     });
+    PENDING_SCROLLS.with_borrow_mut(|pending| pending.push((view.downgrade(), callback)));
 }
 
 fn collection_view_holds_focus(view: &gtk::Widget) -> bool {

--- a/src/ui/browser/collection/tests.rs
+++ b/src/ui/browser/collection/tests.rs
@@ -158,6 +158,52 @@ fn seeded_filter_keeps_first_character_when_typing_continues() {
     window.destroy();
 }
 
+#[test]
+fn an_allocated_scroll_supersedes_the_pending_first_row_scroll() {
+    crate::test_support::gtk_test(
+        "ui::browser::collection::tests::an_allocated_scroll_supersedes_the_pending_first_row_scroll",
+        || {
+            let names: Vec<_> = (0..200).map(|index| format!("Item {index}")).collect();
+            let model = gtk::StringList::new(&names.iter().map(String::as_str).collect::<Vec<_>>());
+            let factory = gtk::SignalListItemFactory::new();
+            factory.connect_setup(|_, item| {
+                item.downcast_ref::<gtk::ListItem>()
+                    .expect("list item")
+                    .set_child(Some(&gtk::Label::new(Some("Item"))));
+            });
+            let selection = gtk::NoSelection::new(Some(model));
+            let list = gtk::ListView::new(Some(selection), Some(factory));
+            let scroller = gtk::ScrolledWindow::builder().child(&list).build();
+            let window = gtk::Window::builder()
+                .child(&scroller)
+                .default_width(300)
+                .default_height(200)
+                .build();
+
+            window.present();
+            list.grab_focus();
+            scroll_collection_when_allocated(list.upcast_ref(), 0);
+            list.allocate(300, 200, -1, None);
+            scroll_collection_when_allocated(list.upcast_ref(), 190);
+
+            let frames = Rc::new(Cell::new(0));
+            let seen = frames.clone();
+            window.add_tick_callback(move |_, _| {
+                seen.set(seen.get() + 1);
+                glib::ControlFlow::Continue
+            });
+            let deadline = std::time::Instant::now() + Duration::from_secs(5);
+            while frames.get() < 5 {
+                assert!(std::time::Instant::now() < deadline, "layout timed out");
+                glib::MainContext::default().iteration(false);
+                std::thread::sleep(Duration::from_millis(2));
+            }
+            assert!(scroller.vadjustment().value() > 1000.0);
+            window.destroy();
+        },
+    );
+}
+
 const SCROLL_PIN_GTK_CHILD: &str = "STRATA_SCROLL_PIN_GTK_CHILD";
 
 const SCROLL_PIN_TEST: &str =

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -1786,14 +1786,6 @@ impl SidebarState {
 
     fn append_devices(self: &Rc<Self>) {
         let volumes = self.volume_monitor.volumes();
-        let represented = self
-            .volume_monitor
-            .mounts()
-            .into_iter()
-            .chain(volumes.iter().filter_map(|volume| volume.get_mount()))
-            .filter_map(|mount| mount.root().path());
-        let fallback =
-            devices::unrepresented_devices(devices::system_mounted_devices(), represented);
         let mounts: Vec<_> = self
             .volume_monitor
             .mounts()
@@ -1813,19 +1805,11 @@ impl SidebarState {
                 Some((name, location, mount))
             })
             .collect();
-        if !volumes.is_empty() || !mounts.is_empty() || !fallback.is_empty() {
+        if !volumes.is_empty() || !mounts.is_empty() {
             self.append_separator();
             self.append_heading("DEVICES");
             for volume in volumes {
                 self.append_volume(volume);
-            }
-            for device in fallback {
-                self.append_device_place(
-                    crate::assets::icons::HARD_DRIVE,
-                    &device.name,
-                    Location::local(device.root),
-                    None,
-                );
             }
             for (name, location, mount) in mounts {
                 if is_smb_location(&location) {

--- a/src/ui/window/devices.rs
+++ b/src/ui/window/devices.rs
@@ -7,19 +7,14 @@ use std::{
 
 use gtk::{gio, prelude::*};
 
-pub(super) struct MountedDevice {
-    pub name: String,
-    pub root: PathBuf,
-}
-
-pub(super) fn system_mounted_devices() -> Vec<MountedDevice> {
+fn system_mounted_devices() -> Vec<PathBuf> {
     // MountEntry bindings require GLib 2.84; retain compatibility with GLib 2.72.
     std::fs::read("/proc/self/mountinfo")
         .map(|table| mounted_devices_from_table(&table))
         .unwrap_or_default()
 }
 
-fn mounted_devices_from_table(table: &[u8]) -> Vec<MountedDevice> {
+fn mounted_devices_from_table(table: &[u8]) -> Vec<PathBuf> {
     table
         .split(|byte| *byte == b'\n')
         .filter_map(|line| {
@@ -36,10 +31,7 @@ fn mounted_devices_from_table(table: &[u8]) -> Vec<MountedDevice> {
             {
                 return None;
             }
-            Some(MountedDevice {
-                name: root.file_name()?.to_string_lossy().into_owned(),
-                root,
-            })
+            Some(root)
         })
         .collect()
 }
@@ -64,17 +56,6 @@ fn mount_path(encoded: &[u8]) -> Option<PathBuf> {
     Some(std::ffi::OsString::from_vec(decoded).into())
 }
 
-pub(super) fn unrepresented_devices(
-    devices: Vec<MountedDevice>,
-    represented: impl IntoIterator<Item = PathBuf>,
-) -> Vec<MountedDevice> {
-    let mut roots: std::collections::HashSet<_> = represented.into_iter().collect();
-    devices
-        .into_iter()
-        .filter(|device| roots.insert(device.root.clone()))
-        .collect()
-}
-
 pub(super) fn global_search_roots() -> Vec<PathBuf> {
     let monitor = gio::VolumeMonitor::get();
     let roots = monitor
@@ -82,11 +63,7 @@ pub(super) fn global_search_roots() -> Vec<PathBuf> {
         .into_iter()
         .filter(|mount| !mount.is_shadowed())
         .filter_map(|mount| mount.root().path())
-        .chain(
-            system_mounted_devices()
-                .into_iter()
-                .map(|device| device.root),
-        );
+        .chain(system_mounted_devices());
     search_roots(&super::home_directory(), roots)
 }
 

--- a/src/ui/window/devices/tests.rs
+++ b/src/ui/window/devices/tests.rs
@@ -66,24 +66,6 @@ fn a_non_system_drive_containing_home_is_still_included() {
 }
 
 #[test]
-fn mount_table_fallback_deduplicates_gio_and_repeated_mount_roots() {
-    let device = |root| MountedDevice {
-        name: "USB".into(),
-        root: PathBuf::from(root),
-    };
-    let devices = unrepresented_devices(
-        vec![
-            device("/mnt/known"),
-            device("/mnt/missing"),
-            device("/mnt/missing"),
-        ],
-        [PathBuf::from("/mnt/known")],
-    );
-    assert_eq!(devices.len(), 1);
-    assert_eq!(devices[0].root, Path::new("/mnt/missing"));
-}
-
-#[test]
 fn mount_table_fallback_keeps_storage_but_not_system_mounts() {
     let devices = mounted_devices_from_table(
         br"25 1 8:1 / / rw - ext4 /dev/sda1 rw
@@ -97,16 +79,12 @@ malformed
 ",
     );
     assert_eq!(
-        devices
-            .iter()
-            .map(|device| device.root.clone())
-            .collect::<Vec<_>>(),
+        devices,
         vec![
             PathBuf::from("/run/media/me/USB Backup"),
             PathBuf::from("/mnt/Archive")
         ]
     );
-    assert_eq!(devices[0].name, "USB Backup");
 }
 
 #[test]


### PR DESCRIPTION
## Description

The Devices sidebar merged GIO's own volumes/mounts with a raw `/proc/self/mountinfo` scan (`devices::system_mounted_devices()` + `unrepresented_devices()`), which reinstated any `/dev`-backed mount the volume-monitor backend chose not to expose. That raw scan has no notion of the backend's own visibility policy (the home/media/run-media allowlist, `x-gvfs-hide`/`x-udisks2.hide`, etc.), so it surfaced mounts the backend deliberately hides — most visibly a Pacman cache directory living on its own mount point or subvolume, which then showed up in Devices named after its last path segment.

This drops that fallback from the sidebar entirely. `append_devices()` now shows exactly what `gio::VolumeMonitor` reports: its volumes, plus non-shadowed mounts not already tied to a volume. No fstab parsing or reimplementation of the backend's hide/show conventions was added — visibility policy stays owned by GIO/GVfs/udisks2, the same way Nautilus, Nemo, Thunar, and Dolphin already do it.

Global search's mount enumeration (`global_search_roots()`) is intentionally unchanged — it still uses the raw mount-table scan for its own root-inclusion policy, which is tracked separately in #533.

## Visual evidence

N/A for this PR from me — reproducing the reported layout requires a mount the backend actually hides (e.g. a real Pacman-cache subvolume), which isn't something this sandboxed environment can set up (no privileged mount access). This is the exact configuration the report came from, so a before/after screenshot from that machine is more convincing than a synthetic one; happy to attach it during review if wanted.

## How to test

1. On a system where a directory like `/var/cache/pacman/pkg` lives on its own mount point or subvolume (not tmpfs) that the volume-monitor backend doesn't surface as a Volume/Mount, open Strata and check the Devices section — confirm the entry is gone.
2. Insert a USB drive and confirm it still appears under Devices, in both its "not yet mounted" state (mounts on click) and once mounted.
3. Unplug/unmount it and confirm the sidebar updates live.
4. Mount an SMB share and confirm it appears exactly once, with no duplicate row against its backing volume.
5. On a machine with no external drives and nothing else to show, confirm the Devices heading and separator don't render at all (no error state).

**Expected result:** Devices shows only what the volume-monitor backend actually reports as a volume or mount; nothing the backend hides on purpose reappears. Global search behavior is unaffected.

## Related issue

Closes #532
