### PR TITLE
refactor(window): simplify sidebar assembly and row bindings

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -167,6 +167,15 @@ per window; both Settings entry points reuse it and the process-wide install gua
 Preferences take effect before Settings opens. Destruction disconnects the clipboard
 subscription, browser observers, and sidebar monitors.
 
+`ui/window/sidebar.rs` assembles the sidebar shell and connects its preferences,
+browser events, and device monitors. Shared place-row bindings retain explicit direct
+versus validated navigation; file drops still exclude virtual locations. Typed device
+signals share a weak rebuild callback and retain their disconnect handles. Standard,
+pinned, and device rows are separate rendering stages, with the chooser's local-only
+filter preserved. Initial construction builds static places; device rows retain their
+existing deferred rebuild timing. Bookmark storage, Trash, and media-release policies
+remain in `window.rs` rather than changing alongside assembly.
+
 ### Window keyboard routing
 
 `ui/window/keyboard.rs` owns the window's capture-phase keyboard dispatcher. Its ordered

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -30,6 +30,10 @@ use super::{
 mod composition;
 mod devices;
 mod keyboard;
+mod sidebar;
+
+use sidebar::PlaceNavigation;
+pub(super) use sidebar::build_sidebar;
 
 pub(super) const SIDEBAR_WIDTH: i32 = 208;
 pub(super) const MIN_SIDEBAR_WIDTH: i32 = 176;
@@ -864,7 +868,11 @@ impl SidebarState {
             );
         }
         self.append_separator();
+        self.append_standard_places();
+        self.append_pinned_places();
+    }
 
+    fn append_standard_places(self: &Rc<Self>) {
         for place in self.place_order.borrow().clone() {
             if let Some((icon, name, directory)) = standard_place(place)
                 && let Some(path) = glib::user_special_dir(directory)
@@ -877,7 +885,9 @@ impl SidebarState {
                 }
             }
         }
+    }
 
+    fn append_pinned_places(self: &Rc<Self>) {
         let pinned = self
             .pinned_places
             .borrow()
@@ -902,8 +912,25 @@ impl SidebarState {
 
     fn append_devices(self: &Rc<Self>) {
         let volumes = self.volume_monitor.volumes();
-        let mounts: Vec<_> = self
-            .volume_monitor
+        let mounts = self.mounts_without_volumes(&volumes);
+        if volumes.is_empty() && mounts.is_empty() {
+            return;
+        }
+        self.append_separator();
+        self.append_heading("DEVICES");
+        for volume in volumes {
+            self.append_volume(volume);
+        }
+        for (name, location, mount) in mounts {
+            self.append_mount(&name, location, mount);
+        }
+    }
+
+    fn mounts_without_volumes(
+        &self,
+        volumes: &[gio::Volume],
+    ) -> Vec<(String, Location, gio::Mount)> {
+        self.volume_monitor
             .mounts()
             .into_iter()
             .filter(|mount| !mount.is_shadowed())
@@ -920,43 +947,31 @@ impl SidebarState {
                 }
                 Some((name, location, mount))
             })
-            .collect();
-        if !volumes.is_empty() || !mounts.is_empty() {
-            self.append_separator();
-            self.append_heading("DEVICES");
-            for volume in volumes {
-                self.append_volume(volume);
-            }
-            for (name, location, mount) in mounts {
-                if is_smb_location(&location) {
-                    self.append_smb_mount(&name, location, mount);
-                } else {
-                    let action = mount_release_action(mount.can_eject(), mount.can_unmount());
-                    let release = action.map(|action| {
-                        let release_mount = mount.clone();
-                        let release_browser = self.browser.clone();
-                        let release_parent = self.view.widget();
-                        let release_in_flight = Rc::new(Cell::new(false));
-                        let on_release: Rc<dyn Fn()> = Rc::new(move || {
-                            release_device_mount(
-                                &release_mount,
-                                action,
-                                &release_parent,
-                                &release_browser,
-                                &release_in_flight,
-                            );
-                        });
-                        (action, on_release)
-                    });
-                    self.append_device_place(
-                        crate::assets::icons::HARD_DRIVE,
-                        &name,
-                        location,
-                        release,
-                    );
-                }
-            }
+            .collect()
+    }
+
+    fn append_mount(self: &Rc<Self>, name: &str, location: Location, mount: gio::Mount) {
+        if is_smb_location(&location) {
+            self.append_smb_mount(name, location, mount);
+            return;
         }
+        let action = mount_release_action(mount.can_eject(), mount.can_unmount());
+        let release = action.map(|action| {
+            let release_browser = self.browser.clone();
+            let release_parent = self.view.widget();
+            let release_in_flight = Rc::new(Cell::new(false));
+            let on_release: Rc<dyn Fn()> = Rc::new(move || {
+                release_device_mount(
+                    &mount,
+                    action,
+                    &release_parent,
+                    &release_browser,
+                    &release_in_flight,
+                );
+            });
+            (action, on_release)
+        });
+        self.append_device_place(crate::assets::icons::HARD_DRIVE, name, location, release);
     }
 
     fn pin_location(self: &Rc<Self>, location: Location, name: String) {
@@ -1082,18 +1097,7 @@ impl SidebarState {
         let location = Location::uri("trash:///");
         let row = sidebar_button(crate::assets::icons::TRASH, "Trash");
         row.set_tooltip_text(Some("trash:///"));
-        self.place_rows
-            .borrow_mut()
-            .push((location.clone(), row.clone()));
-        let weak_browser = Rc::downgrade(&self.browser);
-        let sidebar = self.widget.clone();
-        let selected_row = row.clone();
-        row.connect_clicked(move |_| {
-            select_sidebar_row(&sidebar, &selected_row);
-            if let Some(browser) = weak_browser.upgrade() {
-                browser.navigate(location.clone());
-            }
-        });
+        self.bind_place_row(&row, location, PlaceNavigation::Direct);
 
         let menu = super::accessibility::menu_box();
         menu.add_css_class("folder-context-menu");
@@ -1218,19 +1222,7 @@ impl SidebarState {
     ) {
         let row = sidebar_button(icon, name);
         row.set_tooltip_text(Some(&location.display_path()));
-        self.place_rows
-            .borrow_mut()
-            .push((location.clone(), row.clone()));
-        install_sidebar_file_drop(&self.view, &row, location.clone());
-        let weak_browser = Rc::downgrade(&self.browser);
-        let sidebar = self.widget.clone();
-        let selected_row = row.clone();
-        row.connect_clicked(move |_| {
-            select_sidebar_row(&sidebar, &selected_row);
-            if let Some(browser) = weak_browser.upgrade() {
-                browser.navigate(location.clone());
-            }
-        });
+        self.bind_place_row(&row, location, PlaceNavigation::Direct);
 
         self.make_reorderable(
             &row,
@@ -1497,19 +1489,7 @@ impl SidebarState {
     ) -> gtk::Button {
         let row = sidebar_button(icon, name);
         row.set_tooltip_text(Some(&location.display_path()));
-        self.place_rows
-            .borrow_mut()
-            .push((location.clone(), row.clone()));
-        install_sidebar_file_drop(&self.view, &row, location.clone());
-        let weak_browser = Rc::downgrade(&self.browser);
-        let sidebar = self.widget.clone();
-        let selected_row = row.clone();
-        row.connect_clicked(move |_| {
-            select_sidebar_row(&sidebar, &selected_row);
-            if let Some(browser) = weak_browser.upgrade() {
-                browser.navigate_location(location.clone());
-            }
-        });
+        self.bind_place_row(&row, location, PlaceNavigation::Validate);
         match release {
             Some((action, on_release)) => {
                 let eject = sidebar_eject_button(action, {
@@ -2039,160 +2019,6 @@ fn sidebar_update_label(release: &ReleaseMetadata) -> String {
         format!("v{} available", release.version)
     } else {
         format!("v{} ({}) available", release.version, release.kind.label())
-    }
-}
-
-pub(super) fn build_sidebar(
-    view: BrowserView,
-    theme_manager: Rc<super::theme::ThemeManager>,
-    local_only: bool,
-) -> SidebarView {
-    let widget = gtk::Box::new(gtk::Orientation::Vertical, 2);
-    widget.add_css_class("sidebar");
-    let scroller = gtk::ScrolledWindow::builder()
-        .child(&widget)
-        .hscrollbar_policy(gtk::PolicyType::Never)
-        .vscrollbar_policy(gtk::PolicyType::Automatic)
-        .width_request(SIDEBAR_WIDTH)
-        .vexpand(true)
-        .build();
-    scroller.add_css_class("sidebar-scroll");
-    scroller.add_css_class("fixed-scrollbar");
-
-    let update_content = gtk::Box::new(gtk::Orientation::Horizontal, 8);
-    let dot = gtk::Label::new(Some("●"));
-    dot.add_css_class("sidebar-update-dot");
-    let update_label = gtk::Label::new(None);
-    update_label.add_css_class("sidebar-update-label");
-    update_label.set_xalign(0.0);
-    update_label.set_hexpand(true);
-    update_label.set_ellipsize(gtk::pango::EllipsizeMode::End);
-    update_content.append(&dot);
-    update_content.append(&update_label);
-    update_content.append(&crate::assets::primary_icon(
-        crate::assets::icons::DOWNLOADS,
-        17,
-    ));
-    let update_notice = gtk::Button::builder().child(&update_content).build();
-    update_notice.add_css_class("sidebar-update");
-    let update_separator = gtk::Separator::new(gtk::Orientation::Horizontal);
-    update_separator.add_css_class("sidebar-separator");
-    update_separator.add_css_class("sidebar-update-separator");
-    let update_area = gtk::Box::new(gtk::Orientation::Vertical, 0);
-    update_area.set_visible(false);
-    update_area.append(&update_separator);
-    update_area.append(&update_notice);
-
-    let shell = gtk::Box::new(gtk::Orientation::Vertical, 0);
-    shell.add_css_class("sidebar-shell");
-    shell.append(&scroller);
-    shell.append(&update_area);
-    let volume_monitor = gio::VolumeMonitor::get();
-    let place_order = resolve_place_order(&theme_manager.sidebar_order());
-    let state = Rc::new(SidebarState {
-        widget,
-        browser: view.browser(),
-        view,
-        volume_monitor,
-        mount_monitor: gio_unix::MountMonitor::get(),
-        theme_manager,
-        place_order: RefCell::new(place_order),
-        pinned_places: Rc::new(RefCell::new(load_pinned_places())),
-        place_rows: RefCell::new(Vec::new()),
-        trash_contents: Cell::new(TrashContents::Unknown),
-        trash_menu_rows: RefCell::new(None),
-        trash_monitor: RefCell::new(None),
-        trash_probe_running: Cell::new(false),
-        trash_probe_pending: Cell::new(false),
-        local_only,
-    });
-
-    let weak = Rc::downgrade(&state);
-    state.theme_manager.bind_preference(
-        &state.widget,
-        ThemeManager::sidebar_order,
-        move |_, order| {
-            if let Some(state) = weak.upgrade() {
-                let order = resolve_place_order(&order);
-                if *state.place_order.borrow() != order {
-                    state.place_order.replace(order);
-                    state.rebuild();
-                }
-            }
-        },
-    );
-
-    let weak = Rc::downgrade(&state);
-    state.browser.observe(move |event| {
-        let changes_active_place = SidebarState::event_changes_active_place(event);
-        let changes_trash = event_changes_trash_contents(event);
-        if !changes_active_place && !changes_trash {
-            return;
-        }
-        let Some(state) = weak.upgrade() else {
-            return;
-        };
-        if changes_active_place {
-            state.sync_active_place();
-        }
-        if changes_trash {
-            state.refresh_trash_contents();
-        }
-    });
-
-    let mut handlers = Vec::new();
-    let weak = Rc::downgrade(&state);
-    handlers.push(state.volume_monitor.connect_mount_added(move |_, _| {
-        if let Some(state) = weak.upgrade() {
-            state.rebuild();
-        }
-    }));
-    let weak = Rc::downgrade(&state);
-    handlers.push(state.volume_monitor.connect_mount_removed(move |_, _| {
-        if let Some(state) = weak.upgrade() {
-            state.rebuild();
-        }
-    }));
-    let weak = Rc::downgrade(&state);
-    handlers.push(state.volume_monitor.connect_mount_changed(move |_, _| {
-        if let Some(state) = weak.upgrade() {
-            state.rebuild();
-        }
-    }));
-    let weak = Rc::downgrade(&state);
-    handlers.push(state.volume_monitor.connect_volume_added(move |_, _| {
-        if let Some(state) = weak.upgrade() {
-            state.rebuild();
-        }
-    }));
-    let weak = Rc::downgrade(&state);
-    handlers.push(state.volume_monitor.connect_volume_removed(move |_, _| {
-        if let Some(state) = weak.upgrade() {
-            state.rebuild();
-        }
-    }));
-    let weak = Rc::downgrade(&state);
-    handlers.push(state.volume_monitor.connect_volume_changed(move |_, _| {
-        if let Some(state) = weak.upgrade() {
-            state.rebuild();
-        }
-    }));
-    let weak = Rc::downgrade(&state);
-    let mount_handler = state.mount_monitor.connect_mounts_changed(move |_| {
-        if let Some(state) = weak.upgrade() {
-            state.rebuild();
-        }
-    });
-    state.append_static_places();
-    state.sync_active_place();
-    SidebarView {
-        widget: shell.upcast(),
-        state,
-        update_notice,
-        update_area,
-        update_label,
-        handlers: RefCell::new(handlers),
-        mount_handler: RefCell::new(Some(mount_handler)),
     }
 }
 

--- a/src/ui/window/sidebar.rs
+++ b/src/ui/window/sidebar.rs
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::{
+    cell::{Cell, RefCell},
+    rc::Rc,
+};
+
+use gtk::{gio, glib, prelude::*};
+
+use crate::{
+    model::Location,
+    ui::{browser::BrowserView, theme::ThemeManager},
+};
+
+use super::{
+    SIDEBAR_WIDTH, SidebarState, SidebarView, TrashContents, event_changes_trash_contents,
+    install_sidebar_file_drop, load_pinned_places, resolve_place_order, select_sidebar_row,
+};
+
+pub(in crate::ui) fn build_sidebar(
+    view: BrowserView,
+    preferences: Rc<ThemeManager>,
+    local_only: bool,
+) -> SidebarView {
+    let shell = SidebarShell::new();
+    let state = SidebarState::new(shell.places, view, preferences, local_only);
+    state.bind_order();
+    state.observe_navigation_and_trash();
+    let (handlers, mount_handler) = connect_device_changes(&state);
+    // Device discovery remains deferred to the window's first-paint callback.
+    state.append_static_places();
+    state.sync_active_place();
+    SidebarView {
+        widget: shell.widget.upcast(),
+        state,
+        update_notice: shell.update_notice,
+        update_area: shell.update_area,
+        update_label: shell.update_label,
+        handlers: RefCell::new(handlers),
+        mount_handler: RefCell::new(Some(mount_handler)),
+    }
+}
+
+struct SidebarShell {
+    widget: gtk::Box,
+    places: gtk::Box,
+    update_notice: gtk::Button,
+    update_area: gtk::Box,
+    update_label: gtk::Label,
+}
+
+impl SidebarShell {
+    fn new() -> Self {
+        let places = gtk::Box::new(gtk::Orientation::Vertical, 2);
+        places.add_css_class("sidebar");
+        let scroller = gtk::ScrolledWindow::builder()
+            .child(&places)
+            .hscrollbar_policy(gtk::PolicyType::Never)
+            .vscrollbar_policy(gtk::PolicyType::Automatic)
+            .width_request(SIDEBAR_WIDTH)
+            .vexpand(true)
+            .build();
+        scroller.add_css_class("sidebar-scroll");
+        scroller.add_css_class("fixed-scrollbar");
+        let (update_area, update_notice, update_label) = update_notice();
+        let widget = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        widget.add_css_class("sidebar-shell");
+        widget.append(&scroller);
+        widget.append(&update_area);
+        Self {
+            widget,
+            places,
+            update_notice,
+            update_area,
+            update_label,
+        }
+    }
+}
+
+fn update_notice() -> (gtk::Box, gtk::Button, gtk::Label) {
+    let content = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+    let dot = gtk::Label::new(Some("●"));
+    dot.add_css_class("sidebar-update-dot");
+    let label = gtk::Label::new(None);
+    label.add_css_class("sidebar-update-label");
+    label.set_xalign(0.0);
+    label.set_hexpand(true);
+    label.set_ellipsize(gtk::pango::EllipsizeMode::End);
+    content.append(&dot);
+    content.append(&label);
+    content.append(&crate::assets::primary_icon(
+        crate::assets::icons::DOWNLOADS,
+        17,
+    ));
+    let notice = gtk::Button::builder().child(&content).build();
+    notice.add_css_class("sidebar-update");
+    let separator = gtk::Separator::new(gtk::Orientation::Horizontal);
+    separator.add_css_class("sidebar-separator");
+    separator.add_css_class("sidebar-update-separator");
+    let area = gtk::Box::new(gtk::Orientation::Vertical, 0);
+    area.set_visible(false);
+    area.append(&separator);
+    area.append(&notice);
+    (area, notice, label)
+}
+
+impl SidebarState {
+    fn new(
+        widget: gtk::Box,
+        view: BrowserView,
+        theme_manager: Rc<ThemeManager>,
+        local_only: bool,
+    ) -> Rc<Self> {
+        let volume_monitor = gio::VolumeMonitor::get();
+        let place_order = resolve_place_order(&theme_manager.sidebar_order());
+        Rc::new(Self {
+            widget,
+            browser: view.browser(),
+            view,
+            volume_monitor,
+            mount_monitor: gio_unix::MountMonitor::get(),
+            theme_manager,
+            place_order: RefCell::new(place_order),
+            pinned_places: Rc::new(RefCell::new(load_pinned_places())),
+            place_rows: RefCell::new(Vec::new()),
+            trash_contents: Cell::new(TrashContents::Unknown),
+            trash_menu_rows: RefCell::new(None),
+            trash_monitor: RefCell::new(None),
+            trash_probe_running: Cell::new(false),
+            trash_probe_pending: Cell::new(false),
+            local_only,
+        })
+    }
+
+    fn bind_order(self: &Rc<Self>) {
+        let weak = Rc::downgrade(self);
+        self.theme_manager.bind_preference(
+            &self.widget,
+            ThemeManager::sidebar_order,
+            move |_, order| {
+                if let Some(state) = weak.upgrade() {
+                    let order = resolve_place_order(&order);
+                    if *state.place_order.borrow() != order {
+                        state.place_order.replace(order);
+                        state.rebuild();
+                    }
+                }
+            },
+        );
+    }
+
+    fn observe_navigation_and_trash(self: &Rc<Self>) {
+        let weak = Rc::downgrade(self);
+        self.browser.observe(move |event| {
+            let changes_active_place = Self::event_changes_active_place(event);
+            let changes_trash = event_changes_trash_contents(event);
+            if !changes_active_place && !changes_trash {
+                return;
+            }
+            let Some(state) = weak.upgrade() else {
+                return;
+            };
+            if changes_active_place {
+                state.sync_active_place();
+            }
+            if changes_trash {
+                state.refresh_trash_contents();
+            }
+        });
+    }
+
+    pub(super) fn bind_place_row(
+        &self,
+        row: &gtk::Button,
+        location: Location,
+        navigation: PlaceNavigation,
+    ) {
+        self.place_rows
+            .borrow_mut()
+            .push((location.clone(), row.clone()));
+        install_sidebar_file_drop(&self.view, row, location.clone());
+        let browser = Rc::downgrade(&self.browser);
+        let sidebar = self.widget.clone();
+        let selected_row = row.clone();
+        row.connect_clicked(move |_| {
+            select_sidebar_row(&sidebar, &selected_row);
+            if let Some(browser) = browser.upgrade() {
+                match navigation {
+                    PlaceNavigation::Direct => browser.navigate(location.clone()),
+                    PlaceNavigation::Validate => browser.navigate_location(location.clone()),
+                }
+            }
+        });
+    }
+}
+
+// Trash and reorderable standard places already have a known destination;
+// ordinary place rows retain Browser::navigate_location validation.
+#[derive(Clone, Copy)]
+pub(super) enum PlaceNavigation {
+    Direct,
+    Validate,
+}
+
+fn connect_device_changes(
+    state: &Rc<SidebarState>,
+) -> (Vec<glib::SignalHandlerId>, glib::SignalHandlerId) {
+    let monitor = &state.volume_monitor;
+    let handlers = vec![
+        monitor.connect_mount_added(rebuild_on_change(state)),
+        monitor.connect_mount_removed(rebuild_on_change(state)),
+        monitor.connect_mount_changed(rebuild_on_change(state)),
+        monitor.connect_volume_added(rebuild_on_change(state)),
+        monitor.connect_volume_removed(rebuild_on_change(state)),
+        monitor.connect_volume_changed(rebuild_on_change(state)),
+    ];
+    let weak = Rc::downgrade(state);
+    let mount_handler = state.mount_monitor.connect_mounts_changed(move |_| {
+        if let Some(state) = weak.upgrade() {
+            state.rebuild();
+        }
+    });
+    (handlers, mount_handler)
+}
+
+fn rebuild_on_change<T: 'static>(
+    state: &Rc<SidebarState>,
+) -> impl Fn(&gio::VolumeMonitor, &T) + 'static {
+    let weak = Rc::downgrade(state);
+    move |_, _| {
+        if let Some(state) = weak.upgrade() {
+            state.rebuild();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/ui/window/sidebar/tests.rs
+++ b/src/ui/window/sidebar/tests.rs
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use super::super::{browser_for_window, home_directory, save_pinned_places, sidebar_button};
+use super::*;
+use crate::{
+    services::{DirectoryEvent, DirectoryRequest, FileSource, LoadHandle, LocationValidationError},
+    test_support::gtk_test,
+    ui::browser::PeekBehavior,
+};
+
+fn row(sidebar: &SidebarView, location: &Location) -> gtk::Button {
+    sidebar
+        .state
+        .place_rows
+        .borrow()
+        .iter()
+        .find(|(candidate, _)| candidate == location)
+        .map(|(_, row)| row.clone())
+        .expect("sidebar location row")
+}
+
+fn pinned_locations(sidebar: &SidebarView) -> Vec<Location> {
+    sidebar
+        .state
+        .pinned_places
+        .borrow()
+        .iter()
+        .map(|(location, _)| location.clone())
+        .collect()
+}
+
+#[test]
+fn saved_order_rebuilds_both_sidebars_without_losing_active_places() {
+    gtk_test(
+        "ui::window::sidebar::tests::saved_order_rebuilds_both_sidebars_without_losing_active_places",
+        || {
+            ThemeManager::seed_saved_preferences_for_test();
+            let preferences = ThemeManager::shared();
+            let location = Location::local(home_directory().join("fixture-pin"));
+            save_pinned_places(&[(location.clone(), "Pinned fixture".into())]);
+            let sidebars = [
+                build_sidebar(browser_for_window(), preferences.clone(), true),
+                build_sidebar(browser_for_window(), preferences.clone(), true),
+            ];
+            for sidebar in &sidebars {
+                assert_eq!(
+                    *sidebar.state.place_order.borrow(),
+                    resolve_place_order(&preferences.sidebar_order())
+                );
+                sidebar.state.browser.navigate(location.clone());
+                assert!(row(sidebar, &location).has_css_class("active"));
+            }
+            for order in [
+                vec!["downloads", "desktop", "pictures", "documents", "videos"],
+                vec!["videos", "pictures", "documents", "desktop", "downloads"],
+            ] {
+                let before = sidebars.each_ref().map(|sidebar| row(sidebar, &location));
+                preferences.set_sidebar_order(order.iter().map(|id| (*id).to_owned()).collect());
+                for (sidebar, before) in sidebars.iter().zip(before) {
+                    assert_eq!(*sidebar.state.place_order.borrow(), order);
+                    let after = row(sidebar, &location);
+                    assert_ne!(before, after);
+                    assert!(after.has_css_class("active"));
+                    assert!(!sidebar.update_area.get_visible());
+                }
+            }
+            for sidebar in sidebars {
+                sidebar.disconnect();
+                sidebar.state.browser.clear_observer();
+            }
+        },
+    );
+}
+
+#[test]
+fn pinned_row_reordering_preserves_storage_and_chooser_filtering() {
+    gtk_test(
+        "ui::window::sidebar::tests::pinned_row_reordering_preserves_storage_and_chooser_filtering",
+        || {
+            let preferences = ThemeManager::shared();
+            let sidebar = build_sidebar(browser_for_window(), preferences.clone(), false);
+            let first = Location::local(home_directory().join("first-pin"));
+            let second = Location::local(home_directory().join("second-pin"));
+            let remote =
+                crate::adapters::location_for_file(&gio::File::for_uri("smb://example.test/share"))
+                    .expect("remote bookmark location");
+            sidebar.state.pin_location(first.clone(), "First".into());
+            sidebar.state.pin_location(second.clone(), "Second".into());
+            sidebar.state.pin_location(remote.clone(), "Remote".into());
+            sidebar
+                .state
+                .pin_location(first.clone(), "Duplicate".into());
+            assert_eq!(
+                pinned_locations(&sidebar),
+                [first.clone(), second.clone(), remote.clone()]
+            );
+            sidebar.state.browser.navigate(first.clone());
+            sidebar.state.reorder_pinned_place(0, 1, true);
+            assert_eq!(
+                pinned_locations(&sidebar),
+                [second.clone(), first.clone(), remote.clone()]
+            );
+            assert!(row(&sidebar, &first).has_css_class("active"));
+            assert!(row(&sidebar, &first).has_css_class("reorderable"));
+            assert!(row(&sidebar, &first).has_css_class("file-drop-zone"));
+            let chooser = build_sidebar(browser_for_window(), preferences, true);
+            assert_eq!(pinned_locations(&chooser), pinned_locations(&sidebar));
+            assert!(!row(&chooser, &first).has_css_class("reorderable"));
+            assert!(
+                chooser
+                    .state
+                    .place_rows
+                    .borrow()
+                    .iter()
+                    .all(|(location, _)| location.native_path().is_some())
+            );
+            sidebar.state.unpin_location(&first);
+            assert_eq!(pinned_locations(&sidebar), [second, remote]);
+            assert_eq!(load_pinned_places(), *sidebar.state.pinned_places.borrow());
+            for sidebar in [sidebar, chooser] {
+                sidebar.disconnect();
+                sidebar.state.browser.clear_observer();
+            }
+        },
+    );
+}
+
+#[derive(Default)]
+struct NavigationSource {
+    validations: Cell<usize>,
+    enumerations: Cell<usize>,
+}
+
+impl FileSource for NavigationSource {
+    fn validate_location(&self, _: &Location) -> Result<(), LocationValidationError> {
+        self.validations.set(self.validations.get() + 1);
+        Ok(())
+    }
+
+    fn enumerate(&self, _: DirectoryRequest, _: Rc<dyn Fn(DirectoryEvent)>) -> LoadHandle {
+        self.enumerations.set(self.enumerations.get() + 1);
+        LoadHandle::new(|| {})
+    }
+}
+
+#[test]
+fn shared_place_bindings_keep_navigation_and_drop_policies_distinct() {
+    gtk_test(
+        "ui::window::sidebar::tests::shared_place_bindings_keep_navigation_and_drop_policies_distinct",
+        || {
+            let source = Rc::new(NavigationSource::default());
+            let view = BrowserView::new(source.clone(), PeekBehavior::default());
+            let sidebar = build_sidebar(view, ThemeManager::shared(), true);
+            let direct = Location::uri("fixture:///direct");
+            let validated = Location::uri("fixture:///validated");
+            let direct_row = sidebar_button(crate::assets::icons::FOLDER, "Direct");
+            let validated_row = sidebar_button(crate::assets::icons::FOLDER, "Validated");
+            sidebar
+                .state
+                .bind_place_row(&direct_row, direct.clone(), PlaceNavigation::Direct);
+            sidebar.state.bind_place_row(
+                &validated_row,
+                validated.clone(),
+                PlaceNavigation::Validate,
+            );
+            sidebar.state.widget.append(&direct_row);
+            sidebar.state.widget.append(&validated_row);
+            direct_row.emit_clicked();
+            assert_eq!(source.validations.get(), 0);
+            assert_eq!(sidebar.state.browser.active_location(), Some(direct));
+            assert!(direct_row.has_css_class("active"));
+            validated_row.emit_clicked();
+            assert_eq!(source.validations.get(), 1);
+            assert_eq!(source.enumerations.get(), 2);
+            assert_eq!(sidebar.state.browser.active_location(), Some(validated));
+            assert!(validated_row.has_css_class("active"));
+            assert!(!direct_row.has_css_class("active"));
+            let trash = sidebar_button(crate::assets::icons::TRASH, "Trash");
+            sidebar.state.bind_place_row(
+                &trash,
+                Location::uri("trash:///"),
+                PlaceNavigation::Direct,
+            );
+            assert!(!trash.has_css_class("file-drop-zone"));
+            let controllers = trash.observe_controllers();
+            assert!(!(0..controllers.n_items()).any(|index| {
+                controllers
+                    .item(index)
+                    .is_some_and(|controller| controller.is::<gtk::DropTarget>())
+            }));
+            sidebar.disconnect();
+            sidebar.state.browser.clear_observer();
+        },
+    );
+}
+
+#[test]
+fn device_subscriptions_rebuild_until_disconnected_and_capture_state_weakly() {
+    gtk_test(
+        "ui::window::sidebar::tests::device_subscriptions_rebuild_until_disconnected_and_capture_state_weakly",
+        || {
+            let sidebar = build_sidebar(browser_for_window(), ThemeManager::shared(), true);
+            assert_eq!(sidebar.handlers.borrow().len(), 6);
+            let callback = rebuild_on_change::<()>(&sidebar.state);
+            let monitor = sidebar.state.volume_monitor.clone();
+            let initial = sidebar
+                .state
+                .widget
+                .first_child()
+                .expect("initial Home row");
+            callback(&monitor, &());
+            let before = sidebar.state.widget.first_child().expect("Home row");
+            assert_ne!(initial, before);
+            sidebar
+                .state
+                .mount_monitor
+                .emit_by_name::<()>("mounts-changed", &[]);
+            let rebuilt = sidebar
+                .state
+                .widget
+                .first_child()
+                .expect("rebuilt Home row");
+            assert_ne!(before, rebuilt);
+            sidebar.disconnect();
+            sidebar.disconnect();
+            assert!(sidebar.handlers.borrow().is_empty());
+            assert!(sidebar.mount_handler.borrow().is_none());
+            sidebar
+                .state
+                .mount_monitor
+                .emit_by_name::<()>("mounts-changed", &[]);
+            assert_eq!(sidebar.state.widget.first_child(), Some(rebuilt));
+            let weak = Rc::downgrade(&sidebar.state);
+            sidebar.state.browser.clear_observer();
+            drop(sidebar);
+            assert!(weak.upgrade().is_none());
+            callback(&monitor, &());
+        },
+    );
+}


### PR DESCRIPTION
## Description

Separate sidebar assembly from window policy, share typed weak device-monitor callbacks and place-row bindings, and split standard, pinned, and device rendering stages. Keep direct versus validated navigation explicit; preserve virtual-location drop restrictions, chooser filtering, bookmark storage, and Trash/media-release behavior.

Add coverage for saved-order changes across two windows, pin persistence and chooser filtering, navigation/drop policies, and subscription teardown.

Local CodeScene CLI 1.0.40 against `c779695`: `window.rs` **5.50 → 6.52**, new sidebar assembly module **10.00**. Window cohesion, appearance-menu complexity, and remaining sidebar policies are not declared finished.

## Visual evidence

N/A: behavior-preserving refactor with no intended visual changes or baseline updates.

## How to test

1. Pin two disposable folders, then open a second window. Navigate to a pinned folder and reorder the standard places; check that both windows update and retain the correct active highlight.
2. Reorder and unpin the test bookmarks, then open another window to check persistence. Try navigating Home and an available mounted/remote location.
3. Inspect pinned, device, and Trash context menus without performing destructive actions. Try copying a disposable file onto a local sidebar folder.

**Expected result:** The same row ordering, navigation, active highlights, menus, and file-drop behavior; standard-place order updates live, bookmark changes persist, and local-only chooser filtering is unchanged.

## Related issue

Refs #550 (partial initiative; keep the umbrella open).
