### PR TITLE
fix(search): restore thumbnails in search and filter results

### DIFF
--- a/src/ui/browser/columns/rows.rs
+++ b/src/ui/browser/columns/rows.rs
@@ -568,7 +568,16 @@ pub(super) fn column_rows(
             let mode_active = state
                 .as_ref()
                 .is_some_and(|state| state.mode_views.borrow().mode() == BrowserMode::Columns);
-            if entry.is_directory() || mode_active {
+            if searching && mode_active && !entry.is_directory() {
+                // Search results have no directory metadata-fill producer.
+                crate::ui::thumbnail::set_thumbnail_or_icon_for_path(
+                    &icon,
+                    entry.local_thumbnail_path().expect("local search result"),
+                    entry_icon(entry),
+                    17,
+                    17,
+                );
+            } else if entry.is_directory() || mode_active {
                 crate::ui::thumbnail::set_thumbnail_or_icon(
                     &icon,
                     entry,

--- a/src/ui/inline_search.rs
+++ b/src/ui/inline_search.rs
@@ -123,12 +123,12 @@ pub(super) fn wrap(
             state.generation.set(state.generation.get().wrapping_add(1));
             state.handle.borrow_mut().take();
             state.items.borrow_mut().clear();
-            state.list.remove_all();
+            clear_rows(&state.list);
             state.stack.set_visible_child_name("files");
             return;
         }
         state.stack.set_visible_child_name("search");
-        state.list.remove_all();
+        clear_rows(&state.list);
         state.items.borrow_mut().clear();
         state.status.set_text("Searching…");
         state.status.set_visible(true);
@@ -168,7 +168,7 @@ pub(super) fn wrap(
                 && !returned.is_empty()
                 && returned == entry.text().trim()
             {
-                state.list.remove_all();
+                clear_rows(&state.list);
                 for item in &items {
                     let row = gtk::ListBoxRow::new();
                     // Keep keyboard focus in the query, away from file-operation shortcuts.
@@ -176,14 +176,8 @@ pub(super) fn wrap(
                     super::accessibility::set_label(&row, &item.name);
                     let line = gtk::Box::new(gtk::Orientation::Horizontal, 8);
                     line.add_css_class("file-row");
-                    line.append(&crate::assets::primary_icon(
-                        if item.is_directory {
-                            crate::assets::icons::FOLDER
-                        } else {
-                            crate::assets::icons::DOCUMENTS
-                        },
-                        17,
-                    ));
+                    let icon = super::thumbnail::ThumbnailSlot::new(17);
+                    line.append(&icon);
                     let labels = gtk::Box::new(gtk::Orientation::Vertical, 2);
                     labels.set_hexpand(true);
                     let name = gtk::Label::builder()
@@ -207,6 +201,22 @@ pub(super) fn wrap(
                     line.append(&labels);
                     row.set_child(Some(&line));
                     state.list.append(&row);
+                    if item.is_directory {
+                        super::thumbnail::show_customized_icon(
+                            &icon,
+                            &item.path,
+                            crate::assets::icons::FOLDER,
+                            17,
+                        );
+                    } else {
+                        super::thumbnail::set_thumbnail_or_icon_for_path(
+                            &icon,
+                            &item.path,
+                            crate::assets::icons::DOCUMENTS,
+                            17,
+                            17,
+                        );
+                    }
                 }
                 state
                     .status
@@ -224,6 +234,11 @@ pub(super) fn wrap(
         });
     });
     stack.upcast()
+}
+
+fn clear_rows(list: &gtk::ListBox) {
+    super::thumbnail::cancel_thumbnails_in(list.upcast_ref());
+    list.remove_all();
 }
 
 fn relative_result_path(root: &Path, path: &Path) -> String {

--- a/src/ui/thumbnail/tests.rs
+++ b/src/ui/thumbnail/tests.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+mod search;
 mod trash;
 
 use std::{

--- a/src/ui/thumbnail/tests/search.rs
+++ b/src/ui/thumbnail/tests/search.rs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use super::*;
+use crate::ui::{
+    browser::{BrowserView, PeekBehavior},
+    browser_modes::BrowserMode,
+    thumbnail,
+};
+use std::rc::Rc;
+
+fn wait_until(condition: impl Fn() -> bool) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !condition() {
+        assert!(Instant::now() < deadline, "search thumbnail did not settle");
+        glib::MainContext::default().iteration(false);
+        std::thread::sleep(Duration::from_millis(2));
+    }
+}
+
+#[test]
+fn column_search_results_load_thumbnails_without_directory_metadata() {
+    gtk_test(
+        "ui::thumbnail::tests::search::column_search_results_load_thumbnails_without_directory_metadata",
+        || {
+            let fixture = tempfile::tempdir().expect("fixture");
+            let nested = fixture.path().join("nested");
+            std::fs::create_dir(&nested).expect("nested directory");
+            let path = nested.join("search-photo.png");
+            let pixbuf =
+                gtk::gdk_pixbuf::Pixbuf::new(gtk::gdk_pixbuf::Colorspace::Rgb, false, 8, 32, 32)
+                    .expect("image fixture");
+            pixbuf.fill(0x6699ccff);
+            let png = pixbuf.save_to_bufferv("png", &[]).expect("PNG");
+            std::fs::write(&path, &png).expect("image file");
+            hold_thumbnail_workers();
+
+            let view = BrowserView::new(
+                Rc::new(crate::adapters::LocalFileSource),
+                PeekBehavior::default(),
+            );
+            view.set_view_mode(BrowserMode::Columns);
+            let browser = view.browser();
+            let window = gtk::Window::builder()
+                .child(&view.widget())
+                .default_width(1000)
+                .default_height(600)
+                .build();
+            window.present();
+            browser.navigate(Location::local(fixture.path()));
+            wait_until(|| {
+                browser
+                    .column_snapshot(0)
+                    .is_some_and(|snapshot| !snapshot.loading)
+            });
+            assert_eq!(view.view_mode(), BrowserMode::Columns);
+            assert!(view.show_filter_with_query("search-photo"));
+            wait_until(|| has_pending_thumbnail(&path));
+            let key = ThumbnailKey {
+                path: path.clone(),
+                modified: None,
+                file_size: None,
+                thumbnail_size: 17,
+            };
+            let job_id = PENDING_THUMBNAILS.with(|pending| pending.borrow()[&key].id);
+            let targets = take_pending_targets(&key, job_id).expect("search thumbnail job");
+            assert!(!targets.is_empty());
+            finish_thumbnail_targets(targets, Some(&sample_texture()), &path);
+            wait_until(|| {
+                thumbnail::TRACKED_THUMBNAILS.with(|tracked| {
+                    tracked.borrow().iter().any(|tracked| {
+                        tracked.path == path
+                            && tracked
+                                .image
+                                .upgrade()
+                                .is_some_and(|image| image.is_mapped())
+                    })
+                })
+            });
+            thumbnail::cancel_thumbnails_in(&view.widget());
+            browser.clear_observer();
+            window.destroy();
+            clear_thumbnail_runtime();
+        },
+    );
+}

--- a/src/ui/thumbnail/tests/search.rs
+++ b/src/ui/thumbnail/tests/search.rs
@@ -18,68 +18,75 @@ fn wait_until(condition: impl Fn() -> bool) {
 }
 
 #[test]
-fn column_search_results_load_thumbnails_without_directory_metadata() {
+fn search_results_load_thumbnails_in_every_view() {
     gtk_test(
-        "ui::thumbnail::tests::search::column_search_results_load_thumbnails_without_directory_metadata",
+        "ui::thumbnail::tests::search::search_results_load_thumbnails_in_every_view",
         || {
-            let fixture = tempfile::tempdir().expect("fixture");
-            let nested = fixture.path().join("nested");
-            std::fs::create_dir(&nested).expect("nested directory");
-            let path = nested.join("search-photo.png");
-            let pixbuf =
-                gtk::gdk_pixbuf::Pixbuf::new(gtk::gdk_pixbuf::Colorspace::Rgb, false, 8, 32, 32)
-                    .expect("image fixture");
-            pixbuf.fill(0x6699ccff);
-            let png = pixbuf.save_to_bufferv("png", &[]).expect("PNG");
-            std::fs::write(&path, &png).expect("image file");
-            hold_thumbnail_workers();
+            for mode in [BrowserMode::Columns, BrowserMode::List, BrowserMode::Icons] {
+                let fixture = tempfile::tempdir().expect("fixture");
+                let nested = fixture.path().join("nested");
+                std::fs::create_dir(&nested).expect("nested directory");
+                let path = nested.join("search-photo.png");
+                let pixbuf = gtk::gdk_pixbuf::Pixbuf::new(
+                    gtk::gdk_pixbuf::Colorspace::Rgb,
+                    false,
+                    8,
+                    32,
+                    32,
+                )
+                .expect("image fixture");
+                pixbuf.fill(0x6699ccff);
+                let png = pixbuf.save_to_bufferv("png", &[]).expect("PNG");
+                std::fs::write(&path, &png).expect("image file");
+                hold_thumbnail_workers();
 
-            let view = BrowserView::new(
-                Rc::new(crate::adapters::LocalFileSource),
-                PeekBehavior::default(),
-            );
-            view.set_view_mode(BrowserMode::Columns);
-            let browser = view.browser();
-            let window = gtk::Window::builder()
-                .child(&view.widget())
-                .default_width(1000)
-                .default_height(600)
-                .build();
-            window.present();
-            browser.navigate(Location::local(fixture.path()));
-            wait_until(|| {
-                browser
-                    .column_snapshot(0)
-                    .is_some_and(|snapshot| !snapshot.loading)
-            });
-            assert_eq!(view.view_mode(), BrowserMode::Columns);
-            assert!(view.show_filter_with_query("search-photo"));
-            wait_until(|| has_pending_thumbnail(&path));
-            let key = ThumbnailKey {
-                path: path.clone(),
-                modified: None,
-                file_size: None,
-                thumbnail_size: 17,
-            };
-            let job_id = PENDING_THUMBNAILS.with(|pending| pending.borrow()[&key].id);
-            let targets = take_pending_targets(&key, job_id).expect("search thumbnail job");
-            assert!(!targets.is_empty());
-            finish_thumbnail_targets(targets, Some(&sample_texture()), &path);
-            wait_until(|| {
-                thumbnail::TRACKED_THUMBNAILS.with(|tracked| {
-                    tracked.borrow().iter().any(|tracked| {
-                        tracked.path == path
-                            && tracked
-                                .image
-                                .upgrade()
-                                .is_some_and(|image| image.is_mapped())
+                let view = BrowserView::new(
+                    Rc::new(crate::adapters::LocalFileSource),
+                    PeekBehavior::default(),
+                );
+                view.set_view_mode(mode);
+                let browser = view.browser();
+                let window = gtk::Window::builder()
+                    .child(&view.widget())
+                    .default_width(1000)
+                    .default_height(600)
+                    .build();
+                window.present();
+                browser.navigate(Location::local(fixture.path()));
+                wait_until(|| {
+                    browser
+                        .column_snapshot(0)
+                        .is_some_and(|snapshot| !snapshot.loading)
+                });
+                assert_eq!(view.view_mode(), mode);
+                assert!(view.show_filter_with_query("search-photo"));
+                wait_until(|| has_pending_thumbnail(&path));
+                let key = ThumbnailKey {
+                    path: path.clone(),
+                    modified: None,
+                    file_size: None,
+                    thumbnail_size: 17,
+                };
+                let job_id = PENDING_THUMBNAILS.with(|pending| pending.borrow()[&key].id);
+                let targets = take_pending_targets(&key, job_id).expect("search thumbnail job");
+                assert!(!targets.is_empty());
+                finish_thumbnail_targets(targets, Some(&sample_texture()), &path);
+                wait_until(|| {
+                    thumbnail::TRACKED_THUMBNAILS.with(|tracked| {
+                        tracked.borrow().iter().any(|tracked| {
+                            tracked.path == path
+                                && tracked
+                                    .image
+                                    .upgrade()
+                                    .is_some_and(|image| image.is_mapped())
+                        })
                     })
-                })
-            });
-            thumbnail::cancel_thumbnails_in(&view.widget());
-            browser.clear_observer();
-            window.destroy();
-            clear_thumbnail_runtime();
+                });
+                thumbnail::cancel_thumbnails_in(&view.widget());
+                browser.clear_observer();
+                window.destroy();
+                clear_thumbnail_runtime();
+            }
         },
     );
 }


### PR DESCRIPTION
## Description

Restore thumbnails in search/filter results across Columns, List, and Icons views. Column search results now request thumbnails without waiting for directory metadata fills; inline search rows now request thumbnails instead of showing only fallback icons. Cancel thumbnail work when inline results are replaced or cleared.

## Visual evidence

<img width="1501" height="1133" alt="screenshot-2026-09-07_14-51-59" src="https://github.com/user-attachments/assets/d864a466-3210-45c8-9a82-85284ac8b375" />
<img width="1501" height="1133" alt="screenshot-2026-09-07_14-51-29" src="https://github.com/user-attachments/assets/2f5763be-9e94-4d0e-97e7-ee66fc3eed3a" />
<img width="1501" height="1133" alt="screenshot-2026-09-07_14-51-17" src="https://github.com/user-attachments/assets/c6d939df-6953-430e-a3b8-5a444b617cd0" />

## How to test

1. Open a directory containing PNG/JPEG files, including some in a nested folder.
2. Search/filter for those files in Columns, List, and Icons modes. Change and clear the query, then search again.

**Expected result:** Matching image rows show thumbnails in every mode, with no stale thumbnails when results change. Clearing the query restores the normal listing.

## Related issue

Closes #545
