### PR TITLE
fix(sidebar): merge pinned place changes into the shared bookmarks file

### DIFF
--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -975,20 +975,26 @@ impl SidebarState {
         self.append_device_place(crate::assets::icons::HARD_DRIVE, name, location, release);
     }
 
+    // The bookmarks file is shared with every other Strata window and every
+    // GTK application, so each change re-reads it and merges rather than
+    // writing back this window's snapshot.
     fn pin_location(self: &Rc<Self>, location: Location, name: String) {
-        if pin_status(&self.pinned_places.borrow(), &location) != PinStatus::Available {
-            return;
+        let mut places = load_pinned_places();
+        if pin_status(&places, &location) == PinStatus::Available {
+            places.push((location, name));
+            save_pinned_places(&places);
         }
-        self.pinned_places.borrow_mut().push((location, name));
-        save_pinned_places(&self.pinned_places.borrow());
+        self.pinned_places.replace(places);
         self.rebuild();
     }
 
     fn unpin_location(self: &Rc<Self>, location: &Location) {
-        if remove_pinned_place(&mut self.pinned_places.borrow_mut(), location) {
-            save_pinned_places(&self.pinned_places.borrow());
-            self.rebuild();
+        let mut places = load_pinned_places();
+        if remove_pinned_place(&mut places, location) {
+            save_pinned_places(&places);
         }
+        self.pinned_places.replace(places);
+        self.rebuild();
     }
     fn event_changes_active_place(event: &BrowserEvent) -> bool {
         matches!(
@@ -1256,12 +1262,27 @@ impl SidebarState {
     }
 
     fn reorder_pinned_place(self: &Rc<Self>, source: usize, target: usize, after: bool) {
-        let changed =
-            reorder_pinned_places(&mut self.pinned_places.borrow_mut(), source, target, after);
+        let (source_location, target_location) = {
+            let places = self.pinned_places.borrow();
+            match (places.get(source), places.get(target)) {
+                (Some(source), Some(target)) => (source.0.clone(), target.0.clone()),
+                _ => return,
+            }
+        };
+        let mut places = load_pinned_places();
+        let position =
+            |location: &Location| places.iter().position(|(pinned, _)| pinned == location);
+        let changed = match (position(&source_location), position(&target_location)) {
+            (Some(source), Some(target)) => {
+                reorder_pinned_places(&mut places, source, target, after)
+            }
+            _ => false,
+        };
         if changed {
-            save_pinned_places(&self.pinned_places.borrow());
-            self.rebuild();
+            save_pinned_places(&places);
         }
+        self.pinned_places.replace(places);
+        self.rebuild();
     }
 
     fn append_separator(&self) {

--- a/src/ui/window/tests.rs
+++ b/src/ui/window/tests.rs
@@ -19,15 +19,16 @@ use crate::{
 use super::{
     DEFAULT_ACCELS, MediaRelease, MouseHistoryAction, PinStatus, STANDARD_PLACE_IDS, TrashContents,
     TrashMenuVisibility, TypeToSearchQuery, accepts_sidebar_reorder_payload, begin_media_release,
-    browser_for_window, browser_mode_for_digit, event_changes_trash_contents,
+    browser_for_window, browser_mode_for_digit, build_sidebar, event_changes_trash_contents,
     is_open_terminal_shortcut, is_refresh_shortcut, is_rename_shortcut, is_sidebar_focus_shortcut,
     is_smb_location, is_standard_place_location, is_toggle_hidden_shortcut, is_undo_shortcut,
-    jump_direction, media_release_label, mount_release_action, mouse_history_action,
-    page_direction, parse_pinned_drag_source, parse_pinned_places, pin_status, remove_pinned_place,
-    reorder_pinned_places, reorder_places, resolve_place_order, serialize_pinned_places,
-    should_show_standard_place, sidebar_accepts_file_drop, sidebar_update_label, standard_place,
-    trash_contents_from_probe, trash_has_entries, trash_menu_visibility, type_to_search_query,
-    vim_focus_direction, volume_release_action,
+    jump_direction, load_pinned_places, media_release_label, mount_release_action,
+    mouse_history_action, page_direction, parse_pinned_drag_source, parse_pinned_places,
+    pin_status, pinned_places_path, remove_pinned_place, reorder_pinned_places, reorder_places,
+    resolve_place_order, serialize_pinned_places, should_show_standard_place,
+    sidebar_accepts_file_drop, sidebar_update_label, standard_place, trash_contents_from_probe,
+    trash_has_entries, trash_menu_visibility, type_to_search_query, vim_focus_direction,
+    volume_release_action,
 };
 
 #[test]
@@ -968,6 +969,39 @@ fn refresh_shortcut_keeps_f5_and_releases_control_r() {
         gtk::gdk::Key::r,
         gtk::gdk::ModifierType::CONTROL_MASK
     ));
+}
+
+#[test]
+fn pinned_place_changes_merge_with_the_shared_bookmarks_file() {
+    gtk_test(
+        "ui::window::tests::pinned_place_changes_merge_with_the_shared_bookmarks_file",
+        || {
+            ThemeManager::seed_saved_preferences_for_test();
+            let path = pinned_places_path();
+            std::fs::create_dir_all(path.parent().expect("bookmarks parent"))
+                .expect("isolated config directory");
+            std::fs::write(&path, "file:///tmp/existing Existing\n").expect("seeded bookmarks");
+            let preferences = ThemeManager::shared();
+            let first = build_sidebar(browser_for_window(), preferences.clone(), true);
+            let second = build_sidebar(browser_for_window(), preferences, true);
+
+            first
+                .state
+                .pin_location(Location::local("/tmp/pinned"), "Pinned".into());
+            second
+                .state
+                .unpin_location(&Location::local("/tmp/existing"));
+
+            let saved: Vec<_> = load_pinned_places()
+                .into_iter()
+                .map(|(location, _)| location)
+                .collect();
+            assert_eq!(saved, vec![Location::local("/tmp/pinned")]);
+            assert_eq!(second.state.pinned_places.borrow().len(), 1);
+            first.disconnect();
+            second.disconnect();
+        },
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Description

Re-read the shared GTK bookmarks file before pinning, unpinning, or reordering so sequential edits from other windows and applications survive.

The [compact follow-up](https://github.com/ogarza/strata/tree/fix/647-shared-bookmark-updates) adds read/write error handling and focused regressions: **193 changed lines total against main**. It is based on main at `d5b98bd`, but remains pending because maintainer edits to this PR are disabled. Live monitoring and concurrent-write guarantees are out of scope.

## Visual evidence

N/A — shared-file persistence fix, with no layout or styling changes.

## How to test

1. Open two windows. Pin `~/Projects` in one, then unpin an older folder in the other.
2. Add a bookmark in Nautilus or a GTK chooser, then reorder a pin in Strata.
3. Restart Strata.

**Expected result:** Unrelated pins survive. With the follow-up applied, failed reads or saves report an error and leave cached pins unchanged.

## Related issue

Closes #647
