### PR TITLE
fix(columns): only slide_out source row when drag actually moved it

### DIFF
--- a/src/ui/browser/columns/rows.rs
+++ b/src/ui/browser/columns/rows.rs
@@ -217,11 +217,13 @@ pub(super) fn column_rows(
                 }
             });
             let dragged_row = row.downgrade();
-            drag.connect_drag_end(move |source, _, _| {
+            drag.connect_drag_end(move |source, _, delete_data| {
                 source.set_actions(gtk::gdk::DragAction::COPY | gtk::gdk::DragAction::MOVE);
                 if let Some(row) = dragged_row.upgrade() {
                     row.remove_css_class("dragging");
-                    slide_out(&row);
+                    if delete_data {
+                        slide_out(&row);
+                    }
                 }
             });
             row.add_controller(drag.clone());


### PR DESCRIPTION
## Description
The Columns view `drag_end` handler ignored the `delete_data` argument and ran `slide_out` unconditionally, playing the removal animation on every drag end — including cancelled drags and copies that leave the original in place. Gate `slide_out` on `delete_data` so only actual moves animate.

## Visual evidence

<img width="960" height="518" alt="screenrecording-2026-09-09_19-58-32" src="https://github.com/user-attachments/assets/d961c6a1-50b0-4fe2-927b-6ad198b4aa09" />

## How to test
1. Switch to Columns view.
2. Drag a file by its icon/name and cancel by releasing on empty space (not a folder).
3. Observe the source row.

**Expected result:** The source row stays in place without playing the slide-out/fade animation. Only actual moves (where the source is deleted) animate.

## Related issue
Fixes #598