### PR TITLE
fix(browser): cap delete confirmation rows to prevent UI freeze

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -503,13 +503,30 @@ headerbar menubutton.header-action > button:focus-visible {
 
 .delete-confirmation-list {
   background: alpha(@theme_highlight, 0.42);
-  border: 1px solid alpha(@theme_border, 0.42);
-  border-radius: 5px;
 }
 
 .delete-confirmation-list viewport {
   background: transparent;
-  border-radius: 5px;
+}
+
+.delete-confirmation-list scrollbar {
+  padding: 0 !important;
+}
+
+.delete-confirmation-list scrollbar.vertical {
+  min-width: 6px !important;
+}
+
+.delete-confirmation-list scrollbar.vertical > range > trough {
+  background: transparent !important;
+  border: none !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+.delete-confirmation-list scrollbar.vertical > range > trough > slider {
+  margin: 0 !important;
+  min-width: 6px !important;
 }
 
 .delete-confirmation-files {

--- a/src/ui/browser/trash.rs
+++ b/src/ui/browser/trash.rs
@@ -70,6 +70,27 @@ fn delete_confirmation_focus_target(key: gtk::gdk::Key) -> Option<DeleteConfirma
     }
 }
 
+/// Rows rendered in the delete confirmation; anything beyond this collapses
+/// into a summary so a thousand-file selection cannot stall the UI thread.
+const DELETE_CONFIRMATION_MAX_ROWS: usize = 50;
+
+/// Splits confirmation entries into rendered rows and the hidden remainder.
+fn delete_confirmation_rows(entries: &[FileEntry]) -> (&[FileEntry], usize) {
+    let visible = entries.len().min(DELETE_CONFIRMATION_MAX_ROWS);
+    (&entries[..visible], entries.len() - visible)
+}
+
+/// Summary for the hidden remainder, or nothing when everything is shown.
+fn delete_confirmation_overflow_label(hidden: usize) -> Option<String> {
+    (hidden > 0).then(|| {
+        format!(
+            "… and {} more {}",
+            hidden,
+            if hidden == 1 { "item" } else { "items" }
+        )
+    })
+}
+
 impl ViewState {
     /// Safe to call more than once: whichever of cancel or completion runs first leaves the
     /// other a no-op.
@@ -405,7 +426,8 @@ impl ViewState {
         );
         let files = gtk::Box::new(gtk::Orientation::Vertical, 3);
         files.add_css_class("delete-confirmation-files");
-        for entry in &entries {
+        let (visible, hidden) = delete_confirmation_rows(&entries);
+        for entry in visible {
             let row = gtk::Box::new(gtk::Orientation::Horizontal, 8);
             row.add_css_class("delete-confirmation-file");
             let icon = crate::assets::primary_icon(entry_icon(entry), 16);
@@ -429,6 +451,12 @@ impl ViewState {
             row.append(&metadata);
             files.append(&row);
         }
+        if let Some(summary) = delete_confirmation_overflow_label(hidden) {
+            let overflow = gtk::Label::new(Some(&summary));
+            overflow.set_xalign(0.0);
+            overflow.add_css_class("delete-confirmation-file-metadata");
+            files.append(&overflow);
+        }
         let file_scroller = gtk::ScrolledWindow::builder()
             .child(&files)
             .hscrollbar_policy(gtk::PolicyType::Never)
@@ -441,6 +469,7 @@ impl ViewState {
             .propagate_natural_height(true)
             .build();
         file_scroller.add_css_class("delete-confirmation-list");
+        file_scroller.add_css_class("fixed-scrollbar");
         layout.body.append(&file_scroller);
         let explanation = message_dialog_description(
             "These items will be permanently deleted. This action cannot be undone.",

--- a/src/ui/browser/trash/tests.rs
+++ b/src/ui/browser/trash/tests.rs
@@ -64,3 +64,51 @@ fn retryable_delete_entries_is_empty_when_nothing_matches() {
 
     assert!(kept.is_empty());
 }
+
+#[test]
+fn delete_confirmation_renders_every_row_for_a_small_selection() {
+    let entries = (0..7).map(confirmation_entry).collect::<Vec<_>>();
+
+    let (visible, hidden) = delete_confirmation_rows(&entries);
+
+    assert_eq!(visible.len(), 7);
+    assert_eq!(hidden, 0);
+    assert_eq!(delete_confirmation_overflow_label(hidden), None);
+}
+
+#[test]
+fn delete_confirmation_caps_rows_and_summarizes_the_rest() {
+    let entries = (0..1000).map(confirmation_entry).collect::<Vec<_>>();
+
+    let (visible, hidden) = delete_confirmation_rows(&entries);
+
+    assert_eq!(visible.len(), DELETE_CONFIRMATION_MAX_ROWS);
+    assert_eq!(hidden, 1000 - DELETE_CONFIRMATION_MAX_ROWS);
+    assert_eq!(
+        delete_confirmation_overflow_label(hidden),
+        Some("… and 950 more items".to_owned())
+    );
+}
+
+#[test]
+fn delete_confirmation_overflow_label_uses_the_singular_for_one_item() {
+    assert_eq!(
+        delete_confirmation_overflow_label(1),
+        Some("… and 1 more item".to_owned())
+    );
+}
+
+fn confirmation_entry(index: usize) -> FileEntry {
+    let name = format!("file-{index}.txt");
+    FileEntry {
+        location: Location::local(format!("/fixture/{name}")),
+        native_name: name.clone().into(),
+        thumbnail_path: None,
+        display_name: name,
+        kind: crate::model::EntryKind::File,
+        size: crate::model::MetadataValue::Unknown,
+        modified_unix_seconds: crate::model::MetadataValue::Unknown,
+        is_hidden: false,
+        mode: crate::model::MetadataValue::Unknown,
+    }
+}


### PR DESCRIPTION
## Description

Permanently deleting many files (1000+) freezes the UI because \`show_delete_confirmation\` builds one GTK widget row per selected file on the main thread.

Renders at most **50 rows** in the confirmation dialog and appends \`… and N more items\` for the rest. All selected files are still deleted — the cap only applies to the preview list.

Also moves the scrollbar flush with the list edge by removing margins, padding, trough, and border, matching the thin fixed-scrollbar style used elsewhere.

## Visual evidence

https://github.com/user-attachments/assets/157ab13c-894f-46cf-865e-de38b7de2271

## How to test

1. In \`~/strata-delete-test/\` (or any folder with many files), select 50+ files.
2. Press Shift+Delete.
3. The confirmation dialog must appear instantly, showing up to 50 rows plus a \`… and N more items\` line.
4. Confirm — all selected files should be permanently deleted.

**Expected result:** Dialog appears without freeze, all items are deleted on confirm.

Local validation: 6/6 trash unit tests, 40/40 \`test_entry_management.py\` E2E tests, and 50k-file manual test passed.

## Related issue

Closes #622