### PR TITLE
fix(ui): round before choosing file size unit

### DIFF
--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -63,7 +63,7 @@ pub(super) use crate::ui::browser::context_menu::{
 pub(super) use crate::ui::browser::desktop::{launch_terminal, open_location};
 pub(super) use crate::ui::browser::entry::{
     FOLDER_TYPE_GROUP, entry_filter, entry_icon, entry_model_value, format_file_size,
-    metadata_needs_fill, model_type_group,
+    metadata_needs_fill, model_type_group, rounded_size_and_unit,
 };
 pub(super) use crate::ui::browser::inline_edit::{
     queue_rename, rename_stem_end, reveal_rename_row, update_basename_validation,

--- a/src/ui/browser/entry.rs
+++ b/src/ui/browser/entry.rs
@@ -12,18 +12,19 @@ use std::path::Path;
 use std::rc::Rc;
 
 pub(in crate::ui) fn format_file_size(bytes: u64) -> String {
-    let (value, unit) = rounded_size_and_unit(bytes, &["B", "kB", "MB", "GB", "TB"]);
+    const UNITS: [&str; 5] = ["B", "kB", "MB", "GB", "TB"];
+    let (value, unit) = rounded_size_and_unit(bytes, &UNITS);
     let formatted = format!("{value:.1}");
-    format!("{} {}", formatted.trim_end_matches(".0"), unit)
+    format!("{} {}", formatted.trim_end_matches(".0"), UNITS[unit])
 }
 
 /// Divide `bytes` into the largest unit whose threshold it meets after
-/// rounding to one decimal, returning the rounded value and unit label.
+/// rounding to one decimal, returning the rounded value and unit index.
 /// Callers that format with zero decimals for values >= 10 still receive
 /// the one-decimal rounded value so they can decide their own precision.
-pub(in crate::ui) fn rounded_size_and_unit<'a>(bytes: u64, units: &[&'a str]) -> (f64, &'a str) {
+pub(in crate::ui) fn rounded_size_and_unit(bytes: u64, units: &[&str]) -> (f64, usize) {
     if bytes < 1_000 {
-        return (bytes as f64, units[0]);
+        return (bytes as f64, 0);
     }
     let mut value = bytes as f64;
     let mut unit = 0;
@@ -33,9 +34,9 @@ pub(in crate::ui) fn rounded_size_and_unit<'a>(bytes: u64, units: &[&'a str]) ->
     }
     let rounded = (value * 10.0).round() / 10.0;
     if rounded >= 1_000.0 && unit < units.len() - 1 {
-        (rounded / 1_000.0, units[unit + 1])
+        (rounded / 1_000.0, unit + 1)
     } else {
-        (rounded, units[unit])
+        (rounded, unit)
     }
 }
 

--- a/src/ui/browser/entry.rs
+++ b/src/ui/browser/entry.rs
@@ -12,19 +12,31 @@ use std::path::Path;
 use std::rc::Rc;
 
 pub(in crate::ui) fn format_file_size(bytes: u64) -> String {
-    const UNITS: [&str; 5] = ["B", "kB", "MB", "GB", "TB"];
-    if bytes < 1_000 {
-        return format!("{bytes} B");
-    }
+    let (value, unit) = rounded_size_and_unit(bytes, &["B", "kB", "MB", "GB", "TB"]);
+    let formatted = format!("{value:.1}");
+    format!("{} {}", formatted.trim_end_matches(".0"), unit)
+}
 
+/// Divide `bytes` into the largest unit whose threshold it meets after
+/// rounding to one decimal, returning the rounded value and unit label.
+/// Callers that format with zero decimals for values >= 10 still receive
+/// the one-decimal rounded value so they can decide their own precision.
+pub(in crate::ui) fn rounded_size_and_unit<'a>(bytes: u64, units: &[&'a str]) -> (f64, &'a str) {
+    if bytes < 1_000 {
+        return (bytes as f64, units[0]);
+    }
     let mut value = bytes as f64;
     let mut unit = 0;
-    while value >= 1_000.0 && unit < UNITS.len() - 1 {
+    while value >= 1_000.0 && unit < units.len() - 1 {
         value /= 1_000.0;
         unit += 1;
     }
-    let formatted = format!("{value:.1}");
-    format!("{} {}", formatted.trim_end_matches(".0"), UNITS[unit])
+    let rounded = (value * 10.0).round() / 10.0;
+    if rounded >= 1_000.0 && unit < units.len() - 1 {
+        (rounded / 1_000.0, units[unit + 1])
+    } else {
+        (rounded, units[unit])
+    }
 }
 
 pub(in crate::ui) fn metadata_needs_fill(entry: &FileEntry) -> bool {

--- a/src/ui/browser/entry/tests.rs
+++ b/src/ui/browser/entry/tests.rs
@@ -35,6 +35,14 @@ fn file_sizes_use_compact_decimal_units() {
 }
 
 #[test]
+fn file_sizes_round_before_choosing_the_unit() {
+    assert_eq!(format_file_size(999_950), "1 MB");
+    assert_eq!(format_file_size(999_950_000), "1 GB");
+    assert_eq!(format_file_size(9_949), "9.9 kB");
+    assert_eq!(format_file_size(9_950), "10 kB");
+}
+
+#[test]
 fn delete_confirmation_labels_distinguish_files_and_folders() {
     let file = FileEntry {
         location: Location::local("/fixture/file.txt"),

--- a/src/ui/preview.rs
+++ b/src/ui/preview.rs
@@ -1870,11 +1870,17 @@ fn file_extension(entry: &FileEntry) -> &str {
 }
 
 fn format_file_size(bytes: u64) -> String {
-    let (value, unit) = super::browser::rounded_size_and_unit(bytes, &["B", "kB", "MB", "GB"]);
-    if value >= 10.0 {
-        format!("{value:.0} {unit}")
+    let units = ["B", "kB", "MB", "GB"];
+    let (value, unit) = super::browser::rounded_size_and_unit(bytes, &units);
+    if unit == 0 || value >= 10.0 {
+        let displayed = value.round();
+        if displayed >= 1_000.0 && unit + 1 < units.len() {
+            format!("{:.1} {}", displayed / 1_000.0, units[unit + 1])
+        } else {
+            format!("{displayed:.0} {}", units[unit])
+        }
     } else {
-        format!("{value:.1} {unit}")
+        format!("{value:.1} {}", units[unit])
     }
 }
 

--- a/src/ui/preview.rs
+++ b/src/ui/preview.rs
@@ -1870,17 +1870,11 @@ fn file_extension(entry: &FileEntry) -> &str {
 }
 
 fn format_file_size(bytes: u64) -> String {
-    const UNITS: [&str; 4] = ["B", "kB", "MB", "GB"];
-    let mut value = bytes as f64;
-    let mut unit = 0;
-    while value >= 1000.0 && unit < UNITS.len() - 1 {
-        value /= 1000.0;
-        unit += 1;
-    }
-    if unit == 0 || value >= 10.0 {
-        format!("{value:.0} {}", UNITS[unit])
+    let (value, unit) = super::browser::rounded_size_and_unit(bytes, &["B", "kB", "MB", "GB"]);
+    if value >= 10.0 {
+        format!("{value:.0} {unit}")
     } else {
-        format!("{value:.1} {}", UNITS[unit])
+        format!("{value:.1} {unit}")
     }
 }
 

--- a/src/ui/preview/tests.rs
+++ b/src/ui/preview/tests.rs
@@ -75,6 +75,14 @@ fn formats_preview_file_sizes() {
 }
 
 #[test]
+fn preview_file_sizes_round_before_choosing_the_unit() {
+    assert_eq!(format_file_size(999_950), "1.0 MB");
+    assert_eq!(format_file_size(999_950_000), "1.0 GB");
+    assert_eq!(format_file_size(9_960), "10 kB");
+    assert_eq!(format_file_size(10_000), "10 kB");
+}
+
+#[test]
 fn media_errors_explain_missing_runtime_plugins() {
     let (title, detail, command) =
         media_error_feedback("Your GStreamer installation is missing a plug-in.");

--- a/src/ui/preview/tests.rs
+++ b/src/ui/preview/tests.rs
@@ -83,6 +83,14 @@ fn preview_file_sizes_round_before_choosing_the_unit() {
 }
 
 #[test]
+fn preview_file_sizes_keep_bytes_whole_and_promote_displayed_overflow() {
+    assert_eq!(format_file_size(0), "0 B");
+    assert_eq!(format_file_size(5), "5 B");
+    assert_eq!(format_file_size(999_450), "1.0 MB");
+    assert_eq!(format_file_size(999_449), "999 kB");
+}
+
+#[test]
 fn media_errors_explain_missing_runtime_plugins() {
     let (title, detail, command) =
         media_error_feedback("Your GStreamer installation is missing a plug-in.");


### PR DESCRIPTION
## Summary
- Both `format_file_size` implementations picked the unit from the unrounded value, so a value that rounds up to 1000 stayed in the smaller unit: `999_950` → "1000 kB", `999_950_000` → "1000 MB"
- Extracted a shared `rounded_size_and_unit` helper that rounds to one decimal first, then promotes to the next unit if the rounded value crosses 1000
- Both the browser entry and preview formatters call the shared helper

Fixes #657.

#### Test plan
- [x] `cargo test --bin strata -- file_sizes formats_preview preview_file_sizes` — 4/4 pass
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [ ] Manual: create a 999,950-byte file, verify it shows "1 MB" in list and "1.0 MB" in preview

https://github.com/user-attachments/assets/caa68ab2-64e0-4a7c-b341-9a6cb2b9f869