### PR TITLE
fix(keyboard): let clipboard and Delete keys reach preview text

### DIFF
--- a/src/ui/window/keyboard/commands.rs
+++ b/src/ui/window/keyboard/commands.rs
@@ -193,7 +193,7 @@ impl Dispatcher {
             },
             _ => return None,
         };
-        if self.view.filter_has_focus() {
+        if self.view.filter_has_focus() || event.text_has_focus() {
             return Some(Propagation::Proceed);
         }
         action(&self.view).then_some(Propagation::Stop)

--- a/src/ui/window/keyboard/items.rs
+++ b/src/ui/window/keyboard/items.rs
@@ -32,6 +32,7 @@ impl Dispatcher {
         }
         if event.key == Key::Delete
             && !self.view.filter_has_focus()
+            && !event.text_has_focus()
             && self.view.confirm_delete(event.shift())
         {
             return Some(Propagation::Stop);

--- a/src/ui/window/tests/keyboard_dispatch.rs
+++ b/src/ui/window/tests/keyboard_dispatch.rs
@@ -129,6 +129,20 @@ fn rendered_name(widget: &gtk::Widget, name: &str) -> bool {
     false
 }
 
+fn text_view_in(widget: &gtk::Widget) -> Option<gtk::TextView> {
+    if let Some(view) = widget.downcast_ref::<gtk::TextView>() {
+        return Some(view.clone());
+    }
+    let mut child = widget.first_child();
+    while let Some(widget) = child {
+        if let Some(view) = text_view_in(&widget) {
+            return Some(view);
+        }
+        child = widget.next_sibling();
+    }
+    None
+}
+
 fn wait_until(condition: impl Fn() -> bool) {
     let deadline = Instant::now() + Duration::from_secs(5);
     while !condition() {
@@ -179,6 +193,33 @@ fn inline_editing_owns_filter_keys_but_not_global_search() {
             assert_eq!(searches.get(), 1);
             assert!(fixture.press(Key::Escape, ModifierType::empty()));
             assert!(!fixture.view.rename_is_active());
+            assert_eq!(fixture.selected(), [0]);
+        },
+    );
+}
+
+#[test]
+fn clipboard_and_delete_shortcuts_proceed_inside_preview_text() {
+    crate::test_support::gtk_test(
+        "ui::window::tests::keyboard_dispatch::clipboard_and_delete_shortcuts_proceed_inside_preview_text",
+        || {
+            let fixture = KeyboardFixture::new();
+            assert!(fixture.press(Key::space, ModifierType::empty()));
+            wait_until(|| {
+                fixture.preview.is_open() && text_view_in(&fixture.preview.widget()).is_some()
+            });
+            let text = text_view_in(&fixture.preview.widget()).expect("preview text");
+            text.grab_focus();
+            wait_until(|| text.has_focus());
+
+            for key in [Key::a, Key::c, Key::d, Key::v, Key::x] {
+                assert!(
+                    !fixture.press(key, ModifierType::CONTROL_MASK),
+                    "{key:?} should reach the text view"
+                );
+            }
+            assert!(!fixture.press(Key::Delete, ModifierType::empty()));
+            assert!(!fixture.press(Key::Delete, ModifierType::SHIFT_MASK));
             assert_eq!(fixture.selected(), [0]);
         },
     );


### PR DESCRIPTION
## Description

Stop window-level clipboard and Delete shortcuts from stealing keys when a text widget has focus.

`clipboard_command` and the Delete branch of `dismissal` previously gated only on `filter_has_focus()`. The window key controller runs in the capture phase, so with the caret in the quick preview's text view (or the "copy install command" entry on media errors) Ctrl+C/V/X/A/D acted on files and Delete opened the trash confirmation.

These shortcuts now treat a focused text widget the same way the filter entry is already treated, matching the Escape and undo branches that already check `text_has_focus()`.

This is based on the analysis and patch on [@nixfred](https://github.com/nixfred)'s [`fix/shortcuts-in-preview-text`](https://github.com/lgse/strata/compare/main...nixfred:strata:fix/shortcuts-in-preview-text) branch from #650. The commit was recreated on current `main` without agent attribution so it can be submitted under project contribution policy.

## Visual evidence

N/A — no visual change; behavior is covered by `clipboard_and_delete_shortcuts_proceed_inside_preview_text`.

## How to test

1. Press Space on a `.txt` file to open the quick preview.
2. Click into the preview text and select a few words.
3. Press Ctrl+C, then paste anywhere: the selected text, not the file, is on the clipboard.
4. Press Delete: the text is deleted rather than a trash confirmation appearing.
5. Repeat with Ctrl+A, Ctrl+V, Ctrl+X, and Ctrl+D and confirm they act on the text, not the file.

**Expected result:** Text widgets receive these keys, the same way the filter entry already does.

## Related issue

Closes #650