### PR TITLE
fix(ui): hide path-only applications from Open With for URI locations

### DIFF
--- a/src/ui/browser/context_menu.rs
+++ b/src/ui/browser/context_menu.rs
@@ -1141,27 +1141,15 @@ fn prepare_open_with(
         if generation.get() != expected_generation {
             return;
         }
-        let default =
-            gio::AppInfo::default_for_type(&content_type, false).filter(|app| app.should_show());
-        let mut apps = gio::AppInfo::all_for_type(&content_type)
-            .into_iter()
-            .filter(|app| app.should_show())
-            .collect::<Vec<_>>();
-        apps.sort_by_cached_key(|app| app.display_name().to_lowercase());
-        let mut unique = Vec::with_capacity(apps.len());
-        for app in apps {
-            if !unique
-                .iter()
-                .any(|existing: &gio::AppInfo| existing.equal(&app))
-            {
-                unique.push(app);
-            }
-        }
-        let mut apps = unique;
-        if let Some(default) = default {
-            apps.retain(|app| !app.equal(&default));
-            apps.insert(0, default);
-        }
+        // Without a FUSE mirror GIO drops non-native files from `%f`/`%F` apps,
+        // launching them empty; only URI-capable apps can open such locations.
+        let requires_uris = files.iter().any(|file| !file.is_native());
+        let default = gio::AppInfo::default_for_type(&content_type, requires_uris);
+        let apps = order_open_with_apps(
+            default,
+            gio::AppInfo::all_for_type(&content_type),
+            requires_uris,
+        );
         result.replace(Some(OpenWithSelection {
             locations,
             files,
@@ -1170,6 +1158,32 @@ fn prepare_open_with(
         single_button.set_sensitive(true);
         multiple_button.set_sensitive(true);
     });
+}
+
+/// The default application first, then the remaining handlers by name.
+fn order_open_with_apps(
+    default: Option<gio::AppInfo>,
+    apps: Vec<gio::AppInfo>,
+    requires_uris: bool,
+) -> Vec<gio::AppInfo> {
+    let usable = |app: &gio::AppInfo| app.should_show() && (!requires_uris || app.supports_uris());
+    let mut apps = apps.into_iter().filter(usable).collect::<Vec<_>>();
+    apps.sort_by_cached_key(|app| app.display_name().to_lowercase());
+    let mut unique = Vec::with_capacity(apps.len());
+    for app in apps {
+        if !unique
+            .iter()
+            .any(|existing: &gio::AppInfo| existing.equal(&app))
+        {
+            unique.push(app);
+        }
+    }
+    let mut apps = unique;
+    if let Some(default) = default.filter(usable) {
+        apps.retain(|app| !app.equal(&default));
+        apps.insert(0, default);
+    }
+    apps
 }
 
 #[cfg(test)]

--- a/src/ui/browser/context_menu/tests/open_with.rs
+++ b/src/ui/browser/context_menu/tests/open_with.rs
@@ -17,6 +17,40 @@ fn entry(location: Location) -> FileEntry {
     }
 }
 
+fn app(name: &str, exec: &str) -> gio::AppInfo {
+    let key_file = glib::KeyFile::new();
+    key_file.set_string("Desktop Entry", "Type", "Application");
+    key_file.set_string("Desktop Entry", "Name", name);
+    key_file.set_string("Desktop Entry", "Exec", exec);
+    gio_unix::DesktopAppInfo::from_keyfile(&key_file)
+        .expect("desktop entry")
+        .upcast()
+}
+
+fn names(apps: &[gio::AppInfo]) -> Vec<String> {
+    apps.iter()
+        .map(|app| app.display_name().to_string())
+        .collect()
+}
+
+#[test]
+fn ordering_puts_the_default_first_and_drops_path_only_apps_for_uris() {
+    // GIO rejects entries whose executable is not on PATH.
+    let native_only = app("Path Viewer", "true %f");
+    let uri_capable = app("Zeta Editor", "true %U");
+    let other = app("Alpha Editor", "true %u");
+    let apps = vec![native_only.clone(), uri_capable.clone(), other.clone()];
+
+    let native = order_open_with_apps(Some(uri_capable.clone()), apps.clone(), false);
+    assert_eq!(
+        names(&native),
+        ["Zeta Editor", "Alpha Editor", "Path Viewer"]
+    );
+
+    let remote = order_open_with_apps(Some(native_only), apps, true);
+    assert_eq!(names(&remote), ["Alpha Editor", "Zeta Editor"]);
+}
+
 #[test]
 fn prepared_selection_rejects_changed_targets() {
     let location = Location::local("/fixture/alpha.txt");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Exploratory testing of the **Open With…** chooser from #421 against a real GVfs `trash:///` backend found a silent failure: the chooser listed applications that only accept local paths (`Exec=… %f`/`%F`). GIO expands those macros with `g_file_get_path()`, which is `NULL` for non-native files when no FUSE mirror exists (always the case for `trash://`), so the chosen application was launched **with no file argument** and Strata reported nothing.

`prepare_open_with` now requires URI support from the listed applications (and asks GIO for a URI-capable default) whenever any selected file is not native, matching what `GtkAppChooserWidget` and Nautilus do. Native selections are unchanged. The ordering/filtering is extracted into `order_open_with_apps` with a unit test built on key-file `DesktopAppInfo`s, so it runs without GVfs.

## Visual evidence

Before (Trash, `Path App` is `Exec=… %F`; choosing it launched the script with an empty argument list):

[Open With chooser in Trash before the fix listing path-only applications](https://cursor.com/agents/bc-73579b62-64c8-47a0-b068-b8a45d9a97d6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopen-with-trash-chooser-before-fix.png)

After (only URI-capable handlers remain):

[Open With chooser in Trash after the fix listing only URI-capable applications](https://cursor.com/agents/bc-73579b62-64c8-47a0-b068-b8a45d9a97d6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopen-with-trash-chooser-after-fix.png)

## How to test

1. With `gvfsd` running, move a `.txt` file to Trash and open the Trash location in Strata.
2. Install two handlers for `text/plain`: one with `Exec=script %U`, one with `Exec=script %F` (e.g. in `~/.local/share/applications`).
3. Right-click the trashed file, choose **Open With…**.

**Expected result:** only the `%U` handler (and other URI-capable editors) is listed; choosing it launches the application with `trash:///<file>`. Previously the `%F` handler was listed and launched with no arguments. For local files the list is unchanged.

## Related issue

Follow-up to #421 / #174 (exploratory testing). Does not close an issue.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73579b62-64c8-47a0-b068-b8a45d9a97d6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73579b62-64c8-47a0-b068-b8a45d9a97d6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

