### PR TITLE
fix(archives): skip pax global headers when extracting tar archives

### DIFF
--- a/src/adapters/local_operations/archive/decoders.rs
+++ b/src/adapters/local_operations/archive/decoders.rs
@@ -105,6 +105,18 @@ pub(super) fn extract_tar(
                 return Err(error);
             }
             let mut entry = entry.map_err(archive_failed)?;
+            // tar-rs consumes per-entry extended headers itself, but a pax
+            // global header (the first member of every `git archive` tarball)
+            // is yielded as an ordinary entry. It carries no file.
+            if matches!(
+                entry.header().entry_type(),
+                tar::EntryType::XGlobalHeader
+                    | tar::EntryType::XHeader
+                    | tar::EntryType::GNULongName
+                    | tar::EntryType::GNULongLink
+            ) {
+                continue;
+            }
             let name = entry.path().map_err(archive_failed)?;
             let directory = entry.header().entry_type().is_dir();
             if directory && name == Path::new(".") {

--- a/src/adapters/local_operations/archive/decoders/tests.rs
+++ b/src/adapters/local_operations/archive/decoders/tests.rs
@@ -956,3 +956,42 @@ fn highly_compressible_archives_extract_in_every_format() -> Result<(), Box<dyn 
     }
     Ok(())
 }
+
+#[test]
+fn tar_extraction_skips_pax_global_headers() -> Result<(), Box<dyn Error>> {
+    for gzip in [false, true] {
+        let root = tempfile::tempdir()?;
+        let destination = root.path().join("destination");
+        fs::create_dir_all(&destination)?;
+        let archive = root.path().join("project.tar");
+        write_tar_entries(
+            &archive,
+            &[
+                (
+                    tar::EntryType::XGlobalHeader,
+                    "pax_global_header",
+                    b"52 comment=0123456789abcdef0123456789abcdef01234567\n".as_slice(),
+                ),
+                (tar::EntryType::Directory, "project/", b"".as_slice()),
+                (tar::EntryType::Regular, "project/README", b"hello"),
+            ],
+            gzip,
+        )?;
+        let progress = Arc::new(AtomicUsize::new(0));
+        assert_eq!(
+            completed_extract(extract_tar(
+                &archive,
+                &destination,
+                gzip,
+                &progress,
+                &never_cancelled(),
+            )?)?,
+            Some("project".to_owned()),
+        );
+        assert_eq!(progress.load(Ordering::Relaxed), 2);
+        assert!(!destination.join("pax_global_header").exists());
+        assert_eq!(fs::read(destination.join("project/README"))?, b"hello");
+        assert_eq!(fs::read_dir(&destination)?.count(), 1);
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Description

Skip tar pax global headers so `git archive` / GitHub source tarballs extract the project folder instead of a stray `pax_global_header` file.

`extract_tar` previously treated every non-directory entry as a member. tar-rs consumes per-entry extended headers but yields a pax global header (`EntryType::XGlobalHeader`) as an ordinary entry, so GitHub "Download tar.gz" archives wrote `pax_global_header`, counted it in progress, and selected it.

These headers are now skipped, matching GNU tar, bsdtar, and 7-Zip.

This is based on the analysis and patch on [@nixfred](https://github.com/nixfred)'s [`fix/tar-pax-global-header`](https://github.com/lgse/strata/compare/main...nixfred:strata:fix/tar-pax-global-header) branch from #643. The commit was recreated on current `main` without agent attribution so it can be submitted under project contribution policy.

## Visual evidence

N/A — no visual change; behavior is covered by `tar_extraction_skips_pax_global_headers`.

## How to test

1. Download any repository's tar.gz from GitHub, or run `git archive --prefix=project/ -o project.tar.gz HEAD`.
2. Extract it in Strata into an empty folder.
3. Confirm the destination contains only the project folder, and that folder is selected.

**Expected result:** No `pax_global_header` file is created, progress does not count it, and the project folder is selected.

## Related issue

Closes #643
