### PR TITLE
feat: integrate nixfred fixes, starting with #641

### DIFF
--- a/src/adapters/local_operations.rs
+++ b/src/adapters/local_operations.rs
@@ -401,11 +401,18 @@ fn open_local_copy_source<Fd: AsFd>(parent: &Fd, name: &OsStr) -> Result<LocalCo
             let children = local_directory_children(&handle)?;
             Ok(LocalCopySource::Directory { handle, children })
         }
-        _ => {
+        rustix::fs::FileType::RegularFile => {
+            // NONBLOCK so that an entry swapped for a FIFO between the stat
+            // above and this open cannot block forever waiting for a writer;
+            // the type is re-checked on the opened descriptor below. GIO
+            // reopens the file through `/proc/self/fd`, so the flag never
+            // reaches the copy itself.
             let file = rustix::fs::openat2(
                 parent,
                 name,
-                rustix::fs::OFlags::RDONLY | rustix::fs::OFlags::CLOEXEC,
+                rustix::fs::OFlags::RDONLY
+                    | rustix::fs::OFlags::CLOEXEC
+                    | rustix::fs::OFlags::NONBLOCK,
                 rustix::fs::Mode::empty(),
                 rustix::fs::ResolveFlags::BENEATH
                     | rustix::fs::ResolveFlags::NO_SYMLINKS
@@ -417,8 +424,23 @@ fn open_local_copy_source<Fd: AsFd>(parent: &Fd, name: &OsStr) -> Result<LocalCo
                     name.to_string_lossy()
                 )
             })?;
+            let opened = rustix::fs::fstat(&file).map_err(|error| {
+                format!("Could not inspect {}: {error}", name.to_string_lossy())
+            })?;
+            if rustix::fs::FileType::from_raw_mode(opened.st_mode)
+                != rustix::fs::FileType::RegularFile
+            {
+                return Err(format!(
+                    "{} changed while it was being copied",
+                    name.to_string_lossy()
+                ));
+            }
             Ok(LocalCopySource::File(std::fs::File::from(file)))
         }
+        _ => Err(format!(
+            "Cannot copy {}: it is not a regular file, directory, or symbolic link",
+            name.to_string_lossy()
+        )),
     }
 }
 

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -2717,3 +2717,41 @@ fn mixed_conflict_choices_apply_independently_across_a_multi_item_paste()
 
 mod create_entry;
 mod trash_capabilities;
+
+#[test]
+fn copying_a_tree_with_a_named_pipe_fails_instead_of_blocking() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("strata-fifo-copy-test-{unique}"));
+    let source = root.join("source");
+    let target = root.join("target");
+    fs::create_dir_all(&source)?;
+    fs::write(source.join("before.txt"), b"before")?;
+    rustix::fs::mkfifoat(
+        rustix::fs::CWD,
+        source.join("pipe"),
+        rustix::fs::Mode::RUSR | rustix::fs::Mode::WUSR,
+    )?;
+
+    let result = glib::MainContext::default().block_on(copy_recursively(
+        gio::File::for_path(&source),
+        gio::File::for_path(&target),
+        false,
+        gio::Cancellable::new(),
+        None,
+    ));
+
+    let error = result.expect_err("a named pipe cannot be copied as a regular file");
+    assert!(
+        error.to_string().contains("pipe"),
+        "the error should name the entry: {error}"
+    );
+    assert!(!target.join("pipe").exists());
+
+    fs::remove_dir_all(root)?;
+    Ok(())
+}

--- a/src/adapters/local_operations/tests.rs
+++ b/src/adapters/local_operations/tests.rs
@@ -6,7 +6,11 @@ use std::{
     error::Error,
     ffi::{OsStr, OsString},
     fs,
-    os::unix::{ffi::OsStringExt, fs::PermissionsExt},
+    os::unix::{
+        ffi::OsStringExt,
+        fs::{FileTypeExt, PermissionsExt},
+        net::UnixListener,
+    },
     path::{Path, PathBuf},
     rc::Rc,
     time::{Duration, SystemTime},
@@ -2746,12 +2750,129 @@ fn copying_a_tree_with_a_named_pipe_fails_instead_of_blocking() -> Result<(), Bo
     ));
 
     let error = result.expect_err("a named pipe cannot be copied as a regular file");
-    assert!(
-        error.to_string().contains("pipe"),
-        "the error should name the entry: {error}"
-    );
+    assert_special_copy_error(&error, "pipe");
     assert!(!target.join("pipe").exists());
 
     fs::remove_dir_all(root)?;
     Ok(())
+}
+
+#[test]
+fn copying_a_tree_with_a_unix_socket_fails_instead_of_blocking() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("strata-socket-copy-test-{unique}"));
+    let source = root.join("source");
+    let target = root.join("target");
+    fs::create_dir_all(&source)?;
+    fs::write(source.join("before.txt"), b"before")?;
+    let _listener = UnixListener::bind(source.join("sock"))?;
+
+    let result = glib::MainContext::default().block_on(copy_recursively(
+        gio::File::for_path(&source),
+        gio::File::for_path(&target),
+        false,
+        gio::Cancellable::new(),
+        None,
+    ));
+
+    let error = result.expect_err("a unix socket cannot be copied as a regular file");
+    assert_special_copy_error(&error, "sock");
+    assert!(!target.join("sock").exists());
+
+    fs::remove_dir_all(root)?;
+    Ok(())
+}
+
+#[test]
+fn copying_a_character_device_fails_instead_of_copying_without_end() -> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let device = Path::new("/dev/zero");
+    let metadata = fs::symlink_metadata(device)?;
+    if !metadata.file_type().is_char_device() {
+        return Ok(());
+    }
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_nanos();
+    let target = std::env::temp_dir().join(format!("strata-zero-copy-test-{unique}"));
+
+    let result = glib::MainContext::default().block_on(copy_recursively(
+        gio::File::for_path(device),
+        gio::File::for_path(&target),
+        false,
+        gio::Cancellable::new(),
+        None,
+    ));
+
+    let error = result.expect_err("a character device cannot be copied as a regular file");
+    assert_special_copy_error(&error, "zero");
+    assert!(!target.exists());
+    Ok(())
+}
+
+#[test]
+fn pasting_a_folder_with_a_named_pipe_discards_staging_instead_of_committing()
+-> Result<(), Box<dyn Error>> {
+    let _serial = ASYNC_MAIN_CONTEXT_DEFAULT
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let unique = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("strata-fifo-paste-test-{unique}"));
+    let source = root.join("src");
+    let destination = root.join("dest");
+    fs::create_dir_all(&source)?;
+    fs::create_dir_all(&destination)?;
+    fs::write(source.join("a.txt"), b"hi\n")?;
+    rustix::fs::mkfifoat(
+        rustix::fs::CWD,
+        source.join("pipe"),
+        rustix::fs::Mode::RUSR | rustix::fs::Mode::WUSR,
+    )?;
+
+    let result = glib::MainContext::default().block_on(copy_new_recursively(
+        gio::File::for_path(&source),
+        gio::File::for_path(destination.join("src")),
+        gio::Cancellable::new(),
+    ));
+
+    let error = result.expect_err("paste of a named pipe must fail");
+    assert_special_copy_error(&error, "pipe");
+    assert!(!destination.join("src").exists());
+    let leftovers = fs::read_dir(&destination)?
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            name.starts_with(".strata-") || name == "src"
+        })
+        .count();
+    assert_eq!(leftovers, 0, "failed paste must not leave staging output");
+
+    fs::remove_dir_all(root)?;
+    Ok(())
+}
+
+fn assert_special_copy_error(error: &glib::Error, name: &str) {
+    let message = error.to_string();
+    assert!(
+        message.contains(name),
+        "the error should name the entry: {error}"
+    );
+    assert!(
+        message.contains("Cannot copy"),
+        "the error should say the copy was refused: {error}"
+    );
+    assert!(
+        message.contains("not a regular file, directory, or symbolic link"),
+        "the error should match compression's special-file refusal: {error}"
+    );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Integration branch for verified nixfred fixes, starting with #641 only.

Merges nixfred’s `fix/copy-special-files` (`3d8c4bb`) so copying or cross-device moving a tree that contains a FIFO, socket, or device fails immediately instead of hanging in a blocking `open` (`wait_for_partner`). Regular files still open with `O_NONBLOCK` and are re-checked with `fstat`, matching `open_archive_source` in compression. Other nixfred branches (#643+) are not included in this cycle.

Merge was clean (ort, no conflicts) onto current `main`.

## Visual evidence

Pending GUI verification of the #641 repro (copy `src` containing a named pipe into `dest`). Will update after the run.

## How to test

1. `mkdir -p /tmp/strata-repro-641/src /tmp/strata-repro-641/dest`
2. `mkfifo /tmp/strata-repro-641/src/pipe`
3. `echo hi > /tmp/strata-repro-641/src/a.txt`
4. Open Strata on `/tmp/strata-repro-641`, copy the `src` folder, paste into `dest`.

**Expected result:**

Copy does not hang. It fails with a clear error naming the special entry (and/or skips it). Cancel is not required to unstick a hung worker. Destination is not left with a stuck in-progress copy. Regression test: `copying_a_tree_with_a_named_pipe_fails_instead_of_blocking`.

## Related issue

Closes #641

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9835d507-bcb7-4c27-b932-38739b5a6764?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9835d507-bcb7-4c27-b932-38739b5a6764&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

