### PR TITLE
ci(release): disable unrelated Chrome APT sources

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,8 +209,9 @@ jobs:
           PY
 
       - name: Install native development libraries
-        run: >-
-          sudo apt-get update &&
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
+          sudo apt-get update
           sudo apt-get install --yes libfontconfig1-dev libgtk-4-dev libgtksourceview-5-dev libpoppler-glib-dev
 
       - name: Install Rust


### PR DESCRIPTION
## Description

Remove the runner-provided Chrome APT source files before installing release dependencies. This prevents an unrelated Chrome package-index checksum mismatch from blocking release builds, while preserving package integrity verification and failure handling. The change is YAML-only.

Per explicit owner instruction, full local quality/E2E validation was stopped and skipped for this change; release execution remains unverified.

## Visual evidence

N/A — release workflow only; no interface changes.

## How to test

1. After merging, dispatch the Release workflow for the intended release candidate.
2. Inspect the native dependency installation step on both x86_64 and ARM runners.

**Expected result:** APT no longer contacts the Google Chrome repository, required libraries install, and execution proceeds to the Rust build.

## Related issue

Closes #709