### PR TITLE
docs: Adopt risk-based targeted local testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,15 +28,18 @@ infrastructure, preferences, and views); do not infer coverage automatically
 from changed file names. For a bounded change, run the relevant regression tests
 and targeted checks, confirm the selected test count is nonzero, and record the
 scope rationale, exact commands and results, and any intentionally omitted
-checks in the handoff. Rerun affected checks after making changes; do not rerun
+checks in the handoff. Rerun affected tests after making changes; do not rerun
 unrelated suites merely to satisfy a blanket rule. Passing this justified targeted
 validation is sufficient before pushing a bounded change; full local suites are
 required only for the escalation cases below. Required GitHub checks must still
 pass before merge.
 
-- Rust changes require formatting and all-target/all-feature Clippy checks:
-  `./scripts/quality.sh fmt` and `./scripts/quality.sh clippy`.
-  Use `scripts/test-headless.py` for native targeted Rust tests, for example
+- Run local lint and formatting checks only at the pre-push checkpoint, not
+  after each edit or during the test/implementation loop. For Rust changes, run
+  `./scripts/quality.sh fmt` and `./scripts/quality.sh clippy` on the final code
+  before pushing. If fixes change that code, rerun the affected checks before
+  the push. CI continues to run its existing lint and formatting checks.
+- Use `scripts/test-headless.py` for native targeted Rust tests, for example
   `./scripts/test-headless.py services::operations::tests`; its arguments are
   forwarded after the fixed `cargo test --all-targets --all-features` arguments.
   This filters test names across targets, not compilation to one target.
@@ -53,6 +56,8 @@ pass before merge.
   `STRATA_CONTAINER_ENGINE=podman ./scripts/e2e.sh` when impact is broad or
   uncertain. Escalate to both for shared infrastructure, dependencies,
   build/CI/harness code, cross-cutting behavior, or uncertain coverage.
+  During iteration, use `./scripts/quality.sh test` for full Rust tests; defer
+  the `fmt` and `clippy` phases to the pre-push checkpoint even in these cases.
   Preserve pinned image provenance and the existing `target/quality-container`
   and `target/e2e-container` caches.
 - GUI and delegated checks must never use the desktop or an inherited session

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,35 +22,50 @@ under `.agents/`.
 
 ## Pre-push checks
 
-For documentation-only changes (README, documentation, or `AGENTS.md`), the full
-local CI suite, `./scripts/quality.sh`, and `./scripts/e2e.sh` are not required.
-Review the complete PR diff to confirm it changes only documentation, check
-relevant links and examples, and run `git diff --check`. This exception does not
-apply to mixed changes involving code, build/package metadata, scripts, or CI
-configuration, and does not bypass required CI checks on GitHub.
+Validation is risk-based, but CI remains unchanged and is the authoritative full
+suite. Map the behavior and callers affected by the change (including shared
+infrastructure, preferences, and views); do not infer coverage automatically
+from changed file names. For a bounded change, run the relevant regression tests
+and targeted checks, confirm the selected test count is nonzero, and record the
+scope rationale, exact commands and results, and any intentionally omitted
+checks in the handoff. Rerun affected checks after making changes; do not rerun
+unrelated suites merely to satisfy a blanket rule. Passing this justified targeted
+validation is sufficient before pushing a bounded change; full local suites are
+required only for the escalation cases below. Required GitHub checks must still
+pass before merge.
 
-For all other changes:
-
-- Do not push until the full local CI suite passes: `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all-targets --all-features`.
-- Run `./scripts/quality.sh` before pushing to exercise formatting, Clippy, and the full Rust suite
-  in CI's verified pinned build environment. It reuses the same base as E2E but
-  keeps Cargo artifacts in `target/quality-container`, and requires GTK tests to
-  execute under private Xvfb. Individual phases are `fmt`, `clippy`, and `test`.
-  It never implicitly builds an image; the explicit E2E base-update command below
-  also prepares this shared environment.
-- Agents must never run GTK tests against the user's active Wayland or X11 display. Run the suite under a private Xvfb display with accessibility bridging disabled:
-
-  ```bash
-  xvfb-run -a env -u WAYLAND_DISPLAY GDK_BACKEND=x11 \
-    GTK_A11Y=none NO_AT_BRIDGE=1 STRATA_REQUIRE_GTK_TESTS=1 \
-    cargo test --all-targets --all-features
-  ```
-
-  If `xvfb-run` is unavailable, use a non-root portable extraction of the distribution's Xvfb package or another isolated display server. Do not fall back to the active desktop display, and do not use a backend that causes GTK tests to skip because initialization failed.
-- Run `./scripts/e2e.sh` before pushing. It uses the same pinned container as CI;
-  use `STRATA_CONTAINER_ENGINE=podman` for rootless Podman. Native-host E2E results
-  do not substitute for this gate. See `docs/e2e-testing.md`.
-- Fix failures before pushing rather than relying on CI for feedback. Keep tests portable across supported environments and avoid assertions that depend on platform-specific URI normalization or other incidental system behavior.
+- Rust changes require formatting and all-target/all-feature Clippy checks:
+  `./scripts/quality.sh fmt` and `./scripts/quality.sh clippy`.
+  Use `scripts/test-headless.py` for native targeted Rust tests, for example
+  `./scripts/test-headless.py services::operations::tests`; its arguments are
+  forwarded after the fixed `cargo test --all-targets --all-features` arguments.
+  This filters test names across targets, not compilation to one target.
+  The selected filter must match at least one test, including relevant views,
+  callers, or preferences coverage.
+- E2E selections may use repository-relative test paths and pytest `-k`, for
+  example `./scripts/e2e.sh tests/e2e/scenarios/test_inline_renaming.py` or
+  `./scripts/e2e.sh -k 'rename and not visual'`. Confirm collection selects
+  tests with `--collect-only` when useful. `scripts/e2e.sh` is the canonical
+  pinned-container runner; `scripts/e2e-native.sh` is host-toolkit debugging
+  only and cannot replace it. `scripts/quality.sh` accepts only `all`, `fmt`,
+  `clippy`, or `test` and does not forward test filters.
+- Use full pinned `./scripts/quality.sh` phases and canonical
+  `STRATA_CONTAINER_ENGINE=podman ./scripts/e2e.sh` when impact is broad or
+  uncertain. Escalate to both for shared infrastructure, dependencies,
+  build/CI/harness code, cross-cutting behavior, or uncertain coverage.
+  Preserve pinned image provenance and the existing `target/quality-container`
+  and `target/e2e-container` caches.
+- GUI and delegated checks must never use the desktop or an inherited session
+  bus. Use private Xvfb and private D-Bus, clear inherited display variables,
+  disable accessibility bridging for Rust tests (E2E needs its private AT-SPI
+  bus), and require GTK tests to run (not silently skip). Stop if the isolated display or bus is unavailable; never fall back to
+  the user's display. See `docs/e2e-testing.md`.
+- Documentation-only changes need no GUI/build tests: review the complete diff,
+  validate links and example filters against the scripts and existing tests, and
+  run `git diff --check`. These checks do not bypass required CI checks.
+- Fix failures before pushing rather than relying on CI. Keep tests portable
+  across supported environments and avoid assertions that depend on
+  platform-specific URI normalization or other incidental system behavior.
 
 ## E2E base-image reuse
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,17 @@ pass before merge.
 - Documentation-only changes need no GUI/build tests: review the complete diff,
   validate links and example filters against the scripts and existing tests, and
   run `git diff --check`. These checks do not bypass required CI checks.
-- Fix failures before pushing rather than relying on CI. Keep tests portable
+- Owner-approved exception: the repository owner may explicitly authorize
+  pushing a PR without running otherwise-required local tests. Consent must
+  specifically acknowledge skipping tests for the current change/push; a generic
+  request to push, urgency, silence, or prior approval for another push is not
+  consent. Record the authorization, skipped suites, and any known failures or
+  unverified behavior in the handoff and PR description. Do not claim skipped
+  tests passed. This waives only local test execution for that authorized scope,
+  not lint/format checks, GUI safety, or required CI/merge checks. If scope changes,
+  obtain renewed consent or perform the required validation.
+- Outside that explicit exception, fix failures before pushing rather than
+  relying on CI. Keep tests portable
   across supported environments and avoid assertions that depend on
   platform-specific URI normalization or other incidental system behavior.
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -13,6 +13,57 @@ checks both what the window reports and what happened on disk.
 ./scripts/e2e.sh -k "clipboard and columns"
 ```
 
+### Targeted local validation
+
+Choose checks from the behavior and caller mapping, not from changed-file names
+alone. Bounded changes may use a non-empty, relevant selection; broad,
+cross-cutting, shared infrastructure, dependency/build/CI/harness changes, or
+uncertain coverage require the full pinned quality phases and the full canonical
+E2E run. Include relevant views, callers, and preference behavior, and add or
+run the regression test that proves the change. Record the scope rationale,
+commands, results, and intentional omissions in the handoff. After editing,
+rerun affected checks rather than unrelated suites.
+
+For native Rust selection, `scripts/test-headless.py` starts the private display
+and session buses, then appends its arguments to the fixed
+`cargo test --all-targets --all-features` command. Use module/name filters:
+
+```bash
+./scripts/test-headless.py services::operations::tests
+./scripts/test-headless.py basenames_reject_empty_reserved_nested_absolute_and_nul_names
+```
+
+These select test execution across targets, not compilation to one target.
+Targeted runs can still incur a full test build; Cargo's cache helps subsequent
+iterations. There is no automatic changed-code dependency-to-test mapping.
+
+A filter must collect at least one test; use Cargo's output or a collection
+check to verify that it did. `scripts/quality.sh` only accepts `all`, `fmt`,
+`clippy`, or `test` and does **not** forward test filters, so it cannot be used
+for a targeted test selection.
+
+The E2E runner passes repository-relative paths and normal pytest arguments to
+its configured pytest invocation. Use a file or `-k` expression, then confirm
+collection is nonzero:
+
+```bash
+./scripts/e2e.sh tests/e2e/scenarios/test_inline_renaming.py
+./scripts/e2e.sh -k 'rename and not visual' --collect-only
+```
+
+`./scripts/e2e.sh` is the canonical pinned-container evidence; native
+`scripts/e2e-native.sh` is only for host-toolkit debugging and does not replace
+it. Preserve the verified image provenance and `target/e2e-container` and
+`target/quality-container` caches. CI still runs its complete unchanged gate.
+
+Every GUI or delegated check must clear inherited display variables and use a
+private Xvfb and private D-Bus session. `scripts/test-headless.py` and the E2E
+runners enforce this isolation. Rust tests set `GTK_A11Y=none`, `NO_AT_BRIDGE=1`,
+and `STRATA_REQUIRE_GTK_TESTS=1`; E2E enables accessibility on its private AT-SPI
+bus to drive the application. Other commands must arrange equivalent isolation. A
+missing isolated display or bus is a hard failure. Never run against the desktop
+or an inherited session bus, silently skip GTK tests, or fall back to the desktop.
+
 The runner prefers Podman when available; select an engine explicitly with
 `STRATA_CONTAINER_ENGINE=podman` or `docker`. CI explicitly selects Docker to match
 its runtime archive loader; an image in one engine's store is not visible to the
@@ -46,8 +97,8 @@ Updating the image inputs is an intentional rendering
 environment change and requires reviewing the visual baselines.
 
 For explicit host-toolkit debugging only, `./scripts/e2e-native.sh` accepts
-`STRATA_BINARY` and `STRATA_E2E_VENV`. It is not the pre-push E2E gate; a native
-pass does not replace `./scripts/e2e.sh`.
+`STRATA_BINARY` and `STRATA_E2E_VENV`. A native pass does not replace canonical
+`./scripts/e2e.sh` evidence when targeted or full E2E validation is required.
 
 ### Shared environment for formatting, lint, and Rust tests
 
@@ -119,17 +170,19 @@ setup or Rust compilation.
 ### Keep Rust test windows off the local desktop
 
 Some Rust tests also create GTK windows when a display is available. Run the
-complete Rust test suite on the same private Xvfb/D-Bus infrastructure with:
+complete suite, or a justified targeted selection, on the same private
+Xvfb/private D-Bus infrastructure with:
 
 ```bash
 ./scripts/test-headless.py
 ./scripts/test-headless.py -- --nocapture
+./scripts/test-headless.py relevant_module_or_test_name
 ```
 
 This requires Xvfb and AT-SPI but not the Python E2E packages. It isolates
 application preferences while retaining access to the installed Cargo/Rust
 toolchains, and disables accessibility bridging for Rust tests. A startup failure
-aborts; it never falls back to the real display.
+aborts; it never falls back to the real display or an inherited session bus.
 The E2E runner likewise clears inherited display variables before startup.
 
 ### Native debugging dependencies

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -31,6 +31,14 @@ checks if fixes change the code before the push. Even when full Rust tests are
 needed during iteration, use `./scripts/quality.sh test` and defer lint/format
 phases until pre-push. CI's lint and formatting checks remain unchanged.
 
+The repository owner may explicitly authorize pushing a PR without the normally
+required local tests for the current change/push. A general push request,
+urgency, silence, or consent for another push does not qualify. Record the
+explicit authorization, omitted suites, and known failures or unverified behavior
+in the handoff and PR description; never report skipped tests as passing. This
+exception does not waive lint/format checks, GUI isolation, or required CI/merge
+checks. Renew consent if the authorized scope changes, or run the required tests.
+
 For native Rust selection, `scripts/test-headless.py` starts the private display
 and session buses, then appends its arguments to the fixed
 `cargo test --all-targets --all-features` command. Use module/name filters:

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -22,7 +22,14 @@ uncertain coverage require the full pinned quality phases and the full canonical
 E2E run. Include relevant views, callers, and preference behavior, and add or
 run the regression test that proves the change. Record the scope rationale,
 commands, results, and intentional omissions in the handoff. After editing,
-rerun affected checks rather than unrelated suites.
+rerun affected tests rather than unrelated suites.
+
+Run local lint and formatting checks only before pushing, not during the
+edit/test loop. For Rust changes, run `./scripts/quality.sh fmt` and
+`./scripts/quality.sh clippy` on the final code at that checkpoint; rerun affected
+checks if fixes change the code before the push. Even when full Rust tests are
+needed during iteration, use `./scripts/quality.sh test` and defer lint/format
+phases until pre-push. CI's lint and formatting checks remain unchanged.
 
 For native Rust selection, `scripts/test-headless.py` starts the private display
 and session buses, then appends its arguments to the fixed


### PR DESCRIPTION
## Description
Replace blanket full-suite local checks with behavior-based targeted validation for bounded changes. Require full canonical local suites for broad or uncertain impact, retain full CI, and document safe selection commands and coverage reporting.

## Visual evidence
N/A — documentation and contributor directives only.

## How to test
1. Read the pre-push policy in `AGENTS.md` for a bounded Rust or GUI change, then for a shared-infrastructure change.
2. Follow the targeted-validation examples in `docs/e2e-testing.md` and compare them with the existing runner argument handling.

**Expected result:** Bounded changes permit justified nonempty targeted checks before push; broad or uncertain changes require full local suites. GUI isolation and required full CI remain mandatory.

## Related issue
Closes #675