### PR TITLE
refactor(browser): separate alternate-mode event effects

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,6 +65,20 @@ policy live behind the UI presentation boundary (`ui/browser_modes.rs`); shared 
 the application layer. A future mode should therefore add a renderer rather than add mode checks to
 filesystem, navigation, or operation code.
 
+`ui/browser_modes/events.rs` applies alternate-mode events on the same `ModeViews`.
+Structural events rebuild the active presentation; row, loading, and selection handlers
+keep their effects separate. Only panes belonging to the active mode and event depth
+receive incremental updates. Shared browser effects in `ui/browser/events.rs` still run
+before alternate-mode dispatch.
+
+Pane helpers share string-model splicing, but authoritative entry borrows end before GTK
+notifications. Reload detaches selection/filter models without detaching the collection
+views; completion or failure reconnects them. Teardown retains its stronger detachment.
+Busy insertions/publication, replacement, and splices keep their distinct count/spinner
+rules. Selection restoration captures existing pane focus before applying the selection
+and preserves explicit focus requests and empty-selection behavior. Renderer construction,
+rename, pointer policy, and preference ownership remain separate responsibilities.
+
 Pointer intent is shared through `ui/pointer.rs` and `ui/marquee.rs`. In all three modes,
 thumbnail slots, rendered row text/metadata, and Icons' caption region are item drag targets;
 unused label allocation and the gutters beside thumbnails are marquee origins. Both paths use

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5,3 +5,4 @@ mod navigation;
 mod peek;
 
 pub use browser::{Browser, BrowserColumnSnapshot, BrowserEvent};
+pub(crate) use navigation::{EntryInsertion, EntrySplice};

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -19,10 +19,12 @@ pub(super) use super::icons_cell::{
     icons_card_icon_slot,
 };
 use crate::{
-    app::{Browser, BrowserColumnSnapshot, BrowserEvent},
+    app::{Browser, BrowserColumnSnapshot},
     model::{FileEntry, Location, MetadataValue, SortDirection, SortKey},
     ui::browser::paths::is_trash_location,
 };
+
+mod events;
 
 const LIST_COLUMN_WIDTHS: [i32; 5] = [160, 160, 90, 120, 150];
 const LIST_COLUMN_MIN_WIDTHS: [i32; 5] = [160, 80, 70, 80, 110];
@@ -795,185 +797,6 @@ impl ModeViews {
         self.group_by_type = enabled;
         if self.mode.supports_type_grouping() {
             self.rebuild_list();
-        }
-    }
-
-    pub fn handle(&mut self, event: &BrowserEvent) {
-        match event {
-            BrowserEvent::Reset => {
-                self.clear_icons();
-                self.clear_list();
-            }
-            BrowserEvent::ColumnsTruncated { .. } => match self.mode {
-                BrowserMode::Columns => {}
-                BrowserMode::Icons => self.rebuild_icons(),
-                BrowserMode::List => self.rebuild_list(),
-            },
-            BrowserEvent::ColumnAdded { depth, .. }
-                if self.browser.active_depth() == Some(*depth) =>
-            {
-                self.browser.select_first_on_load(*depth);
-                match self.mode {
-                    BrowserMode::Columns => {}
-                    BrowserMode::Icons => {
-                        self.rebuild_icons();
-                    }
-                    BrowserMode::List => {
-                        self.rebuild_list();
-                    }
-                }
-            }
-            BrowserEvent::ColumnAdded { .. } => {}
-            BrowserEvent::EntriesInserted { depth, insertions } => {
-                for pane in self.panes_at(*depth) {
-                    for insertion in insertions {
-                        let values: Vec<String> = insertion
-                            .entries
-                            .iter()
-                            .map(super::browser::entry_model_value)
-                            .collect();
-                        let values_ref: Vec<&str> = values.iter().map(String::as_str).collect();
-                        pane.model.splice(insertion.position as u32, 0, &values_ref);
-                    }
-                    if !pane.spinner.is_spinning() {
-                        show_count(pane);
-                    }
-                }
-            }
-            BrowserEvent::EntriesReplaced { depth, count } => {
-                for pane in self.panes_at(*depth) {
-                    if *count > 0 {
-                        pane.spinner.stop();
-                        pane.spinner.set_visible(false);
-                    }
-                    replace_entries(pane, &self.browser, *count);
-                }
-            }
-            BrowserEvent::EntriesPublished {
-                depth,
-                position,
-                count,
-            } => {
-                for pane in self.panes_at(*depth) {
-                    let values = self
-                        .browser
-                        .with_entries(
-                            *depth,
-                            *position..position.saturating_add(*count),
-                            |entries| {
-                                entries
-                                    .iter()
-                                    .map(super::browser::entry_model_value)
-                                    .collect::<Vec<_>>()
-                            },
-                        )
-                        .unwrap_or_default();
-                    let values: Vec<_> = values.iter().map(String::as_str).collect();
-                    pane.model.splice(*position as u32, 0, &values);
-                    if !pane.spinner.is_spinning() {
-                        show_count(pane);
-                    }
-                }
-            }
-            BrowserEvent::MetadataFilled { depth, updates } => {
-                if self.mode == BrowserMode::List {
-                    for pane in self.panes_at(*depth) {
-                        update_bound_list_metadata(pane, updates);
-                    }
-                }
-            }
-            BrowserEvent::SortingStarted { depth } => {
-                for pane in self.panes_at(*depth) {
-                    pane.spinner.set_tooltip_text(Some("Sorting…"));
-                    pane.spinner.set_visible(true);
-                    pane.spinner.start();
-                }
-            }
-            BrowserEvent::SortingFinished { depth } => {
-                for pane in self.panes_at(*depth) {
-                    pane.spinner.stop();
-                    pane.spinner.set_visible(false);
-                    pane.spinner.set_tooltip_text(None);
-                }
-            }
-            BrowserEvent::EntriesSpliced { depth, splices, .. } => {
-                for pane in self.panes_at(*depth) {
-                    for splice in splices {
-                        let values: Vec<String> = splice
-                            .entries
-                            .iter()
-                            .map(super::browser::entry_model_value)
-                            .collect();
-                        let values_ref: Vec<&str> = values.iter().map(String::as_str).collect();
-                        pane.model.splice(
-                            splice.position as u32,
-                            splice.removed as u32,
-                            &values_ref,
-                        );
-                    }
-                    show_count(pane);
-                }
-            }
-            BrowserEvent::ColumnReloaded { depth } => {
-                for pane in self.panes_at(*depth) {
-                    pane.detached.set(true);
-                    for section in pane.all_sections() {
-                        section.syncing.set(true);
-                        section.selection.set_model(None::<&gio::ListModel>);
-                    }
-                    if let Some(filtered) = pane.filter_model.as_ref() {
-                        filtered.set_model(None::<&gio::ListModel>);
-                    }
-                    pane.model.splice(0, pane.model.n_items(), &[]);
-                    pane.truncated_hint.set_visible(false);
-                    pane.spinner.set_visible(true);
-                    pane.spinner.start();
-                    pane.loading.start();
-                }
-            }
-            BrowserEvent::LoadFinished { depth, truncated } => {
-                for pane in self.panes_at(*depth) {
-                    reconnect_pane_model(pane);
-                    pane.spinner.stop();
-                    pane.spinner.set_visible(false);
-                    pane.truncated_hint.set_visible(*truncated);
-                    show_count(pane);
-                }
-            }
-            BrowserEvent::LoadFailed { depth, message } => {
-                for pane in self.panes_at(*depth) {
-                    reconnect_pane_model(pane);
-                    pane.spinner.stop();
-                    pane.status
-                        .set_label(&format!("Unable to read this directory\n{message}"));
-                    pane.status.add_css_class("error");
-                    pane.loading.show("status");
-                }
-            }
-            BrowserEvent::SelectionSetChanged {
-                depth,
-                positions,
-                take_focus,
-                ..
-            } => {
-                let view_has_focus = self
-                    .panes_at(*depth)
-                    .iter()
-                    .any(|pane| pane_holds_keyboard_focus(pane));
-                for pane in self.panes_at(*depth) {
-                    set_selections(pane, positions);
-                }
-                if *take_focus || (view_has_focus && !positions.is_empty()) {
-                    self.focus_visible_pane(*depth);
-                }
-            }
-            BrowserEvent::FocusChanged { depth, position } => {
-                for pane in self.panes_at(*depth) {
-                    set_selections(pane, &position.iter().copied().collect::<Vec<_>>());
-                }
-                self.focus_visible_pane(*depth);
-            }
-            _ => {}
         }
     }
 
@@ -3517,8 +3340,7 @@ fn replace_entries(pane: &Pane, browser: &Browser, count: usize) {
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
-    let values_ref: Vec<&str> = values.iter().map(String::as_str).collect();
-    pane.model.splice(0, pane.model.n_items(), &values_ref);
+    pane.splice_values(0, pane.model.n_items(), &values);
     show_count(pane);
 }
 

--- a/src/ui/browser_modes/events.rs
+++ b/src/ui/browser_modes/events.rs
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use gtk::{gio, prelude::*};
+
+use super::{
+    BrowserMode, ModeViews, Pane, pane_holds_keyboard_focus, reconnect_pane_model, replace_entries,
+    set_selections, show_count, update_bound_list_metadata,
+};
+use crate::{
+    app::{Browser, BrowserEvent, EntryInsertion, EntrySplice},
+    ui::browser::entry_model_value,
+};
+
+impl ModeViews {
+    pub fn handle(&mut self, event: &BrowserEvent) {
+        if self.handle_structure_event(event) {
+            return;
+        }
+        if self.handle_rows_event(event) {
+            return;
+        }
+        if self.handle_loading_event(event) {
+            return;
+        }
+        self.handle_selection_event(event);
+    }
+
+    fn handle_structure_event(&mut self, event: &BrowserEvent) -> bool {
+        match event {
+            BrowserEvent::Reset => {
+                self.clear_icons();
+                self.clear_list();
+            }
+            BrowserEvent::ColumnsTruncated { .. } => self.rebuild_active_mode(),
+            BrowserEvent::ColumnAdded { depth, .. } => {
+                if self.browser.active_depth() == Some(*depth) {
+                    self.browser.select_first_on_load(*depth);
+                    self.rebuild_active_mode();
+                }
+            }
+            _ => return false,
+        }
+        true
+    }
+
+    fn rebuild_active_mode(&mut self) {
+        match self.mode {
+            BrowserMode::Columns => {}
+            BrowserMode::Icons => self.rebuild_icons(),
+            BrowserMode::List => self.rebuild_list(),
+        }
+    }
+
+    fn handle_rows_event(&self, event: &BrowserEvent) -> bool {
+        match event {
+            BrowserEvent::EntriesInserted { depth, insertions } => {
+                self.update_panes(*depth, |pane| pane.insert_rows(insertions));
+            }
+            BrowserEvent::EntriesReplaced { depth, count } => {
+                self.update_panes(*depth, |pane| pane.replace_rows(&self.browser, *count));
+            }
+            BrowserEvent::EntriesPublished {
+                depth,
+                position,
+                count,
+            } => {
+                self.update_panes(*depth, |pane| {
+                    pane.publish_rows(&self.browser, *position, *count)
+                });
+            }
+            BrowserEvent::EntriesSpliced { depth, splices, .. } => {
+                self.update_panes(*depth, |pane| pane.splice_rows(splices));
+            }
+            BrowserEvent::MetadataFilled { depth, updates } => {
+                if self.mode == BrowserMode::List {
+                    self.update_panes(*depth, |pane| update_bound_list_metadata(pane, updates));
+                }
+            }
+            _ => return false,
+        }
+        true
+    }
+
+    fn handle_loading_event(&self, event: &BrowserEvent) -> bool {
+        match event {
+            BrowserEvent::SortingStarted { depth } => {
+                self.update_panes(*depth, Pane::start_sorting)
+            }
+            BrowserEvent::SortingFinished { depth } => {
+                self.update_panes(*depth, Pane::finish_sorting)
+            }
+            BrowserEvent::ColumnReloaded { depth } => self.update_panes(*depth, Pane::reload_rows),
+            BrowserEvent::LoadFinished { depth, truncated } => {
+                self.update_panes(*depth, |pane| pane.finish_loading(*truncated));
+            }
+            BrowserEvent::LoadFailed { depth, message } => {
+                self.update_panes(*depth, |pane| pane.fail_loading(message));
+            }
+            _ => return false,
+        }
+        true
+    }
+
+    fn handle_selection_event(&self, event: &BrowserEvent) {
+        match event {
+            BrowserEvent::SelectionSetChanged {
+                depth,
+                positions,
+                take_focus,
+                ..
+            } => {
+                self.update_selection(*depth, positions, *take_focus);
+            }
+            BrowserEvent::FocusChanged { depth, position } => {
+                self.update_panes(*depth, |pane| {
+                    set_selections(pane, &position.iter().copied().collect::<Vec<_>>())
+                });
+                self.focus_visible_pane(*depth);
+            }
+            _ => {}
+        }
+    }
+
+    fn update_selection(&self, depth: usize, positions: &[usize], take_focus: bool) {
+        let view_has_focus = self
+            .panes_at(depth)
+            .iter()
+            .any(|pane| pane_holds_keyboard_focus(pane));
+        self.update_panes(depth, |pane| set_selections(pane, positions));
+        if take_focus || (view_has_focus && !positions.is_empty()) {
+            self.focus_visible_pane(depth);
+        }
+    }
+
+    fn update_panes(&self, depth: usize, update: impl FnMut(&Pane)) {
+        self.panes_at(depth).into_iter().for_each(update);
+    }
+}
+
+impl Pane {
+    fn insert_rows(&self, insertions: &[EntryInsertion]) {
+        for insertion in insertions {
+            let values: Vec<_> = insertion.entries.iter().map(entry_model_value).collect();
+            self.splice_values(insertion.position as u32, 0, &values);
+        }
+        self.show_count_when_idle();
+    }
+
+    fn replace_rows(&self, browser: &Browser, count: usize) {
+        if count > 0 {
+            self.hide_spinner();
+        }
+        replace_entries(self, browser, count);
+    }
+
+    fn publish_rows(&self, browser: &Browser, position: usize, count: usize) {
+        // Finish borrowing authoritative entries before GTK model notifications.
+        let values = browser
+            .with_entries(
+                self.depth,
+                position..position.saturating_add(count),
+                |entries| entries.iter().map(entry_model_value).collect::<Vec<_>>(),
+            )
+            .unwrap_or_default();
+        self.splice_values(position as u32, 0, &values);
+        self.show_count_when_idle();
+    }
+
+    fn splice_rows(&self, splices: &[EntrySplice]) {
+        for splice in splices {
+            let values: Vec<_> = splice.entries.iter().map(entry_model_value).collect();
+            self.splice_values(splice.position as u32, splice.removed as u32, &values);
+        }
+        show_count(self);
+    }
+
+    pub(super) fn splice_values(&self, position: u32, removed: u32, values: &[String]) {
+        let values: Vec<_> = values.iter().map(String::as_str).collect();
+        self.model.splice(position, removed, &values);
+    }
+
+    fn show_count_when_idle(&self) {
+        if !self.spinner.is_spinning() {
+            show_count(self);
+        }
+    }
+
+    fn hide_spinner(&self) {
+        self.spinner.stop();
+        self.spinner.set_visible(false);
+    }
+
+    fn start_sorting(&self) {
+        self.spinner.set_tooltip_text(Some("Sorting…"));
+        self.spinner.set_visible(true);
+        self.spinner.start();
+    }
+
+    fn finish_sorting(&self) {
+        self.hide_spinner();
+        self.spinner.set_tooltip_text(None);
+    }
+
+    fn reload_rows(&self) {
+        // Reload disconnects selection/filter models, not the collection views:
+        // teardown's detach_pane_models also detaches those views.
+        self.detached.set(true);
+        for section in self.all_sections() {
+            section.syncing.set(true);
+            section.selection.set_model(None::<&gio::ListModel>);
+        }
+        if let Some(filtered) = self.filter_model.as_ref() {
+            filtered.set_model(None::<&gio::ListModel>);
+        }
+        self.model.splice(0, self.model.n_items(), &[]);
+        self.truncated_hint.set_visible(false);
+        self.spinner.set_visible(true);
+        self.spinner.start();
+        self.loading.start();
+    }
+
+    fn finish_loading(&self, truncated: bool) {
+        reconnect_pane_model(self);
+        self.hide_spinner();
+        self.truncated_hint.set_visible(truncated);
+        show_count(self);
+    }
+
+    fn fail_loading(&self, message: &str) {
+        reconnect_pane_model(self);
+        self.spinner.stop();
+        self.status
+            .set_label(&format!("Unable to read this directory\n{message}"));
+        self.status.add_css_class("error");
+        self.loading.show("status");
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/ui/browser_modes/events/tests.rs
+++ b/src/ui/browser_modes/events/tests.rs
@@ -1,0 +1,473 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::{
+    cell::Cell,
+    rc::Rc,
+    time::{Duration, Instant},
+};
+
+use gtk::glib;
+
+use super::*;
+use crate::{
+    model::{EntryKind, FileEntry, Location, MetadataValue},
+    services::{DirectoryEvent, DirectoryRequest, FileSource, LoadHandle, LocationValidationError},
+    test_support::gtk_test,
+};
+
+struct StaticSource;
+
+impl FileSource for StaticSource {
+    fn validate_location(&self, _: &Location) -> Result<(), LocationValidationError> {
+        Ok(())
+    }
+
+    fn enumerate(&self, request: DirectoryRequest, emit: Rc<dyn Fn(DirectoryEvent)>) -> LoadHandle {
+        emit(DirectoryEvent::Batch {
+            request_id: request.id,
+            entries: entries(),
+        });
+        emit(DirectoryEvent::Finished {
+            request_id: request.id,
+            truncated: false,
+            can_trash: None,
+            can_delete: None,
+        });
+        LoadHandle::new(|| {})
+    }
+}
+
+fn entry(name: &str) -> FileEntry {
+    FileEntry {
+        location: Location::local(format!("/fixture/{name}")),
+        native_name: name.into(),
+        display_name: name.into(),
+        thumbnail_path: None,
+        kind: EntryKind::File,
+        size: MetadataValue::Known(10),
+        modified_unix_seconds: MetadataValue::Known(1),
+        mode: MetadataValue::Known(0o100644),
+        is_hidden: name.starts_with('.'),
+    }
+}
+
+fn entries() -> Vec<FileEntry> {
+    ["a.txt", "b.png", "c.rs"].into_iter().map(entry).collect()
+}
+
+fn presentations() -> [(BrowserMode, bool); 3] {
+    [
+        (BrowserMode::Icons, false),
+        (BrowserMode::List, false),
+        (BrowserMode::List, true),
+    ]
+}
+
+struct Fixture {
+    views: ModeViews,
+    browser: Rc<Browser>,
+    window: gtk::Window,
+    outside: gtk::Entry,
+}
+
+impl Fixture {
+    fn new(mode: BrowserMode, grouped: bool) -> Self {
+        let browser = Browser::new(Rc::new(StaticSource));
+        browser.navigate(Location::local("/fixture"));
+        let mut views = ModeViews::new(
+            &gtk::ScrolledWindow::new(),
+            browser.clone(),
+            Rc::new(Cell::new(true)),
+        );
+        views.set_group_by_type(grouped);
+        views.prepare_mode(mode);
+        views.show_mode(mode);
+        let outside = gtk::Entry::new();
+        let root = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        root.append(&outside);
+        root.append(&views.widget());
+        let window = gtk::Window::builder()
+            .default_width(800)
+            .default_height(600)
+            .child(&root)
+            .build();
+        Self {
+            views,
+            browser,
+            window,
+            outside,
+        }
+    }
+
+    fn pane(&self) -> Pane {
+        self.views.single_pane().expect("visible pane").clone()
+    }
+
+    fn show(&self) {
+        self.window.present();
+        pump_until(|| self.pane().section.view.is_mapped());
+    }
+
+    fn names(&self) -> Vec<String> {
+        let pane = self.pane();
+        (0..pane.model.n_items())
+            .map(|position| pane.model.string(position).expect("row").to_string())
+            .collect()
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        self.views.clear_icons();
+        self.views.clear_list();
+        self.browser.clear_observer();
+        self.window.close();
+    }
+}
+
+fn pump_until(done: impl Fn() -> bool) {
+    let context = glib::MainContext::default();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !done() {
+        assert!(Instant::now() < deadline, "GTK state did not settle");
+        context.iteration(false);
+    }
+}
+
+fn visible_page(pane: &Pane) -> String {
+    pane.stack.visible_child_name().expect("page").to_string()
+}
+
+fn assert_attached(pane: &Pane, attached: bool) {
+    assert_eq!(pane.detached.get(), !attached);
+    for section in pane.all_sections() {
+        assert_eq!(section.selection.model().is_some(), attached);
+        assert_eq!(section.syncing.get(), !attached);
+        let model = if let Some(view) = section.view.downcast_ref::<gtk::GridView>() {
+            view.model()
+        } else {
+            section
+                .view
+                .downcast_ref::<gtk::ListView>()
+                .expect("collection")
+                .model()
+        };
+        assert!(
+            model.is_some(),
+            "reload must retain the collection's selection model"
+        );
+    }
+    if let Some(filtered) = &pane.filter_model {
+        assert_eq!(filtered.model().is_some(), attached);
+    }
+}
+
+#[test]
+fn reload_retains_views_until_terminal_reconnects_models() {
+    gtk_test(
+        "ui::browser_modes::events::tests::reload_retains_views_until_terminal_reconnects_models",
+        || {
+            for (mode, grouped) in presentations() {
+                let mut fixture = Fixture::new(mode, grouped);
+                let pane = fixture.pane();
+                fixture
+                    .views
+                    .handle(&BrowserEvent::ColumnReloaded { depth: 0 });
+                assert_attached(&pane, false);
+                assert_eq!(pane.model.n_items(), 0);
+                assert!(pane.spinner.is_spinning());
+                assert!(!pane.truncated_hint.get_visible());
+                fixture
+                    .views
+                    .handle(&BrowserEvent::EntriesReplaced { depth: 0, count: 1 });
+                assert_attached(&pane, false);
+                assert_eq!(pane.model.n_items(), 1);
+                assert!(!pane.spinner.is_spinning());
+                fixture.views.handle(&BrowserEvent::EntriesPublished {
+                    depth: 0,
+                    position: 1,
+                    count: 2,
+                });
+                fixture.views.handle(&BrowserEvent::LoadFinished {
+                    depth: 0,
+                    truncated: true,
+                });
+                assert_attached(&pane, true);
+                assert_eq!(pane.model.n_items(), 3);
+                assert!(pane.truncated_hint.get_visible());
+                assert!(!pane.spinner.get_visible());
+                assert_eq!(visible_page(&pane), "content");
+            }
+        },
+    );
+}
+
+#[test]
+fn busy_insertions_and_splices_preserve_distinct_presentation_rules() {
+    gtk_test(
+        "ui::browser_modes::events::tests::busy_insertions_and_splices_preserve_distinct_presentation_rules",
+        || {
+            for (mode, grouped) in presentations() {
+                let mut fixture = Fixture::new(mode, grouped);
+                let pane = fixture.pane();
+                fixture
+                    .views
+                    .handle(&BrowserEvent::EntriesReplaced { depth: 0, count: 0 });
+                fixture
+                    .views
+                    .handle(&BrowserEvent::SortingStarted { depth: 0 });
+                fixture.views.handle(&BrowserEvent::EntriesInserted {
+                    depth: 0,
+                    insertions: vec![EntryInsertion {
+                        position: 0,
+                        entries: vec![entry("x.txt")],
+                    }],
+                });
+                assert_eq!(visible_page(&pane), "status");
+                assert!(pane.spinner.is_spinning());
+                assert_eq!(pane.spinner.tooltip_text().as_deref(), Some("Sorting…"));
+                fixture.views.handle(&BrowserEvent::EntriesSpliced {
+                    depth: 0,
+                    selected: None,
+                    splices: vec![EntrySplice {
+                        position: 0,
+                        removed: 1,
+                        entries: vec![entry("y.txt"), entry("z.txt")],
+                    }],
+                });
+                assert_eq!(visible_page(&pane), "content");
+                assert_eq!(
+                    fixture.names(),
+                    vec![
+                        entry_model_value(&entry("y.txt")),
+                        entry_model_value(&entry("z.txt"))
+                    ]
+                );
+                assert!(pane.spinner.is_spinning());
+                fixture
+                    .views
+                    .handle(&BrowserEvent::SortingFinished { depth: 0 });
+                assert!(!pane.spinner.is_spinning());
+                assert!(!pane.spinner.get_visible());
+                assert!(pane.spinner.tooltip_text().is_none());
+            }
+        },
+    );
+}
+
+#[test]
+fn failures_reconnect_without_losing_error_and_empty_transitions() {
+    gtk_test(
+        "ui::browser_modes::events::tests::failures_reconnect_without_losing_error_and_empty_transitions",
+        || {
+            for (mode, grouped) in presentations() {
+                let mut fixture = Fixture::new(mode, grouped);
+                let pane = fixture.pane();
+                fixture
+                    .views
+                    .handle(&BrowserEvent::ColumnReloaded { depth: 0 });
+                fixture.views.handle(&BrowserEvent::LoadFailed {
+                    depth: 0,
+                    message: "provider failure".into(),
+                });
+                assert_attached(&pane, true);
+                assert_eq!(visible_page(&pane), "status");
+                assert_eq!(
+                    pane.status.label(),
+                    "Unable to read this directory\nprovider failure"
+                );
+                assert!(pane.status.has_css_class("error"));
+                assert!(!pane.spinner.is_spinning());
+                assert!(pane.spinner.get_visible());
+                fixture.views.handle(&BrowserEvent::LoadFinished {
+                    depth: 0,
+                    truncated: false,
+                });
+                assert_eq!(pane.status.label(), "This directory is empty");
+                assert!(!pane.status.has_css_class("error"));
+                assert!(!pane.spinner.get_visible());
+                assert_eq!(visible_page(&pane), "status");
+            }
+        },
+    );
+}
+
+#[test]
+fn publication_releases_browser_borrows_before_gtk_notifications() {
+    gtk_test(
+        "ui::browser_modes::events::tests::publication_releases_browser_borrows_before_gtk_notifications",
+        || {
+            for (mode, grouped) in presentations() {
+                let mut fixture = Fixture::new(mode, grouped);
+                fixture
+                    .views
+                    .handle(&BrowserEvent::EntriesReplaced { depth: 0, count: 0 });
+                let changed = Rc::new(Cell::new(false));
+                let observed = changed.clone();
+                let weak = Rc::downgrade(&fixture.browser);
+                fixture
+                    .pane()
+                    .model
+                    .connect_items_changed(move |_, _, _, _| {
+                        weak.upgrade().expect("browser").set_selection(0, &[], None);
+                        observed.set(true);
+                    });
+                fixture.views.handle(&BrowserEvent::EntriesPublished {
+                    depth: 0,
+                    position: 0,
+                    count: 3,
+                });
+                assert!(changed.get());
+                assert_eq!(
+                    fixture.names(),
+                    entries().iter().map(entry_model_value).collect::<Vec<_>>()
+                );
+            }
+        },
+    );
+}
+
+#[test]
+fn inactive_depths_and_cached_modes_do_not_receive_row_updates() {
+    gtk_test(
+        "ui::browser_modes::events::tests::inactive_depths_and_cached_modes_do_not_receive_row_updates",
+        || {
+            let mut fixture = Fixture::new(BrowserMode::Icons, false);
+            let icons = fixture.pane();
+            fixture.views.prepare_mode(BrowserMode::List);
+            fixture.views.show_mode(BrowserMode::List);
+            let list = fixture.pane();
+            let insert = |depth| BrowserEvent::EntriesInserted {
+                depth,
+                insertions: vec![EntryInsertion {
+                    position: 3,
+                    entries: vec![entry("d.txt")],
+                }],
+            };
+            fixture.views.handle(&insert(9));
+            assert_eq!(list.model.n_items(), 3);
+            fixture.views.handle(&insert(0));
+            assert_eq!(list.model.n_items(), 4);
+            assert_eq!(icons.model.n_items(), 3);
+            fixture.views.prepare_mode(BrowserMode::Columns);
+            fixture.views.handle(&insert(0));
+            assert_eq!(list.model.n_items(), 4);
+            fixture.views.handle(&BrowserEvent::Reset);
+            assert!(fixture.views.icons_panes.is_empty());
+            assert!(fixture.views.list_pane.is_none());
+            assert!(fixture.views.icons_root.first_child().is_none());
+            assert!(fixture.views.list_root.first_child().is_none());
+        },
+    );
+}
+
+#[test]
+fn structural_events_rebuild_only_the_active_presentation() {
+    gtk_test(
+        "ui::browser_modes::events::tests::structural_events_rebuild_only_the_active_presentation",
+        || {
+            for (mode, grouped) in presentations() {
+                let mut fixture = Fixture::new(mode, grouped);
+                let old = fixture.pane().shell;
+                fixture.views.handle(&BrowserEvent::ColumnAdded {
+                    depth: 9,
+                    location: Location::local("/other"),
+                });
+                assert_eq!(fixture.pane().shell, old);
+                fixture.views.handle(&BrowserEvent::ColumnAdded {
+                    depth: 0,
+                    location: Location::local("/fixture"),
+                });
+                assert_ne!(fixture.pane().shell, old);
+                let old = fixture.pane().shell;
+                fixture
+                    .views
+                    .handle(&BrowserEvent::ColumnsTruncated { len: 1 });
+                assert_ne!(fixture.pane().shell, old);
+                assert_eq!(fixture.names().len(), 3);
+            }
+        },
+    );
+}
+
+#[test]
+fn selection_preserves_external_focus_and_restores_requested_pane_focus() {
+    gtk_test(
+        "ui::browser_modes::events::tests::selection_preserves_external_focus_and_restores_requested_pane_focus",
+        || {
+            for (mode, grouped) in presentations() {
+                let mut fixture = Fixture::new(mode, grouped);
+                fixture.show();
+                fixture.outside.grab_focus();
+                fixture.browser.set_selection(0, &[1], Some(1));
+                let selection = |positions, take_focus| BrowserEvent::SelectionSetChanged {
+                    depth: 0,
+                    positions,
+                    focused: 1,
+                    take_focus,
+                };
+                fixture.views.handle(&selection(vec![1], false));
+                assert!(super::super::widget_has_focus(
+                    &fixture.outside,
+                    gtk::prelude::RootExt::focus(&fixture.window).as_ref()
+                ));
+                assert_eq!(fixture.views.selected_positions(), Some((0, vec![1])));
+                fixture.views.handle(&selection(vec![1], true));
+                pump_until(|| fixture.views.item_view_has_focus());
+                fixture.views.suppress_focus_scroll();
+                fixture.views.handle(&selection(vec![1], false));
+                assert!(!fixture.views.suppress_focus_scroll.get());
+                fixture.views.suppress_focus_scroll();
+                fixture.views.handle(&selection(vec![], false));
+                assert!(fixture.views.suppress_focus_scroll.get());
+                fixture.views.handle(&BrowserEvent::FocusChanged {
+                    depth: 0,
+                    position: Some(1),
+                });
+                assert!(!fixture.views.suppress_focus_scroll.get());
+                assert_eq!(fixture.views.selected_positions(), Some((0, vec![1])));
+            }
+        },
+    );
+}
+
+fn bound_row(pane: &Pane, source: usize) -> Option<gtk::Box> {
+    pane.section.bound_items.borrow().iter().find_map(|bound| {
+        let item = bound.item.upgrade()?;
+        (pane.source_index.of_item(&item.item()?) == Some(source))
+            .then(|| bound.widget.upgrade()?.downcast::<gtk::Box>().ok())
+            .flatten()
+    })
+}
+
+#[test]
+fn list_metadata_updates_bound_rows_without_replacing_the_model() {
+    gtk_test(
+        "ui::browser_modes::events::tests::list_metadata_updates_bound_rows_without_replacing_the_model",
+        || {
+            for grouped in [false, true] {
+                let mut fixture = Fixture::new(BrowserMode::List, grouped);
+                fixture.show();
+                let pane = fixture.pane();
+                pump_until(|| bound_row(&pane, 1).is_some());
+                let row = bound_row(&pane, 1).expect("bound row");
+                let (_, _, _, mode, size, _, _) =
+                    super::super::list_row_parts(&row).expect("list labels");
+                let changed = Rc::new(Cell::new(false));
+                let observed = changed.clone();
+                pane.model
+                    .connect_items_changed(move |_, _, _, _| observed.set(true));
+                let mut update = entry("b.png");
+                update.size = MetadataValue::Known(2048);
+                update.mode = MetadataValue::Known(0o100600);
+                fixture.views.handle(&BrowserEvent::MetadataFilled {
+                    depth: 0,
+                    updates: vec![(1, update.clone())],
+                });
+                assert_eq!(size.label(), super::super::entry_size(&update));
+                assert_eq!(mode.label(), super::super::entry_mode(&update));
+                assert!(!changed.get());
+            }
+        },
+    );
+}


### PR DESCRIPTION
## Description

Separate Icons/List event handling into structural, row, loading, and selection effects on the existing `ModeViews`. Pane helpers share string-model splicing and busy-state operations without changing when each event updates presentation. Name the existing insertion/splice payloads through the crate-local application facade rather than exposing navigation internals.

Preserve reload-versus-teardown attachment, active-mode/depth routing, metadata updates, and focus policy. Eight adjacent GTK tests exercise grouped/ungrouped List and Icons, including synchronous model notifications and focus restoration. Renderer factories, rename behavior, pointer policy, and preference ownership remain separate work.

Local CodeScene CLI 1.0.40 against `0bd3870`: `browser_modes.rs` **2.75 → 3.18**, event implementation **9.68**, tests **9.38**. The former 178-line / complexity-28 handler is decomposed; remaining factory, focus-condition, and assertion findings are not suppressed.

## Visual evidence

N/A: behavior-preserving event-handling refactor; no intended visual changes or baseline updates.

## How to test

1. In Icons and List, open a directory with many files, refresh, and navigate away during loading. Check that rows and loading/error indicators settle normally.
2. Repeat in List with type grouping enabled. Sort, select multiple files, and modify or rename a file; check ordering, metadata, and selection remain correct.
3. Put focus in a header/filter field while the listing updates, then return to the items and navigate with the keyboard. Check that background selection updates do not steal editing focus and explicit item-focus actions still work.
4. Switch through Columns, Icons, and List, then navigate back. Check that cached views do not receive rows belonging to another directory.

**Expected result:** Unchanged listings, reload/error states, metadata, and focus behavior in all modes.

## Related issue

Refs #550 (partial initiative; keep the umbrella open).
