### PR TITLE
refactor(browser): simplify staged row publication

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -171,8 +171,26 @@ stale work is still checked against the owning directory or peek request.
 validated against directory identity and row-position/location tokens. Metadata chunks
 never complete a sort; `MetadataFinished` retains that responsibility. Both modules release
 state and routing borrows before synchronous observer dispatch, allowing observers to
-navigate safely. Sorting, publication budgets, timers, and cancellation remain in the
-browser controller; this extraction does not change those policies.
+navigate safely. Sorting, metadata scheduling, and cancellation remain in the browser
+controller; event routing does not change those policies.
+
+### Browser staged publication
+
+`app/browser/publication.rs` owns staged row publication on the same `Browser`, not a
+second controller. A `PublicationPlan` captures request identity, row count, selection,
+and terminal payload; only the separate progress cursor advances while tails stream.
+Sort paths capture the plan before notifying preference observers.
+
+Inline publication, idle completion, and synchronous draining share selection/terminal
+dispatch. Selection follows the final rows; a load's metadata retry follows its load
+completion event. Idle tails reject superseded directory requests and respect both the
+captured total and current model length. Draining instead publishes the entire remaining
+current model before mutations that require convergence. Borrows end before synchronous
+observer calls, including cancellation from a tail observer.
+
+Inline thresholds, prefix/chunk sizes, idle priority, and the cooperative time budget
+are unchanged. Queue ownership and cancellation/truncation remain on `Browser`; sort
+workers, remote coalescing, and operation callbacks are separate responsibilities.
 
 ### Window composition
 

--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -22,8 +22,10 @@ use crate::{
 };
 
 mod loading;
+mod publication;
 
 use loading::{LoadCompletion, RemoteTerminal};
+use publication::{PublicationPlan, PublishTerminal, StagedPublish};
 
 /// Caps a normal directory load at this project's own documented performance baseline for
 /// 100,000 entries (docs/performance-baseline.md: 3,755 ms, 286 MiB) -- past this, per-batch
@@ -401,15 +403,9 @@ const COALESCE_ENTRIES: usize = 2048;
 const REMOTE_FLUSH_CAP: usize = 512;
 /// Latency bound so later remote batches flush on the next idle/frame.
 const REMOTE_FLUSH_DELAY: Duration = Duration::from_millis(50);
-/// Rows published synchronously with a staged load or sort; the rest stream
-/// from idle callbacks inside an 8 ms work budget.
-const FIRST_PUBLISH_COUNT: usize = 128;
-const STAGE_INLINE_LIMIT: usize = 512;
 /// Snapshots at or below this size sort synchronously; larger ones sort in a
 /// blocking worker.
 const SORT_INLINE_LIMIT: usize = 2048;
-const PUBLISH_TAIL_CHUNK: usize = 2048;
-const PUBLISH_SLICE_BUDGET: Duration = Duration::from_millis(8);
 
 /// Last selection emitted per depth on the batch path, keyed by request so a
 /// new load re-emits; lets background batches skip redundant refreshes.
@@ -465,26 +461,6 @@ struct SortPlan {
     truncated: bool,
     can_trash: Option<bool>,
     can_delete: Option<bool>,
-}
-
-enum PublishTerminal {
-    LoadFinished {
-        truncated: bool,
-        retry_metadata: bool,
-    },
-    SortingFinished,
-}
-
-/// A staged publication streaming to the UI: the prefix is already in the model,
-/// tails append from idle callbacks in a work budget, and selection plus the
-/// terminal event wait for the final tail.
-struct StagedPublish {
-    request_id: RequestId,
-    published: usize,
-    total: usize,
-    focused: Option<usize>,
-    positions: Vec<usize>,
-    terminal: PublishTerminal,
 }
 
 pub struct Browser {
@@ -1056,23 +1032,19 @@ impl Browser {
             self.preferences.set(preferences);
             let request_id = state.request_id_for_depth(depth);
             let total = state.columns.get(depth).map(|column| column.entries.len());
-            result.map(|(focused, positions)| (request_id, total, focused, positions))
-        };
-        self.notify_preferences_observers();
-        if let Some((request_id, total, focused, positions)) = result {
-            if let (Some(request_id), Some(total)) = (request_id, total) {
-                self.publish_staged(
-                    depth,
-                    request_id,
-                    total,
+            result.and_then(|(focused, positions)| {
+                Some(PublicationPlan {
+                    request_id: request_id?,
+                    total: total?,
                     focused,
                     positions,
-                    PublishTerminal::SortingFinished,
-                );
-            } else {
-                self.pending_sort.set(None);
-                self.emit(BrowserEvent::SortingFinished { depth });
-            }
+                    terminal: PublishTerminal::SortingFinished,
+                })
+            })
+        };
+        self.notify_preferences_observers();
+        if let Some(plan) = result {
+            self.publish_staged(depth, plan);
         } else {
             self.pending_sort.set(None);
             self.emit(BrowserEvent::SortingFinished { depth });
@@ -2560,13 +2532,15 @@ impl Browser {
             .finish(request_id, truncated, can_trash, can_delete);
         self.publish_staged(
             depth,
-            request_id,
-            total,
-            focused,
-            positions,
-            PublishTerminal::LoadFinished {
-                truncated,
-                retry_metadata,
+            PublicationPlan {
+                request_id,
+                total,
+                focused,
+                positions,
+                terminal: PublishTerminal::LoadFinished {
+                    truncated,
+                    retry_metadata,
+                },
             },
         );
     }
@@ -2627,194 +2601,6 @@ impl Browser {
         }
     }
 
-    /// Publishes an installed column in stages: a synchronous prefix for fast first
-    /// rows, tails from idle callbacks in a work budget, and deferred selection
-    /// plus terminal on the final tail.
-    fn publish_staged(
-        self: &Rc<Self>,
-        depth: usize,
-        request_id: RequestId,
-        total: usize,
-        focused: Option<usize>,
-        positions: Vec<usize>,
-        terminal: PublishTerminal,
-    ) {
-        self.drain_publish(depth);
-        if total <= STAGE_INLINE_LIMIT {
-            if self.state.borrow().columns.get(depth).is_none() {
-                return;
-            }
-            self.emit(BrowserEvent::EntriesReplaced {
-                depth,
-                count: total,
-            });
-            if let Some(focused) = focused {
-                self.emit(BrowserEvent::SelectionSetChanged {
-                    depth,
-                    positions,
-                    focused,
-                    take_focus: false,
-                });
-            }
-            self.emit_publish_terminal(depth, terminal);
-            return;
-        }
-        let published = self
-            .state
-            .borrow()
-            .columns
-            .get(depth)
-            .map_or(0, |column| column.entries.len().min(FIRST_PUBLISH_COUNT));
-        self.emit(BrowserEvent::EntriesReplaced {
-            depth,
-            count: published,
-        });
-        self.staged_publishes.borrow_mut().insert(
-            depth,
-            StagedPublish {
-                request_id,
-                published,
-                total,
-                focused,
-                positions,
-                terminal,
-            },
-        );
-        self.arm_publish_timer();
-    }
-
-    fn emit_publish_terminal(self: &Rc<Self>, depth: usize, terminal: PublishTerminal) {
-        match terminal {
-            PublishTerminal::LoadFinished {
-                truncated,
-                retry_metadata,
-            } => {
-                self.emit(BrowserEvent::LoadFinished { depth, truncated });
-                if retry_metadata {
-                    self.ensure_sorted_after_load(depth);
-                }
-            }
-            PublishTerminal::SortingFinished => self.emit(BrowserEvent::SortingFinished { depth }),
-        }
-    }
-
-    /// Completes a staged publication synchronously before any mutation assuming a
-    /// converged model.
-    fn drain_publish(self: &Rc<Self>, depth: usize) {
-        let staged = self.staged_publishes.borrow_mut().remove(&depth);
-        let Some(staged) = staged else {
-            return;
-        };
-        let remainder = self.state.borrow().columns.get(depth).map_or(0, |column| {
-            column.entries.len().saturating_sub(staged.published)
-        });
-        if remainder > 0 {
-            self.emit(BrowserEvent::EntriesPublished {
-                depth,
-                position: staged.published,
-                count: remainder,
-            });
-        }
-        if let Some(focused) = staged.focused {
-            self.emit(BrowserEvent::SelectionSetChanged {
-                depth,
-                positions: staged.positions,
-                focused,
-                take_focus: false,
-            });
-        }
-        self.emit_publish_terminal(depth, staged.terminal);
-    }
-
-    fn cancel_publish(&self, depth: usize) {
-        self.staged_publishes.borrow_mut().remove(&depth);
-        if self.staged_publishes.borrow().is_empty()
-            && let Some(source) = self.publish_timer.borrow_mut().take()
-        {
-            source.remove();
-        }
-    }
-
-    fn arm_publish_timer(self: &Rc<Self>) {
-        if self.publish_timer.borrow().is_some() {
-            return;
-        }
-        let weak: Weak<Self> = Rc::downgrade(self);
-        // Run after GDK redraw (priority 120), but before default idle (200):
-        // frames stay smooth without letting continuous frame work starve tails.
-        let source = gio::glib::idle_add_local_full(glib::Priority::from(130), move || {
-            if let Some(browser) = weak.upgrade() {
-                browser.fire_publish_tails();
-            }
-            glib::ControlFlow::Break
-        });
-        *self.publish_timer.borrow_mut() = Some(source);
-    }
-
-    fn fire_publish_tails(self: &Rc<Self>) {
-        self.publish_timer.borrow_mut().take();
-        let started = std::time::Instant::now();
-        loop {
-            let depth = self.staged_publishes.borrow().keys().copied().next();
-            let Some(depth) = depth else {
-                return;
-            };
-            let current = self
-                .staged_publishes
-                .borrow()
-                .get(&depth)
-                .map(|staged| staged.request_id);
-            if current.is_some_and(|id| self.state.borrow().request_id_for_depth(depth) != Some(id))
-            {
-                self.staged_publishes.borrow_mut().remove(&depth);
-                continue;
-            }
-            if started.elapsed() >= PUBLISH_SLICE_BUDGET {
-                self.arm_publish_timer();
-                return;
-            }
-            let chunk: Option<(usize, usize)> = self
-                .staged_publishes
-                .borrow()
-                .get(&depth)
-                .and_then(|staged| {
-                    self.state.borrow().columns.get(depth).map(|column| {
-                        let end = (staged.published + PUBLISH_TAIL_CHUNK)
-                            .min(column.entries.len())
-                            .min(staged.total);
-                        (staged.published, end.saturating_sub(staged.published))
-                    })
-                });
-            let Some((position, chunk)) = chunk else {
-                self.staged_publishes.borrow_mut().remove(&depth);
-                continue;
-            };
-            if chunk == 0 {
-                let staged = self.staged_publishes.borrow_mut().remove(&depth);
-                let Some(staged) = staged else {
-                    continue;
-                };
-                if let Some(focused) = staged.focused {
-                    self.emit(BrowserEvent::SelectionSetChanged {
-                        depth,
-                        positions: staged.positions,
-                        focused,
-                        take_focus: false,
-                    });
-                }
-                self.emit_publish_terminal(depth, staged.terminal);
-                continue;
-            }
-            self.emit(BrowserEvent::EntriesPublished {
-                depth,
-                position,
-                count: chunk,
-            });
-            if let Some(staged) = self.staged_publishes.borrow_mut().get_mut(&depth) {
-                staged.published += chunk;
-            }
-        }
-    }
     pub fn request_metadata_fill(
         self: &Rc<Self>,
         depth: usize,
@@ -2910,24 +2696,19 @@ impl Browser {
             let outcome = state.apply_sort_preferences(depth, preferences);
             self.preferences.set(preferences);
             self.pending_sort.set(None);
-            outcome.map(|(focused, positions)| {
-                let request_id = state.request_id_for_depth(depth);
-                let total = state.columns.get(depth).map(|column| column.entries.len());
-                (request_id, total, focused, positions)
+            outcome.and_then(|(focused, positions)| {
+                Some(PublicationPlan {
+                    request_id: state.request_id_for_depth(depth)?,
+                    total: state.columns.get(depth)?.entries.len(),
+                    focused,
+                    positions,
+                    terminal: PublishTerminal::SortingFinished,
+                })
             })
         };
         self.notify_preferences_observers();
         match outcome {
-            Some((Some(request_id), Some(total), focused, positions)) => {
-                self.publish_staged(
-                    depth,
-                    request_id,
-                    total,
-                    focused,
-                    positions,
-                    PublishTerminal::SortingFinished,
-                );
-            }
+            Some(plan) => self.publish_staged(depth, plan),
             _ => {
                 self.emit(BrowserEvent::SortingFinished { depth });
             }

--- a/src/app/browser/publication.rs
+++ b/src/app/browser/publication.rs
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::{
+    rc::Rc,
+    time::{Duration, Instant},
+};
+
+use gio::glib;
+
+use super::{Browser, BrowserEvent, RequestId};
+
+/// Rows exposed immediately; larger publications continue within idle budgets.
+const FIRST_PUBLISH_COUNT: usize = 128;
+const STAGE_INLINE_LIMIT: usize = 512;
+const PUBLISH_TAIL_CHUNK: usize = 2048;
+const PUBLISH_SLICE_BUDGET: Duration = Duration::from_millis(8);
+
+pub(super) enum PublishTerminal {
+    LoadFinished {
+        truncated: bool,
+        retry_metadata: bool,
+    },
+    SortingFinished,
+}
+
+pub(super) struct PublicationPlan {
+    pub(super) request_id: RequestId,
+    pub(super) total: usize,
+    pub(super) focused: Option<usize>,
+    pub(super) positions: Vec<usize>,
+    pub(super) terminal: PublishTerminal,
+}
+
+/// Progress is separate from the captured selection and terminal payload.
+pub(super) struct StagedPublish {
+    plan: PublicationPlan,
+    published: usize,
+}
+
+impl StagedPublish {
+    fn next_chunk(&self, available: usize) -> (usize, usize) {
+        let end = (self.published + PUBLISH_TAIL_CHUNK)
+            .min(available)
+            .min(self.plan.total);
+        (self.published, end.saturating_sub(self.published))
+    }
+}
+
+impl Browser {
+    pub(super) fn publish_staged(self: &Rc<Self>, depth: usize, plan: PublicationPlan) {
+        self.drain_publish(depth);
+        if plan.total <= STAGE_INLINE_LIMIT {
+            if self.state.borrow().columns.get(depth).is_none() {
+                return;
+            }
+            self.emit(BrowserEvent::EntriesReplaced {
+                depth,
+                count: plan.total,
+            });
+            self.complete_publication(depth, plan);
+            return;
+        }
+        let published = self
+            .state
+            .borrow()
+            .columns
+            .get(depth)
+            .map_or(0, |column| column.entries.len().min(FIRST_PUBLISH_COUNT));
+        self.emit(BrowserEvent::EntriesReplaced {
+            depth,
+            count: published,
+        });
+        self.staged_publishes
+            .borrow_mut()
+            .insert(depth, StagedPublish { plan, published });
+        self.arm_publish_timer();
+    }
+
+    fn complete_publication(self: &Rc<Self>, depth: usize, plan: PublicationPlan) {
+        if let Some(focused) = plan.focused {
+            self.emit(BrowserEvent::SelectionSetChanged {
+                depth,
+                positions: plan.positions,
+                focused,
+                take_focus: false,
+            });
+        }
+        match plan.terminal {
+            PublishTerminal::LoadFinished {
+                truncated,
+                retry_metadata,
+            } => {
+                self.emit(BrowserEvent::LoadFinished { depth, truncated });
+                if retry_metadata {
+                    self.ensure_sorted_after_load(depth);
+                }
+            }
+            PublishTerminal::SortingFinished => self.emit(BrowserEvent::SortingFinished { depth }),
+        }
+    }
+
+    /// Converge with the authoritative model before mutations that assume all
+    /// rows are visible; unlike an idle tail, draining is not chunk-limited.
+    pub(super) fn drain_publish(self: &Rc<Self>, depth: usize) {
+        let staged = self.staged_publishes.borrow_mut().remove(&depth);
+        let Some(staged) = staged else {
+            return;
+        };
+        let remainder = self.state.borrow().columns.get(depth).map_or(0, |column| {
+            column.entries.len().saturating_sub(staged.published)
+        });
+        if remainder > 0 {
+            self.emit(BrowserEvent::EntriesPublished {
+                depth,
+                position: staged.published,
+                count: remainder,
+            });
+        }
+        self.complete_publication(depth, staged.plan);
+    }
+
+    pub(super) fn cancel_publish(&self, depth: usize) {
+        self.staged_publishes.borrow_mut().remove(&depth);
+        if self.staged_publishes.borrow().is_empty()
+            && let Some(source) = self.publish_timer.borrow_mut().take()
+        {
+            source.remove();
+        }
+    }
+
+    fn arm_publish_timer(self: &Rc<Self>) {
+        if self.publish_timer.borrow().is_some() {
+            return;
+        }
+        let weak = Rc::downgrade(self);
+        // Run after GDK redraw (priority 120), but before default idle (200):
+        // frames stay smooth without letting continuous frame work starve tails.
+        let source = glib::idle_add_local_full(glib::Priority::from(130), move || {
+            if let Some(browser) = weak.upgrade() {
+                browser.fire_publish_tails();
+            }
+            glib::ControlFlow::Break
+        });
+        *self.publish_timer.borrow_mut() = Some(source);
+    }
+
+    fn fire_publish_tails(self: &Rc<Self>) {
+        self.publish_timer.borrow_mut().take();
+        let started = Instant::now();
+        loop {
+            let depth = self.staged_publishes.borrow().keys().copied().next();
+            let Some(depth) = depth else {
+                return;
+            };
+            if self.discard_stale_publication(depth) {
+                continue;
+            }
+            if started.elapsed() >= PUBLISH_SLICE_BUDGET {
+                self.arm_publish_timer();
+                return;
+            }
+            self.publish_next_chunk(depth);
+        }
+    }
+
+    fn discard_stale_publication(&self, depth: usize) -> bool {
+        let current = self
+            .staged_publishes
+            .borrow()
+            .get(&depth)
+            .map(|staged| staged.plan.request_id);
+        let stale =
+            current.is_some_and(|id| self.state.borrow().request_id_for_depth(depth) != Some(id));
+        if stale {
+            self.staged_publishes.borrow_mut().remove(&depth);
+        }
+        stale
+    }
+
+    fn next_publication_chunk(&self, depth: usize) -> Option<(usize, usize)> {
+        self.staged_publishes
+            .borrow()
+            .get(&depth)
+            .and_then(|staged| {
+                self.state
+                    .borrow()
+                    .columns
+                    .get(depth)
+                    .map(|column| staged.next_chunk(column.entries.len()))
+            })
+    }
+
+    fn publish_next_chunk(self: &Rc<Self>, depth: usize) {
+        match self.next_publication_chunk(depth) {
+            None => {
+                self.staged_publishes.borrow_mut().remove(&depth);
+            }
+            Some((_, 0)) => {
+                let staged = self.staged_publishes.borrow_mut().remove(&depth);
+                if let Some(staged) = staged {
+                    self.complete_publication(depth, staged.plan);
+                }
+            }
+            Some((position, count)) => {
+                self.emit(BrowserEvent::EntriesPublished {
+                    depth,
+                    position,
+                    count,
+                });
+                if let Some(staged) = self.staged_publishes.borrow_mut().get_mut(&depth) {
+                    staged.published += count;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/app/browser/publication/tests.rs
+++ b/src/app/browser/publication/tests.rs
@@ -1,0 +1,382 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::cell::{Cell, RefCell};
+
+use super::*;
+use crate::{
+    model::{EntryKind, FileEntry, Location, MetadataValue, SortKey, ViewPreferences},
+    services::{DirectoryEvent, DirectoryRequest, FileSource, LoadHandle, LocationValidationError},
+    test_support::ASYNC_MAIN_CONTEXT_DEFAULT,
+};
+
+struct PendingSource;
+
+impl FileSource for PendingSource {
+    fn validate_location(&self, _: &Location) -> Result<(), LocationValidationError> {
+        Ok(())
+    }
+    fn enumerate(&self, _: DirectoryRequest, _: Rc<dyn Fn(DirectoryEvent)>) -> LoadHandle {
+        LoadHandle::new(|| {})
+    }
+}
+
+struct Fixture {
+    browser: Rc<Browser>,
+    events: Rc<RefCell<Vec<BrowserEvent>>>,
+}
+
+impl Fixture {
+    fn new(count: usize) -> Self {
+        let browser = Browser::new(Rc::new(PendingSource));
+        browser.navigate(Location::local("/fixture"));
+        let request = browser
+            .state
+            .borrow()
+            .request_id_for_depth(0)
+            .expect("request");
+        {
+            let mut state = browser.state.borrow_mut();
+            state.install_snapshot(request, (0..count).map(entry).collect());
+            state.finish(request, false, None, None);
+            if let Some(last) = count.checked_sub(1) {
+                state.select(0, last);
+            }
+        }
+        let events = Rc::new(RefCell::new(Vec::new()));
+        let observed = events.clone();
+        browser.observe(move |event| observed.borrow_mut().push(event.clone()));
+        Self { browser, events }
+    }
+
+    fn plan(&self, terminal: PublishTerminal) -> PublicationPlan {
+        let state = self.browser.state.borrow();
+        PublicationPlan {
+            request_id: state.request_id_for_depth(0).expect("request"),
+            total: state.columns[0].entries.len(),
+            focused: state.columns[0].selected,
+            positions: state.selected_positions(0),
+            terminal,
+        }
+    }
+
+    fn publish(&self) {
+        self.browser
+            .publish_staged(0, self.plan(PublishTerminal::SortingFinished));
+    }
+
+    fn wait_for_completion(&self) {
+        pump_until(|| self.browser.staged_publishes.borrow().is_empty());
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        self.browser.clear_observer();
+        self.browser.cancel_deferred_work();
+    }
+}
+
+fn entry(index: usize) -> FileEntry {
+    let name = format!("entry-{index:05}");
+    FileEntry {
+        location: Location::local(format!("/fixture/{name}")),
+        native_name: name.clone().into(),
+        display_name: name,
+        thumbnail_path: None,
+        kind: EntryKind::File,
+        size: MetadataValue::Unknown,
+        modified_unix_seconds: MetadataValue::Unknown,
+        mode: MetadataValue::Unknown,
+        is_hidden: false,
+    }
+}
+
+fn pump_until(done: impl Fn() -> bool) {
+    let context = glib::MainContext::default();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !done() {
+        assert!(Instant::now() < deadline, "publication did not converge");
+        context.iteration(false);
+    }
+}
+
+fn assert_selection_then_sorting(events: &[BrowserEvent], focused: usize) {
+    assert!(matches!(&events[events.len() - 2],
+        BrowserEvent::SelectionSetChanged { depth: 0, positions, focused: actual, take_focus: false }
+        if *actual == focused && positions == &[focused]));
+    assert!(matches!(
+        events.last(),
+        Some(BrowserEvent::SortingFinished { depth: 0 })
+    ));
+}
+
+#[test]
+fn chunks_are_bounded_by_budget_snapshot_and_current_model() {
+    for (published, total, available, expected) in [
+        (128, 5000, 5000, 2048),
+        (128, 700, 900, 572),
+        (128, 900, 700, 572),
+        (700, 700, 900, 0),
+        (700, 900, 700, 0),
+        (700, 900, 600, 0),
+    ] {
+        let staged = StagedPublish {
+            published,
+            plan: PublicationPlan {
+                request_id: RequestId(1),
+                total,
+                focused: None,
+                positions: vec![],
+                terminal: PublishTerminal::SortingFinished,
+            },
+        };
+        assert_eq!(staged.next_chunk(available), (published, expected));
+    }
+}
+
+#[test]
+fn inline_boundary_preserves_row_selection_and_terminal_order() {
+    let _guard = ASYNC_MAIN_CONTEXT_DEFAULT.lock().expect("async test lock");
+    for count in [0, STAGE_INLINE_LIMIT] {
+        let fixture = Fixture::new(count);
+        fixture.publish();
+        let events = fixture.events.borrow();
+        assert!(
+            matches!(events.first(), Some(BrowserEvent::EntriesReplaced { depth: 0, count: actual }) if *actual == count)
+        );
+        assert_eq!(events.len(), if count == 0 { 2 } else { 3 });
+        if count > 0 {
+            assert_selection_then_sorting(&events, count - 1);
+        }
+        assert!(matches!(
+            events.last(),
+            Some(BrowserEvent::SortingFinished { depth: 0 })
+        ));
+        assert!(fixture.browser.staged_publishes.borrow().is_empty());
+        assert!(fixture.browser.publish_timer.borrow().is_none());
+    }
+}
+
+#[test]
+fn staged_boundary_defers_selection_and_completion_until_tails() {
+    let _guard = ASYNC_MAIN_CONTEXT_DEFAULT.lock().expect("async test lock");
+    let fixture = Fixture::new(STAGE_INLINE_LIMIT + 1);
+    fixture.publish();
+    assert!(matches!(
+        fixture.events.borrow().as_slice(),
+        [BrowserEvent::EntriesReplaced {
+            depth: 0,
+            count: FIRST_PUBLISH_COUNT
+        }]
+    ));
+    assert!(fixture.browser.publish_timer.borrow().is_some());
+    fixture.wait_for_completion();
+    let events = fixture.events.borrow();
+    assert_eq!(events.len(), 4);
+    assert!(
+        matches!(events[1], BrowserEvent::EntriesPublished { depth: 0, position: FIRST_PUBLISH_COUNT, count } if count == STAGE_INLINE_LIMIT + 1 - FIRST_PUBLISH_COUNT)
+    );
+    assert_selection_then_sorting(&events, STAGE_INLINE_LIMIT);
+    assert!(fixture.browser.publish_timer.borrow().is_none());
+}
+
+#[test]
+fn slow_observers_yield_between_chunks_without_early_completion() {
+    let _guard = ASYNC_MAIN_CONTEXT_DEFAULT.lock().expect("async test lock");
+    let total = FIRST_PUBLISH_COUNT + PUBLISH_TAIL_CHUNK * 2 + 9;
+    let fixture = Fixture::new(total);
+    let delayed = Rc::new(Cell::new(false));
+    let observed = delayed.clone();
+    fixture.browser.observe(move |event| {
+        if matches!(event, BrowserEvent::EntriesPublished { .. }) && !observed.replace(true) {
+            // Consume the slice deliberately; this is not a wait for async state.
+            std::thread::sleep(PUBLISH_SLICE_BUDGET);
+        }
+    });
+    fixture.publish();
+    pump_until(|| delayed.get());
+    assert_eq!(fixture.events.borrow().len(), 2);
+    assert_eq!(
+        fixture.browser.staged_publishes.borrow()[&0].published,
+        FIRST_PUBLISH_COUNT + PUBLISH_TAIL_CHUNK
+    );
+    assert!(fixture.browser.publish_timer.borrow().is_some());
+    fixture.wait_for_completion();
+    let events = fixture.events.borrow();
+    let chunks: Vec<_> = events
+        .iter()
+        .filter_map(|event| match event {
+            BrowserEvent::EntriesPublished {
+                position, count, ..
+            } => Some((*position, *count)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(chunks, vec![(128, 2048), (2176, 2048), (4224, 9)]);
+    assert_selection_then_sorting(&events, total - 1);
+}
+
+#[test]
+fn draining_uses_current_rows_and_completes_only_once() {
+    let _guard = ASYNC_MAIN_CONTEXT_DEFAULT.lock().expect("async test lock");
+    let fixture = Fixture::new(700);
+    fixture.browser.publish_staged(
+        0,
+        fixture.plan(PublishTerminal::LoadFinished {
+            truncated: true,
+            retry_metadata: false,
+        }),
+    );
+    fixture.browser.state.borrow_mut().columns[0]
+        .entries
+        .extend((700..703).map(entry));
+    fixture.events.borrow_mut().clear();
+    fixture.browser.drain_publish(0);
+    {
+        let events = fixture.events.borrow();
+        assert_eq!(events.len(), 3);
+        assert!(matches!(
+            events[0],
+            BrowserEvent::EntriesPublished {
+                depth: 0,
+                position: 128,
+                count: 575
+            }
+        ));
+        assert!(
+            matches!(&events[1], BrowserEvent::SelectionSetChanged { focused: 699, positions, take_focus: false, .. } if positions == &[699])
+        );
+        assert!(matches!(
+            events[2],
+            BrowserEvent::LoadFinished {
+                depth: 0,
+                truncated: true
+            }
+        ));
+    }
+    fixture.browser.drain_publish(0);
+    pump_until(|| fixture.browser.publish_timer.borrow().is_none());
+    assert_eq!(fixture.events.borrow().len(), 3);
+}
+
+#[test]
+fn stale_request_discards_queued_rows_and_terminal() {
+    let _guard = ASYNC_MAIN_CONTEXT_DEFAULT.lock().expect("async test lock");
+    let fixture = Fixture::new(700);
+    fixture.publish();
+    fixture.events.borrow_mut().clear();
+    fixture
+        .browser
+        .state
+        .borrow_mut()
+        .navigate(Location::local("/replacement"), RequestId(99));
+    fixture.wait_for_completion();
+    assert!(fixture.events.borrow().is_empty());
+    assert!(fixture.browser.publish_timer.borrow().is_none());
+    assert!(fixture.browser.state.borrow().columns[0].entries.is_empty());
+}
+
+#[test]
+fn metadata_retry_starts_only_after_load_completion() {
+    let _guard = ASYNC_MAIN_CONTEXT_DEFAULT.lock().expect("async test lock");
+    for count in [1, 700] {
+        for retry_metadata in [false, true] {
+            let fixture = Fixture::new(count);
+            fixture.browser.state.borrow_mut().apply_sort_preferences(
+                0,
+                ViewPreferences {
+                    sort_key: SortKey::Size,
+                    ..ViewPreferences::default()
+                },
+            );
+            fixture.browser.publish_staged(
+                0,
+                fixture.plan(PublishTerminal::LoadFinished {
+                    truncated: false,
+                    retry_metadata,
+                }),
+            );
+            fixture.wait_for_completion();
+            let events = fixture.events.borrow();
+            let finished = events
+                .iter()
+                .position(|event| matches!(event, BrowserEvent::LoadFinished { .. }))
+                .expect("load completion");
+            let retry = events
+                .iter()
+                .position(|event| matches!(event, BrowserEvent::SortingStarted { .. }));
+            assert_eq!(retry.is_some(), retry_metadata);
+            assert!(retry.is_none_or(|position| position > finished));
+        }
+    }
+}
+
+#[test]
+fn sort_paths_capture_selection_before_preference_observers() {
+    let _guard = ASYNC_MAIN_CONTEXT_DEFAULT.lock().expect("async test lock");
+    for awaited in [false, true] {
+        let fixture = Fixture::new(700);
+        let weak = Rc::downgrade(&fixture.browser);
+        fixture.browser.observe_preferences(move |_| {
+            weak.upgrade()
+                .expect("browser")
+                .state
+                .borrow_mut()
+                .select(0, 0);
+        });
+        fixture.browser.pending_sort.set(Some((17, 0)));
+        if awaited {
+            fixture
+                .browser
+                .finish_awaited_sort(0, 17, ViewPreferences::default());
+        } else {
+            fixture.browser.apply_debounced_sort(0, 17, |_| {});
+        }
+        assert_eq!(fixture.browser.state.borrow().columns[0].selected, Some(0));
+        {
+            let staged = fixture.browser.staged_publishes.borrow();
+            assert_eq!(staged[&0].plan.focused, Some(699));
+            assert_eq!(staged[&0].plan.positions, vec![699]);
+            assert_eq!(staged[&0].plan.total, 700);
+        }
+        fixture.wait_for_completion();
+        assert_selection_then_sorting(&fixture.events.borrow(), 699);
+    }
+}
+
+#[test]
+fn cancelling_last_publication_removes_the_idle_source() {
+    let _guard = ASYNC_MAIN_CONTEXT_DEFAULT.lock().expect("async test lock");
+    let fixture = Fixture::new(700);
+    fixture.publish();
+    fixture.events.borrow_mut().clear();
+    fixture.browser.cancel_publish(0);
+    fixture.browser.cancel_publish(0);
+    assert!(fixture.browser.staged_publishes.borrow().is_empty());
+    assert!(fixture.browser.publish_timer.borrow().is_none());
+    assert!(fixture.events.borrow().is_empty());
+}
+
+#[test]
+fn tail_observer_can_cancel_publication_without_borrowing_or_completion() {
+    let _guard = ASYNC_MAIN_CONTEXT_DEFAULT.lock().expect("async test lock");
+    let fixture = Fixture::new(5000);
+    let weak = Rc::downgrade(&fixture.browser);
+    fixture.browser.observe(move |event| {
+        if matches!(event, BrowserEvent::EntriesPublished { .. }) {
+            let browser = weak.upgrade().expect("browser");
+            assert_eq!(browser.state.borrow_mut().columns.len(), 1);
+            browser.cancel_publish(0);
+        }
+    });
+    fixture.publish();
+    fixture.wait_for_completion();
+    assert!(matches!(
+        fixture.events.borrow().as_slice(),
+        [
+            BrowserEvent::EntriesReplaced { .. },
+            BrowserEvent::EntriesPublished { .. }
+        ]
+    ));
+    assert!(fixture.browser.publish_timer.borrow().is_none());
+}


### PR DESCRIPTION
## Description

Separate staged row publication from the application browser controller. An owned publication plan carries request identity, row count, selection, and terminal data; streaming progress stays separate. Share selection/completion dispatch across inline publication, idle tails, and synchronous draining, and separate chunk calculation from observer calls.

Preserve prefix/chunk limits, idle priority, cooperative time budgets, cancellation, and event order. Sort paths still capture their publication data before preference observers run. Ten focused tests cover these boundaries; sorting workers, remote coalescing, and operation callbacks remain separate follow-ups.

Local CodeScene CLI 1.0.40 against `ed5e1bd`: `app/browser.rs` **3.94 → 4.04**; publication implementation/tests **10.00**. This removes the complex tail-dispatch and argument-heavy publication findings, not the controller's remaining debt.

## Visual evidence

N/A: internal behavior-preserving refactor; no intended visual changes or baseline updates.

## How to test

1. Open a directory containing several thousand files. Check that the first rows appear promptly and the rest arrive without losing the final selection.
2. Select a file near the end, change sorting (Name, Size, Modified), and switch between Columns, Icons, and List. Check that selection follows the same file and loading/sorting indicators settle.
3. Refresh or navigate away while rows are arriving. Return to the directory and create or rename a file; check that the listing converges without stale rows or a stuck indicator.

**Expected result:** Unchanged row ordering, selection restoration, and completion behavior; superseded work does not publish into the current directory.

## Related issue

Refs #550 (partial initiative; keep the umbrella open).
