### PR TITLE
ci(e2e): publish pinned environments and explain bootstrap failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
 on:
+  workflow_dispatch:
+    inputs:
+      require_published_environments:
+        description: Bypass the fast dependency cache and require verified published base images
+        type: boolean
+        default: false
   push:
     branches: [main]
   pull_request:
@@ -10,7 +16,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ inputs.require_published_environments && 'published' || 'normal' }}
   cancel-in-progress: true
 
 jobs:
@@ -80,6 +86,7 @@ jobs:
           lookup-only: true
 
       - name: Restore the compiled dependency layers with segmented cache transfers
+        if: ${{ !inputs.require_published_environments }}
         id: dependency-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -88,6 +95,18 @@ jobs:
 
       - name: Set up cached container builder
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Resolve trusted published base images to OCI digests
+        if: steps.dependency-cache.outputs.cache-hit != 'true'
+        id: registry
+        env:
+          REQUIRE_PUBLISHED: ${{ inputs.require_published_environments }}
+        run: |
+          if [ "$REQUIRE_PUBLISHED" = true ]; then
+            python3 scripts/e2e_images.py bases --require-published >> "$GITHUB_OUTPUT"
+          else
+            python3 scripts/e2e_images.py bases >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Build the tested revision once and collect its exact inventory
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -99,12 +118,15 @@ jobs:
           build-args: |
             E2E_UID=${{ steps.identity.outputs.uid }}
             E2E_GID=${{ steps.identity.outputs.gid }}
-            E2E_IMAGE_KEY=${{ steps.identity.outputs.image_key }}
             STRATA_BUILD_COMMIT=${{ github.sha }}
+            E2E_DEPENDENCIES_IMAGE=${{ steps.registry.outputs.dependencies_image || 'dependencies' }}
           outputs: type=local,dest=target/e2e-bundle
           cache-from: |
-            ${{ steps.dependency-cache.outputs.cache-hit == 'true' && 'type=local,src=target/e2e-dependency-cache' || 'type=gha,scope=strata-e2e-dependencies-v1' }}
-            ${{ steps.dependency-cache.outputs.cache-hit != 'true' && 'type=gha,scope=strata-e2e-v1' || '' }}
+            ${{ steps.dependency-cache.outputs.cache-hit == 'true' && 'type=local,src=target/e2e-dependency-cache' || '' }}
+            ${{ steps.dependency-cache.outputs.cache-hit != 'true' && steps.registry.outputs.dependencies_image == 'dependencies' && 'type=gha,scope=strata-e2e-dependencies-v1' || '' }}
+            ${{ steps.dependency-cache.outputs.cache-hit != 'true' && steps.registry.outputs.dependencies_image == 'dependencies' && 'type=gha,scope=strata-e2e-v1' || '' }}
+            ${{ steps.dependency-cache.outputs.cache-hit != 'true' && steps.registry.outputs.dependencies_image == 'dependencies' && 'type=gha,scope=strata-e2e-indexes-v1' || '' }}
+            ${{ steps.registry.outputs.dependencies_image == 'dependencies' && steps.registry.outputs.cache_from || '' }}
 
       - name: Prepare a runtime archive on cache miss
         if: steps.runtime-cache.outputs.cache-hit != 'true'
@@ -116,17 +138,21 @@ jobs:
         with:
           context: .
           file: tests/e2e/Dockerfile
-          target: runtime
+          target: ci-runtime
           platforms: linux/amd64
           build-args: |
             E2E_UID=${{ steps.identity.outputs.uid }}
             E2E_GID=${{ steps.identity.outputs.gid }}
-            E2E_IMAGE_KEY=${{ steps.identity.outputs.image_key }}
+            E2E_RUNTIME_IMAGE=${{ steps.registry.outputs.runtime_image || 'runtime' }}
+          labels: ${{ (steps.registry.outputs.runtime_image == '' || steps.registry.outputs.runtime_image == 'runtime') && format('org.strata.e2e.inputs={0}', steps.identity.outputs.image_key) || '' }}
           tags: strata-e2e:ci-runtime
           outputs: type=docker,dest=target/e2e-runtime/runtime.tar
           cache-from: |
-            ${{ steps.dependency-cache.outputs.cache-hit == 'true' && 'type=local,src=target/e2e-dependency-cache' || 'type=gha,scope=strata-e2e-dependencies-v1' }}
-            ${{ steps.dependency-cache.outputs.cache-hit != 'true' && 'type=gha,scope=strata-e2e-v1' || '' }}
+            ${{ steps.dependency-cache.outputs.cache-hit == 'true' && 'type=local,src=target/e2e-dependency-cache' || '' }}
+            ${{ steps.dependency-cache.outputs.cache-hit != 'true' && steps.registry.outputs.runtime_image == 'runtime' && 'type=gha,scope=strata-e2e-dependencies-v1' || '' }}
+            ${{ steps.dependency-cache.outputs.cache-hit != 'true' && steps.registry.outputs.runtime_image == 'runtime' && 'type=gha,scope=strata-e2e-v1' || '' }}
+            ${{ steps.dependency-cache.outputs.cache-hit != 'true' && steps.registry.outputs.runtime_image == 'runtime' && 'type=gha,scope=strata-e2e-indexes-v1' || '' }}
+            ${{ steps.registry.outputs.runtime_image == 'runtime' && steps.registry.outputs.cache_from || '' }}
 
       - name: Compress the runtime without another image load or build
         if: steps.runtime-cache.outputs.cache-hit != 'true'
@@ -310,7 +336,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Test release version calculation
+      - name: Test CI and release helpers
         run: python3 -m unittest discover -s scripts -p 'test_*.py'
 
   repository-policy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,7 @@ jobs:
     env:
       DOCKER_BUILD_RECORD_UPLOAD: 'false'
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    # Preserve cold-build diagnostics without exempting them from the 180s gate.
-    # The separate warmer publishes the large dependency cache.
+    # Bound hung bootstrap jobs independently of informational timing reports.
     timeout-minutes: 10
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
@@ -209,7 +208,7 @@ jobs:
     name: E2E shard ${{ matrix.shard }}
     needs: e2e-build
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 3
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.e2e-build.outputs.matrix) }}
@@ -321,11 +320,12 @@ jobs:
       - name: Verify exact coverage
         run: python3 scripts/e2e_ci.py verify target/e2e-bundle/plan.json target/e2e-reports
 
-      - name: Enforce and report the three-minute critical path, including failures
+      - name: Report E2E timing without affecting test results
         if: ${{ always() }}
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
-        run: python3 scripts/e2e_ci.py budget
+        run: python3 scripts/e2e_ci.py timing
 
   release-scripts:
     name: Release workflow scripts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,7 @@ jobs:
 
       - name: Run the assigned scenarios without rebuilding or installing
         env:
+          STRATA_CONTAINER_ENGINE: docker
           STRATA_E2E_IMAGE: strata-e2e:ci-runtime
           STRATA_E2E_BUNDLE: target/e2e-bundle
           STRATA_E2E_WORKERS: '2'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,12 +284,13 @@ jobs:
           path: target/e2e-reports
           merge-multiple: true
 
-      - name: Require every dependency to succeed
+      - name: Explain unsuccessful prerequisites and require them to succeed
         if: ${{ always() }}
         env:
+          GH_TOKEN: ${{ github.token }}
           BUILD_RESULT: ${{ needs.e2e-build.result }}
           SHARD_RESULT: ${{ needs.e2e-shard.result }}
-        run: test "$BUILD_RESULT" = success && test "$SHARD_RESULT" = success
+        run: python3 scripts/e2e_ci.py dependencies
 
       - name: Verify exact coverage
         run: python3 scripts/e2e_ci.py verify target/e2e-bundle/plan.json target/e2e-reports

--- a/.github/workflows/e2e-cache.yml
+++ b/.github/workflows/e2e-cache.yml
@@ -60,6 +60,32 @@ jobs:
       - name: Set up cached container builder
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
+      - name: Identify published environment references
+        if: steps.dependency-cache.outputs.cache-hit != 'true'
+        id: images
+        run: python3 scripts/e2e_images.py references >> "$GITHUB_OUTPUT"
+
+      - name: Resolve the trusted published dependency cache to an OCI digest
+        if: steps.dependency-cache.outputs.cache-hit != 'true'
+        id: registry
+        env:
+          E2E_CACHE_REF: ${{ steps.images.outputs.cache }}
+          E2E_ENVIRONMENT_REF: ${{ steps.images.outputs.environment_cache }}
+        run: python3 scripts/e2e_images.py cache "$E2E_CACHE_REF" --environment "$E2E_ENVIRONMENT_REF" >> "$GITHUB_OUTPUT"
+
+      - name: Publish authenticated snapshot indexes before package or compiler bootstrap
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: tests/e2e/Dockerfile
+          target: package-indexes
+          platforms: linux/amd64
+          cache-from: |
+            ${{ steps.dependency-cache.outputs.cache-hit == 'true' && 'type=local,src=target/e2e-dependency-cache' || 'type=gha,scope=strata-e2e-indexes-v1' }}
+            ${{ steps.dependency-cache.outputs.cache-hit != 'true' && 'type=gha,scope=strata-e2e-dependencies-v1' || '' }}
+            ${{ steps.registry.outputs.cache_from }}
+          cache-to: type=gha,mode=max,scope=strata-e2e-indexes-v1
+
       - name: Cache pinned packages, Python, Rust, and locked Rust dependencies
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
@@ -70,10 +96,11 @@ jobs:
           build-args: |
             E2E_UID=${{ steps.identity.outputs.uid }}
             E2E_GID=${{ steps.identity.outputs.gid }}
-            E2E_IMAGE_KEY=${{ steps.identity.outputs.image_key }}
           cache-from: |
             ${{ steps.dependency-cache.outputs.cache-hit == 'true' && 'type=local,src=target/e2e-dependency-cache' || 'type=gha,scope=strata-e2e-dependencies-v1' }}
             ${{ steps.dependency-cache.outputs.cache-hit != 'true' && 'type=gha,scope=strata-e2e-v1' || '' }}
+            ${{ steps.dependency-cache.outputs.cache-hit != 'true' && 'type=gha,scope=strata-e2e-indexes-v1' || '' }}
+            ${{ steps.registry.outputs.cache_from }}
           cache-to: |
             type=gha,mode=max,scope=strata-e2e-dependencies-v1
             type=local,mode=max,dest=target/e2e-dependency-cache-next

--- a/.github/workflows/e2e-images.yml
+++ b/.github/workflows/e2e-images.yml
@@ -62,9 +62,10 @@ jobs:
           BUILD_REF: ${{ steps.identity.outputs.build }}
           CACHE_REF: ${{ steps.identity.outputs.cache }}
           ENVIRONMENT_CACHE_REF: ${{ steps.identity.outputs.environment_cache }}
+          ENVIRONMENT_IMAGE_REF: ${{ steps.identity.outputs.environment_image }}
         shell: bash
         run: |
-          for kind in runtime build cache environment_cache; do
+          for kind in runtime build cache environment_cache environment_image; do
             variable="${kind^^}_REF"
             if docker buildx imagetools inspect "${!variable}" >/dev/null 2>&1; then
               echo "$kind=true" >> "$GITHUB_OUTPUT"
@@ -74,7 +75,7 @@ jobs:
           done
 
       - name: Restore trusted default-branch dependency layers
-        if: steps.existing.outputs.build != 'true' || steps.existing.outputs.cache != 'true' || steps.existing.outputs.environment_cache != 'true' || steps.existing.outputs.runtime != 'true'
+        if: steps.existing.outputs.build != 'true' || steps.existing.outputs.cache != 'true' || steps.existing.outputs.environment_cache != 'true' || steps.existing.outputs.runtime != 'true' || steps.existing.outputs.environment_image != 'true'
         id: dependency-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -82,7 +83,7 @@ jobs:
           key: strata-e2e-dependencies-local-v1-${{ steps.identity.outputs.image_key }}-${{ hashFiles('Cargo.toml', 'Cargo.lock', '.dockerignore') }}-${{ steps.identity.outputs.uid }}-${{ steps.identity.outputs.gid }}
 
       - name: Publish the build environment and its complete dependency cache
-        if: steps.existing.outputs.build != 'true' || steps.existing.outputs.cache != 'true' || steps.existing.outputs.environment_cache != 'true'
+        if: steps.existing.outputs.build != 'true' || steps.existing.outputs.cache != 'true' || steps.existing.outputs.environment_cache != 'true' || steps.existing.outputs.environment_image != 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
@@ -97,7 +98,9 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.strata.e2e.inputs=${{ steps.identity.outputs.image_key }}
             org.strata.e2e.dependencies=${{ steps.identity.outputs.dependency_key }}
-          tags: ${{ steps.identity.outputs.build }}
+          tags: |
+            ${{ steps.identity.outputs.build }}
+            ${{ steps.existing.outputs.environment_image != 'true' && steps.identity.outputs.environment_image || '' }}
           push: true
           cache-from: |
             ${{ steps.dependency-cache.outputs.cache-hit == 'true' && 'type=local,src=target/e2e-dependency-cache' || 'type=gha,scope=strata-e2e-dependencies-v1' }}
@@ -150,8 +153,9 @@ jobs:
             echo '::error title=Published E2E bases failed anonymous verification::Make both GHCR packages public after their first publication, then rerun this publisher. If they are already public, inspect the logged registry/provenance error. Do not give fork PRs package-write credentials.'
             exit 1
           fi
+          python3 scripts/e2e_images.py environment >> "$RUNNER_TEMP/e2e-public-bases.txt"
           while IFS= read -r reference; do
             case "$reference" in
-              dependencies_image=*|runtime_image=*) printf '\nVerified: `%s`\n' "$reference" >> "$GITHUB_STEP_SUMMARY" ;;
+              dependencies_image=*|runtime_image=*|environment_image=*) printf '\nVerified: `%s`\n' "$reference" >> "$GITHUB_STEP_SUMMARY" ;;
             esac
           done < "$RUNNER_TEMP/e2e-public-bases.txt"

--- a/.github/workflows/e2e-images.yml
+++ b/.github/workflows/e2e-images.yml
@@ -1,0 +1,157 @@
+name: Publish pinned E2E environments
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - tests/e2e/Dockerfile
+      - tests/e2e/requirements.txt
+      - tests/e2e/install-packages.sh
+      - scripts/e2e_bundle.py
+      - scripts/e2e_images.py
+      - .dockerignore
+      - .github/workflows/e2e-images.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-image-publication
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.ref == 'refs/heads/main'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    env:
+      DOCKER_BUILD_RECORD_UPLOAD: 'false'
+    steps:
+      - name: Check out trusted main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Identify the pinned environment inputs
+        id: identity
+        run: |
+          python3 scripts/e2e_images.py references >> "$GITHUB_OUTPUT"
+          echo "image_key=$(python3 scripts/e2e_bundle.py image-key)" >> "$GITHUB_OUTPUT"
+          echo "dependency_key=$(python3 scripts/e2e_bundle.py dependency-key)" >> "$GITHUB_OUTPUT"
+          echo "uid=$(id -u)" >> "$GITHUB_OUTPUT"
+          echo "gid=$(id -g)" >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate only the trusted publisher
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Set up the publisher's container builder
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Check which input-addressed images already exist
+        id: existing
+        env:
+          RUNTIME_REF: ${{ steps.identity.outputs.runtime }}
+          BUILD_REF: ${{ steps.identity.outputs.build }}
+          CACHE_REF: ${{ steps.identity.outputs.cache }}
+          ENVIRONMENT_CACHE_REF: ${{ steps.identity.outputs.environment_cache }}
+        shell: bash
+        run: |
+          for kind in runtime build cache environment_cache; do
+            variable="${kind^^}_REF"
+            if docker buildx imagetools inspect "${!variable}" >/dev/null 2>&1; then
+              echo "$kind=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "$kind=false" >> "$GITHUB_OUTPUT"
+            fi
+          done
+
+      - name: Restore trusted default-branch dependency layers
+        if: steps.existing.outputs.build != 'true' || steps.existing.outputs.cache != 'true' || steps.existing.outputs.environment_cache != 'true' || steps.existing.outputs.runtime != 'true'
+        id: dependency-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: target/e2e-dependency-cache
+          key: strata-e2e-dependencies-local-v1-${{ steps.identity.outputs.image_key }}-${{ hashFiles('Cargo.toml', 'Cargo.lock', '.dockerignore') }}-${{ steps.identity.outputs.uid }}-${{ steps.identity.outputs.gid }}
+
+      - name: Publish the build environment and its complete dependency cache
+        if: steps.existing.outputs.build != 'true' || steps.existing.outputs.cache != 'true' || steps.existing.outputs.environment_cache != 'true'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: tests/e2e/Dockerfile
+          target: dependencies
+          platforms: linux/amd64
+          build-args: |
+            E2E_UID=${{ steps.identity.outputs.uid }}
+            E2E_GID=${{ steps.identity.outputs.gid }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.strata.e2e.inputs=${{ steps.identity.outputs.image_key }}
+            org.strata.e2e.dependencies=${{ steps.identity.outputs.dependency_key }}
+          tags: ${{ steps.identity.outputs.build }}
+          push: true
+          cache-from: |
+            ${{ steps.dependency-cache.outputs.cache-hit == 'true' && 'type=local,src=target/e2e-dependency-cache' || 'type=gha,scope=strata-e2e-dependencies-v1' }}
+            type=gha,scope=strata-e2e-indexes-v1
+            type=registry,ref=${{ steps.identity.outputs.environment_cache }}
+          cache-to: |
+            type=registry,ref=${{ steps.identity.outputs.cache }},mode=max
+            ${{ steps.existing.outputs.environment_cache != 'true' && format('type=registry,ref={0},mode=max', steps.identity.outputs.environment_cache) || '' }}
+
+      - name: Publish the runtime without Rust or Cargo
+        if: steps.existing.outputs.runtime != 'true'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: tests/e2e/Dockerfile
+          target: runtime
+          platforms: linux/amd64
+          build-args: |
+            E2E_UID=${{ steps.identity.outputs.uid }}
+            E2E_GID=${{ steps.identity.outputs.gid }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.strata.e2e.inputs=${{ steps.identity.outputs.image_key }}
+          tags: ${{ steps.identity.outputs.runtime }}
+          push: true
+          cache-from: type=registry,ref=${{ steps.identity.outputs.cache }}
+
+      - name: Report published references and anonymous-access setup
+        env:
+          RUNTIME_REF: ${{ steps.identity.outputs.runtime }}
+          BUILD_REF: ${{ steps.identity.outputs.build }}
+          CACHE_REF: ${{ steps.identity.outputs.cache }}
+        run: |
+          {
+            echo '## Pinned E2E environments'
+            echo
+            echo "Runtime: \`$RUNTIME_REF\`"
+            echo "Build environment: \`$BUILD_REF\`"
+            echo "BuildKit cache: \`$CACHE_REF\`"
+            echo
+            echo 'Make both GHCR packages public in package settings for anonymous CI/fork pulls.'
+            echo 'CI resolves matching base/cache tags to OCI digests before use; it never consumes latest.'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Require anonymous access and matching provenance for ordinary CI and fork PRs
+        run: |
+          docker logout ghcr.io
+          if ! python3 scripts/e2e_images.py bases --require-published > "$RUNNER_TEMP/e2e-public-bases.txt"; then
+            echo '::error title=Published E2E bases failed anonymous verification::Make both GHCR packages public after their first publication, then rerun this publisher. If they are already public, inspect the logged registry/provenance error. Do not give fork PRs package-write credentials.'
+            exit 1
+          fi
+          while IFS= read -r reference; do
+            case "$reference" in
+              dependencies_image=*|runtime_image=*) printf '\nVerified: `%s`\n' "$reference" >> "$GITHUB_STEP_SUMMARY" ;;
+            esac
+          done < "$RUNNER_TEMP/e2e-public-bases.txt"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,26 @@ under `.agents/`.
   do not substitute for this gate. See `docs/e2e-testing.md`.
 - Fix failures before pushing rather than relying on CI for feedback. Keep tests portable across supported environments and avoid assertions that depend on platform-specific URI normalization or other incidental system behavior.
 
+## E2E base-image reuse
+
+- Run `./scripts/e2e.sh` for normal local testing. It verifies and reuses the local
+  pinned base, or pulls the published base once if missing. It must not rebuild
+  images or fetch Ubuntu packages during ordinary test runs.
+- Prefer rootless Podman and keep the task's isolated configuration, storage, and
+  runtime directories across commands. Do not create a fresh container store for
+  every invocation, prune other sessions' images, or bypass image-input checks.
+- Only when intentionally changing environment inputs, or when an unpublished
+  environment must be bootstrapped, run explicitly:
+  `STRATA_CONTAINER_ENGINE=podman python3 scripts/e2e_base.py build`.
+  Run this once, then return to `./scripts/e2e.sh`. Do not habitually rebuild bases
+  as a pre-test step. Preserve `target/e2e-container` so Cargo can reuse its cache.
+- Published bases are updated by the trusted-main publisher when environment
+  inputs change. Application edits do not require rebuilding the base. Different
+  local UID/GID values are handled by generated container account files.
+- The three-minute CI duration is a performance target, not a merge requirement.
+  Timing is informational; test failures, incomplete coverage, and invalid
+  provenance still fail CI. See `docs/e2e-testing.md`.
+
 ## Issues and pull requests
 
 - Automated agents must follow the same issue-first workflow and pull request template as human contributors; do not remove or bypass template sections.

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -13,20 +13,33 @@ checks both what the window reports and what happened on disk.
 ./scripts/e2e.sh -k "clipboard and columns"
 ```
 
-Docker is required by default. For rootless Podman, set
-`STRATA_CONTAINER_ENGINE=podman`. The script builds and runs the same image
-locally and in CI, using `tests/e2e/Dockerfile`: a digest-pinned Ubuntu 24.04
-base, a dated Ubuntu package snapshot (GTK 4.14 and fonts), Rust 1.98.1, and
-pinned Python dependencies. The Docker build context is the repository root;
-`.dockerignore` excludes host artifacts and configuration. The local runner
-builds the `toolchain` stage; CI shards need only the `runtime` stage. No host GTK libraries, fonts, desktop sockets, or
-Rust binaries are mounted into the container.
+The runner prefers Podman when available; select an engine explicitly with
+`STRATA_CONTAINER_ENGINE=podman` or `docker`. Normal runs verify and reuse the
+local base image. If missing, they pull the published environment once, verify
+its input label and platform, and record it locally. They **never automatically
+build images or fetch Ubuntu packages**. A missing publication fails with an
+actionable message rather than silently bootstrapping.
+
+When intentionally updating the environment, or before its first publication,
+explicitly build the local base once:
+
+```bash
+STRATA_CONTAINER_ENGINE=podman python3 scripts/e2e_base.py build
+./scripts/e2e.sh
+```
+
+The recipe remains `tests/e2e/Dockerfile`: digest-pinned Ubuntu 24.04, a dated
+package snapshot (GTK 4.14 and fonts), Rust 1.98.1, and pinned Python dependencies.
+Changing those inputs selects a new base; application edits do not. The normal
+runner still compiles the checked-out application and retains Cargo's worktree
+cache. No host GTK libraries, fonts, desktop sockets, or Rust binaries are mounted.
 
 The checkout is mounted at `/workspace`; pass test paths relative to the
 repository. Build and Cargo caches live in `target/e2e-container`, separately
 from native builds. Artifacts remain in `target/e2e-artifacts` and are owned by
-the invoking user. The image adds an account for the invoking UID/GID because
-D-Bus requires an account entry; this does not change the rendering packages.
+the invoking user. Minimal generated passwd/group files provide the invoking
+UID/GID to D-Bus, so one published environment works across local user IDs without
+rebuilding it or mounting the host's account database.
 Updating the image inputs is an intentional rendering
 environment change and requires reviewing the visual baselines.
 
@@ -303,13 +316,14 @@ a workflow that does not have a mutation yet.
    the same pinned rendering packages and baselines as a local canonical run.
 3. **End-to-end GUI suite** retains the existing required-check name. It requires
    every dependency to succeed, verifies that all planned node IDs passed setup,
-   call, and teardown exactly once, and enforces **less than 180 seconds** from
-   the build job's creation through aggregation. The initial E2E queue, setup,
+   call, and teardown exactly once. Timing is **informational**, with a three-minute
+   performance target—not a pass/fail condition. From build-job creation through
+   aggregation, the initial E2E queue, setup,
    dependency installation or cache retrieval, compilation, transfers, downstream
    runner queues, and test execution are included—not just pytest time. Queue and
-   execution durations appear in the Actions summary; five seconds are reserved
-   for final teardown rather than spending the entire budget before the job can
-   finish. Final GitHub job teardown cannot be measured from inside its own job;
+   execution durations appear in the Actions summary. Slow runs and unavailable
+   timing telemetry do not fail passing tests. Final teardown cannot be measured
+   from inside its own job;
    use the Actions completion timestamp to verify the final observed runtime.
 
 The matrix is generated from `harness/sharding.py`, not a fixed runner count or
@@ -320,13 +334,14 @@ weight. More tests or longer measured durations add runners. Baselines stay in
 one serial scheduling group. An indivisible group over budget or a plan requiring
 more than GitHub's 256 matrix jobs fails explicitly instead of silently extending
 the gate. There is no `max-parallel` throttle; the runner provider must have enough
-concurrent capacity. A busy runner pool can therefore fail the wall-clock budget.
+concurrent capacity. Runner queues affect reported timing, not test correctness.
 
 Shards validate their entire collection against the plan before selecting tests.
 A missing, extra, skipped, failed, or stale result fails the aggregate gate.
 `fail-fast: false` preserves other shards' diagnostics. Worker crashes and failed
 assertions are not retried; only display infrastructure startup retains its one
-retry. CI caps each test at 60 seconds and each shard job at three minutes.
+retry. CI caps each test at 60 seconds and each shard job at ten minutes to stop
+hung execution, independently of the informational three-minute overall target.
 Reports and JUnit files are uploaded on both success and failure, with distinct
 artifact names per runner and run attempt; screenshots/trees/logs are uploaded on
 failures. The gate never mixes previous attempts into a fresh measurement.
@@ -337,7 +352,7 @@ The prerequisite check reports whether bootstrap or shard execution failed, link
 unsuccessful jobs and steps, and inspects a bounded amount of their logs. Confirmed
 Ubuntu Snapshot HTTP errors, compiler diagnostics, and provenance failures are
 identified separately. When bootstrap fails, it explicitly says that no scenarios
-ran; a subsequent time-budget failure is not presented as slow GUI tests. If logs
+ran. Timing is reported separately and never changes the test result. If logs
 cannot be retrieved or classified, it says so rather than guessing the cause.
 
 ### Cache lifecycle and cold starts
@@ -390,7 +405,7 @@ The runtime archive uses a separate exact-key cache; shards restore it without
 starting BuildKit. Only the producer exports or saves a missing archive. It confirms
 that publication succeeded before telling shards to use the cache. If publication
 is unavailable (including read-only fork caches), it instead uploads an explicit
-attempt-scoped `e2e-runtime-<attempt>` artifact; the same strict time budget applies.
+attempt-scoped `e2e-runtime-<attempt>` artifact; transfer time remains in the timing report.
 This avoids repeatedly uploading and unzipping a large unchanged runtime on ordinary
 source revisions without making cache-write permission a prerequisite for testing.
 
@@ -418,7 +433,10 @@ Tags include SHA256 input identifiers, architecture, UID, and GID. Runtime input
 are independent of application source; the build identifier additionally includes
 `Cargo.toml`, `Cargo.lock`, and `.dockerignore`. Publication runs on input changes
 or manual dispatch, not ordinary application commits. Existing publications are
-checked before rebuilding. GHCR storage is independent of Actions cache eviction;
+checked before rebuilding. A separate `base-<environment-inputs>-linux-amd64-1001-1001`
+tag in the build package provides a reusable local environment independent of
+application manifests. It is published once per environment input set and is not
+retagged on ordinary Cargo changes. GHCR storage is independent of Actions cache eviction;
 retain tags needed by supported revisions rather than treating them as disposable
 per-run artifacts.
 
@@ -446,18 +464,18 @@ readable without credentials. Do not give fork PRs package-write credentials.
 To exercise the registry path, manually dispatch **CI** with
 `require_published_environments` enabled. This bypasses the fast dependency cache
 and fails if matching public bases are unavailable; it cannot silently benchmark a
-source-build fallback. All scenarios and the same time budget still apply. The
+source-build fallback. All scenarios and the same informational timing report still apply. The
 runtime archive cache remains enabled, so this is not a completely cold transport
 benchmark.
 
 New environment inputs still require an initial trusted publication; a PR cannot
-seed main by publishing its own build. No cold-start exemption has been added to
-the three-minute gate.
+seed main by publishing its own build. The three-minute target is informational
+for both warm and cold runs.
 
 **New inputs without published images or cached bootstrap are not guaranteed to
 install and compile within three minutes.** The timed build retains a ten-minute
-limit for cold-build diagnostics, but the aggregate still fails the 180-second
-budget: a cold run is not silently exempted or advertised as a fast pass. Large
+limit to stop hung bootstrap jobs; elapsed time alone never fails the aggregate.
+Cold and warm durations are reported honestly rather than conflated. Large
 cache publication no longer blocks binary handoff or races that ten-minute limit;
 the separate warmer owns it. Seed the dependency cache before enabling the new
 required gate, and rerun the **entire workflow** after the warmer completes. External package outages, cache eviction, and runner queues cannot
@@ -508,10 +526,10 @@ STRATA_CONTAINER_ENGINE=podman STRATA_E2E_IMAGE=strata-e2e:ci-runtime \
 ```
 
 The bundle must be inside the checkout. Without these explicit bundle/image
-variables the local canonical runner still builds the source normally.
+variables the local canonical runner reuses its verified base and compiles the
+checked-out application normally; it does not rebuild the base.
 
-After a complete CI attempt with every test passing (even if its wall-clock gate
-failed), download its `e2e-report-<attempt>-*` artifacts into an empty
+After a complete CI attempt with every test passing, download its `e2e-report-<attempt>-*` artifacts into an empty
 `target/e2e-reports` directory and its `e2e-plan-<attempt>` into
 `target/e2e-bundle`, then refresh timings:
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -331,6 +331,15 @@ Reports and JUnit files are uploaded on both success and failure, with distinct
 artifact names per runner and run attempt; screenshots/trees/logs are uploaded on
 failures. The gate never mixes previous attempts into a fresh measurement.
 
+### Understanding a failed gate
+
+The prerequisite check reports whether bootstrap or shard execution failed, links
+unsuccessful jobs and steps, and inspects a bounded amount of their logs. Confirmed
+Ubuntu Snapshot HTTP errors, compiler diagnostics, and provenance failures are
+identified separately. When bootstrap fails, it explicitly says that no scenarios
+ran; a subsequent time-budget failure is not presented as slow GUI tests. If logs
+cannot be retrieved or classified, it says so rather than guessing the cause.
+
 ### Cache lifecycle and cold starts
 
 BuildKit's content-addressed cache invalidates on the actual Dockerfile, package
@@ -338,9 +347,20 @@ installer, requirements, Rust manifest/lockfile, source, and resource inputs.
 `install-packages.sh` downloads from the official archive using byte-identical,
 signed snapshot indexes, then installs against the original snapshot sources.
 It never refreshes indexes from the moving archive: versions and APT checksum
-verification stay pinned. Superseded packages unavailable on the archive fall back
-to the snapshot; failed maintainer scripts are not retried. This avoids making every
+verification stay pinned. For superseded packages missing from the archive,
+Launchpad's primary archive is tried using the exact filename and mandatory SHA256
+from the signed snapshot metadata. Downloads use APT's sandboxed partial directory;
+APT verifies them again when installing against the original snapshot sources.
+The snapshot remains the final fallback; failed maintainer scripts are not retried. This avoids making every
 package download wait on the slower snapshot service during cold recovery.
+
+The `package-indexes` stage fetches and authenticates the dated APT indexes once.
+Runtime and toolchain installation reuse them through read-only build mounts;
+neither downloads a second copy, and the lists are removed before each install
+layer is committed. The warmer publishes the index-stage cache **before** package
+and compiler bootstrap, so a later failure does not discard a successful index
+fetch. Source builds attach the public input digest as an output image label, not
+an environment variable or secret-looking build argument.
 
 A stub application
 warms dependencies only; its executable and all Strata fingerprints are removed
@@ -355,7 +375,8 @@ and PRs, and on manual dispatch. PRs warm only their own branch-scoped cache.
 The timed build restores a BuildKit local-cache directory through the cache action's
 segmented transfer path, keyed by image inputs, manifests, ignore rules, and UID/GID.
 BuildKit still validates content-addressed dependency records before reusing them.
-A missing local cache falls back to the shared GHA dependency cache; the old
+A missing local cache first looks for published environments, then falls back to
+the shared GHA dependency cache; the old
 `strata-e2e-v1` cache remains a read-only migration source. The warmer publishes both
 formats and replaces its local export directory so obsolete blobs do not accumulate.
 
@@ -377,9 +398,63 @@ Node-24-native actions verify artifact download digests; the runner also checks
 bundle provenance and the loaded image's input label. GitHub's cache branch scoping
 allows fork PRs to read the main cache without credentials or registry access and
 prevents PR caches from replacing main's cache. No `pull_request_target` execution
-or package-write permission is needed.
+or package-write permission is needed. Main cannot restore a PR-scoped cache:
+a successful PR run does not seed main's first bootstrap after merging a new
+workflow. Run the trusted default-branch warmer to populate main's own caches;
+do not promote untrusted PR build caches into main. These caches are evictable,
+not permanent package storage. Published environments provide the durable fallback
+below; upstream outages can still block the first publication of new inputs.
 
-**A completely cold/evicted cache or a newly changed image is not guaranteed to
+### Persistent published environments
+
+`Publish pinned E2E environments` publishes two GHCR packages from trusted main:
+
+- `ghcr.io/lgse/strata-e2e-runtime`: the pinned GUI/Python/font environment.
+- `ghcr.io/lgse/strata-e2e-build`: Rust plus the runtime and compiled locked Cargo
+  dependencies. The stub application and its fingerprints are removed; no tested
+  application binary is published here.
+
+Tags include SHA256 input identifiers, architecture, UID, and GID. Runtime inputs
+are independent of application source; the build identifier additionally includes
+`Cargo.toml`, `Cargo.lock`, and `.dockerignore`. Publication runs on input changes
+or manual dispatch, not ordinary application commits. Existing publications are
+checked before rebuilding. GHCR storage is independent of Actions cache eviction;
+retain tags needed by supported revisions rather than treating them as disposable
+per-run artifacts.
+
+On a fast dependency-cache miss, CI resolves matching image tags to **OCI digests**,
+checks their platform and input labels, and uses them directly as application and
+runtime bases. Published labels are preserved, not overwritten to match a checkout. Those builds do not
+execute Ubuntu/Python/Rust bootstrap stages, even with an empty BuildKit cache.
+The application still compiles for the tested revision, and the base's Cargo
+manifests must match the checkout. A fresh runner still transfers image layers;
+this avoids package-server requests and dependency compilation, not all network I/O.
+
+The build package also stores complete BuildKit caches. An environment-only cache
+identifier lets new Cargo inputs reuse unchanged GTK/Rust dependencies. The warmer
+can import these persistent caches to refill the faster segmented GitHub caches.
+If an image is absent or inaccessible, CI reports that fact and falls back to
+verified cache/source building; it never substitutes `latest`, another dependency
+version, or an unverified bundle.
+
+Only the main-only publisher has `packages: write` and registry login credentials.
+PR CI and warmers pull anonymously and cannot publish shared images. After the
+first publication, **make both packages public in GHCR package settings** and rerun
+the publisher. Its anonymous-access check fails descriptively until they are
+readable without credentials. Do not give fork PRs package-write credentials.
+
+To exercise the registry path, manually dispatch **CI** with
+`require_published_environments` enabled. This bypasses the fast dependency cache
+and fails if matching public bases are unavailable; it cannot silently benchmark a
+source-build fallback. All scenarios and the same time budget still apply. The
+runtime archive cache remains enabled, so this is not a completely cold transport
+benchmark.
+
+New environment inputs still require an initial trusted publication; a PR cannot
+seed main by publishing its own build. No cold-start exemption has been added to
+the three-minute gate.
+
+**New inputs without published images or cached bootstrap are not guaranteed to
 install and compile within three minutes.** The timed build retains a ten-minute
 limit for cold-build diagnostics, but the aggregate still fails the 180-second
 budget: a cold run is not silently exempted or advertised as a fast pass. Large
@@ -400,6 +475,13 @@ dependency cache missed, so this run exercised the GHA dependency-cache fallback
 while the separate warmer published the new format. This was not an identical
 binary-cache rerun or a completely cold package bootstrap.
 
+Attempt 2 of the same run restored both segmented caches and **recompiled Strata
+in 7.51 seconds**. All 581 cases passed exactly once: **139 seconds** from initial
+E2E queue to completion, **141 seconds** from attempt start, and 137.4 seconds at
+the internal measurement. This is same-revision recompilation, not a second new
+revision or a binary-cache shortcut. These measurements predate persistent GHCR
+base images; they are not a benchmark of the registry-only cold-runner path.
+
 ### Reproducing and maintaining shards
 
 To collect the current inventory inside the canonical container:
@@ -418,7 +500,7 @@ For the exact CI binary, use a disposable checkout at the commit in its metadata
 ```bash
 podman build --target runtime --tag strata-e2e:ci-runtime \
   --build-arg E2E_UID="$(id -u)" --build-arg E2E_GID="$(id -g)" \
-  --build-arg E2E_IMAGE_KEY="$(python3 scripts/e2e_bundle.py image-key)" \
+  --label org.strata.e2e.inputs="$(python3 scripts/e2e_bundle.py image-key)" \
   --file tests/e2e/Dockerfile .
 chmod +x target/e2e-bundle/strata
 STRATA_CONTAINER_ENGINE=podman STRATA_E2E_IMAGE=strata-e2e:ci-runtime \

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -14,7 +14,9 @@ checks both what the window reports and what happened on disk.
 ```
 
 The runner prefers Podman when available; select an engine explicitly with
-`STRATA_CONTAINER_ENGINE=podman` or `docker`. Normal runs verify and reuse the
+`STRATA_CONTAINER_ENGINE=podman` or `docker`. CI explicitly selects Docker to match
+its runtime archive loader; an image in one engine's store is not visible to the
+other. Normal runs verify and reuse the
 local base image. If missing, they pull the published environment once, verify
 its input label and platform, and record it locally. They **never automatically
 build images or fetch Ubuntu packages**. A missing publication fails with an

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -389,6 +389,17 @@ required gate, and rerun the **entire workflow** after the warmer completes. Ext
 be solved by adding test shards. Inspect the build logs' `CACHED` entries and the
 critical-path summary rather than raising the time limit.
 
+### Measured fresh-revision run
+
+[CI run 34235908938](https://github.com/lgse/strata/actions/runs/34235908938)
+(`84d8e82`, 2026-09-08) compiled Strata again and passed all 581 cases exactly once
+on 30 runners in **172 seconds**, measured from the initial E2E queue/attempt start
+through the aggregate job's completed timestamp. The internal measurement was
+168.7 seconds before teardown. The runtime archive was cached; the new segmented
+dependency cache missed, so this run exercised the GHA dependency-cache fallback
+while the separate warmer published the new format. This was not an identical
+binary-cache rerun or a completely cold package bootstrap.
+
 ### Reproducing and maintaining shards
 
 To collect the current inventory inside the canonical container:

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -39,7 +39,7 @@ if [[ -z "$image" ]]; then
   image="strata-e2e:${image_key:0:16}-$user_id-$group_id"
   "$engine" build --platform=linux/amd64 --target toolchain --tag "$image" \
     --build-arg "E2E_UID=$user_id" --build-arg "E2E_GID=$group_id" \
-    --build-arg "E2E_IMAGE_KEY=$image_key" \
+    --label "org.strata.e2e.inputs=$image_key" \
     --file "$repository/tests/e2e/Dockerfile" "$repository"
 fi
 

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -3,7 +3,10 @@ set -euo pipefail
 
 unset DISPLAY WAYLAND_DISPLAY NOTIFY_SOCKET
 repository="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-engine="${STRATA_CONTAINER_ENGINE:-docker}"
+engine="${STRATA_CONTAINER_ENGINE:-}"
+if [[ -z "$engine" ]]; then
+  if command -v podman >/dev/null 2>&1; then engine=podman; else engine=docker; fi
+fi
 if ! command -v "$engine" >/dev/null 2>&1; then
   echo "E2E tests require Docker or Podman; see docs/e2e-testing.md" >&2
   exit 1
@@ -36,11 +39,20 @@ if [[ -n "${STRATA_E2E_BUNDLE:-}" ]]; then
   fi
 fi
 if [[ -z "$image" ]]; then
-  image="strata-e2e:${image_key:0:16}-$user_id-$group_id"
-  "$engine" build --platform=linux/amd64 --target toolchain --tag "$image" \
-    --build-arg "E2E_UID=$user_id" --build-arg "E2E_GID=$group_id" \
-    --label "org.strata.e2e.inputs=$image_key" \
-    --file "$repository/tests/e2e/Dockerfile" "$repository"
+  image="$(python3 "$repository/scripts/e2e_base.py" ensure --engine "$engine")"
+elif [[ -z "$bundle" ]]; then
+  image="$(python3 "$repository/scripts/e2e_base.py" verify "$image" --engine "$engine")"
+fi
+
+accounts="$repository/target/e2e-container/accounts-$user_id-$group_id"
+mkdir -p "$accounts"
+printf 'root:x:0:0:root:/root:/bin/sh\n' > "$accounts/passwd"
+printf 'root:x:0:\n' > "$accounts/group"
+if [[ "$user_id" != 0 ]]; then
+  printf 'strata-e2e:x:%s:%s:E2E:/tmp/strata-build-home:/bin/sh\n' "$user_id" "$group_id" >> "$accounts/passwd"
+fi
+if [[ "$group_id" != 0 ]]; then
+  printf 'strata-e2e:x:%s:\n' "$group_id" >> "$accounts/group"
 fi
 
 options=(--rm --platform=linux/amd64 --user "$user_id:$group_id" --shm-size=512m)
@@ -49,10 +61,13 @@ if [[ "$(basename "$engine")" == podman ]]; then
 fi
 exec "$engine" run "${options[@]}" \
   --mount "type=bind,source=$repository,target=/workspace" \
+  --mount "type=bind,source=$accounts/passwd,target=/etc/passwd,readonly" \
+  --mount "type=bind,source=$accounts/group,target=/etc/group,readonly" \
   --workdir /workspace \
   --env HOME=/tmp/strata-build-home \
   --env CARGO_HOME=/workspace/target/e2e-container/cargo \
   --env CARGO_TARGET_DIR=/workspace/target/e2e-container/build \
+  --env CARGO_PROFILE_DEV_DEBUG=0 --env CARGO_INCREMENTAL=0 \
   --env "STRATA_E2E_UPDATE_BASELINES=${STRATA_E2E_UPDATE_BASELINES:-0}" \
   --env "STRATA_E2E_WORKERS=${STRATA_E2E_WORKERS:-auto}" \
   --env "STRATA_E2E_BUNDLE=${bundle:+/workspace/$bundle}" \

--- a/scripts/e2e_base.py
+++ b/scripts/e2e_base.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Reuse a verified local E2E environment; building it is always explicit."""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+
+from e2e_bundle import REPOSITORY, dependency_key, image_key
+from e2e_images import check_image_labels, references
+
+
+def inspect(engine, reference):
+    result = subprocess.run([engine, "image", "inspect", reference],
+                            capture_output=True, text=True, check=False)
+    if result.returncode:
+        return None
+    images = json.loads(result.stdout)
+    if not isinstance(images, list) or len(images) != 1:
+        raise ValueError("expected exactly one local base image")
+    return images[0]
+
+
+def verify_image(image, inputs):
+    check_image_labels({"os": image.get("Os"), "architecture": image.get("Architecture"),
+                        "config": image.get("Config")}, {"org.strata.e2e.inputs": inputs})
+    if not any(value.startswith("RUSTUP_HOME=") for value in image["Config"].get("Env", [])):
+        raise ValueError("the selected base is a runtime-only image, not a Rust build environment")
+    identity = image.get("Id", "")
+    if not re.fullmatch(r"(?:sha256:)?[0-9a-f]{64}", identity):
+        raise ValueError("invalid local image identity")
+    return identity
+
+
+def ensure_base(engine, repository=REPOSITORY):
+    inputs = image_key(repository)
+    local = f"strata-e2e:base-{inputs}-{os.getuid()}-{os.getgid()}"
+    image = inspect(engine, local)
+    if image is not None:
+        return verify_image(image, inputs)
+    # Published environments use the CI account. The runner supplies its own
+    # minimal passwd/group entries and executes with the invoking user's IDs.
+    refs = references(os.environ.get("STRATA_E2E_IMAGE_REPOSITORY", "lgse/strata"),
+                      inputs, dependency_key(repository), 1001, 1001)
+    remote = refs["environment_image"]
+    image = inspect(engine, remote)
+    if image is None:
+        print("Pulling the pinned E2E base once; no Ubuntu bootstrap will run.", file=sys.stderr)
+        result = subprocess.run([engine, "pull", "--platform=linux/amd64", remote],
+                                stdout=sys.stderr, check=False)
+        if result.returncode:
+            raise ValueError("published base unavailable. Run `python3 scripts/e2e_base.py build` "
+                             "only when an explicit local environment build is intended; "
+                             "otherwise publish the matching environment first")
+        image = inspect(engine, remote)
+    if image is None:
+        raise ValueError("the pulled base could not be inspected")
+    identity = verify_image(image, inputs)
+    subprocess.run([engine, "tag", identity, local], stdout=sys.stderr, check=True)
+    return identity
+
+
+def build_base(engine, repository=REPOSITORY):
+    inputs = image_key(repository)
+    local = f"strata-e2e:base-{inputs}-{os.getuid()}-{os.getgid()}"
+    subprocess.run([engine, "build", "--platform=linux/amd64", "--target", "toolchain",
+                    "--tag", local, "--build-arg", f"E2E_UID={os.getuid()}",
+                    "--build-arg", f"E2E_GID={os.getgid()}",
+                    "--label", f"org.strata.e2e.inputs={inputs}",
+                    "--file", str(repository / "tests/e2e/Dockerfile"), str(repository)],
+                   stdout=sys.stderr, check=True)
+    image = inspect(engine, local)
+    if image is None:
+        raise ValueError("the built base could not be inspected")
+    return verify_image(image, inputs)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("ensure", "build", "verify"))
+    parser.add_argument("reference", nargs="?")
+    parser.add_argument("--engine", default=os.environ.get("STRATA_CONTAINER_ENGINE")
+                        or ("podman" if shutil.which("podman") else "docker"))
+    args = parser.parse_args()
+    try:
+        if args.command == "verify":
+            if not args.reference:
+                raise ValueError("verify requires an image reference")
+            image = inspect(args.engine, args.reference)
+            if image is None:
+                raise ValueError("the explicitly selected base is not present locally")
+            identity = verify_image(image, image_key())
+        else:
+            identity = (build_base if args.command == "build" else ensure_base)(args.engine)
+        print(identity)
+    except (OSError, ValueError, KeyError, TypeError, subprocess.CalledProcessError) as error:
+        parser.exit(1, f"E2E base: {error}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/e2e_bundle.py
+++ b/scripts/e2e_bundle.py
@@ -22,6 +22,12 @@ def image_key(repository=REPOSITORY):
     )).encode()).hexdigest()
 
 
+def dependency_key(repository=REPOSITORY):
+    inputs = [image_key(repository)] + [digest(repository / name)
+                                       for name in ("Cargo.toml", "Cargo.lock", ".dockerignore")]
+    return hashlib.sha256("".join(inputs).encode()).hexdigest()
+
+
 def source_key(repository=REPOSITORY):
     files = [repository / name for name in ("Cargo.toml", "Cargo.lock", "build.rs")]
     for directory in ("src", "data"):
@@ -56,13 +62,14 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
     sub.add_parser("image-key")
+    sub.add_parser("dependency-key")
     for command in ("create", "verify"):
         child = sub.add_parser(command)
         child.add_argument("bundle", type=Path)
         child.add_argument("--commit")
     args = parser.parse_args()
-    if args.command == "image-key":
-        print(image_key())
+    if args.command in ("image-key", "dependency-key"):
+        print(image_key() if args.command == "image-key" else dependency_key())
         return
     commit = args.commit or subprocess.check_output(
         ["git", "rev-parse", "HEAD"], cwd=REPOSITORY, text=True).strip()

--- a/scripts/e2e_ci.py
+++ b/scripts/e2e_ci.py
@@ -17,7 +17,7 @@ from e2e_diagnostics import require_dependencies
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tests/e2e"))
 from harness.sharding import validate_plan, verify_reports  # noqa: E402
 
-BUDGET_SECONDS = 180
+TARGET_SECONDS = 180
 
 
 def critical_path(jobs: list[dict], now: datetime) -> tuple[float, str]:
@@ -33,7 +33,7 @@ def critical_path(jobs: list[dict], now: datetime) -> tuple[float, str]:
     elapsed = (now - start).total_seconds()
     if elapsed < 0:
         raise ValueError("runner clock precedes the initial E2E queue timestamp")
-    lines = ["## E2E critical path", "", f"**{elapsed:.1f}s / <{BUDGET_SECONDS}s**, "
+    lines = ["## E2E critical path", "", f"**{elapsed:.1f}s elapsed; <{TARGET_SECONDS}s target (informational)**, "
              f"{len(shards)} runners (two isolated GUI workers each).", "",
              "Includes the initial E2E queue, build-job startup, dependency/cache setup, compilation, "
              "artifact transfers, downstream runner queues, tests, and aggregation through this measurement.", "",
@@ -56,15 +56,17 @@ def publish_summary(summary):
             stream.write(summary)
 
 
-def check_budget():
-    jobs = workflow_jobs()
-    elapsed, summary = critical_path(jobs, datetime.now(timezone.utc))
+def report_timing():
+    try:
+        jobs = workflow_jobs()
+        elapsed, summary = critical_path(jobs, datetime.now(timezone.utc))
+    except (OSError, ValueError, KeyError, TypeError):
+        publish_summary("## E2E timing\n\nTiming data is unavailable; test and coverage results are unaffected.\n")
+        return
     publish_summary(summary)
-    # Leave room for the final step and runner teardown, which cannot be timed
-    # from inside their own job. The summary always reports actual elapsed time.
-    if elapsed >= BUDGET_SECONDS - 5:
-        raise ValueError("E2E exhausted the three-minute budget (including 5s teardown reserve); "
-                         "inspect cache misses and shard timings, not just pytest duration")
+    if elapsed >= TARGET_SECONDS:
+        print("::notice title=E2E timing::The three-minute performance target was exceeded. "
+              "Timing is informational and does not fail passing tests.")
 
 
 def workflow_jobs() -> list[dict]:
@@ -89,7 +91,7 @@ def workflow_jobs() -> list[dict]:
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
-    sub.add_parser("budget")
+    sub.add_parser("timing")
     sub.add_parser("dependencies")
     matrix = sub.add_parser("matrix")
     matrix.add_argument("plan", type=Path)
@@ -102,8 +104,8 @@ def main():
         if args.command == "dependencies":
             require_dependencies(workflow_jobs, publish_summary)
             return
-        if args.command == "budget":
-            check_budget()
+        if args.command == "timing":
+            report_timing()
             return
         plan = json.loads(args.plan.read_text())
         validate_plan(plan)

--- a/scripts/e2e_ci.py
+++ b/scripts/e2e_ci.py
@@ -12,6 +12,8 @@ from pathlib import Path
 import sys
 from urllib.request import Request, urlopen
 
+from e2e_diagnostics import require_dependencies
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tests/e2e"))
 from harness.sharding import validate_plan, verify_reports  # noqa: E402
 
@@ -41,6 +43,9 @@ def critical_path(jobs: list[dict], now: datetime) -> tuple[float, str]:
         queued = (started - parse(job["created_at"])).total_seconds()
         end = parse(job["completed_at"]) if job.get("completed_at") else now
         lines.append(f"| {job['name']} | {queued:.1f} | {(end - started).total_seconds():.1f} |")
+    if build[0].get("conclusion") in {"failure", "cancelled", "timed_out"}:
+        lines += ["", "The build/plan prerequisite failed. This duration includes failed bootstrap; "
+                  "it is not a measurement of GUI scenario execution. See the E2E failure summary."]
     return elapsed, "\n".join(lines) + "\n"
 
 
@@ -85,6 +90,7 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
     sub.add_parser("budget")
+    sub.add_parser("dependencies")
     matrix = sub.add_parser("matrix")
     matrix.add_argument("plan", type=Path)
     for command in ("verify", "durations"):
@@ -93,6 +99,9 @@ def main():
         child.add_argument("reports", type=Path)
     args = parser.parse_args()
     try:
+        if args.command == "dependencies":
+            require_dependencies(workflow_jobs, publish_summary)
+            return
         if args.command == "budget":
             check_budget()
             return

--- a/scripts/e2e_diagnostics.py
+++ b/scripts/e2e_diagnostics.py
@@ -38,6 +38,10 @@ def job_log(job_id: int) -> str:
 
 def classify_log(log: str) -> str | None:
     log = re.sub(r"\x1b\[[0-?]*[ -/]*[@-~]", "", log)
+    log = re.sub(r"##\[group\]Run [\s\S]*?##\[endgroup\]", "", log)
+    if re.search(r"(?m)^.*\bError: [^\n]+: image not known\s*$", log):
+        return ("The selected container engine cannot find the loaded runtime. "
+                "Use the same engine for image loading and scenario execution.")
     statuses = sorted(set(re.findall(
         r"E: Failed to fetch https?://snapshot\.ubuntu\.com/\S+[^\n]*?\s(5\d\d)\s", log)))
     if statuses:

--- a/scripts/e2e_diagnostics.py
+++ b/scripts/e2e_diagnostics.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Bounded, credential-safe explanations of upstream E2E job failures."""
+
+from __future__ import annotations
+
+import os
+import re
+from urllib.parse import urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+MAX_LOG_BYTES = 2 * 1024 * 1024
+MAX_LOG_JOBS = 3
+FAILED = {"failure", "cancelled", "timed_out", "action_required", "startup_failure"}
+
+
+class LogRedirectHandler(HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        if urlsplit(newurl).scheme != "https":
+            raise ValueError("refusing an insecure job-log redirect")
+        redirected = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if redirected is not None:
+            # GitHub redirects to signed blob URLs; never forward its API token.
+            redirected.remove_header("Authorization")
+        return redirected
+
+
+def job_log(job_id: int) -> str:
+    api = os.environ.get("GITHUB_API_URL", "https://api.github.com")
+    repository = os.environ["GITHUB_REPOSITORY"]
+    request = Request(f"{api}/repos/{repository}/actions/jobs/{int(job_id)}/logs", headers={
+        "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    })
+    with build_opener(LogRedirectHandler()).open(request, timeout=10) as response:
+        return response.read(MAX_LOG_BYTES).decode("utf-8", errors="replace")
+
+
+def classify_log(log: str) -> str | None:
+    log = re.sub(r"\x1b\[[0-?]*[ -/]*[@-~]", "", log)
+    statuses = sorted(set(re.findall(
+        r"E: Failed to fetch https?://snapshot\.ubuntu\.com/\S+[^\n]*?\s(5\d\d)\s", log)))
+    if statuses:
+        return (f"Ubuntu Snapshot returned HTTP {'/'.join(statuses)} while fetching pinned "
+                "package metadata or packages. This is an upstream bootstrap/download failure, "
+                "not a GUI assertion failure. Package verification remains enabled.")
+    if re.search(r"E:.*(?:NO_PUBKEY|not signed|signatures? couldn't be verified|Hash Sum mismatch)", log):
+        return "APT rejected package metadata or its integrity; do not bypass signature/checksum verification."
+    codes = sorted(set(re.findall(r"\berror\[(E\d{4})\]", log)))
+    if codes:
+        return f"Rust compilation failed ({', '.join(codes[:5])}); inspect the linked compiler output."
+    if ("E2E bundle:" in log or "published base input labels do not match" in log
+            or "The runtime image was not built from this checkout's pinned E2E inputs." in log):
+        return "The runner rejected the supplied bundle or image provenance. Rebuild the matching inputs; do not bypass these checks."
+    if "Runtime cache did not match the exact pinned key" in log:
+        return "The runtime cache did not match its exact pinned key; no substitute runtime was accepted."
+    return None
+
+
+def scenario_job(job: dict) -> bool:
+    return bool(re.fullmatch(r"E2E shard \d+", job["name"]))
+
+
+def markdown_text(value: str) -> str:
+    return re.sub(r"([\\`*_{}\[\]()<>|])", r"\\\1", " ".join(value.split()))
+
+
+def failure_summary(build_result: str, shard_result: str, jobs: list[dict],
+                    logs: dict[int, str], unavailable: set[int]) -> tuple[str, str]:
+    build_failed = build_result != "success"
+    title = "E2E build/bootstrap failed" if build_failed else "E2E shard execution failed"
+    lines = [f"## {title}", "", f"Build result: **{build_result}**. "
+             f"Shard result: **{shard_result}**.", ""]
+    shards = [job for job in jobs if scenario_job(job)]
+    if build_failed and not any(job.get("conclusion") != "skipped" for job in shards):
+        lines += ["**No E2E scenarios ran: the build/plan prerequisite did not succeed.**", ""]
+    lines += ["| Job | Result | Unsuccessful step |", "| --- | --- | --- |"]
+    failed_jobs = [job for job in jobs if
+                   (job["name"] == "E2E build and plan" or scenario_job(job))
+                   and job.get("conclusion") in FAILED]
+    reasons = []
+    for job in failed_jobs:
+        steps = [step for step in job.get("steps", []) if step.get("conclusion") in FAILED]
+        step_text = "; ".join(markdown_text(step["name"]) for step in steps) or "See job log"
+        name = markdown_text(job["name"])
+        link = job.get("html_url")
+        if link and urlsplit(link).scheme == "https":
+            name = f"[{name}]({link})"
+        lines.append(f"| {name} | {job['conclusion']} | {step_text} |")
+        if job.get("conclusion") == "timed_out":
+            reasons.append("A runner job hit its timeout. Inspect its last active step; "
+                           "a timeout alone does not establish an Ubuntu outage.")
+        if reason := classify_log(logs.get(job["id"], "")):
+            reasons.append(reason)
+    if reasons:
+        lines += ["", "### Observed cause", ""] + [f"- {reason}" for reason in dict.fromkeys(reasons)]
+    else:
+        lines += ["", "The exact cause could not be extracted automatically; open the linked "
+                  "unsuccessful step. Do not infer an Ubuntu outage from exit code 1 alone."]
+    if unavailable:
+        lines += ["", "Some job logs were unavailable through the API; the job links remain authoritative."]
+    lines += ["", "### Next steps", ""]
+    if any("Ubuntu Snapshot returned" in reason for reason in reasons):
+        lines += ["- If matching environments are already published, verify both GHCR packages "
+                  "are publicly readable; missing access can force source bootstrap unnecessarily.",
+                  "- After Ubuntu Snapshot recovers, run **Warm E2E dependencies** on the affected "
+                  "branch, then rerun the **entire CI workflow**.",
+                  "- Main cannot restore PR-scoped caches. A passing PR does not seed main's "
+                  "first bootstrap; do not promote untrusted PR caches into main."]
+    else:
+        lines += ["- Inspect the unsuccessful step above and any shard JSON/JUnit/failure artifacts.",
+                  "- Correct the underlying failure, then rerun the entire workflow."]
+    lines += ["- The time budget is enforced separately. An overrun after failed bootstrap is "
+              "not evidence that GUI scenarios were slow.",
+              "- Log inspection is bounded; follow the job links for full output."]
+    return title, "\n".join(lines) + "\n"
+
+
+def require_dependencies(workflow_jobs, publish_summary):
+    build = os.environ.get("BUILD_RESULT", "missing")
+    shards = os.environ.get("SHARD_RESULT", "missing")
+    if build == shards == "success":
+        print("E2E build and every shard succeeded; checking exact coverage next.")
+        return
+    # Only known GitHub result values enter annotations/Markdown, never raw env text.
+    known = FAILED | {"success", "skipped", "missing"}
+    build = build if build in known else "unknown"
+    shards = shards if shards in known else "unknown"
+    logs, unavailable = {}, set()
+    try:
+        jobs = workflow_jobs()
+    except (OSError, ValueError, KeyError, TypeError):
+        jobs = []
+    failed = [job for job in jobs if
+              (job["name"] == "E2E build and plan" or scenario_job(job))
+              and job.get("conclusion") in FAILED]
+    for job in failed[:MAX_LOG_JOBS]:
+        try:
+            logs[job["id"]] = job_log(job["id"])
+        except (OSError, ValueError, KeyError, TypeError):
+            unavailable.add(job["id"])
+    title, summary = failure_summary(build, shards, jobs, logs, unavailable)
+    if not jobs:
+        summary += "\nJob metadata was unavailable; open **E2E build and plan** and the shard jobs in this attempt.\n"
+    publish_summary(summary)
+    cause = next((reason for log in logs.values() if (reason := classify_log(log))), None)
+    detail = cause or "See the E2E failure summary for failed steps and log links."
+    print(f"::error title={title}::{title}. Build={build}; shards={shards}. {detail}")
+    raise ValueError(f"{title}; see the E2E failure summary")

--- a/scripts/e2e_diagnostics.py
+++ b/scripts/e2e_diagnostics.py
@@ -110,8 +110,8 @@ def failure_summary(build_result: str, shard_result: str, jobs: list[dict],
     else:
         lines += ["- Inspect the unsuccessful step above and any shard JSON/JUnit/failure artifacts.",
                   "- Correct the underlying failure, then rerun the entire workflow."]
-    lines += ["- The time budget is enforced separately. An overrun after failed bootstrap is "
-              "not evidence that GUI scenarios were slow.",
+    lines += ["- Timing is informational and never fails passing tests. A long failed bootstrap "
+              "is not evidence that GUI scenarios were slow.",
               "- Log inspection is bounded; follow the job links for full output."]
     return title, "\n".join(lines) + "\n"
 

--- a/scripts/e2e_images.py
+++ b/scripts/e2e_images.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Input-addressed public E2E images and digest-pinned registry cache discovery."""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+from e2e_bundle import dependency_key, image_key
+
+
+def references(repository, image_inputs, dependencies, uid, gid):
+    repository = repository.lower()
+    if (not re.fullmatch(r"[a-z0-9_.-]+/[a-z0-9_.-]+", repository)
+            or any(part in (".", "..") for part in repository.split("/"))):
+        raise ValueError("invalid image repository")
+    if uid < 0 or gid < 0 or not all(re.fullmatch(r"[0-9a-f]{64}", key)
+                                    for key in (image_inputs, dependencies)):
+        raise ValueError("images require SHA256 input identifiers and nonnegative account IDs")
+    prefix = f"ghcr.io/{repository}-e2e"
+    profile = f"linux-amd64-{uid}-{gid}"
+    return {"runtime": f"{prefix}-runtime:{image_inputs}-{profile}",
+            "build": f"{prefix}-build:{dependencies}-{profile}",
+            "cache": f"{prefix}-build:cache-{dependencies}-{profile}",
+            "environment_cache": f"{prefix}-build:environment-{image_inputs}-{profile}"}
+
+
+def check_image_labels(document, expected):
+    if not isinstance(document, dict):
+        raise ValueError("invalid published image configuration")
+    image = document.get("linux/amd64", document)
+    if not isinstance(image, dict) or image.get("os") != "linux" or image.get("architecture") != "amd64":
+        raise ValueError("published base does not provide the required linux/amd64 environment")
+    config = image.get("config", {})
+    labels = config.get("Labels", {}) if isinstance(config, dict) else {}
+    if not isinstance(labels, dict) or any(labels.get(key) != value for key, value in expected.items()):
+        raise ValueError("published base input labels do not match this checkout; refusing to substitute it")
+
+
+def resolve(reference, timeout=20, expected_labels=None):
+    deadline = time.monotonic() + timeout
+    result = subprocess.run(
+        ["docker", "buildx", "imagetools", "inspect", reference, "--format", "{{json .Manifest}}"],
+        capture_output=True, text=True, timeout=timeout, check=False)
+    if result.returncode:
+        return None
+    manifest = json.loads(result.stdout)
+    digest = manifest.get("digest", "") if isinstance(manifest, dict) else ""
+    if not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+        raise ValueError("registry returned an invalid manifest digest")
+    pinned = reference.rsplit(":", 1)[0] + "@" + digest
+    if expected_labels is not None:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise subprocess.TimeoutExpired("inspect image configuration", timeout)
+        config = subprocess.run(
+            ["docker", "buildx", "imagetools", "inspect", pinned, "--format", "{{json .Image}}"],
+            capture_output=True, text=True, timeout=remaining, check=False)
+        if config.returncode:
+            return None
+        check_image_labels(json.loads(config.stdout), expected_labels)
+    return pinned
+
+
+def discover_bases(refs, image_inputs, dependencies):
+    deadline = time.monotonic() + 20
+
+    def lookup(reference, labels=None):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return None
+        try:
+            return resolve(reference, timeout=remaining, expected_labels=labels)
+        except subprocess.TimeoutExpired:
+            return None
+
+    labels = {"org.strata.e2e.inputs": image_inputs}
+    build = lookup(refs["build"], {**labels, "org.strata.e2e.dependencies": dependencies})
+    runtime = lookup(refs["runtime"], labels)
+    cache = None
+    if not build or not runtime:
+        cache = lookup(refs["cache"]) or lookup(refs["environment_cache"])
+    return {"dependencies_image": build or "dependencies", "runtime_image": runtime or "runtime",
+            "cache_from": f"type=registry,ref={cache}" if cache else ""}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("references")
+    bases = sub.add_parser("bases")
+    bases.add_argument("--require-published", action="store_true")
+    cache = sub.add_parser("cache")
+    cache.add_argument("reference")
+    cache.add_argument("--environment")
+    args = parser.parse_args()
+    try:
+        if args.command in ("references", "bases"):
+            refs = references(os.environ["GITHUB_REPOSITORY"], image_key(),
+                              dependency_key(), os.getuid(), os.getgid())
+            outputs = refs if args.command == "references" else discover_bases(refs, image_key(), dependency_key())
+            missing = args.command == "bases" and (outputs["dependencies_image"] == "dependencies"
+                                                    or outputs["runtime_image"] == "runtime")
+            if missing and args.require_published:
+                raise ValueError("matching published bases are required but unavailable; publish them and verify anonymous access first")
+            for key, value in outputs.items():
+                print(f"{key}={value}")
+            if missing:
+                print("::notice::Some published E2E bases are unavailable. Missing stages will use "
+                      "verified caches/source bootstrap. Publish the matching trusted main inputs "
+                      "and make both GHCR packages public for anonymous fork access.", file=sys.stderr)
+        else:
+            try:
+                pinned = resolve(args.reference)
+                if pinned is None and args.environment:
+                    pinned = resolve(args.environment)
+            except subprocess.TimeoutExpired:
+                pinned = None
+            if pinned:
+                print(f"cache_from=type=registry,ref={pinned}")
+            else:
+                print("cache_from=")
+                print("::notice::Published E2E environment unavailable (not published, private, or "
+                      "registry unreachable). Falling back to verified dependency/index caches "
+                      "and source bootstrap. Publish the trusted main-branch images and make "
+                      "both GHCR packages public for anonymous fork access.", file=sys.stderr)
+    except (OSError, ValueError, KeyError) as error:
+        parser.exit(1, f"E2E images: {error}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/e2e_images.py
+++ b/scripts/e2e_images.py
@@ -26,7 +26,8 @@ def references(repository, image_inputs, dependencies, uid, gid):
     return {"runtime": f"{prefix}-runtime:{image_inputs}-{profile}",
             "build": f"{prefix}-build:{dependencies}-{profile}",
             "cache": f"{prefix}-build:cache-{dependencies}-{profile}",
-            "environment_cache": f"{prefix}-build:environment-{image_inputs}-{profile}"}
+            "environment_cache": f"{prefix}-build:environment-{image_inputs}-{profile}",
+            "environment_image": f"{prefix}-build:base-{image_inputs}-{profile}"}
 
 
 def check_image_labels(document, expected):
@@ -92,6 +93,7 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
     sub.add_parser("references")
+    sub.add_parser("environment")
     bases = sub.add_parser("bases")
     bases.add_argument("--require-published", action="store_true")
     cache = sub.add_parser("cache")
@@ -99,7 +101,14 @@ def main():
     cache.add_argument("--environment")
     args = parser.parse_args()
     try:
-        if args.command in ("references", "bases"):
+        if args.command == "environment":
+            inputs = image_key()
+            refs = references(os.environ["GITHUB_REPOSITORY"], inputs, dependency_key(), os.getuid(), os.getgid())
+            pinned = resolve(refs["environment_image"], expected_labels={"org.strata.e2e.inputs": inputs})
+            if not pinned:
+                raise ValueError("the published local-development base is unavailable anonymously")
+            print(f"environment_image={pinned}")
+        elif args.command in ("references", "bases"):
             refs = references(os.environ["GITHUB_REPOSITORY"], image_key(),
                               dependency_key(), os.getuid(), os.getgid())
             outputs = refs if args.command == "references" else discover_bases(refs, image_key(), dependency_key())
@@ -128,7 +137,7 @@ def main():
                       "registry unreachable). Falling back to verified dependency/index caches "
                       "and source bootstrap. Publish the trusted main-branch images and make "
                       "both GHCR packages public for anonymous fork access.", file=sys.stderr)
-    except (OSError, ValueError, KeyError) as error:
+    except (OSError, ValueError, KeyError, subprocess.TimeoutExpired) as error:
         parser.exit(1, f"E2E images: {error}\n")
 
 

--- a/scripts/test_e2e_base.py
+++ b/scripts/test_e2e_base.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import unittest
+from unittest.mock import Mock, patch
+
+from e2e_base import build_base, ensure_base, verify_image
+from e2e_bundle import image_key
+
+
+def valid_image():
+    return {"Id": "sha256:" + "a" * 64, "Os": "linux", "Architecture": "amd64",
+            "Config": {"Labels": {"org.strata.e2e.inputs": image_key()},
+                       "Env": ["RUSTUP_HOME=/opt/rustup"]}}
+
+
+class LocalBaseTests(unittest.TestCase):
+    def test_cached_base_requires_no_pull_or_build(self):
+        with patch("e2e_base.inspect", return_value=valid_image()), \
+             patch("e2e_base.subprocess.run") as run:
+            self.assertEqual(ensure_base("podman"), valid_image()["Id"])
+        run.assert_not_called()
+
+    def test_application_manifest_changes_do_not_force_an_environment_refresh(self):
+        with patch("e2e_base.inspect", return_value=valid_image()), \
+             patch("e2e_base.dependency_key", side_effect=AssertionError("must reuse the environment")), \
+             patch("e2e_base.subprocess.run") as run:
+            ensure_base("podman")
+        run.assert_not_called()
+
+    def test_cached_registry_reference_is_reused_without_network(self):
+        with patch("e2e_base.inspect", side_effect=[None, valid_image()]), \
+             patch("e2e_base.subprocess.run", return_value=Mock(returncode=0)) as run:
+            ensure_base("podman")
+        self.assertEqual(run.call_count, 1)
+        self.assertEqual(run.call_args.args[0][:2], ["podman", "tag"])
+
+    def test_missing_base_is_pulled_verified_and_recorded_locally(self):
+        with patch("e2e_base.inspect", side_effect=[None, None, valid_image()]), \
+             patch("e2e_base.subprocess.run", return_value=Mock(returncode=0)) as run, \
+             patch("builtins.print"):
+            ensure_base("podman")
+        self.assertEqual([call.args[0][1] for call in run.call_args_list], ["pull", "tag"])
+        self.assertIn("-1001-1001", run.call_args_list[0].args[0][-1])
+        self.assertEqual(run.call_args_list[1].args[0][2], valid_image()["Id"])
+
+    def test_missing_publication_never_silently_builds_from_ubuntu(self):
+        with patch("e2e_base.inspect", return_value=None), \
+             patch("e2e_base.subprocess.run", return_value=Mock(returncode=1)) as run, \
+             patch("builtins.print"), self.assertRaisesRegex(ValueError, "explicit local environment build"):
+            ensure_base("podman")
+        self.assertEqual(run.call_count, 1)
+        self.assertEqual(run.call_args.args[0][1], "pull")
+
+    def test_wrong_local_provenance_is_rejected_without_replacing_the_image(self):
+        image = valid_image()
+        image["Config"]["Labels"]["org.strata.e2e.inputs"] = "wrong"
+        with patch("e2e_base.inspect", return_value=image), patch("e2e_base.subprocess.run") as run, \
+             self.assertRaisesRegex(ValueError, "input labels"):
+            ensure_base("podman")
+        run.assert_not_called()
+
+    def test_runtime_only_images_cannot_be_used_to_compile_the_application(self):
+        image = valid_image()
+        image["Config"]["Env"] = []
+        with self.assertRaisesRegex(ValueError, "runtime-only"):
+            verify_image(image, image_key())
+
+    def test_explicit_build_uses_pinned_recipe_and_current_account_ids(self):
+        with patch("e2e_base.os.getuid", return_value=1234), patch("e2e_base.os.getgid", return_value=5678), \
+             patch("e2e_base.subprocess.run", return_value=Mock(returncode=0)) as run, \
+             patch("e2e_base.inspect", return_value=valid_image()):
+            build_base("podman")
+        command = run.call_args.args[0]
+        self.assertEqual(command[:2], ["podman", "build"])
+        self.assertIn("E2E_UID=1234", command)
+        self.assertIn("E2E_GID=5678", command)
+        self.assertIn("org.strata.e2e.inputs=" + image_key(), command)
+        self.assertIn("toolchain", command)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_e2e_diagnostics.py
+++ b/scripts/test_e2e_diagnostics.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import io
+import unittest
+from unittest.mock import Mock, patch
+from urllib.request import Request
+
+from e2e_diagnostics import (LogRedirectHandler, MAX_LOG_BYTES, classify_log,
+                             failure_summary, job_log, require_dependencies)
+
+
+def failed_job(index=1, name="E2E build and plan", conclusion="failure"):
+    return {"id": index, "name": name, "conclusion": conclusion,
+            "html_url": f"https://github.com/example/strata/actions/runs/10/job/{index}",
+            "steps": [{"name": "Build the tested revision", "conclusion": conclusion}]}
+
+
+class ClassificationTests(unittest.TestCase):
+    def test_snapshot_errors_are_attributed_to_bootstrap_not_gui_assertions(self):
+        log = "\n".join(
+            f"E: Failed to fetch https://snapshot.ubuntu.com/ubuntu/date/dists/noble/InRelease  {code} Error"
+            for code in (503, 500, 502, 503))
+        reason = classify_log(log)
+        self.assertIn("HTTP 500/502/503", reason)
+        self.assertIn("not a GUI assertion", reason)
+
+    def test_commands_urls_and_unrelated_ubuntu_errors_are_not_outage_evidence(self):
+        for log in ("RUN apt-get update https://snapshot.ubuntu.com/ubuntu/date",
+                    "error: exit code 100", "some request returned 503",
+                    "E: Failed to fetch https://archive.ubuntu.com/ubuntu/pkg  503 Error",
+                    "E: Failed to fetch https://snapshot.ubuntu.com.evil.test/pkg  503 Error"):
+            with self.subTest(log=log):
+                self.assertIsNone(classify_log(log))
+
+    def test_compiler_integrity_and_provenance_failures_are_distinct(self):
+        self.assertIn("E0382", classify_log("error[E0382]: use of moved value"))
+        self.assertIn("integrity", classify_log("E: Hash Sum mismatch"))
+        self.assertIn("bundle", classify_log("E2E bundle: source differs"))
+
+
+class SummaryTests(unittest.TestCase):
+    def test_build_failure_explains_no_tests_and_links_to_the_failed_step(self):
+        job = failed_job()
+        title, summary = failure_summary("failure", "skipped", [job], {1:
+            "E: Failed to fetch http://snapshot.ubuntu.com/ubuntu/date/pkg  502 Bad Gateway"}, set())
+        self.assertIn("bootstrap", title)
+        self.assertIn("No E2E scenarios ran", summary)
+        self.assertIn(job["html_url"], summary)
+        self.assertIn("Build the tested revision", summary)
+        self.assertIn("Main cannot restore PR-scoped caches", summary)
+        self.assertIn("entire CI workflow", summary)
+
+    def test_failed_shards_are_not_reported_as_zero_executed_scenarios(self):
+        job = failed_job(2, "E2E shard 0")
+        title, summary = failure_summary("success", "failure", [job], {}, {2})
+        self.assertIn("shard execution", title)
+        self.assertNotIn("No E2E scenarios ran", summary)
+        self.assertIn("logs were unavailable", summary)
+        self.assertIn("could not be extracted", summary)
+
+    def test_timeout_without_log_evidence_does_not_claim_an_ubuntu_outage(self):
+        _, summary = failure_summary("timed_out", "skipped",
+                                     [failed_job(conclusion="timed_out")], {}, set())
+        self.assertIn("timeout alone does not establish", summary)
+        self.assertNotIn("Ubuntu Snapshot returned", summary)
+
+    def test_success_needs_no_diagnostic_api_calls(self):
+        jobs, publish = Mock(), Mock()
+        with patch.dict("os.environ", {"BUILD_RESULT": "success", "SHARD_RESULT": "success"}), \
+             patch("builtins.print"):
+            require_dependencies(jobs, publish)
+        jobs.assert_not_called()
+        publish.assert_not_called()
+
+    def test_log_requests_are_bounded_but_all_failed_jobs_are_linked(self):
+        jobs = [failed_job(index, f"E2E shard {index}") for index in range(5)]
+        publish = Mock()
+        with patch.dict("os.environ", {"BUILD_RESULT": "success", "SHARD_RESULT": "failure"}), \
+             patch("e2e_diagnostics.job_log", return_value="") as logs, patch("builtins.print"), \
+             self.assertRaises(ValueError):
+            require_dependencies(lambda: jobs, publish)
+        self.assertEqual(logs.call_count, 3)
+        for job in jobs:
+            self.assertIn(job["html_url"], publish.call_args.args[0])
+
+    def test_api_failure_still_fails_with_an_actionable_summary(self):
+        publish = Mock()
+        with patch.dict("os.environ", {"BUILD_RESULT": "failure", "SHARD_RESULT": "skipped"}), \
+             patch("builtins.print"), self.assertRaises(ValueError):
+            require_dependencies(Mock(side_effect=OSError("unavailable")), publish)
+        self.assertIn("Job metadata was unavailable", publish.call_args.args[0])
+
+
+class LogTransportTests(unittest.TestCase):
+    def test_redirect_strips_github_credentials_before_contacting_blob_storage(self):
+        request = Request("https://api.github.com/repos/example/strata/actions/jobs/1/logs",
+                          headers={"Authorization": "Bearer test-only"})
+        redirected = LogRedirectHandler().redirect_request(
+            request, None, 302, "Found", {}, "https://example.blob.core.windows.net/log?sig=test-only")
+        self.assertIsNone(redirected.get_header("Authorization"))
+        self.assertEqual(request.get_header("Authorization"), "Bearer test-only")
+        with self.assertRaisesRegex(ValueError, "insecure"):
+            LogRedirectHandler().redirect_request(request, None, 302, "Found", {}, "http://example.test/log")
+
+    def test_log_fetch_has_a_size_limit_and_api_timeout(self):
+        response = io.BytesIO(b"x" * (MAX_LOG_BYTES + 1))
+        opener = Mock()
+        opener.open.return_value = response
+        with patch.dict("os.environ", {"GITHUB_REPOSITORY": "example/strata", "GH_TOKEN": "test-only",
+                                       "GITHUB_API_URL": "https://api.github.com"}), \
+             patch("e2e_diagnostics.build_opener", return_value=opener):
+            self.assertEqual(len(job_log(123)), MAX_LOG_BYTES)
+        self.assertEqual(opener.open.call_args.kwargs["timeout"], 10)
+        self.assertTrue(opener.open.call_args.args[0].full_url.endswith("/actions/jobs/123/logs"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_e2e_diagnostics.py
+++ b/scripts/test_e2e_diagnostics.py
@@ -16,6 +16,13 @@ def failed_job(index=1, name="E2E build and plan", conclusion="failure"):
 
 
 class ClassificationTests(unittest.TestCase):
+    def test_rendered_commands_are_not_mistaken_for_executed_errors(self):
+        command = "##[group]Run echo 'Runtime cache did not match its exact pinned key'\n##[endgroup]\n"
+        self.assertIsNone(classify_log(command))
+        reason = classify_log(command + "Error: strata-e2e:ci-runtime: image not known\n")
+        self.assertIn("same engine", reason)
+        self.assertNotIn("cache did not match", reason)
+
     def test_snapshot_errors_are_attributed_to_bootstrap_not_gui_assertions(self):
         log = "\n".join(
             f"E: Failed to fetch https://snapshot.ubuntu.com/ubuntu/date/dists/noble/InRelease  {code} Error"

--- a/scripts/test_e2e_images.py
+++ b/scripts/test_e2e_images.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from contextlib import redirect_stderr, redirect_stdout
+import io
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+from e2e_bundle import dependency_key
+from e2e_images import check_image_labels, discover_bases, main, references, resolve
+
+
+class ImageIdentityTests(unittest.TestCase):
+    def test_tags_bind_platform_accounts_and_inputs_without_latest(self):
+        refs = references("Example/Strata", "a" * 64, "b" * 64, 1001, 1001)
+        self.assertTrue(all(ref.startswith("ghcr.io/example/strata-e2e-") for ref in refs.values()))
+        self.assertTrue(all(ref.endswith("-linux-amd64-1001-1001") for ref in refs.values()))
+        self.assertIn("a" * 64, refs["runtime"])
+        self.assertIn("b" * 64, refs["build"])
+        self.assertIn("a" * 64, refs["environment_cache"])
+        self.assertTrue(all(len(ref.split(":")[-1]) <= 128 for ref in refs.values()))
+        self.assertNotEqual(refs, references("Example/Strata", "a" * 64, "b" * 64, 1000, 1000))
+
+    def test_rejects_invalid_names_and_non_digest_input_keys(self):
+        for repository, key in (("../strata", "a" * 64), ("example/strata;command", "a" * 64),
+                                ("example/strata", "latest")):
+            with self.subTest(repository=repository, key=key), self.assertRaises(ValueError):
+                references(repository, key, "b" * 64, 1001, 1001)
+
+    def test_dependency_identity_changes_only_with_environment_or_dependency_inputs(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            files = ("tests/e2e/Dockerfile", "tests/e2e/requirements.txt", "tests/e2e/install-packages.sh",
+                     "Cargo.toml", "Cargo.lock", ".dockerignore")
+            for name in files:
+                path = root / name
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(name)
+            original = dependency_key(root)
+            (root / "application.rs").write_text("changed application")
+            self.assertEqual(dependency_key(root), original)
+            for name in files:
+                with self.subTest(name=name):
+                    (root / name).write_text(name + "changed")
+                    self.assertNotEqual(dependency_key(root), original)
+                    (root / name).write_text(name)
+
+
+class RegistryDiscoveryTests(unittest.TestCase):
+    def test_pins_the_top_level_manifest_digest_not_an_arbitrary_platform(self):
+        manifest = {"digest": "sha256:" + "a" * 64,
+                    "manifests": [{"digest": "sha256:" + "b" * 64}]}
+        result = Mock(returncode=0, stdout=json.dumps(manifest))
+        with patch("e2e_images.subprocess.run", return_value=result) as run:
+            pinned = resolve("ghcr.io/example/strata-e2e-build:inputs")
+        self.assertEqual(pinned, "ghcr.io/example/strata-e2e-build@sha256:" + "a" * 64)
+        self.assertEqual(run.call_args.kwargs["timeout"], 20)
+        self.assertNotIn("shell", run.call_args.kwargs)
+
+    def test_unavailable_is_a_cache_miss_but_malformed_success_fails_closed(self):
+        with patch("e2e_images.subprocess.run", return_value=Mock(returncode=1)):
+            self.assertIsNone(resolve("ghcr.io/example/build:missing"))
+        for manifest in ({}, [], {"digest": "latest"}, {"digest": "sha256:bad\ncache_from=other"}):
+            with self.subTest(manifest=manifest), \
+                 patch("e2e_images.subprocess.run", return_value=Mock(returncode=0, stdout=json.dumps(manifest))), \
+                 self.assertRaises(ValueError):
+                resolve("ghcr.io/example/build:bad")
+
+    def test_base_configuration_is_read_by_digest_before_accepting_its_labels(self):
+        labels = {"org.strata.e2e.inputs": "a" * 64}
+        image = {"os": "linux", "architecture": "amd64", "config": {"Labels": labels}}
+        results = [Mock(returncode=0, stdout=json.dumps({"digest": "sha256:" + "b" * 64})),
+                   Mock(returncode=0, stdout=json.dumps({"linux/amd64": image}))]
+        with patch("e2e_images.subprocess.run", side_effect=results) as run:
+            pinned = resolve("ghcr.io/example/build:inputs", expected_labels=labels)
+        self.assertIn(pinned, run.call_args.args[0])
+        self.assertIn("{{json .Image}}", run.call_args.args[0])
+
+    def test_wrong_or_missing_input_labels_and_platforms_are_rejected(self):
+        labels = {"org.strata.e2e.inputs": "a" * 64}
+        correct = {"os": "linux", "architecture": "amd64", "config": {"Labels": labels}}
+        check_image_labels(correct, labels)
+        check_image_labels({"linux/amd64": correct}, labels)
+        for image in ([], {}, {**correct, "architecture": "arm64"}, {**correct, "config": {}},
+                      {**correct, "config": {"Labels": {"org.strata.e2e.inputs": "wrong"}}}):
+            with self.subTest(image=image), self.assertRaises(ValueError):
+                check_image_labels(image, labels)
+
+    def test_available_images_are_direct_bases_not_merely_cache_hints(self):
+        refs = references("example/strata", "a" * 64, "b" * 64, 1001, 1001)
+        with patch("e2e_images.resolve", side_effect=["build@sha256:123", "runtime@sha256:456"]) as lookup:
+            outputs = discover_bases(refs, "a" * 64, "b" * 64)
+        self.assertEqual(lookup.call_count, 2)
+        self.assertEqual(lookup.call_args_list[0].kwargs["expected_labels"],
+                         {"org.strata.e2e.inputs": "a" * 64, "org.strata.e2e.dependencies": "b" * 64})
+        self.assertEqual(outputs["dependencies_image"], "build@sha256:123")
+        self.assertEqual(outputs["runtime_image"], "runtime@sha256:456")
+        self.assertEqual(outputs["cache_from"], "")
+
+    def test_new_cargo_inputs_can_reuse_the_persistent_environment_cache(self):
+        refs = references("example/strata", "a" * 64, "b" * 64, 1001, 1001)
+        with patch("e2e_images.resolve", side_effect=[None, "runtime@sha256:456", None,
+                                                      "environment@sha256:789"]) as lookup:
+            outputs = discover_bases(refs, "a" * 64, "b" * 64)
+        self.assertEqual(lookup.call_args.args[0], refs["environment_cache"])
+        self.assertEqual(outputs["dependencies_image"], "dependencies")
+        self.assertEqual(outputs["runtime_image"], "runtime@sha256:456")
+        self.assertEqual(outputs["cache_from"], "type=registry,ref=environment@sha256:789")
+
+    def test_discovery_has_one_shared_deadline_not_twenty_seconds_per_reference(self):
+        refs = references("example/strata", "a" * 64, "b" * 64, 1001, 1001)
+        with patch("e2e_images.time.monotonic", side_effect=[0, 0, 21, 21, 21]), \
+             patch("e2e_images.resolve", return_value=None) as lookup:
+            outputs = discover_bases(refs, "a" * 64, "b" * 64)
+        self.assertEqual(lookup.call_count, 1)
+        self.assertEqual(outputs["dependencies_image"], "dependencies")
+
+    def test_required_published_mode_cannot_silently_fall_back_to_source(self):
+        output, error = io.StringIO(), io.StringIO()
+        with patch.dict("os.environ", {"GITHUB_REPOSITORY": "example/strata"}), \
+             patch("sys.argv", ["e2e_images.py", "bases", "--require-published"]), \
+             patch("e2e_images.discover_bases", return_value={"dependencies_image": "dependencies",
+                                                              "runtime_image": "runtime", "cache_from": ""}), \
+             redirect_stdout(output), redirect_stderr(error), self.assertRaises(SystemExit) as exited:
+            main()
+        self.assertEqual(exited.exception.code, 1)
+        self.assertEqual(output.getvalue(), "")
+        self.assertIn("matching published bases are required", error.getvalue())
+
+    def test_registry_timeout_retains_verified_source_building(self):
+        refs = references("example/strata", "a" * 64, "b" * 64, 1001, 1001)
+        with patch("e2e_images.resolve", side_effect=subprocess.TimeoutExpired("inspect", 20)):
+            outputs = discover_bases(refs, "a" * 64, "b" * 64)
+        self.assertEqual(outputs, {"dependencies_image": "dependencies", "runtime_image": "runtime",
+                                   "cache_from": ""})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_e2e_packages.py
+++ b/scripts/test_e2e_packages.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -40,17 +41,34 @@ class PinnedPackageTests(unittest.TestCase):
             "call = {'args': sys.argv[1:], 'sources': (root/'etc/apt/sources.list').read_text(),\n"
             "        'indexes': {p.name: p.read_text() for p in (root/'var/lib/apt/lists').iterdir()}}\n"
             "with (root/'calls.jsonl').open('a') as f: f.write(json.dumps(call)+'\\n')\n"
+            "if '--print-uris' in sys.argv:\n"
+            "    uris = root/'uris.txt'\n"
+            "    print(uris.read_text() if uris.exists() else '')\n"
+            "    raise SystemExit(0)\n"
             "key = 'DOWNLOAD_STATUS' if '--download-only' in sys.argv else 'INSTALL_STATUS'\n"
             "raise SystemExit(int(os.environ[key]))\n"
         )
         apt.chmod(0o755)
+        helper = self.root / "usr/lib/apt/apt-helper"
+        helper.parent.mkdir(parents=True)
+        helper.write_text(
+            f"#!{sys.executable}\n"
+            "import hashlib, json, os, sys\n"
+            "from pathlib import Path\n"
+            "root = Path(os.environ['STRATA_E2E_APT_ROOT'])\n"
+            "with (root/'helper.jsonl').open('a') as f: f.write(json.dumps(sys.argv[1:])+'\\n')\n"
+            "data = os.environ['ARCHIVE_PAYLOAD'].encode()\n"
+            "if sys.argv[-1] != 'SHA256:'+hashlib.sha256(data).hexdigest(): raise SystemExit(100)\n"
+            "Path(sys.argv[-2]).write_bytes(data)\n"
+        )
+        helper.chmod(0o755)
 
-    def run_installer(self, download=0, install=0):
+    def run_installer(self, download=0, install=0, payload="pinned archive fixture"):
         result = subprocess.run(
             ["sh", str(SCRIPT), "libgtk-4-dev", "fonts-cantarell"],
             env={**os.environ, "PATH": f"{self.bin}:{os.environ.get('PATH', os.defpath)}",
                  "STRATA_E2E_APT_ROOT": str(self.root), "STRATA_E2E_SNAPSHOT_URL": SNAPSHOT,
-                 "DOWNLOAD_STATUS": str(download), "INSTALL_STATUS": str(install)},
+                 "DOWNLOAD_STATUS": str(download), "INSTALL_STATUS": str(install), "ARCHIVE_PAYLOAD": payload},
             text=True, capture_output=True, check=False,
         )
         log = self.root / "calls.jsonl"
@@ -81,10 +99,58 @@ class PinnedPackageTests(unittest.TestCase):
     def test_unavailable_mirror_versions_fall_back_without_changing_resolution(self):
         result, calls = self.run_installer(download=100)
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(len(calls), 2)
-        self.assertEqual(calls[1]["sources"], self.original)
-        self.assertIn("completing downloads from the snapshot", result.stderr)
+        self.assertEqual(len(calls), 3)
+        self.assertIn("--print-uris", calls[1]["args"])
+        self.assertIn("Acquire::ForceHash=SHA256", calls[1]["args"])
+        self.assertEqual(calls[2]["sources"], self.original)
+        self.assertIn("Launchpad archive fallback", result.stderr)
         self.assert_restored()
+
+    def archive_uri(self, checksum=None, cached="fixture_1_amd64.deb"):
+        checksum = checksum or hashlib.sha256(b"pinned archive fixture").hexdigest()
+        (self.root / "uris.txt").write_text(
+            "'https://archive.ubuntu.com/ubuntu/pool/main/f/fixture/fixture_1_amd64.deb' "
+            f"{cached} 22 SHA256:{checksum}\n")
+        return checksum
+
+    def test_archival_fallback_uses_the_signed_snapshot_hash_and_original_install_sources(self):
+        checksum = self.archive_uri()
+        result, calls = self.run_installer(download=100)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        helper = json.loads((self.root / "helper.jsonl").read_text())
+        self.assertEqual(helper[-3], "https://launchpad.net/ubuntu/+archive/primary/+files/fixture_1_amd64.deb")
+        self.assertEqual(helper[-1], "SHA256:" + checksum)
+        self.assertEqual(calls[-1]["sources"], self.original)
+        self.assertEqual(sum("--download-only" not in call["args"] for call in calls), 1)
+        self.assert_restored()
+
+    def test_bad_archival_bytes_fall_back_without_becoming_an_installable_cache_entry(self):
+        self.archive_uri()
+        result, calls = self.run_installer(download=100, install=87, payload="different bytes")
+        self.assertEqual(result.returncode, 87)
+        self.assertFalse((self.root / "var/cache/apt/archives/fixture_1_amd64.deb").exists())
+        self.assertIn("completing downloads from the snapshot", result.stderr)
+        self.assertEqual(sum("--download-only" not in call["args"] for call in calls), 1)
+        self.assert_restored()
+
+    def test_valid_local_archives_do_not_contact_the_archival_mirror(self):
+        self.archive_uri()
+        cached = self.root / "var/cache/apt/archives/fixture_1_amd64.deb"
+        cached.parent.mkdir(parents=True)
+        cached.write_bytes(b"pinned archive fixture")
+        result, _ = self.run_installer(download=100)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse((self.root / "helper.jsonl").exists())
+        self.assert_restored()
+
+    def test_untrusted_archive_destinations_or_missing_sha256_are_rejected(self):
+        for checksum, cached in (("bad", "fixture.deb"), ("a" * 64, "../outside.deb")):
+            with self.subTest(checksum=checksum, cached=cached):
+                self.archive_uri(checksum, cached)
+                result, _ = self.run_installer(download=100)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertFalse((self.root / "helper.jsonl").exists())
+                self.assert_restored()
 
     def test_installation_failure_is_propagated_and_not_retried(self):
         result, calls = self.run_installer(install=87)

--- a/scripts/test_e2e_runner.py
+++ b/scripts/test_e2e_runner.py
@@ -63,6 +63,8 @@ class ContainerRunnerTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         build, run = [call["args"] for call in calls]
         self.assertEqual(build[0], "build")
+        from e2e_bundle import image_key
+        self.assertIn(f"org.strata.e2e.inputs={image_key()}", build)
         image = build[build.index("--tag") + 1]
         self.assertIn(image, run)
         self.assertEqual(run[-2:], ["-k", "columns and baseline"])

--- a/scripts/test_e2e_runner.py
+++ b/scripts/test_e2e_runner.py
@@ -6,6 +6,8 @@ import sys
 import tempfile
 import unittest
 
+from e2e_bundle import image_key
+
 
 REPOSITORY = Path(__file__).resolve().parents[1]
 
@@ -25,13 +27,17 @@ class ContainerRunnerTests(unittest.TestCase):
                 "'wayland': os.environ.get('WAYLAND_DISPLAY'), "
                 "'notify': os.environ.get('NOTIFY_SOCKET')}) + '\\n')\n"
                 "if sys.argv[1:3] == ['image', 'inspect']:\n"
-                "    print(os.environ.get('MOCK_IMAGE_KEY', ''))\n"
+                "    if '--format' in sys.argv: print(os.environ.get('MOCK_IMAGE_KEY', ''))\n"
+                "    else: print(json.dumps([{'Id':'sha256:'+'a'*64, 'Os':'linux', 'Architecture':'amd64',\n"
+                "         'Config':{'Labels':{'org.strata.e2e.inputs':os.environ['MOCK_IMAGE_KEY']},\n"
+                "                   'Env':['RUSTUP_HOME=/opt/rustup']}}]))\n"
             )
             engine.chmod(0o755)
             environment = {
                 **os.environ,
                 "STRATA_CONTAINER_ENGINE": str(engine),
                 "ENGINE_LOG": str(log),
+                "MOCK_IMAGE_KEY": image_key(),
                 "DISPLAY": ":0",
                 "WAYLAND_DISPLAY": "wayland-0",
                 "NOTIFY_SOCKET": "/run/user/1000/systemd/notify",
@@ -58,15 +64,13 @@ class ContainerRunnerTests(unittest.TestCase):
             calls = [json.loads(line) for line in log.read_text().splitlines()] if log.exists() else []
             return result, calls
 
-    def test_build_and_run_share_image_and_forward_arguments(self):
+    def test_cached_base_is_verified_and_run_without_building_or_pulling(self):
         result, calls = self.run_runner()
         self.assertEqual(result.returncode, 0, result.stderr)
-        build, run = [call["args"] for call in calls]
-        self.assertEqual(build[0], "build")
-        from e2e_bundle import image_key
-        self.assertIn(f"org.strata.e2e.inputs={image_key()}", build)
-        image = build[build.index("--tag") + 1]
-        self.assertIn(image, run)
+        inspect, run = [call["args"] for call in calls]
+        self.assertEqual(inspect[:2], ["image", "inspect"])
+        self.assertIn("sha256:" + "a" * 64, run)
+        self.assertFalse(any(call["args"][0] in ("build", "pull") for call in calls))
         self.assertEqual(run[-2:], ["-k", "columns and baseline"])
         self.assertIn(f"type=bind,source={REPOSITORY},target=/workspace", run)
         self.assertIn("STRATA_E2E_UPDATE_BASELINES=1", run)
@@ -94,11 +98,11 @@ class ContainerRunnerTests(unittest.TestCase):
     def test_non_default_uid_has_a_matching_image_account(self):
         result, calls = self.run_runner(uid=1001)
         self.assertEqual(result.returncode, 0, result.stderr)
-        build, run = [call["args"] for call in calls]
-        self.assertIn("E2E_UID=1001", build)
-        self.assertIn("E2E_GID=1001", build)
-        self.assertTrue(build[build.index("--tag") + 1].endswith("-1001-1001"))
+        _, run = [call["args"] for call in calls]
         self.assertEqual(run[run.index("--user") + 1], "1001:1001")
+        account = REPOSITORY / "target/e2e-container/accounts-1001-1001/passwd"
+        self.assertIn("strata-e2e:x:1001:1001:", account.read_text())
+        self.assertIn(f"type=bind,source={account},target=/etc/passwd,readonly", run)
 
     def test_failed_container_build_cannot_run_stale_binary(self):
         _, calls = self.run_runner()
@@ -136,9 +140,10 @@ class ContainerRunnerTests(unittest.TestCase):
     def test_preloaded_image_skips_the_container_build(self):
         result, calls = self.run_runner(extra_env={"STRATA_E2E_IMAGE": "pinned-runtime"})
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(len(calls), 1)
-        self.assertEqual(calls[0]["args"][0], "run")
-        self.assertIn("pinned-runtime", calls[0]["args"])
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0]["args"][:2], ["image", "inspect"])
+        self.assertEqual(calls[1]["args"][0], "run")
+        self.assertIn("sha256:" + "a" * 64, calls[1]["args"])
 
     def test_ci_bundle_is_verified_before_the_engine_can_execute_it(self):
         from e2e_bundle import create, image_key

--- a/scripts/test_e2e_runner.py
+++ b/scripts/test_e2e_runner.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 from pathlib import Path
 import subprocess
 import sys
@@ -81,6 +82,16 @@ class ContainerRunnerTests(unittest.TestCase):
             self.assertIsNone(call["display"])
             self.assertIsNone(call["wayland"])
             self.assertIsNone(call["notify"])
+
+    def test_ci_explicitly_runs_the_engine_that_loaded_its_runtime(self):
+        workflow = (REPOSITORY / ".github/workflows/ci.yml").read_text()
+        loader = re.search(r"zstd -dc target/e2e-runtime/runtime.tar.zst \| (\w+) load", workflow)
+        step = workflow.split("- name: Run the assigned scenarios without rebuilding or installing", 1)[1]
+        step = step.split("- name:", 1)[0]
+        runner = re.search(r"STRATA_CONTAINER_ENGINE: (\w+)", step)
+        self.assertIsNotNone(loader)
+        self.assertIsNotNone(runner)
+        self.assertEqual(loader.group(1), runner.group(1))
 
     def test_worker_budget_is_forwarded_into_container(self):
         for workers in ("auto", "1", "8"):

--- a/scripts/test_e2e_sharding.py
+++ b/scripts/test_e2e_sharding.py
@@ -12,7 +12,7 @@ import unittest
 from unittest.mock import patch
 
 from e2e_bundle import create, image_key, verify
-from e2e_ci import check_budget, critical_path, main as ci_main, workflow_jobs
+from e2e_ci import report_timing, critical_path, main as ci_main, workflow_jobs
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tests/e2e"))
 from harness.sharding import TARGET_SECONDS, make_plan, validate_plan, verify_reports
@@ -199,7 +199,7 @@ class CliTests(unittest.TestCase):
                     self.assertEqual(len(json.loads(result)), 25)
 
 
-class BudgetTests(unittest.TestCase):
+class TimingTests(unittest.TestCase):
     def test_budget_includes_dependency_setup_transfers_and_downstream_queues(self):
         jobs = [
             {"name": "E2E build and plan", "created_at": "2026-09-07T23:59:45Z",
@@ -216,21 +216,27 @@ class BudgetTests(unittest.TestCase):
         self.assertIn("| E2E build and plan | 15.0 | 60.0 |", summary)
         self.assertIn("| E2E shard 1 | 25.0 | 40.0 |", summary)
 
-    def test_budget_reserves_teardown_time_and_always_writes_the_measurement(self):
+    def test_slow_runs_report_timing_without_failing_tests(self):
         with tempfile.TemporaryDirectory() as directory:
             summary = Path(directory) / "summary.md"
             with patch.dict("os.environ", {"GITHUB_STEP_SUMMARY": str(summary)}), \
                  patch("e2e_ci.workflow_jobs", return_value=[]), \
                  patch("e2e_ci.critical_path", return_value=(174.9, "measured runtime\n")), \
                  patch("builtins.print"):
-                check_budget()
+                report_timing()
                 self.assertEqual(summary.read_text(), "measured runtime\n")
             with patch.dict("os.environ", {"GITHUB_STEP_SUMMARY": str(summary)}), \
                  patch("e2e_ci.workflow_jobs", return_value=[]), \
-                 patch("e2e_ci.critical_path", return_value=(175, "too slow\n")), \
-                 patch("builtins.print"), self.assertRaisesRegex(ValueError, "budget"):
-                check_budget()
-            self.assertIn("too slow", summary.read_text())
+                 patch("e2e_ci.critical_path", return_value=(600, "slow runtime\n")), \
+                 patch("builtins.print"):
+                report_timing()
+            self.assertIn("slow runtime", summary.read_text())
+
+    def test_unavailable_telemetry_does_not_fail_the_required_check(self):
+        with patch("e2e_ci.workflow_jobs", side_effect=OSError("unavailable")), \
+             patch("e2e_ci.publish_summary") as publish:
+            report_timing()
+        self.assertIn("unavailable", publish.call_args.args[0])
 
     def test_job_measurement_paginates_and_uses_the_current_run_attempt(self):
         batches = [{"jobs": [{"name": f"job-{index}"} for index in range(100)]},

--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -1,10 +1,12 @@
+ARG E2E_DEPENDENCIES_IMAGE=dependencies
+ARG E2E_RUNTIME_IMAGE=runtime
+
 FROM docker.io/library/ubuntu:24.04@sha256:1e0a86e57d247923571b75e0aaf48a1449cf8c543d51fb3e07a4a7d7bfa79316 AS certificates
 
 RUN apt-get update && apt-get install --yes --no-install-recommends ca-certificates=20260601~24.04.1
 
-FROM docker.io/library/ubuntu:24.04@sha256:1e0a86e57d247923571b75e0aaf48a1449cf8c543d51fb3e07a4a7d7bfa79316 AS runtime
+FROM docker.io/library/ubuntu:24.04@sha256:1e0a86e57d247923571b75e0aaf48a1449cf8c543d51fb3e07a4a7d7bfa79316 AS snapshot-base
 COPY --from=certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY tests/e2e/install-packages.sh /opt/e2e-install-packages.sh
 ENV STRATA_E2E_SNAPSHOT_URL=http://snapshot.ubuntu.com/ubuntu/20260901T000000Z
 
 RUN printf '%s\n' \
@@ -12,8 +14,16 @@ RUN printf '%s\n' \
     "deb [check-valid-until=no] $STRATA_E2E_SNAPSHOT_URL noble-updates main universe" \
     "deb [check-valid-until=no] $STRATA_E2E_SNAPSHOT_URL noble-security main universe" \
     > /etc/apt/sources.list \
-    && rm /etc/apt/sources.list.d/ubuntu.sources \
-    && apt-get update --error-on=any \
+    && rm /etc/apt/sources.list.d/ubuntu.sources
+
+FROM snapshot-base AS package-indexes
+RUN apt-get update --error-on=any
+
+FROM snapshot-base AS runtime
+COPY tests/e2e/install-packages.sh /opt/e2e-install-packages.sh
+# Reuse authenticated indexes without retaining them in the runtime image.
+RUN --mount=type=bind,from=package-indexes,source=/var/lib/apt/lists,target=/opt/e2e-apt-lists \
+    cp -a /opt/e2e-apt-lists/. /var/lib/apt/lists/ \
     && DEBIAN_FRONTEND=noninteractive sh /opt/e2e-install-packages.sh \
     at-spi2-core ca-certificates dbus-bin dbus-daemon fonts-cantarell \
     gir1.2-atspi-2.0 gir1.2-gtk-4.0 imagemagick libfontconfig1 libgtk-4-1 \
@@ -34,11 +44,9 @@ RUN (getent group "$E2E_GID" || groupadd --gid "$E2E_GID" strata-e2e) \
         --gid "$E2E_GID" --home-dir /tmp/strata-build-home --no-create-home strata-e2e)
 
 ENV STRATA_E2E_VENV=/opt/e2e-venv
-ARG E2E_IMAGE_KEY
-LABEL org.strata.e2e.inputs=$E2E_IMAGE_KEY
-
 FROM runtime AS toolchain
-RUN apt-get update --error-on=any \
+RUN --mount=type=bind,from=package-indexes,source=/var/lib/apt/lists,target=/opt/e2e-apt-lists \
+    cp -a /opt/e2e-apt-lists/. /var/lib/apt/lists/ \
     && DEBIAN_FRONTEND=noninteractive sh /opt/e2e-install-packages.sh \
         build-essential libfontconfig1-dev libgtk-4-dev libgtksourceview-5-dev \
         libpoppler-glib-dev pkg-config rustup \
@@ -57,7 +65,12 @@ RUN mkdir src && printf 'fn main() {}\n' > src/main.rs \
     && rm -rf src build.rs target/debug/strata target/debug/deps/strata* \
         target/debug/.fingerprint/strata-* target/debug/build/strata-*
 
-FROM dependencies AS application
+FROM ${E2E_RUNTIME_IMAGE} AS ci-runtime
+
+FROM ${E2E_DEPENDENCIES_IMAGE} AS application
+COPY Cargo.toml Cargo.lock /tmp/strata-e2e-manifests/
+RUN cmp Cargo.toml /tmp/strata-e2e-manifests/Cargo.toml \
+    && cmp Cargo.lock /tmp/strata-e2e-manifests/Cargo.lock
 COPY src ./src
 COPY data ./data
 COPY build.rs ./

--- a/tests/e2e/install-packages.sh
+++ b/tests/e2e/install-packages.sh
@@ -30,9 +30,11 @@ done
 
 backup=$(mktemp "$sources.strata-XXXXXX")
 cp "$sources" "$backup"
+uris=
 restore() {
     cp "$backup" "$sources"
     rm -f "$backup" "$lists/${mirror_prefix}"_*
+    [ -z "$uris" ] || rm -f "$uris"
 }
 trap restore EXIT
 trap 'exit 129' HUP
@@ -53,9 +55,50 @@ while IFS= read -r line; do
 done < "$backup" > "$sources"
 
 if ! apt-get --download-only install --yes --no-install-recommends "$@"; then
-    printf 'Mirror lacks pinned packages; completing downloads from the snapshot.\n' >&2
+    printf 'Mirror lacks pinned packages; trying the authenticated Launchpad archive fallback.\n' >&2
+    uris=$(mktemp "$sources.strata-uris-XXXXXX")
+    if apt-get --print-uris --download-only -o Acquire::ForceHash=SHA256 \
+        install --yes --no-install-recommends "$@" > "$uris"; then
+        archives="$root/var/cache/apt/archives"
+        mkdir -p "$archives/partial"
+        while read -r uri cached _size hash _extra; do
+            case "$uri" in
+                "'https://archive.ubuntu.com/ubuntu/pool/"*".deb'") ;;
+                *) continue ;;
+            esac
+            remote=${uri##*/}
+            remote=${remote%\'}
+            for name in "$remote" "$cached"; do
+                case "$name" in
+                    ''|*[!a-zA-Z0-9._+~:%-]*) fail 'invalid package download filename' ;;
+                esac
+            done
+            case "$hash" in
+                SHA256:*) checksum=${hash#SHA256:} ;;
+                *) fail 'APT did not provide a SHA256 package identity' ;;
+            esac
+            [ "${#checksum}" -eq 64 ] || fail 'invalid package SHA256 length'
+            case "$checksum" in *[!0-9a-f]*) fail 'invalid package SHA256' ;; esac
+            if [ -f "$archives/$cached" ] && \
+                printf '%s  %s\n' "$checksum" "$archives/$cached" | sha256sum --check --status; then
+                continue
+            fi
+            # Launchpad retains superseded binaries. The signed snapshot, not
+            # the mirror, supplies the mandatory hash for every downloaded byte.
+            temporary="$archives/partial/$cached"
+            if "$root/usr/lib/apt/apt-helper" -o Acquire::Retries=0 \
+                -o Acquire::https::Timeout=20 -o Acquire::http::Timeout=20 download-file \
+                "https://launchpad.net/ubuntu/+archive/primary/+files/$remote" \
+                "$temporary" "$hash"; then
+                install -m 0644 "$temporary" "$archives/$cached"
+                rm -f "$temporary"
+            else
+                printf 'Archive fallback unavailable for %s; completing downloads from the snapshot.\n' "$cached" >&2
+            fi
+        done < "$uris"
+    fi
 fi
-# Superseded versions may exist only in the snapshot. Install once, retaining
-# verified mirror downloads but never retrying a failed maintainer script.
+# Install once against the original snapshot, retaining only downloads that APT
+# verifies against its signed indexes; never retry a failed maintainer script.
 cp "$backup" "$sources"
 apt-get install --yes --no-install-recommends "$@"


### PR DESCRIPTION
## Description

Publish input-addressed runtime and Rust/dependency base images to GHCR from trusted main. CI keeps the fast segmented-cache path; on a miss it validates published image labels and uses digest-pinned bases directly, without Ubuntu bootstrap. PRs remain anonymous readers, and Strata still compiles for the tested revision.

Cache authenticated APT indexes before the remaining bootstrap and reuse them without enlarging runtime layers. Superseded packages can download from Launchpad using the signed snapshot's mandatory SHA256. Explain failed prerequisites with observed causes, failed-step links, and clear separation from GUI failures and budget overruns. The complete scenario inventory is unchanged. Timing is now informational, not a merge-blocking requirement.

Local runs verify/reuse the existing base or pull it once. They never automatically rebuild images or fetch Ubuntu packages. An explicit `e2e_base.py build` command handles intentional environment updates; `AGENTS.md` documents this workflow.

## Visual evidence

N/A — CI/package infrastructure; application UI and installed runtime package versions are unchanged.

## How to test

1. Run `./scripts/e2e.sh` twice with a prepared base. Both runs should inspect/reuse it without an image build or pull. If no publication exists yet, explicitly prepare it once with `STRATA_CONTAINER_ENGINE=podman python3 scripts/e2e_base.py build`.
2. After merging, run **Publish pinned E2E environments** on main. Make the two newly created GHCR packages public, then rerun the publisher to verify anonymous access and provenance.
3. Manually run **CI** with `require_published_environments` enabled. Inspect the build log for digest-pinned base images and Strata compilation, without package/bootstrap stages. The runtime archive cache remains enabled in this mode.
4. For a failed prerequisite, open **End-to-end GUI suite**: its summary should identify the unsuccessful job/step and any confirmed download, compilation, or provenance error. Bootstrap failures must explicitly say that scenarios did not run.

**Expected result:** Ordinary revisions reuse pinned environments without fetching Ubuntu packages or rebuilding dependencies. Missing required publications and invalid provenance fail explicitly. Slow runs or unavailable timing telemetry do not turn passing tests red. Initial publication of new environment inputs still needs a trusted bootstrap.

## Related issue

Closes #628
