### PR TITLE
refactor(browser): separate directory-event and metadata routing

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -151,6 +151,21 @@ publication/metadata orchestration, native transfer security and the settings wo
 refactored independently of browser composition. Investigation and scope decisions are recorded in
 [issue #397](https://github.com/lgse/strata/issues/397).
 
+### Browser directory-event routing
+
+`app/browser/loading.rs` dispatches provider events through an owned open-load target:
+native batches stage for sorting/publication, while remote batches keep the first-batch
+and coalesced-tail paths. Completion carries truncation and both filesystem capabilities
+together. Requests outside the open-load gate retain their existing peek/failure handling;
+stale work is still checked against the owning directory or peek request.
+
+`loading/metadata.rs` separates full-sort fills, applied by location, from viewport fills,
+validated against directory identity and row-position/location tokens. Metadata chunks
+never complete a sort; `MetadataFinished` retains that responsibility. Both modules release
+state and routing borrows before synchronous observer dispatch, allowing observers to
+navigate safely. Sorting, publication budgets, timers, and cancellation remain in the
+browser controller; this extraction does not change those policies.
+
 ### Window composition
 
 `ui/window.rs::present_target` owns the startup sequence: prepare theme/styles, compose

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -13,13 +13,17 @@ use crate::{
     model::{FileEntry, Location, SortDirection, SortKey, ViewPreferences},
     services::{
         ArchiveFormat, CompressRequest, CreateDirectoryRequest, CreateFileRequest, DeleteRequest,
-        DirectoryChange, DirectoryEvent, DirectoryRequest, ExtractRequest, FileSource, LoadHandle,
+        DirectoryChange, DirectoryRequest, ExtractRequest, FileSource, LoadHandle,
         LocationValidationError, MetadataOutcome, MetadataRequest, MoveRecord, OperationEvent,
         OperationProvider, OperationRequestId, PasteItem, PasteRequest, RenameRequest, RequestId,
         RestoreRequest, RestoreSource, TransferConflict, UndoCopyRequest, UndoMoveItem,
         UndoMoveRequest, validate_basename, validate_uri_credentials,
     },
 };
+
+mod loading;
+
+use loading::{LoadCompletion, RemoteTerminal};
 
 /// Caps a normal directory load at this project's own documented performance baseline for
 /// 100,000 entries (docs/performance-baseline.md: 3,755 ms, 286 MiB) -- past this, per-batch
@@ -466,19 +470,6 @@ enum PublishTerminal {
         retry_metadata: bool,
     },
     SortingFinished,
-}
-
-enum RemoteTerminal {
-    Finished {
-        request_id: RequestId,
-        truncated: bool,
-        can_trash: Option<bool>,
-        can_delete: Option<bool>,
-    },
-    Failed {
-        request_id: RequestId,
-        message: String,
-    },
 }
 
 /// A staged publication streaming to the UI: the prefix is already in the model,
@@ -2335,9 +2326,12 @@ impl Browser {
         match terminal {
             RemoteTerminal::Finished {
                 request_id,
-                truncated,
-                can_trash,
-                can_delete,
+                completion:
+                    LoadCompletion {
+                        truncated,
+                        can_trash,
+                        can_delete,
+                    },
             } => {
                 let finished = self
                     .state
@@ -2381,10 +2375,13 @@ impl Browser {
         self: &Rc<Self>,
         depth: usize,
         request_id: RequestId,
-        truncated: bool,
-        can_trash: Option<bool>,
-        can_delete: Option<bool>,
+        completion: LoadCompletion,
     ) {
+        let LoadCompletion {
+            truncated,
+            can_trash,
+            can_delete,
+        } = completion;
         let staging = self.staging.borrow_mut().remove(&depth);
         let Some(staging) = staging.filter(|staged| staged.request_id == request_id) else {
             return;
@@ -3341,13 +3338,6 @@ impl Browser {
         });
     }
 
-    fn load_target(&self, request_id: RequestId) -> Option<(usize, bool)> {
-        let state = self.state.borrow();
-        let depth = state.depth_for_request(request_id)?;
-        let native = state.location_at(depth)?.native_path().is_some();
-        Some((depth, native))
-    }
-
     fn handle_directory_change(
         self: &Rc<Self>,
         depth: usize,
@@ -3420,209 +3410,6 @@ impl Browser {
         }
     }
 
-    fn handle_directory_event(self: &Rc<Self>, event: DirectoryEvent) {
-        match event {
-            DirectoryEvent::Batch {
-                request_id,
-                entries,
-            } => {
-                let target = self.load_target(request_id);
-                let open = self.state.borrow().open_load_depth(request_id);
-                match (target, open) {
-                    (Some((depth, true)), Some(_)) => {
-                        self.stage_batch(request_id, depth, entries);
-                    }
-                    (Some((depth, false)), Some(_)) => {
-                        let entry_count = self
-                            .state
-                            .borrow()
-                            .loading_column(request_id)
-                            .map(|(_, count)| count)
-                            .unwrap_or(0);
-                        if entry_count == 0 {
-                            self.apply_owned_batch(request_id, entries);
-                        } else {
-                            self.accumulate_batch(request_id, depth, entries);
-                        }
-                    }
-                    _ => {
-                        let peek_entries: Vec<_> = if self.preferences.get().show_hidden {
-                            entries
-                        } else {
-                            entries
-                                .into_iter()
-                                .filter(|entry| !entry.is_hidden)
-                                .collect()
-                        };
-                        let mut state = self.state.borrow_mut();
-                        if state.apply_peek_batch(request_id, &peek_entries) {
-                            drop(state);
-                            self.emit(BrowserEvent::PeekEntriesAdded {
-                                entries: peek_entries,
-                            });
-                        }
-                    }
-                }
-            }
-
-            DirectoryEvent::Finished {
-                request_id,
-                truncated,
-                can_trash,
-                can_delete,
-            } => {
-                // Bound to a variable first: an if-let scrutinee borrow would stay live
-                // across the flush and panic inside it.
-                let target = self.load_target(request_id);
-                let open = self.state.borrow().open_load_depth(request_id);
-                match (target, open) {
-                    (Some((depth, true)), Some(_)) => {
-                        self.stage_batch(request_id, depth, Vec::new());
-                        self.finish_staged_load(
-                            depth, request_id, truncated, can_trash, can_delete,
-                        );
-                    }
-                    (Some((depth, _)), Some(_)) => {
-                        self.remote_terminals.borrow_mut().insert(
-                            depth,
-                            RemoteTerminal::Finished {
-                                request_id,
-                                truncated,
-                                can_trash,
-                                can_delete,
-                            },
-                        );
-                        self.flush_coalesced_capped(Some(depth));
-                    }
-                    _ => {
-                        let mut state = self.state.borrow_mut();
-                        if state.finish_peek(request_id) {
-                            drop(state);
-                            self.emit(BrowserEvent::PeekFinished);
-                        }
-                    }
-                }
-            }
-            DirectoryEvent::MetadataIncomplete { request_id } => {
-                let target = self.load_target(request_id);
-                let open = self.state.borrow().open_load_depth(request_id);
-                if let Some((depth, true)) = target.filter(|_| open.is_some()) {
-                    self.stage_batch(request_id, depth, Vec::new());
-                    if let Some(staging) = self.staging.borrow_mut().get_mut(&depth) {
-                        staging.metadata_incomplete = true;
-                    }
-                }
-            }
-            DirectoryEvent::Failed {
-                request_id,
-                message,
-            } => {
-                let target = self.load_target(request_id);
-                let open = self.state.borrow().open_load_depth(request_id);
-                if let Some((depth, true)) = target.filter(|_| open.is_some()) {
-                    self.staging.borrow_mut().remove(&depth);
-                    self.sorting.borrow_mut().remove(&depth);
-                    self.cancel_publish(depth);
-                } else if let Some((depth, false)) = target.filter(|_| open.is_some()) {
-                    self.remote_terminals.borrow_mut().insert(
-                        depth,
-                        RemoteTerminal::Failed {
-                            request_id,
-                            message,
-                        },
-                    );
-                    self.flush_coalesced_capped(Some(depth));
-                    return;
-                }
-                let mut state = self.state.borrow_mut();
-                if let Some(depth) = state.fail(request_id, message.clone()) {
-                    drop(state);
-                    self.emit(BrowserEvent::LoadFailed { depth, message });
-                } else if state.fail_peek(request_id, message.clone()) {
-                    drop(state);
-                    self.emit(BrowserEvent::PeekFailed { message });
-                }
-            }
-            DirectoryEvent::MetadataFilled {
-                request_id,
-                updates,
-            } => {
-                // Full sort fills apply by location: positional tokens would only add
-                // validation churn to an already O(n log n) path.
-                let awaiting_sort = self
-                    .sort_awaiting_fill
-                    .borrow()
-                    .as_ref()
-                    .copied()
-                    .filter(|fill| fill.fill_request == request_id);
-                if let Some(awaiting) = awaiting_sort {
-                    let mut state = self.state.borrow_mut();
-                    if let Some((depth, positions)) =
-                        state.apply_metadata(awaiting.directory_request, updates)
-                    {
-                        let filled = filled_entries(&state, depth, &positions);
-                        tracing::debug!(
-                            request_id = request_id.0,
-                            depth,
-                            filled = positions.len(),
-                            "metadata fill applied"
-                        );
-                        drop(state);
-                        self.emit(BrowserEvent::MetadataFilled {
-                            depth,
-                            updates: filled,
-                        });
-                    }
-                    return;
-                }
-                let fill = self
-                    .fill_tokens
-                    .borrow()
-                    .get(&request_id)
-                    .map(|fill| (fill.directory_request, fill.tokens.clone()));
-                let Some((directory_request, tokens)) = fill else {
-                    return;
-                };
-                let token_positions: HashMap<&Location, usize> = tokens
-                    .iter()
-                    .map(|(position, location)| (location, *position))
-                    .collect();
-                let mut positioned = Vec::with_capacity(updates.len());
-                for update in &updates {
-                    if let Some(position) = token_positions.get(&update.location) {
-                        positioned.push((*position, update.clone()));
-                    }
-                }
-                let mut state = self.state.borrow_mut();
-                if let Some((depth, positions, stale)) =
-                    state.apply_positioned_metadata(directory_request, positioned)
-                {
-                    let filled = filled_entries(&state, depth, &positions);
-                    tracing::debug!(
-                        request_id = request_id.0,
-                        depth,
-                        filled = positions.len(),
-                        stale = stale.len(),
-                        "metadata fill applied"
-                    );
-                    drop(state);
-                    if !filled.is_empty() {
-                        self.emit(BrowserEvent::MetadataFilled {
-                            depth,
-                            updates: filled,
-                        });
-                    }
-                }
-            }
-            DirectoryEvent::MetadataFinished {
-                request_id,
-                outcome,
-            } => {
-                self.handle_metadata_finished(request_id, outcome);
-            }
-        }
-    }
-
     fn emit(&self, event: BrowserEvent) {
         let observers = self.observers.borrow().clone();
         for observer in &observers {
@@ -3635,20 +3422,6 @@ impl Browser {
         self.next_request.set(id.saturating_add(1));
         RequestId(id)
     }
-}
-
-fn filled_entries(
-    state: &NavigationState,
-    depth: usize,
-    positions: &[usize],
-) -> Vec<(usize, FileEntry)> {
-    positions
-        .iter()
-        .filter_map(|position| {
-            let entry = state.columns.get(depth)?.entries.get(*position)?.clone();
-            Some((*position, entry))
-        })
-        .collect()
 }
 
 fn location_or_ancestor_is_affected(location: &Location, roots: &HashSet<Location>) -> bool {

--- a/src/app/browser/loading.rs
+++ b/src/app/browser/loading.rs
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::rc::Rc;
+
+use crate::{
+    model::FileEntry,
+    services::{DirectoryEvent, RequestId},
+};
+
+use super::{Browser, BrowserEvent};
+
+mod metadata;
+
+#[derive(Clone, Copy)]
+pub(super) struct LoadCompletion {
+    pub(super) truncated: bool,
+    pub(super) can_trash: Option<bool>,
+    pub(super) can_delete: Option<bool>,
+}
+
+pub(super) enum RemoteTerminal {
+    Finished {
+        request_id: RequestId,
+        completion: LoadCompletion,
+    },
+    Failed {
+        request_id: RequestId,
+        message: String,
+    },
+}
+
+enum OpenLoad {
+    Native(usize),
+    Remote(usize),
+}
+
+impl Browser {
+    pub(super) fn handle_directory_event(self: &Rc<Self>, event: DirectoryEvent) {
+        match event {
+            DirectoryEvent::Batch {
+                request_id,
+                entries,
+            } => self.receive_batch(request_id, entries),
+            DirectoryEvent::Finished {
+                request_id,
+                truncated,
+                can_trash,
+                can_delete,
+            } => {
+                self.receive_completion(
+                    request_id,
+                    LoadCompletion {
+                        truncated,
+                        can_trash,
+                        can_delete,
+                    },
+                );
+            }
+            DirectoryEvent::MetadataIncomplete { request_id } => {
+                self.receive_incomplete_metadata(request_id)
+            }
+            DirectoryEvent::Failed {
+                request_id,
+                message,
+            } => self.receive_failure(request_id, message),
+            DirectoryEvent::MetadataFilled {
+                request_id,
+                updates,
+            } => self.receive_metadata(request_id, updates),
+            DirectoryEvent::MetadataFinished {
+                request_id,
+                outcome,
+            } => self.handle_metadata_finished(request_id, outcome),
+        }
+    }
+
+    fn open_load_target(&self, request_id: RequestId) -> Option<OpenLoad> {
+        // Return owned routing information so no state borrow survives a flush
+        // or synchronous observer callback that navigates to another location.
+        let state = self.state.borrow();
+        let depth = state.depth_for_request(request_id)?;
+        state.open_load_depth(request_id)?;
+        if state.location_at(depth)?.native_path().is_some() {
+            Some(OpenLoad::Native(depth))
+        } else {
+            Some(OpenLoad::Remote(depth))
+        }
+    }
+
+    fn receive_batch(self: &Rc<Self>, request_id: RequestId, entries: Vec<FileEntry>) {
+        match self.open_load_target(request_id) {
+            Some(OpenLoad::Native(depth)) => self.stage_batch(request_id, depth, entries),
+            Some(OpenLoad::Remote(depth)) => self.receive_remote_batch(request_id, depth, entries),
+            None => self.receive_peek_batch(request_id, entries),
+        }
+    }
+
+    fn receive_remote_batch(
+        self: &Rc<Self>,
+        request_id: RequestId,
+        depth: usize,
+        entries: Vec<FileEntry>,
+    ) {
+        let entry_count = self
+            .state
+            .borrow()
+            .loading_column(request_id)
+            .map(|(_, count)| count)
+            .unwrap_or(0);
+        if entry_count == 0 {
+            self.apply_owned_batch(request_id, entries);
+        } else {
+            self.accumulate_batch(request_id, depth, entries);
+        }
+    }
+
+    fn receive_peek_batch(&self, request_id: RequestId, entries: Vec<FileEntry>) {
+        let entries = if self.preferences.get().show_hidden {
+            entries
+        } else {
+            entries
+                .into_iter()
+                .filter(|entry| !entry.is_hidden)
+                .collect()
+        };
+        let applied = self
+            .state
+            .borrow_mut()
+            .apply_peek_batch(request_id, &entries);
+        if applied {
+            self.emit(BrowserEvent::PeekEntriesAdded { entries });
+        }
+    }
+
+    fn receive_completion(self: &Rc<Self>, request_id: RequestId, completion: LoadCompletion) {
+        match self.open_load_target(request_id) {
+            Some(OpenLoad::Native(depth)) => {
+                self.stage_batch(request_id, depth, Vec::new());
+                self.finish_staged_load(depth, request_id, completion);
+            }
+            Some(OpenLoad::Remote(depth)) => {
+                self.remote_terminals.borrow_mut().insert(
+                    depth,
+                    RemoteTerminal::Finished {
+                        request_id,
+                        completion,
+                    },
+                );
+                self.flush_coalesced_capped(Some(depth));
+            }
+            None => {
+                let finished = self.state.borrow_mut().finish_peek(request_id);
+                if finished {
+                    self.emit(BrowserEvent::PeekFinished);
+                }
+            }
+        }
+    }
+
+    fn receive_incomplete_metadata(self: &Rc<Self>, request_id: RequestId) {
+        let Some(OpenLoad::Native(depth)) = self.open_load_target(request_id) else {
+            return;
+        };
+        self.stage_batch(request_id, depth, Vec::new());
+        if let Some(staging) = self.staging.borrow_mut().get_mut(&depth) {
+            staging.metadata_incomplete = true;
+        }
+    }
+
+    fn receive_failure(self: &Rc<Self>, request_id: RequestId, message: String) {
+        match self.open_load_target(request_id) {
+            Some(OpenLoad::Native(depth)) => {
+                self.staging.borrow_mut().remove(&depth);
+                self.sorting.borrow_mut().remove(&depth);
+                self.cancel_publish(depth);
+            }
+            Some(OpenLoad::Remote(depth)) => {
+                self.remote_terminals.borrow_mut().insert(
+                    depth,
+                    RemoteTerminal::Failed {
+                        request_id,
+                        message,
+                    },
+                );
+                self.flush_coalesced_capped(Some(depth));
+                return;
+            }
+            None => {}
+        }
+        let mut state = self.state.borrow_mut();
+        if let Some(depth) = state.fail(request_id, message.clone()) {
+            drop(state);
+            self.emit(BrowserEvent::LoadFailed { depth, message });
+        } else if state.fail_peek(request_id, message.clone()) {
+            drop(state);
+            self.emit(BrowserEvent::PeekFailed { message });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/app/browser/loading/metadata.rs
+++ b/src/app/browser/loading/metadata.rs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::collections::HashMap;
+
+use crate::{
+    app::navigation::NavigationState,
+    model::{FileEntry, Location},
+    services::{MetadataUpdate, RequestId},
+};
+
+use super::super::{Browser, BrowserEvent, SortFill};
+
+#[cfg(test)]
+mod tests;
+
+impl Browser {
+    pub(super) fn receive_metadata(&self, request_id: RequestId, updates: Vec<MetadataUpdate>) {
+        let awaiting = self
+            .sort_awaiting_fill
+            .borrow()
+            .as_ref()
+            .copied()
+            .filter(|fill| fill.fill_request == request_id);
+        if let Some(fill) = awaiting {
+            self.apply_sort_metadata(fill, updates);
+        } else {
+            self.apply_viewport_metadata(request_id, updates);
+        }
+    }
+
+    fn apply_sort_metadata(&self, fill: SortFill, updates: Vec<MetadataUpdate>) {
+        // Full sort fills apply by location, independently of viewport positions.
+        let mut state = self.state.borrow_mut();
+        if let Some((depth, positions)) = state.apply_metadata(fill.directory_request, updates) {
+            let filled = filled_entries(&state, depth, &positions);
+            tracing::debug!(
+                request_id = fill.fill_request.0,
+                depth,
+                filled = positions.len(),
+                "metadata fill applied"
+            );
+            drop(state);
+            self.emit(BrowserEvent::MetadataFilled {
+                depth,
+                updates: filled,
+            });
+        }
+    }
+
+    fn apply_viewport_metadata(&self, request_id: RequestId, updates: Vec<MetadataUpdate>) {
+        let fill = self
+            .fill_tokens
+            .borrow()
+            .get(&request_id)
+            .map(|fill| (fill.directory_request, fill.tokens.clone()));
+        let Some((directory_request, tokens)) = fill else {
+            return;
+        };
+        let positioned = position_updates(&tokens, updates);
+        let mut state = self.state.borrow_mut();
+        if let Some((depth, positions, stale)) =
+            state.apply_positioned_metadata(directory_request, positioned)
+        {
+            let filled = filled_entries(&state, depth, &positions);
+            tracing::debug!(
+                request_id = request_id.0,
+                depth,
+                filled = positions.len(),
+                stale = stale.len(),
+                "metadata fill applied"
+            );
+            drop(state);
+            if !filled.is_empty() {
+                self.emit(BrowserEvent::MetadataFilled {
+                    depth,
+                    updates: filled,
+                });
+            }
+        }
+    }
+}
+
+fn position_updates(
+    tokens: &[(usize, Location)],
+    updates: Vec<MetadataUpdate>,
+) -> Vec<(usize, MetadataUpdate)> {
+    let positions: HashMap<&Location, usize> = tokens
+        .iter()
+        .map(|(position, location)| (location, *position))
+        .collect();
+    let mut positioned = Vec::with_capacity(updates.len());
+    for update in updates {
+        if let Some(position) = positions.get(&update.location) {
+            positioned.push((*position, update));
+        }
+    }
+    positioned
+}
+
+fn filled_entries(
+    state: &NavigationState,
+    depth: usize,
+    positions: &[usize],
+) -> Vec<(usize, FileEntry)> {
+    positions
+        .iter()
+        .filter_map(|position| {
+            let entry = state.columns.get(depth)?.entries.get(*position)?.clone();
+            Some((*position, entry))
+        })
+        .collect()
+}

--- a/src/app/browser/loading/metadata/tests.rs
+++ b/src/app/browser/loading/metadata/tests.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::rc::Rc;
+
+use super::super::super::ViewportFill;
+use super::super::tests::Fixture;
+use super::*;
+use crate::{
+    model::MetadataValue,
+    services::{DirectoryChange, DirectoryEvent},
+    test_support::ASYNC_MAIN_CONTEXT_DEFAULT,
+};
+
+fn loaded() -> Fixture {
+    let fixture = Fixture::new(Location::local("/fixture"));
+    fixture.batch(vec![fixture.entry("beta"), fixture.entry("alpha")]);
+    fixture.finish();
+    fixture.events.borrow_mut().clear();
+    fixture
+}
+
+fn install_fill(fixture: &Fixture, full_sort: bool) -> RequestId {
+    let request_id = fixture.browser.new_request_id();
+    fixture.browser.fill_tokens.borrow_mut().insert(
+        request_id,
+        ViewportFill {
+            depth: 0,
+            directory_request: fixture.request(),
+            tokens: vec![(1, fixture.entry("beta").location)],
+        },
+    );
+    if full_sort {
+        fixture.browser.sort_awaiting_fill.replace(Some(SortFill {
+            generation: 1,
+            depth: 0,
+            fill_request: request_id,
+            directory_request: fixture.request(),
+            preferences: fixture.browser.preferences(),
+        }));
+    }
+    request_id
+}
+
+fn update(fixture: &Fixture, name: &str) -> MetadataUpdate {
+    MetadataUpdate {
+        location: fixture.entry(name).location,
+        size: MetadataValue::Known(41),
+        modified_unix_seconds: MetadataValue::Known(123),
+        mode: MetadataValue::Known(0o644),
+    }
+}
+
+#[test]
+fn shifted_viewport_tokens_are_rejected_but_sort_fills_follow_locations() {
+    let _guard = ASYNC_MAIN_CONTEXT_DEFAULT.lock().expect("async test lock");
+    for full_sort in [false, true] {
+        let fixture = loaded();
+        let request_id = install_fill(&fixture, full_sort);
+        fixture.browser.handle_directory_change(
+            0,
+            &fixture.location,
+            DirectoryChange::Upsert(fixture.entry("aardvark")),
+        );
+        fixture.events.borrow_mut().clear();
+        fixture
+            .browser
+            .handle_directory_event(DirectoryEvent::MetadataFilled {
+                request_id,
+                updates: vec![update(&fixture, "beta"), update(&fixture, "unrequested")],
+            });
+        let beta = fixture.browser.entry_at(0, 2).expect("shifted beta row");
+        assert_eq!(beta.display_name, "beta");
+        if full_sort {
+            assert_eq!(beta.size, MetadataValue::Known(41));
+            assert!(
+                matches!(fixture.events.borrow().as_slice(), [BrowserEvent::MetadataFilled { depth: 0, updates }] if updates.len() == 1 && updates[0].0 == 2)
+            );
+        } else {
+            assert_eq!(beta.size, MetadataValue::Unknown);
+            assert!(fixture.events.borrow().is_empty());
+        }
+    }
+}
+
+#[test]
+fn metadata_observers_can_navigate_during_both_fill_routes() {
+    let _guard = ASYNC_MAIN_CONTEXT_DEFAULT.lock().expect("async test lock");
+    for full_sort in [false, true] {
+        let fixture = loaded();
+        let request_id = install_fill(&fixture, full_sort);
+        let weak = Rc::downgrade(&fixture.browser);
+        fixture.browser.observe(move |event| {
+            if matches!(event, BrowserEvent::MetadataFilled { .. }) {
+                weak.upgrade()
+                    .expect("observed browser")
+                    .navigate(Location::local("/replacement"));
+            }
+        });
+        fixture
+            .browser
+            .handle_directory_event(DirectoryEvent::MetadataFilled {
+                request_id,
+                updates: vec![update(&fixture, "beta")],
+            });
+        assert_eq!(
+            fixture.browser.active_location(),
+            Some(Location::local("/replacement"))
+        );
+        assert!(fixture.browser.fill_tokens.borrow().is_empty());
+        assert!(fixture.browser.sort_awaiting_fill.borrow().is_none());
+        assert_eq!(
+            fixture
+                .browser
+                .column_snapshot(0)
+                .expect("new column")
+                .count,
+            0
+        );
+    }
+}
+
+#[test]
+fn superseded_directory_identity_rejects_both_metadata_routes() {
+    let _guard = ASYNC_MAIN_CONTEXT_DEFAULT.lock().expect("async test lock");
+    for full_sort in [false, true] {
+        let fixture = loaded();
+        let request_id = install_fill(&fixture, full_sort);
+        let replacement = fixture.browser.new_request_id();
+        fixture
+            .browser
+            .state
+            .borrow_mut()
+            .navigate(fixture.location.clone(), replacement);
+        fixture
+            .browser
+            .handle_directory_event(DirectoryEvent::MetadataFilled {
+                request_id,
+                updates: vec![update(&fixture, "beta")],
+            });
+        assert!(fixture.events.borrow().is_empty());
+        assert_eq!(
+            fixture
+                .browser
+                .column_snapshot(0)
+                .expect("replacement column")
+                .count,
+            0
+        );
+    }
+}
+
+#[test]
+fn positioned_updates_keep_token_membership_and_update_order() {
+    let fixture_location = Location::local("/fixture/beta");
+    let update = MetadataUpdate {
+        location: fixture_location.clone(),
+        size: MetadataValue::Known(41),
+        modified_unix_seconds: MetadataValue::Unknown,
+        mode: MetadataValue::Unknown,
+    };
+    let other = MetadataUpdate {
+        location: Location::local("/fixture/other"),
+        ..update.clone()
+    };
+    let later = MetadataUpdate {
+        size: MetadataValue::Known(42),
+        ..update.clone()
+    };
+    let positioned = position_updates(
+        &[(1, fixture_location.clone()), (3, fixture_location)],
+        vec![update, other, later],
+    );
+    assert_eq!(positioned.len(), 2);
+    assert_eq!((positioned[0].0, positioned[1].0), (3, 3));
+    assert_eq!(positioned[0].1.size, MetadataValue::Known(41));
+    assert_eq!(positioned[1].1.size, MetadataValue::Known(42));
+}

--- a/src/app/browser/loading/tests.rs
+++ b/src/app/browser/loading/tests.rs
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::cell::{Cell, RefCell};
+
+use super::*;
+use crate::{
+    model::{EntryKind, Location, MetadataValue, ViewPreferences},
+    services::{DirectoryRequest, FileSource, LoadHandle, LocationValidationError},
+    test_support::ASYNC_MAIN_CONTEXT_DEFAULT,
+};
+
+#[derive(Default)]
+struct PendingSource {
+    last_request: Cell<Option<RequestId>>,
+}
+
+impl FileSource for PendingSource {
+    fn validate_location(&self, _: &Location) -> Result<(), LocationValidationError> {
+        Ok(())
+    }
+
+    fn enumerate(&self, request: DirectoryRequest, _: Rc<dyn Fn(DirectoryEvent)>) -> LoadHandle {
+        self.last_request.set(Some(request.id));
+        LoadHandle::new(|| {})
+    }
+}
+
+pub(super) struct Fixture {
+    pub(super) browser: Rc<Browser>,
+    pub(super) events: Rc<RefCell<Vec<BrowserEvent>>>,
+    pub(super) location: Location,
+    source: Rc<PendingSource>,
+}
+
+impl Fixture {
+    pub(super) fn new(location: Location) -> Self {
+        let source = Rc::new(PendingSource::default());
+        let browser = Browser::new(source.clone());
+        let events = Rc::new(RefCell::new(Vec::new()));
+        let observed = events.clone();
+        browser.observe(move |event| observed.borrow_mut().push(event.clone()));
+        browser.navigate(location.clone());
+        events.borrow_mut().clear();
+        Self {
+            browser,
+            events,
+            location,
+            source,
+        }
+    }
+
+    pub(super) fn request(&self) -> RequestId {
+        self.browser
+            .state
+            .borrow()
+            .request_id_for_depth(0)
+            .expect("directory request")
+    }
+
+    pub(super) fn entry(&self, name: &str) -> FileEntry {
+        FileEntry {
+            location: self
+                .location
+                .child(std::ffi::OsStr::new(name))
+                .expect("fixture child"),
+            native_name: name.into(),
+            display_name: name.into(),
+            thumbnail_path: None,
+            kind: EntryKind::File,
+            size: MetadataValue::Unknown,
+            modified_unix_seconds: MetadataValue::Unknown,
+            mode: MetadataValue::Unknown,
+            is_hidden: name.starts_with('.'),
+        }
+    }
+
+    pub(super) fn batch(&self, entries: Vec<FileEntry>) {
+        self.browser.handle_directory_event(DirectoryEvent::Batch {
+            request_id: self.request(),
+            entries,
+        });
+    }
+
+    pub(super) fn finish(&self) {
+        self.browser
+            .handle_directory_event(DirectoryEvent::Finished {
+                request_id: self.request(),
+                truncated: false,
+                can_trash: None,
+                can_delete: None,
+            });
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        self.browser.clear_observer();
+        self.browser.cancel_deferred_work();
+    }
+}
+
+fn roots() -> [Location; 2] {
+    [
+        Location::local("/fixture"),
+        Location::uri("sftp://example.test/fixture"),
+    ]
+}
+
+#[test]
+fn native_and_remote_completions_preserve_capabilities_and_terminal_order() {
+    let _guard = ASYNC_MAIN_CONTEXT_DEFAULT.lock().expect("async test lock");
+    for location in roots() {
+        for (truncated, can_trash, can_delete) in [
+            (true, Some(false), Some(true)),
+            (false, Some(true), None),
+            (false, None, Some(false)),
+        ] {
+            let fixture = Fixture::new(location.clone());
+            fixture.batch(vec![fixture.entry("entry")]);
+            fixture
+                .browser
+                .handle_directory_event(DirectoryEvent::Finished {
+                    request_id: fixture.request(),
+                    truncated,
+                    can_trash,
+                    can_delete,
+                });
+            let column = fixture.browser.column_snapshot(0).expect("loaded column");
+            assert_eq!(column.count, 1);
+            assert!(!column.loading);
+            assert_eq!(column.truncated, truncated);
+            assert_eq!(fixture.browser.can_trash_at(0), can_trash);
+            assert_eq!(fixture.browser.can_delete_at(0), can_delete);
+            let events = fixture.events.borrow();
+            assert!(
+                matches!(events.last(), Some(BrowserEvent::LoadFinished { depth: 0, truncated: actual }) if *actual == truncated)
+            );
+            assert_eq!(
+                events
+                    .iter()
+                    .filter(|event| matches!(event, BrowserEvent::LoadFinished { .. }))
+                    .count(),
+                1
+            );
+        }
+    }
+}
+
+#[test]
+fn stale_loading_events_cannot_mutate_a_replacement_request() {
+    let _guard = ASYNC_MAIN_CONTEXT_DEFAULT.lock().expect("async test lock");
+    for location in roots() {
+        let fixture = Fixture::new(location);
+        let old = fixture.request();
+        fixture.batch(vec![fixture.entry("discarded")]);
+        fixture.browser.navigate(Location::local("/replacement"));
+        fixture.events.borrow_mut().clear();
+        for event in [
+            DirectoryEvent::Batch {
+                request_id: old,
+                entries: vec![fixture.entry("late")],
+            },
+            DirectoryEvent::MetadataIncomplete { request_id: old },
+            DirectoryEvent::Finished {
+                request_id: old,
+                truncated: true,
+                can_trash: Some(false),
+                can_delete: Some(false),
+            },
+            DirectoryEvent::Failed {
+                request_id: old,
+                message: "late failure".into(),
+            },
+        ] {
+            fixture.browser.handle_directory_event(event);
+        }
+        let column = fixture
+            .browser
+            .column_snapshot(0)
+            .expect("replacement column");
+        assert!(column.loading);
+        assert_eq!(column.count, 0);
+        assert!(column.error.is_none());
+        assert!(fixture.events.borrow().is_empty());
+        assert!(fixture.browser.staging.borrow().is_empty());
+        assert!(fixture.browser.remote_terminals.borrow().is_empty());
+        assert!(fixture.browser.coalesce_pending.borrow().is_empty());
+        fixture.finish();
+        assert!(
+            !fixture
+                .browser
+                .column_snapshot(0)
+                .expect("finished replacement")
+                .loading
+        );
+    }
+}
+
+#[test]
+fn native_failure_discards_staged_entries_without_publishing_them() {
+    let _guard = ASYNC_MAIN_CONTEXT_DEFAULT.lock().expect("async test lock");
+    let fixture = Fixture::new(Location::local("/fixture"));
+    fixture
+        .browser
+        .handle_directory_event(DirectoryEvent::MetadataIncomplete {
+            request_id: fixture.request(),
+        });
+    fixture.batch(vec![fixture.entry("partial")]);
+    assert!(
+        fixture
+            .browser
+            .staging
+            .borrow()
+            .get(&0)
+            .expect("staged load")
+            .metadata_incomplete
+    );
+    fixture
+        .browser
+        .handle_directory_event(DirectoryEvent::Failed {
+            request_id: fixture.request(),
+            message: "load failed".into(),
+        });
+    assert!(fixture.browser.staging.borrow().is_empty());
+    assert!(fixture.browser.sorting.borrow().is_empty());
+    assert!(fixture.browser.staged_publishes.borrow().is_empty());
+    let column = fixture.browser.column_snapshot(0).expect("failed column");
+    assert_eq!(column.count, 0);
+    assert_eq!(column.error.as_deref(), Some("load failed"));
+    assert!(matches!(
+        fixture.events.borrow().as_slice(),
+        [BrowserEvent::LoadFailed { depth: 0, .. }]
+    ));
+}
+
+#[test]
+fn completed_requests_reject_batches_but_retain_the_existing_failure_transition() {
+    let _guard = ASYNC_MAIN_CONTEXT_DEFAULT.lock().expect("async test lock");
+    for location in roots() {
+        let fixture = Fixture::new(location);
+        fixture.batch(vec![fixture.entry("accepted")]);
+        fixture.finish();
+        fixture.events.borrow_mut().clear();
+        fixture.batch(vec![fixture.entry("late")]);
+        fixture.finish();
+        assert!(fixture.events.borrow().is_empty());
+        assert_eq!(
+            fixture
+                .browser
+                .column_snapshot(0)
+                .expect("completed column")
+                .count,
+            1
+        );
+        // Failure applies by owning request, unlike the open-load batch/finish gate.
+        fixture
+            .browser
+            .handle_directory_event(DirectoryEvent::Failed {
+                request_id: fixture.request(),
+                message: "provider failure".into(),
+            });
+        assert!(matches!(
+            fixture.events.borrow().as_slice(),
+            [BrowserEvent::LoadFailed { depth: 0, .. }]
+        ));
+    }
+}
+
+#[test]
+fn completion_observers_can_navigate_without_borrowing_or_replacing_new_state() {
+    let _guard = ASYNC_MAIN_CONTEXT_DEFAULT.lock().expect("async test lock");
+    for location in roots() {
+        let fixture = Fixture::new(location);
+        let weak = Rc::downgrade(&fixture.browser);
+        fixture.browser.observe(move |event| {
+            if matches!(event, BrowserEvent::LoadFinished { .. }) {
+                weak.upgrade()
+                    .expect("observed browser")
+                    .navigate(Location::local("/replacement"));
+            }
+        });
+        fixture.batch(vec![fixture.entry("entry")]);
+        fixture.finish();
+        let column = fixture
+            .browser
+            .column_snapshot(0)
+            .expect("replacement column");
+        assert_eq!(column.location, Location::local("/replacement"));
+        assert!(column.loading);
+        assert_eq!(column.count, 0);
+    }
+}
+
+#[test]
+fn peek_events_keep_hidden_filtering_and_terminals_separate_from_columns() {
+    let _guard = ASYNC_MAIN_CONTEXT_DEFAULT.lock().expect("async test lock");
+    for show_hidden in [false, true] {
+        let fixture = Fixture::new(Location::local("/fixture"));
+        fixture.finish();
+        fixture.browser.apply_default_preferences(ViewPreferences {
+            show_hidden,
+            ..fixture.browser.preferences()
+        });
+        fixture
+            .browser
+            .begin_peek(0, Location::local("/fixture/peek"));
+        let request_id = fixture.source.last_request.get().expect("peek request");
+        fixture.events.borrow_mut().clear();
+        fixture
+            .browser
+            .handle_directory_event(DirectoryEvent::Batch {
+                request_id,
+                entries: vec![fixture.entry(".hidden"), fixture.entry("visible")],
+            });
+        fixture
+            .browser
+            .handle_directory_event(DirectoryEvent::MetadataIncomplete { request_id });
+        fixture
+            .browser
+            .handle_directory_event(DirectoryEvent::Finished {
+                request_id,
+                truncated: true,
+                can_trash: Some(false),
+                can_delete: Some(false),
+            });
+        let events = fixture.events.borrow();
+        assert!(
+            matches!(events.as_slice(), [BrowserEvent::PeekEntriesAdded { entries }, BrowserEvent::PeekFinished] if entries.len() == if show_hidden { 2 } else { 1 })
+        );
+        assert!(fixture.browser.staging.borrow().is_empty());
+        assert_eq!(
+            fixture
+                .browser
+                .column_snapshot(0)
+                .expect("parent column")
+                .count,
+            0
+        );
+    }
+}

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -6,8 +6,8 @@ use super::*;
 use crate::{
     model::{EntryKind, MetadataValue},
     services::{
-        CancelledOperation, CompressRequest, ExtractRequest, LoadHandle, MetadataOutcome,
-        MetadataRequest, MetadataUpdate, UndoCopyRequest, UndoMoveRequest,
+        CancelledOperation, CompressRequest, DirectoryEvent, ExtractRequest, LoadHandle,
+        MetadataOutcome, MetadataRequest, MetadataUpdate, UndoCopyRequest, UndoMoveRequest,
     },
 };
 


### PR DESCRIPTION
## Description

Separate provider-event routing from the application browser controller. Native staging, remote streaming, and peek handling use one owned open-load classification; completion keeps truncation and filesystem capabilities together. Metadata application now separates location-based sort fills from position-token-validated viewport fills.

Preserve scheduling, cancellation, request ownership, terminal ordering, and reentrant observer behavior. Add ten focused tests for those boundaries while retaining existing loading/sorting coverage. Operation callbacks and publication scheduling remain separate follow-ups.

Local CodeScene CLI 1.0.40 against `4277537`: `app/browser.rs` **3.57 → 3.97**; new loading and metadata modules **10.00**. The controller's remaining complexity is not waived.

## Visual evidence

N/A: internal behavior-preserving refactor; no intended visual changes or baseline updates.

## How to test

1. Open a local directory with many files. Navigate away or refresh during loading, then switch between Name, Size, and Modified sorting. Check that rows settle in the chosen order without stale entries returning.
2. If available, repeat on a remote directory, including navigating away while rows are arriving. Check that completion follows the final rows and errors do not leave a loading indicator stuck.
3. Hover-peek folders with hidden files both enabled and disabled; check previews, selection, and navigation still behave normally.

**Expected result:** Unchanged listings, metadata, sorting, peek behavior, and loading/error transitions; superseded requests do not affect the current location.

## Related issue

Refs #550 (partial initiative; keep the umbrella open).
