### PR TITLE
fix(sidebar): keep pinned places when the GTK bookmarks file has bad UTF-8

### DIFF
--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -2056,22 +2056,29 @@ fn pinned_places_path() -> PathBuf {
 }
 
 fn load_pinned_places() -> std::io::Result<Vec<(Location, String)>> {
-    match std::fs::read_to_string(pinned_places_path()) {
+    match std::fs::read(pinned_places_path()) {
         Ok(contents) => Ok(parse_pinned_places(&contents)),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
         Err(error) => Err(error),
     }
 }
 
-fn parse_pinned_places(contents: &str) -> Vec<(Location, String)> {
+/// GTK writes the bookmarks file without validating UTF-8, so labels are
+/// decoded leniently and only lines whose URI is not valid UTF-8 are skipped.
+fn parse_pinned_places(contents: &[u8]) -> Vec<(Location, String)> {
     let mut places = Vec::new();
-    for line in contents.lines() {
-        let (uri, label) = line
-            .split_once(' ')
-            .map_or((line, None), |(uri, label)| (uri, Some(label)));
+    for line in contents.split(|byte| *byte == b'\n') {
+        let line = line.strip_suffix(b"\r").unwrap_or(line);
+        let (uri, label) = match line.iter().position(|byte| *byte == b' ') {
+            Some(space) => (&line[..space], Some(&line[space + 1..])),
+            None => (line, None),
+        };
         if uri.is_empty() {
             continue;
         }
+        let Ok(uri) = std::str::from_utf8(uri) else {
+            continue;
+        };
         let file = gio::File::for_uri(uri);
         let Some(location) = location_for_file(&file) else {
             continue;
@@ -2084,7 +2091,7 @@ fn parse_pinned_places(contents: &str) -> Vec<(Location, String)> {
         }
         let name = label
             .filter(|label| !label.is_empty())
-            .map(str::to_owned)
+            .map(|label| String::from_utf8_lossy(label).into_owned())
             .unwrap_or_else(|| location.display_name());
         places.push((location, name));
     }

--- a/src/ui/window/tests.rs
+++ b/src/ui/window/tests.rs
@@ -509,7 +509,7 @@ fn only_pinned_drag_payloads_resolve_to_a_pinned_place() {
 #[test]
 fn gtk_bookmarks_become_native_and_remote_pinned_places() {
     let places = parse_pinned_places(
-        "file:///home/user/Projects Work\nsftp://host.example/home/user Remote\nfile:///home/user/Projects Duplicate\n",
+        b"file:///home/user/Projects Work\nsftp://host.example/home/user Remote\nfile:///home/user/Projects Duplicate\n",
     );
 
     assert_eq!(
@@ -526,9 +526,28 @@ fn gtk_bookmarks_become_native_and_remote_pinned_places() {
 }
 
 #[test]
+fn gtk_bookmarks_survive_non_utf8_labels_and_windows_line_endings() {
+    let places = parse_pinned_places(b"file:///tmp/a A\r\nfile:///tmp/b \xff\nfile:///tmp/c C\n");
+
+    assert_eq!(places.len(), 3);
+    assert_eq!(places[0].1, "A");
+    assert_eq!(places[1].1, "\u{FFFD}");
+    assert_eq!(places[2].1, "C");
+}
+
+#[test]
+fn gtk_bookmarks_drop_lines_with_non_utf8_uris() {
+    let places = parse_pinned_places(b"file:///tmp/\xff bad\nfile:///tmp/good Good\n");
+
+    assert_eq!(places.len(), 1);
+    assert_eq!(places[0].0.native_path(), Some(Path::new("/tmp/good")));
+    assert_eq!(places[0].1, "Good");
+}
+
+#[test]
 fn gtk_bookmarks_sanitize_uris_with_credentials() {
     let places = parse_pinned_places(
-        "smb://alice@host/safe Safe\nsmb://alice:secret@host/private Password\nsmb://alice%3Asecret@host/private Encoded password delimiter\nsmb://alice;password=secret@host/private Auth\nsmb://alice%3Bpassword=secret@host/private Encoded auth delimiter\nsmb://alice;password=sec%72et@host/private Encoded value\nsmb://alice%ZZ@host/private Invalid\n",
+        b"smb://alice@host/safe Safe\nsmb://alice:secret@host/private Password\nsmb://alice%3Asecret@host/private Encoded password delimiter\nsmb://alice;password=secret@host/private Auth\nsmb://alice%3Bpassword=secret@host/private Encoded auth delimiter\nsmb://alice;password=sec%72et@host/private Encoded value\nsmb://alice%ZZ@host/private Invalid\n",
     );
 
     assert_eq!(places.len(), 2);
@@ -1026,14 +1045,16 @@ fn failed_bookmark_reads_and_saves_preserve_disk_and_window_state() {
                 .pin_location(existing.clone(), "Existing".into());
             let original = sidebar.state.pinned_places.borrow().clone();
             let path = pinned_places_path();
-            std::fs::write(&path, [0xff]).expect("unreadable UTF-8 fixture");
+            std::fs::remove_file(&path).expect("remove seeded bookmarks file");
+            std::fs::create_dir(&path).expect("unreadable bookmarks directory");
             sidebar
                 .state
                 .pin_location(Location::local("/tmp/new"), "New".into());
-            assert_eq!(std::fs::read(&path).expect("preserved bytes"), [0xff]);
+            assert!(path.is_dir());
             assert_eq!(*sidebar.state.pinned_places.borrow(), original);
 
             let contents = serialize_pinned_places(&original);
+            std::fs::remove_dir(&path).expect("remove directory fixture");
             std::fs::write(&path, &contents).expect("restore readable bookmarks");
             let target = path.with_extension("target");
             std::fs::rename(&path, &target).expect("move fixture");


### PR DESCRIPTION
## Description

`load_pinned_places` read the GTK bookmarks file with `read_to_string`, so a single non-UTF-8 byte in any label (GTK itself never validates the file) made the whole file parse as empty and the sidebar showed no pinned places. The next pin then wrote a one-line file over all the others.

The file is now read as bytes (`std::fs::read`) and `parse_pinned_places` splits on `\n`, tolerates CRLF, decodes labels with `from_utf8_lossy`, and skips only lines whose URI is not valid UTF-8. Valid URIs survive a bad byte anywhere else in the file.

## Visual evidence

N/A — no visual change; the sidebar already renders pinned places from the parsed list, the fix only changes which entries survive a malformed file.

## How to test

1. `printf 'file:///tmp/a A\nfile:///tmp/b \xff\n' > ~/.config/gtk-3.0/bookmarks`
2. Start Strata.

**Expected result:** both `/tmp/a` (label "A") and `/tmp/b` (label U+FFFD) appear in the sidebar; no pinned places are lost to the single invalid byte.

3. Pin any folder.

**Expected result:** the bookmarks file gains the new entry alongside the existing two, instead of being overwritten with only the new one.

## Related issue

Closes #648