### PR TITLE
feat(preview): render CSV files as a table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1680,6 +1701,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1888,6 +1915,7 @@ dependencies = [
  "ashpd",
  "async-io",
  "cairo-rs",
+ "csv",
  "flate2",
  "futures-channel",
  "futures-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["filesystem", "gui"]
 ashpd = { version = "=0.13.13", default-features = false, features = ["backend", "file_chooser", "async-io", "tracing"] }
 async-io = "2.6.0"
 cairo-rs = { version = "0.22.9", features = ["pdf", "png"] }
+csv = "1.4.0"
 flate2 = "1.1.10"
 fontconfig-sys = { package = "yeslogic-fontconfig-sys", version = "6.0.1" }
 futures-channel = "0.3.31"

--- a/src/adapters/local_preview.rs
+++ b/src/adapters/local_preview.rs
@@ -9,7 +9,8 @@ use crate::{
     sandbox::{Cancellation, MediaPreviewBackend, ParseOperation},
     services::{
         LoadHandle, Preview, PreviewContent, PreviewEvent, PreviewProvider, PreviewRequest,
-        content_family, has_plain_text_extension, is_non_executable_extensionless_dotfile,
+        content_family, has_csv_extension, has_plain_text_extension,
+        is_non_executable_extensionless_dotfile, parse_csv_table,
     },
 };
 
@@ -70,12 +71,22 @@ impl PreviewProvider for LocalPreviewProvider {
                     truncated: false,
                 };
             }
+            if matches!(content, PreviewContent::Text { .. })
+                && has_csv_extension(&entry.native_name)
+            {
+                content = PreviewContent::Table {
+                    headers: Vec::new(),
+                    rows: Vec::new(),
+                    truncated: false,
+                };
+            }
 
             let operation = match content {
                 PreviewContent::Pdf { .. } => Some(ParseOperation::PreviewPdf),
                 PreviewContent::Image => Some(ParseOperation::PreviewImage),
                 PreviewContent::Media => Some(ParseOperation::PreviewMedia),
                 PreviewContent::Text { .. }
+                | PreviewContent::Table { .. }
                 | PreviewContent::Rasterized { .. }
                 | PreviewContent::SandboxedMedia { .. }
                 | PreviewContent::Unsupported => None,
@@ -126,6 +137,25 @@ impl PreviewProvider for LocalPreviewProvider {
             } else if matches!(content, PreviewContent::Text { .. }) {
                 content = match read_text(&file, request.text_byte_limit).await {
                     Ok((content, truncated)) => PreviewContent::Text { content, truncated },
+                    Err(error) => {
+                        emit(PreviewEvent::Failed {
+                            request_id,
+                            entry,
+                            message: error.to_string(),
+                        });
+                        return;
+                    }
+                };
+            } else if matches!(content, PreviewContent::Table { .. }) {
+                content = match read_text(&file, request.text_byte_limit).await {
+                    Ok((text, byte_truncated)) => {
+                        let (headers, rows, row_truncated) = parse_csv_table(&text);
+                        PreviewContent::Table {
+                            headers,
+                            rows,
+                            truncated: byte_truncated || row_truncated,
+                        }
+                    }
                     Err(error) => {
                         emit(PreviewEvent::Failed {
                             request_id,

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -27,8 +27,8 @@ pub use preview::{
     Preview, PreviewContent, PreviewEvent, PreviewProvider, PreviewRequest, PreviewRequestId,
 };
 pub(crate) use preview::{
-    content_family, has_plain_text_extension, is_extensionless_dotfile,
-    is_non_executable_extensionless_dotfile,
+    TABLE_ROW_LIMIT, content_family, has_csv_extension, has_plain_text_extension,
+    is_extensionless_dotfile, is_non_executable_extensionless_dotfile, parse_csv_table,
 };
 // `best_update`, `rollback_target`, and `ReleaseSummary` are deliberately not
 // re-exported here: `rollback_target` is the never-downgrade bypass, and only

--- a/src/services/preview.rs
+++ b/src/services/preview.rs
@@ -19,12 +19,28 @@ pub struct PreviewRequest {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum PreviewContent {
-    Text { content: String, truncated: bool },
+    Text {
+        content: String,
+        truncated: bool,
+    },
+    Table {
+        headers: Vec<String>,
+        rows: Vec<Vec<String>>,
+        truncated: bool,
+    },
     Image,
     Media,
-    Rasterized { png: Vec<u8> },
-    SandboxedMedia { data: Vec<u8> },
-    Pdf { png: Vec<u8>, page: i32, pages: i32 },
+    Rasterized {
+        png: Vec<u8>,
+    },
+    SandboxedMedia {
+        data: Vec<u8>,
+    },
+    Pdf {
+        png: Vec<u8>,
+        page: i32,
+        pages: i32,
+    },
     Unsupported,
 }
 
@@ -57,6 +73,38 @@ pub(crate) fn has_plain_text_extension(name: &OsStr) -> bool {
         .is_some_and(|extension| matches!(extension.to_ascii_lowercase().as_str(), "conf" | "ini"))
 }
 
+pub(crate) fn has_csv_extension(name: &OsStr) -> bool {
+    Path::new(name)
+        .extension()
+        .and_then(OsStr::to_str)
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("csv"))
+}
+
+/// Cap on rows parsed for a table preview, matching pandas' truncated-display feel.
+pub(crate) const TABLE_ROW_LIMIT: usize = 200;
+
+/// Parses CSV text into a header row plus up to `TABLE_ROW_LIMIT` data rows.
+/// Ragged rows are tolerated (`flexible`); unparsable rows are skipped.
+pub(crate) fn parse_csv_table(content: &str) -> (Vec<String>, Vec<Vec<String>>, bool) {
+    let mut reader = csv::ReaderBuilder::new()
+        .flexible(true)
+        .from_reader(content.as_bytes());
+    let headers = reader
+        .headers()
+        .map(|record| record.iter().map(str::to_owned).collect())
+        .unwrap_or_default();
+    let mut rows = Vec::new();
+    let mut truncated = false;
+    for record in reader.records().flatten() {
+        if rows.len() >= TABLE_ROW_LIMIT {
+            truncated = true;
+            break;
+        }
+        rows.push(record.iter().map(str::to_owned).collect());
+    }
+    (headers, rows, truncated)
+}
+
 pub(crate) fn is_extensionless_dotfile(name: &OsStr) -> bool {
     let bytes = name.as_encoded_bytes();
     bytes.len() > 1 && bytes.starts_with(b".") && Path::new(name).extension().is_none()
@@ -82,6 +130,12 @@ pub(crate) fn content_family(content_type: &str) -> PreviewContent {
         PreviewContent::Image
     } else if content_type.starts_with("audio/") || content_type.starts_with("video/") {
         PreviewContent::Media
+    } else if content_type == "text/csv" {
+        PreviewContent::Table {
+            headers: Vec::new(),
+            rows: Vec::new(),
+            truncated: false,
+        }
     } else if content_type.starts_with("text/")
         || matches!(
             content_type,

--- a/src/services/preview/tests.rs
+++ b/src/services/preview/tests.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use super::{
-    PreviewContent, content_family, has_plain_text_extension, is_extensionless_dotfile,
-    is_non_executable_extensionless_dotfile,
+    PreviewContent, content_family, has_csv_extension, has_plain_text_extension,
+    is_extensionless_dotfile, is_non_executable_extensionless_dotfile, parse_csv_table,
 };
 
 #[test]
@@ -63,4 +63,63 @@ fn classifies_common_preview_content_types() {
         content_family("application/octet-stream"),
         PreviewContent::Unsupported
     );
+    assert!(matches!(
+        content_family("text/csv"),
+        PreviewContent::Table { .. }
+    ));
+}
+
+#[test]
+fn recognizes_csv_extension() {
+    assert!(has_csv_extension(std::ffi::OsStr::new("expenses.CSV")));
+    assert!(!has_csv_extension(std::ffi::OsStr::new("notes.txt")));
+}
+
+#[test]
+fn parses_headers_and_quoted_fields() {
+    let (headers, rows, truncated) =
+        parse_csv_table("name,description\nwidget,\"a, tricky value\"\ngizmo,plain\n");
+
+    assert_eq!(headers, vec!["name", "description"]);
+    assert_eq!(
+        rows,
+        vec![
+            vec!["widget".to_owned(), "a, tricky value".to_owned()],
+            vec!["gizmo".to_owned(), "plain".to_owned()],
+        ]
+    );
+    assert!(!truncated);
+}
+
+#[test]
+fn truncates_rows_past_the_limit() {
+    let mut content = String::from("id\n");
+    for row in 0..250 {
+        content.push_str(&format!("{row}\n"));
+    }
+
+    let (_, rows, truncated) = parse_csv_table(&content);
+
+    assert_eq!(rows.len(), super::TABLE_ROW_LIMIT);
+    assert!(truncated);
+}
+
+#[test]
+fn tolerates_ragged_rows() {
+    let (headers, rows, truncated) = parse_csv_table("a,b,c\n1,2\n3,4,5,6\n");
+
+    assert_eq!(headers, vec!["a", "b", "c"]);
+    assert_eq!(
+        rows,
+        vec![
+            vec!["1".to_owned(), "2".to_owned()],
+            vec![
+                "3".to_owned(),
+                "4".to_owned(),
+                "5".to_owned(),
+                "6".to_owned()
+            ],
+        ]
+    );
+    assert!(!truncated);
 }

--- a/src/style.css
+++ b/src/style.css
@@ -1757,6 +1757,23 @@ paned > separator {
   padding: 6px 10px;
 }
 
+.preview-table-header,
+.preview-table-cell {
+  border-bottom: 1px solid alpha(@theme_border, 0.24);
+  border-right: 1px solid alpha(@theme_border, 0.24);
+  padding: 4px 10px;
+}
+
+.preview-table-header {
+  background: @theme_muted;
+  color: @theme_text;
+  font-weight: 700;
+}
+
+.preview-table-cell {
+  color: @theme_text;
+}
+
 .preview-volume-toggle {
   background: alpha(@theme_bg, 0.72);
   border: 1px solid alpha(@theme_border, 0.42);

--- a/src/ui/preview.rs
+++ b/src/ui/preview.rs
@@ -16,7 +16,7 @@ use crate::{
     model::{EntryKind, FileEntry, MetadataValue},
     services::{
         LoadHandle, Preview, PreviewContent, PreviewEvent, PreviewProvider, PreviewRequest,
-        PreviewRequestId,
+        PreviewRequestId, TABLE_ROW_LIMIT,
     },
 };
 
@@ -707,7 +707,8 @@ impl PreviewState {
                             print_rasterized(pages, &entry.display_name, parent.as_ref());
                         }
                     }
-                    PreviewContent::Image
+                    PreviewContent::Table { .. }
+                    | PreviewContent::Image
                     | PreviewContent::Media
                     | PreviewContent::SandboxedMedia { .. }
                     | PreviewContent::Unsupported => {}
@@ -827,6 +828,58 @@ impl PreviewState {
                 self.content.append(&scroll);
                 if truncated {
                     let notice = gtk::Label::new(Some("Preview limited to the first 1 MB"));
+                    notice.add_css_class("preview-note");
+                    self.content.append(&notice);
+                }
+            }
+            PreviewContent::Table {
+                headers,
+                rows,
+                truncated,
+            } => {
+                let grid = gtk::Grid::new();
+                grid.add_css_class("preview-table");
+                for (column, header) in headers.iter().enumerate() {
+                    grid.attach(
+                        &table_cell(header, "preview-table-header"),
+                        column as i32,
+                        0,
+                        1,
+                        1,
+                    );
+                }
+                for (row_index, row) in rows.iter().enumerate() {
+                    for (column, value) in row.iter().enumerate() {
+                        grid.attach(
+                            &table_cell(value, "preview-table-cell"),
+                            column as i32,
+                            (row_index + 1) as i32,
+                            1,
+                            1,
+                        );
+                    }
+                }
+                // Auto-hide overlay scrollbars only fade when a ScrolledWindow scrolls a
+                // single axis; nest one per axis rather than combining both in one.
+                let horizontal_scroll = gtk::ScrolledWindow::builder()
+                    .child(&grid)
+                    .hscrollbar_policy(gtk::PolicyType::Automatic)
+                    .vscrollbar_policy(gtk::PolicyType::Never)
+                    .build();
+                horizontal_scroll.add_css_class("fixed-scrollbar");
+                let vertical_scroll = gtk::ScrolledWindow::builder()
+                    .child(&horizontal_scroll)
+                    .hscrollbar_policy(gtk::PolicyType::Never)
+                    .vscrollbar_policy(gtk::PolicyType::Automatic)
+                    .hexpand(true)
+                    .vexpand(true)
+                    .build();
+                vertical_scroll.add_css_class("fixed-scrollbar");
+                self.content.append(&vertical_scroll);
+                if truncated {
+                    let notice = gtk::Label::new(Some(&format!(
+                        "Preview limited to the first {TABLE_ROW_LIMIT} rows"
+                    )));
                     notice.add_css_class("preview-note");
                     self.content.append(&notice);
                 }
@@ -1851,6 +1904,14 @@ fn clear_box(box_: &gtk::Box) {
     while let Some(child) = box_.first_child() {
         box_.remove(&child);
     }
+}
+
+fn table_cell(text: &str, css_class: &str) -> gtk::Label {
+    let label = gtk::Label::new(Some(text));
+    label.add_css_class(css_class);
+    label.set_halign(gtk::Align::Fill);
+    label.set_xalign(0.0);
+    label
 }
 
 fn metadata_size(entry: &FileEntry) -> String {

--- a/tests/e2e/scenarios/test_quick_preview.py
+++ b/tests/e2e/scenarios/test_quick_preview.py
@@ -197,6 +197,16 @@ def test_preview_renders_markdown(strata):
     )
 
 
+def test_preview_renders_csv_as_a_table(strata):
+    strata.select_entry_with_keyboard("data.csv")
+    strata.keyboard.press("space")
+
+    strata.wait(lambda: strata.preview_shows("name"), "the CSV header row")
+    assert strata.preview_shows("value")
+    assert strata.preview_shows("alpha")
+    assert strata.preview_shows("1")
+
+
 def test_space_opens_the_preview_after_a_pointer_selection(strata):
     strata.select_entry("notes.txt")
 


### PR DESCRIPTION
## Description

CSV files previously fell through to the plain-text/sourceview viewer used for any other text file, so tabular data showed as a flat monospace dump. This renders CSV as a real table in the quick preview instead: proper comma-delimited parsing with quote/escape handling, first row treated as headers, an aligned scrollable grid, and a cap of 200 displayed rows with a truncation notice for larger files.

Scoped from the larger tabular/office preview epic in #244; TSV, spreadsheets, and document formats remain out of scope here.

## Visual evidence

User-visible change. Screenshots to be attached directly to this PR.

## How to test

1. Open a folder containing a `.csv` file (a plain comma-delimited file with a header row works; try one with a quoted field containing a comma, e.g. `"Legal, Compliance & Risk"`, to exercise quote handling).
2. Select the file and press Space to open the quick preview.
3. For a file with more than 200 data rows, scroll to the bottom of the table.

**Expected result:** The preview renders a table with a bold header row and aligned columns instead of raw CSV text. Quoted fields containing commas render as a single cell. Horizontal and vertical scrollbars appear only while hovered, matching the rest of the app. Files with more than 200 data rows show a "Preview limited to the first 200 rows" notice at the bottom.

## Related issue

Closes #723
