### PR TITLE
fix(startup): preserve arguments and open every requested location

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -64,11 +64,7 @@ fn main() -> gtk::glib::ExitCode {
     let arguments: Vec<OsString> = std::env::args_os().collect();
     match launch_mode(&arguments) {
         LaunchMode::PreviewHelper => {
-            let helper_arguments: Vec<String> = arguments[2..]
-                .iter()
-                .map(|argument| argument.to_string_lossy().into_owned())
-                .collect();
-            if let Err(error) = sandbox_helper::run(&helper_arguments) {
+            if let Err(error) = run_preview_helper(&arguments[2..]) {
                 eprintln!("Preview helper failed: {error}");
                 return gtk::glib::ExitCode::FAILURE;
             }
@@ -135,6 +131,19 @@ fn main() -> gtk::glib::ExitCode {
         }
     });
     application.run()
+}
+
+fn run_preview_helper(arguments: &[OsString]) -> Result<(), String> {
+    let arguments = arguments
+        .iter()
+        .map(|argument| {
+            argument
+                .to_str()
+                .map(str::to_owned)
+                .ok_or_else(|| "Invalid UTF-8 in preview helper arguments".to_owned())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    sandbox_helper::run(&arguments)
 }
 
 fn finish_portal_setup(result: Result<String, String>) -> gtk::glib::ExitCode {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ mod test_support;
 mod ui;
 mod util;
 
-use std::{os::unix::process::CommandExt, process::Stdio, time::Duration};
+use std::{ffi::OsString, os::unix::process::CommandExt, process::Stdio, time::Duration};
 
 use gtk::{gio, prelude::*};
 
@@ -27,47 +27,68 @@ const GVFS_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 const GIO_FALLBACK_BACKENDS: [(&str, &str); 2] =
     [("GIO_USE_VFS", "local"), ("GIO_USE_VOLUME_MONITOR", "unix")];
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LaunchMode {
+    PreviewHelper,
+    GvfsProbe,
+    Portal,
+    InstallPortal,
+    DismissPortalPrompt,
+    UninstallPortal,
+    Application,
+}
+
+/// Byte-safe: a non-UTF-8 path argument is an ordinary application launch,
+/// not a reason to abort before GIO ever sees it.
+fn launch_mode(arguments: &[OsString]) -> LaunchMode {
+    match arguments.get(1).and_then(|argument| argument.to_str()) {
+        Some("--preview-helper") => LaunchMode::PreviewHelper,
+        Some(GVFS_PROBE_ARGUMENT) => LaunchMode::GvfsProbe,
+        Some("--portal") => LaunchMode::Portal,
+        Some("--install-portal") => LaunchMode::InstallPortal,
+        Some("--dismiss-portal-prompt") => LaunchMode::DismissPortalPrompt,
+        Some("--uninstall-portal") => LaunchMode::UninstallPortal,
+        _ => LaunchMode::Application,
+    }
+}
+
+/// Every location the launcher or shell asked to open, local or remote, in order.
+fn open_locations(files: &[gio::File]) -> Vec<model::Location> {
+    files
+        .iter()
+        .filter_map(adapters::location_for_file)
+        .collect()
+}
+
 fn main() -> gtk::glib::ExitCode {
-    let arguments: Vec<_> = std::env::args().collect();
-    if arguments
-        .get(1)
-        .is_some_and(|value| value == "--preview-helper")
-    {
-        if let Err(error) = sandbox_helper::run(&arguments[2..]) {
-            eprintln!("Preview helper failed: {error}");
-            return gtk::glib::ExitCode::FAILURE;
+    let arguments: Vec<OsString> = std::env::args_os().collect();
+    match launch_mode(&arguments) {
+        LaunchMode::PreviewHelper => {
+            let helper_arguments: Vec<String> = arguments[2..]
+                .iter()
+                .map(|argument| argument.to_string_lossy().into_owned())
+                .collect();
+            if let Err(error) = sandbox_helper::run(&helper_arguments) {
+                eprintln!("Preview helper failed: {error}");
+                return gtk::glib::ExitCode::FAILURE;
+            }
+            return gtk::glib::ExitCode::SUCCESS;
         }
-        return gtk::glib::ExitCode::SUCCESS;
-    }
-    if arguments
-        .get(1)
-        .is_some_and(|value| value == GVFS_PROBE_ARGUMENT)
-    {
-        let _vfs = gio::Vfs::default();
-        let _volumes = gio::VolumeMonitor::get();
-        return gtk::glib::ExitCode::SUCCESS;
-    }
-    if arguments.get(1).is_some_and(|value| value == "--portal") {
-        restart_with_local_vfs_if_gvfs_is_unresponsive();
-        return portal::run();
-    }
-    if arguments
-        .get(1)
-        .is_some_and(|value| value == "--install-portal")
-    {
-        return finish_portal_setup(portal_setup::install());
-    }
-    if arguments
-        .get(1)
-        .is_some_and(|value| value == "--dismiss-portal-prompt")
-    {
-        return finish_portal_setup(portal_setup::dismiss_prompt());
-    }
-    if arguments
-        .get(1)
-        .is_some_and(|value| value == "--uninstall-portal")
-    {
-        return finish_portal_setup(portal_setup::uninstall());
+        LaunchMode::GvfsProbe => {
+            let _vfs = gio::Vfs::default();
+            let _volumes = gio::VolumeMonitor::get();
+            return gtk::glib::ExitCode::SUCCESS;
+        }
+        LaunchMode::Portal => {
+            restart_with_local_vfs_if_gvfs_is_unresponsive();
+            return portal::run();
+        }
+        LaunchMode::InstallPortal => return finish_portal_setup(portal_setup::install()),
+        LaunchMode::DismissPortalPrompt => {
+            return finish_portal_setup(portal_setup::dismiss_prompt());
+        }
+        LaunchMode::UninstallPortal => return finish_portal_setup(portal_setup::uninstall()),
+        LaunchMode::Application => {}
     }
 
     metrics::initialize();
@@ -105,8 +126,13 @@ fn main() -> gtk::glib::ExitCode {
     application.connect_startup(export_file_manager_interface);
     application.connect_activate(ui::present);
     application.connect_open(|application, files, _| {
-        let location = files.first().and_then(gio::File::path);
-        ui::present_location(application, location);
+        let locations = open_locations(files);
+        if locations.is_empty() {
+            ui::present(application);
+        }
+        for location in locations {
+            ui::present_location(application, Some(location));
+        }
     });
     application.run()
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -7,6 +7,7 @@ use gtk::gio;
 use super::{
     GIO_FALLBACK_BACKENDS, LaunchMode, encode_daemon_pids, gvfs_daemon_pids,
     gvfs_probe_marker_is_fresh_at, gvfs_probe_marker_path_in, launch_mode, open_locations,
+    run_preview_helper,
 };
 
 #[test]
@@ -26,16 +27,53 @@ fn launch_mode_treats_non_utf8_arguments_as_an_ordinary_launch() {
 }
 
 #[test]
+fn launch_mode_recognizes_only_the_first_argument_as_a_mode() {
+    for (flag, mode) in [
+        ("--preview-helper", LaunchMode::PreviewHelper),
+        ("--gvfs-probe", LaunchMode::GvfsProbe),
+        ("--portal", LaunchMode::Portal),
+        ("--install-portal", LaunchMode::InstallPortal),
+        ("--dismiss-portal-prompt", LaunchMode::DismissPortalPrompt),
+        ("--uninstall-portal", LaunchMode::UninstallPortal),
+    ] {
+        assert_eq!(launch_mode(&["strata".into(), flag.into()]), mode);
+        assert_eq!(
+            launch_mode(&["strata".into(), "/tmp".into(), flag.into()]),
+            LaunchMode::Application
+        );
+    }
+}
+
+#[test]
+fn preview_helper_rejects_non_utf8_instead_of_changing_paths() {
+    let arguments = [
+        "thumbnail-image".into(),
+        OsString::from_vec(b"/tmp/\xff".to_vec()),
+        "/tmp/result.png".into(),
+        "128".into(),
+        "software".into(),
+    ];
+    assert_eq!(
+        run_preview_helper(&arguments),
+        Err("Invalid UTF-8 in preview helper arguments".to_owned())
+    );
+}
+
+#[test]
 fn every_opened_argument_becomes_a_location() {
+    let non_utf8 = OsString::from_vec(b"/tmp/\xff".to_vec());
     let files = [
         gio::File::for_uri("smb://host/share"),
         gio::File::for_path("/tmp/first"),
         gio::File::for_path("/tmp/second"),
+        gio::File::for_path(&non_utf8),
+        gio::File::for_uri("sftp://host/share"),
+        gio::File::for_uri("trash:///"),
     ];
 
     let locations = open_locations(&files);
 
-    assert_eq!(locations.len(), 3);
+    assert_eq!(locations.len(), files.len());
     assert!(
         locations[0]
             .uri_value()
@@ -45,6 +83,15 @@ fn every_opened_argument_becomes_a_location() {
     );
     assert_eq!(locations[1].native_path(), Some(Path::new("/tmp/first")));
     assert_eq!(locations[2].native_path(), Some(Path::new("/tmp/second")));
+    assert_eq!(locations[3].native_path(), Some(Path::new(&non_utf8)));
+    for (location, scheme) in locations[4..].iter().zip(["sftp:", "trash:"]) {
+        assert!(
+            location
+                .uri_value()
+                .is_some_and(|uri| uri.starts_with(scheme))
+        );
+    }
+    assert!(open_locations(&[]).is_empty());
 }
 
 fn fake_proc(label: &str, processes: &[(&str, &str)]) -> std::path::PathBuf {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,11 +1,51 @@
 // SPDX-License-Identifier: MIT
 
-use std::ffi::OsString;
+use std::{ffi::OsString, os::unix::ffi::OsStringExt, path::Path};
+
+use gtk::gio;
 
 use super::{
-    GIO_FALLBACK_BACKENDS, encode_daemon_pids, gvfs_daemon_pids, gvfs_probe_marker_is_fresh_at,
-    gvfs_probe_marker_path_in,
+    GIO_FALLBACK_BACKENDS, LaunchMode, encode_daemon_pids, gvfs_daemon_pids,
+    gvfs_probe_marker_is_fresh_at, gvfs_probe_marker_path_in, launch_mode, open_locations,
 };
+
+#[test]
+fn launch_mode_treats_non_utf8_arguments_as_an_ordinary_launch() {
+    let program = OsString::from("strata");
+    let non_utf8 = OsString::from_vec(b"/tmp/\xff".to_vec());
+
+    assert_eq!(
+        launch_mode(&[program.clone(), non_utf8]),
+        LaunchMode::Application
+    );
+    assert_eq!(
+        launch_mode(&[program.clone(), OsString::from("--portal")]),
+        LaunchMode::Portal
+    );
+    assert_eq!(launch_mode(&[program]), LaunchMode::Application);
+}
+
+#[test]
+fn every_opened_argument_becomes_a_location() {
+    let files = [
+        gio::File::for_uri("smb://host/share"),
+        gio::File::for_path("/tmp/first"),
+        gio::File::for_path("/tmp/second"),
+    ];
+
+    let locations = open_locations(&files);
+
+    assert_eq!(locations.len(), 3);
+    assert!(
+        locations[0]
+            .uri_value()
+            .is_some_and(|uri| uri.starts_with("smb://host/share")),
+        "{:?}",
+        locations[0]
+    );
+    assert_eq!(locations[1].native_path(), Some(Path::new("/tmp/first")));
+    assert_eq!(locations[2].native_path(), Some(Path::new("/tmp/second")));
+}
 
 fn fake_proc(label: &str, processes: &[(&str, &str)]) -> std::path::PathBuf {
     let root = std::env::temp_dir().join(format!(

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -83,13 +83,8 @@ pub fn present(application: &gtk::Application) {
     present_target(application, None, Vec::new(), false);
 }
 
-pub fn present_location(application: &gtk::Application, location: Option<PathBuf>) {
-    present_target(
-        application,
-        location.map(Location::local),
-        Vec::new(),
-        false,
-    );
+pub fn present_location(application: &gtk::Application, location: Option<Location>) {
+    present_target(application, location, Vec::new(), false);
 }
 
 /// Opens the window an `org.freedesktop.FileManager1` caller asked for: the

--- a/tests/e2e/scenarios/test_startup_arguments.py
+++ b/tests/e2e/scenarios/test_startup_arguments.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: MIT
+"""Shell arguments reach every requested location without changing path bytes."""
+
+import os
+import subprocess
+
+from harness.application import binary_path
+from harness.environment import process_environment
+
+
+def test_multiple_arguments_include_non_utf8_directory(strata):
+    root = os.fsencode(strata.fixture.root)
+    directories = [root + b"/startup-first", root + b"/startup-\xff"]
+    markers = ["first-argument.txt", "non-utf8-argument.txt"]
+    for directory, marker in zip(directories, markers):
+        os.mkdir(directory)
+        with open(directory + b"/" + marker.encode(), "wb") as stream:
+            stream.write(b"startup regression\n")
+
+    variables = process_environment()
+    variables.update(strata.environment.variables())
+    variables.update(strata.display.environment)
+    subprocess.run(
+        [os.fsencode(binary_path()), *directories],
+        env=variables,
+        cwd=strata.fixture.root,
+        check=True,
+        timeout=30,
+        capture_output=True,
+    )
+
+    def requested_windows_exist():
+        windows = strata.application.application_node.find_all(role="frame", name="Strata")
+        if len(windows) != 3:
+            return False
+        return all(
+            any(window.find(name=marker) is not None for window in windows)
+            for marker in markers
+        )
+
+    strata.wait(requested_windows_exist, "one populated window for each path argument")


### PR DESCRIPTION
## Description

Preserve non-UTF-8 startup arguments, open every requested location, and resolve remote URIs through the existing FileManager1 location adapter instead of falling back to home.

Adapted from @nixfred's proposed fix, retaining authorship. The review follow-up rejects invalid UTF-8 in internal preview-helper arguments rather than silently changing paths, and adds focused unit and real-process regression coverage. Rebased onto current main (`01d348b`).

## Visual evidence

N/A — command-line argument handling only; no interface styling or layout changes.

## How to test

1. Create two directories, including a non-UTF-8 name: `mkdir -p /tmp/strata-649-a "$(printf '/tmp/strata-649-\377')"`. Launch `strata /tmp/strata-649-a "$(printf '/tmp/strata-649-\377')"`, both with Strata closed and with an existing window.
2. Launch `strata trash:///` and, with a configured GVfs backend and reachable share, `strata smb://host/share` or `strata sftp://host/share`.

**Expected result:** Each supplied directory opens in its own window without a panic. URI arguments retain their requested locations rather than opening home; remote access still depends on the backend and server being available.

## Related issue

Closes #649
