### PR TITLE
fix(archives): allow extracting into a folder reached through a symlink

### DIFF
--- a/src/adapters/local_operations/archive/destination.rs
+++ b/src/adapters/local_operations/archive/destination.rs
@@ -71,19 +71,37 @@ pub(super) struct ExtractionDestination {
 }
 
 impl ExtractionDestination {
-    /// Opens `path` as a directory without following a final symbolic link.
+    /// Opens `path` as a directory. Ordinary symlinks along the path are
+    /// resolved, since users browse symlinked folders, but the resolved
+    /// directory is pinned so later replacement of any component cannot
+    /// redirect writes. This mirrors how copy and compress open their parents.
     ///
     /// # Errors
     ///
-    /// Returns an error if `path` cannot be opened as a directory.
+    /// Returns an error if `path` is not absolute or cannot be opened as a directory.
     pub(super) fn open(path: &Path) -> Result<Self, String> {
-        let root = rustix::fs::open(
-            path,
+        let relative = path
+            .strip_prefix("/")
+            .map_err(|_| "Extraction destination must use an absolute path".to_owned())?;
+        let filesystem_root = rustix::fs::open(
+            c"/",
+            rustix::fs::OFlags::PATH | rustix::fs::OFlags::DIRECTORY | rustix::fs::OFlags::CLOEXEC,
+            rustix::fs::Mode::empty(),
+        )
+        .map_err(|error| format!("Could not open the filesystem root: {error}"))?;
+        let relative = if relative.as_os_str().is_empty() {
+            Path::new(".")
+        } else {
+            relative
+        };
+        let root = rustix::fs::openat2(
+            &filesystem_root,
+            relative,
             rustix::fs::OFlags::RDONLY
                 | rustix::fs::OFlags::DIRECTORY
-                | rustix::fs::OFlags::NOFOLLOW
                 | rustix::fs::OFlags::CLOEXEC,
             rustix::fs::Mode::empty(),
+            rustix::fs::ResolveFlags::IN_ROOT | rustix::fs::ResolveFlags::NO_MAGICLINKS,
         )
         .map_err(|error| format!("Could not open extraction destination: {error}"))?;
         Ok(Self { root })

--- a/src/adapters/local_operations/archive/destination/tests.rs
+++ b/src/adapters/local_operations/archive/destination/tests.rs
@@ -53,9 +53,31 @@ fn pinned_destination_survives_path_replacement() -> Result<(), Box<dyn Error>> 
     drop(file);
     assert_eq!(fs::read(moved.join(&created))?, b"contents");
     assert!(external.read_dir()?.next().is_none());
-    assert!(ExtractionDestination::open(&target).is_err());
     destination.remove_file(&created)?;
     assert!(!moved.join(&created).exists());
+    Ok(())
+}
+
+#[test]
+fn destination_resolves_a_symlinked_directory_and_pins_it() -> Result<(), Box<dyn Error>> {
+    let root = tempfile::tempdir()?;
+    let real = root.path().join("real");
+    let alias = root.path().join("alias");
+    let other = root.path().join("other");
+    fs::create_dir(&real)?;
+    fs::create_dir(&other)?;
+    symlink(&real, &alias)?;
+
+    let destination = ExtractionDestination::open(&alias)?;
+    fs::remove_file(&alias)?;
+    symlink(&other, &alias)?;
+
+    let (mut file, created) = destination.create_file(Path::new("file.txt"))?;
+    file.write_all(b"contents")?;
+    drop(file);
+    assert_eq!(fs::read(real.join(&created))?, b"contents");
+    assert!(other.read_dir()?.next().is_none());
+    assert!(ExtractionDestination::open(Path::new("relative")).is_err());
     Ok(())
 }
 


### PR DESCRIPTION
## Description

Allow extracting into a folder reached through a symlink, matching copy and compress.

`ExtractionDestination::open` previously used `O_NOFOLLOW` on the final component, so extracting while browsing a symlink path (`~/Desktop -> /data/desktop`, or any typed alias) failed with "Could not open extraction destination". Compressing in the same folder already worked.

The destination is now opened the way copy and compress open their parents: resolve ordinary symlinks with `openat2(RESOLVE_IN_ROOT | RESOLVE_NO_MAGICLINKS)` and pin the resolved directory. Member writes keep refusing symlink components.

This is based on the analysis and patch on [@nixfred](https://github.com/nixfred)'s [`fix/extract-into-symlinked-folder`](https://github.com/lgse/strata/compare/main...nixfred:strata:fix/extract-into-symlinked-folder) branch from #644. The commit was recreated on current `main` without agent attribution so it can be submitted under project contribution policy.

## Visual evidence

N/A — no visual change; behavior is covered by `destination_resolves_a_symlinked_directory_and_pins_it`.

## How to test

1. `mkdir /tmp/real && ln -s /tmp/real /tmp/alias`
2. Navigate Strata to `/tmp/alias` and extract any archive there.
3. Confirm the members appear in `/tmp/real` and that replacing the alias after extract starts does not redirect later writes.

**Expected result:** Extract succeeds into the resolved folder. Compress in the same folder still works. Member writes still refuse symlink components.

## Related issue

Closes #644
