### PR TITLE
fix(theme): remove rounded-corner artifacts from color swatches

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -3411,6 +3411,7 @@ entry.theme-search {
 .theme-color-picker button {
   background: transparent;
   border: 1px solid alpha(@theme_border, 0.7);
+  border-radius: 6px;
   box-shadow: none;
   padding: 0;
   transition: transform 160ms ease-out, border-color 160ms ease-out;
@@ -3430,6 +3431,16 @@ entry.theme-search {
   box-shadow: none;
   padding: 0;
   transform: scale(0.97);
+}
+
+/* GTK's default theme forces radius 0 here, assuming the button's own 4px
+   padding hides the swatch's square corners; we zero that padding above, so
+   the fill must carry the same radius as the button to avoid corner seams. */
+.theme-color-picker colorswatch,
+.theme-color-picker colorswatch:only-child,
+.theme-color-picker colorswatch overlay {
+  border-radius: 6px;
+  box-shadow: none;
 }
 
 .theme-editor-error {

--- a/src/ui/window/tests.rs
+++ b/src/ui/window/tests.rs
@@ -914,6 +914,24 @@ fn the_bundled_stylesheet_only_uses_at_rules_gtk_parses() {
 }
 
 #[test]
+fn theme_color_picker_swatch_shares_the_buttons_corner_radius() {
+    // GTK's default theme zeroes the swatch's radius, relying on the
+    // button's own padding to hide the square corners. We zero that padding
+    // to let the fill go edge-to-edge, so the swatch and its overlay must
+    // carry the same radius as the button or the corners show as seams
+    // (issue #539).
+    let css = include_str!("../../style.css");
+    assert!(
+        css.contains(".theme-color-picker button {\n  background: transparent;\n  border: 1px solid alpha(@theme_border, 0.7);\n  border-radius: 6px;"),
+        "the theme-color-picker button must set an explicit border-radius"
+    );
+    assert!(
+        css.contains(".theme-color-picker colorswatch,\n.theme-color-picker colorswatch:only-child,\n.theme-color-picker colorswatch overlay {\n  border-radius: 6px;"),
+        "the color swatch and its overlay must match the button's border-radius"
+    );
+}
+
+#[test]
 fn chrome_stylesheet_requests_header_bar_icon_size() {
     let css = include_str!("../../style.css");
     assert!(

--- a/src/ui/window/tests.rs
+++ b/src/ui/window/tests.rs
@@ -914,24 +914,6 @@ fn the_bundled_stylesheet_only_uses_at_rules_gtk_parses() {
 }
 
 #[test]
-fn theme_color_picker_swatch_shares_the_buttons_corner_radius() {
-    // GTK's default theme zeroes the swatch's radius, relying on the
-    // button's own padding to hide the square corners. We zero that padding
-    // to let the fill go edge-to-edge, so the swatch and its overlay must
-    // carry the same radius as the button or the corners show as seams
-    // (issue #539).
-    let css = include_str!("../../style.css");
-    assert!(
-        css.contains(".theme-color-picker button {\n  background: transparent;\n  border: 1px solid alpha(@theme_border, 0.7);\n  border-radius: 6px;"),
-        "the theme-color-picker button must set an explicit border-radius"
-    );
-    assert!(
-        css.contains(".theme-color-picker colorswatch,\n.theme-color-picker colorswatch:only-child,\n.theme-color-picker colorswatch overlay {\n  border-radius: 6px;"),
-        "the color swatch and its overlay must match the button's border-radius"
-    );
-}
-
-#[test]
 fn chrome_stylesheet_requests_header_bar_icon_size() {
     let css = include_str!("../../style.css");
     assert!(


### PR DESCRIPTION
## Description

The theme editor's color swatches (`.theme-color-picker`, used by `gtk::ColorDialogButton` in the "Add a theme" panel) zero out the button's padding so the color fill sits edge-to-edge, but GTK's default theme forces the internal `colorswatch` node's `border-radius` to `0`, assuming that 4px of button padding (which we removed) hides its square corners. With no padding and no matching radius, the swatch's sharp corners showed through as dark fragments at every rounded corner of the button.

Fixed by giving the button, the swatch, and its overlay the same `border-radius`, so the fill is consistently clipped in every state (normal, hover, focus, active), matching the pattern this stylesheet already uses for the native color-chooser's circular swatches.

## How to test

1. Open Strata Settings → Theme & appearance → Your themes → Add a theme.
2. Inspect the corners of each color swatch (Background, Surface, Text, Accent, Danger, etc.) at normal, hover, and keyboard-focus (Tab) states.

**Expected result:** Every swatch has clean, consistently rounded corners — no square edges, dark corner fragments, gaps, or seams — matching the button's border.

## Related issue

Closes #539