### PR TITLE
fix(navigation): start a Shift-selection from one entry when nothing is selected

### DIFF
--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -769,7 +769,12 @@ impl NavigationState {
             first_visible
         });
 
-        let focused = if direction < 0 {
+        // Escape clears filled selection without dropping the cursor or leftover
+        // range anchor. Start a new range from that cursor instead of stepping.
+        let starting_from_empty = column.selected_locations.is_empty();
+        let focused = if starting_from_empty {
+            current
+        } else if direction < 0 {
             column.entries[..current]
                 .iter()
                 .rposition(is_visible)
@@ -784,19 +789,21 @@ impl NavigationState {
             current
         };
 
-        let anchor = column
-            .selection_anchor
-            .as_ref()
-            .and_then(|location| {
-                column
-                    .entries
-                    .iter()
-                    .position(|entry| &entry.location == location)
-            })
-            .unwrap_or(current);
-        if column.selection_anchor.is_none() {
-            column.selection_anchor = Some(column.entries[anchor].location.clone());
-        }
+        let anchor = if starting_from_empty {
+            current
+        } else {
+            column
+                .selection_anchor
+                .as_ref()
+                .and_then(|location| {
+                    column
+                        .entries
+                        .iter()
+                        .position(|entry| &entry.location == location)
+                })
+                .unwrap_or(current)
+        };
+        column.selection_anchor = Some(column.entries[anchor].location.clone());
         let start = anchor.min(focused);
         let end = anchor.max(focused);
         let selected_positions: Vec<usize> = (start..=end)

--- a/src/app/navigation/tests.rs
+++ b/src/app/navigation/tests.rs
@@ -30,6 +30,31 @@ fn named_entry(path: &str, name: &str) -> FileEntry {
     }
 }
 
+fn listing_without_a_load_cursor(state: &mut NavigationState) {
+    state.navigate(location("/fixture"), RequestId(1));
+    state.apply_batch(
+        RequestId(1),
+        vec![
+            named_entry("/fixture/alpha", "alpha"),
+            named_entry("/fixture/bravo", "bravo"),
+            named_entry("/fixture/charlie", "charlie"),
+        ],
+    );
+}
+
+fn listing_with_the_first_entry_selected(state: &mut NavigationState) {
+    state.navigate(location("/fixture"), RequestId(1));
+    state.select_first_on_load(0);
+    state.apply_batch(
+        RequestId(1),
+        vec![
+            named_entry("/fixture/alpha", "alpha"),
+            named_entry("/fixture/bravo", "bravo"),
+            named_entry("/fixture/charlie", "charlie"),
+        ],
+    );
+}
+
 #[test]
 fn shared_defaults_do_not_replace_existing_column_sort_selection_or_location() {
     let mut state = NavigationState::default();
@@ -166,6 +191,82 @@ fn keyboard_range_selection_extends_and_contracts_from_its_anchor() {
         Some(vec![0, 1])
     );
     assert_eq!(state.selected_entries().len(), 2);
+}
+
+#[test]
+fn extending_from_no_selection_starts_at_a_single_edge_entry() {
+    let mut state = NavigationState::default();
+    listing_without_a_load_cursor(&mut state);
+
+    assert_eq!(
+        state.extend_selection(1).map(|(_, _, range)| range),
+        Some(vec![0])
+    );
+    assert_eq!(
+        state.extend_selection(1).map(|(_, _, range)| range),
+        Some(vec![0, 1])
+    );
+
+    let mut state = NavigationState::default();
+    listing_without_a_load_cursor(&mut state);
+    assert_eq!(
+        state.extend_selection(-1).map(|(_, _, range)| range),
+        Some(vec![2])
+    );
+    assert_eq!(
+        state.extend_selection(-1).map(|(_, _, range)| range),
+        Some(vec![1, 2])
+    );
+}
+
+#[test]
+fn extending_from_an_escape_cleared_cursor_starts_on_that_entry() {
+    let mut state = NavigationState::default();
+    listing_with_the_first_entry_selected(&mut state);
+    assert_eq!(state.active_focus(), Some((0, Some(0))));
+    assert_eq!(state.selected_positions(0), [0]);
+
+    assert_eq!(state.clear_active_selection(), Some((0, 0)));
+    assert!(state.selected_positions(0).is_empty());
+    assert_eq!(state.active_focus(), Some((0, Some(0))));
+    assert_eq!(state.selection_anchor_position(0), Some(0));
+
+    assert_eq!(
+        state.extend_selection(1).map(|(_, _, range)| range),
+        Some(vec![0])
+    );
+    assert_eq!(state.selection_anchor_position(0), Some(0));
+    assert_eq!(
+        state.extend_selection(1).map(|(_, _, range)| range),
+        Some(vec![0, 1])
+    );
+}
+
+#[test]
+fn extending_from_an_escape_cleared_range_starts_on_the_cursor() {
+    let mut state = NavigationState::default();
+    listing_with_the_first_entry_selected(&mut state);
+    assert_eq!(
+        state.extend_selection(1).map(|(_, _, range)| range),
+        Some(vec![0, 1])
+    );
+    assert_eq!(state.active_focus(), Some((0, Some(1))));
+    assert_eq!(state.selection_anchor_position(0), Some(0));
+
+    assert_eq!(state.clear_active_selection(), Some((0, 1)));
+    assert!(state.selected_positions(0).is_empty());
+    assert_eq!(state.active_focus(), Some((0, Some(1))));
+    assert_eq!(state.selection_anchor_position(0), Some(0));
+
+    assert_eq!(
+        state.extend_selection(1).map(|(_, _, range)| range),
+        Some(vec![1])
+    );
+    assert_eq!(state.selection_anchor_position(0), Some(1));
+    assert_eq!(
+        state.extend_selection(1).map(|(_, _, range)| range),
+        Some(vec![1, 2])
+    );
 }
 
 #[test]

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -638,8 +638,8 @@ impl BrowserView {
         self.state.browser.commit_selection();
     }
 
-    pub fn resume_native_selection(&self) {
-        self.state.mode_views.borrow().resume_native_selection();
+    pub fn resume_native_selection(&self) -> bool {
+        self.state.mode_views.borrow().resume_native_selection()
     }
 
     pub fn navigate_left(&self) {

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -928,19 +928,22 @@ impl ModeViews {
         }
     }
 
-    pub fn resume_native_selection(&self) {
+    pub fn resume_native_selection(&self) -> bool {
         let Some((depth, focused, _)) = self.browser.focused_item() else {
-            return;
+            return false;
         };
         if !self.browser.selected_positions(depth).is_empty() {
-            return;
+            return false;
         }
         // Seed GTK's empty selection before the arrow moves it, without scheduling
         // a focus restore that would undo the native move after key dispatch.
         for pane in self.panes_at(depth) {
             set_selections(pane, &[focused]);
+            reset_native_range_origin(pane, focused);
         }
         self.browser.set_selection(depth, &[focused], Some(focused));
+        self.browser.set_selection_anchor(depth, focused);
+        true
     }
 
     pub fn focused_position(&self) -> Option<(usize, usize)> {
@@ -3445,6 +3448,27 @@ fn set_selections(pane: &Pane, positions: &[usize]) {
                 section.selection.select_item(position, false);
             }
         }
+        section.syncing.set(false);
+    }
+}
+
+fn reset_native_range_origin(pane: &Pane, source_position: usize) {
+    for section in pane.item_sections() {
+        let Some(position) =
+            view_position_for_source(&pane.model, Some(&section.view_model), source_position)
+        else {
+            continue;
+        };
+        // MultiSelection bits do not move GtkListView/GridView's Shift range
+        // origin; list.select-item does.
+        section.syncing.set(true);
+        section
+            .view
+            .activate_action(
+                "list.select-item",
+                Some(&(position, false, false).to_variant()),
+            )
+            .expect("ListView and GridView expose list.select-item");
         section.syncing.set(false);
     }
 }

--- a/src/ui/browser_modes/events/tests.rs
+++ b/src/ui/browser_modes/events/tests.rs
@@ -471,3 +471,83 @@ fn list_metadata_updates_bound_rows_without_replacing_the_model() {
         },
     );
 }
+
+fn native_select_item(view: &gtk::Widget, position: u32, modify: bool, extend: bool) {
+    view.activate_action(
+        "list.select-item",
+        Some(&(position, modify, extend).to_variant()),
+    )
+    .expect("list.select-item");
+}
+
+fn gtk_selected(pane: &Pane) -> Vec<usize> {
+    (0..pane.section.selection.n_items())
+        .filter(|&position| pane.section.selection.is_selected(position))
+        .map(|position| position as usize)
+        .collect()
+}
+
+#[test]
+fn resume_native_selection_starts_from_the_cursor_after_escape() {
+    gtk_test(
+        "ui::browser_modes::events::tests::resume_native_selection_starts_from_the_cursor_after_escape",
+        || {
+            for (mode, grouped) in presentations() {
+                let fixture = Fixture::new(mode, grouped);
+                fixture.show();
+                fixture.browser.select(0, 0);
+                fixture.browser.set_selection(0, &[0, 1], Some(1));
+                assert_eq!(fixture.browser.selected_positions(0), [0, 1]);
+                assert_eq!(fixture.browser.selection_anchor_position(0), Some(0));
+
+                assert!(fixture.browser.clear_active_selection());
+                assert!(fixture.browser.selected_positions(0).is_empty());
+                assert_eq!(
+                    fixture
+                        .browser
+                        .focused_item()
+                        .map(|(_, position, _)| position),
+                    Some(1)
+                );
+                assert_eq!(fixture.browser.selection_anchor_position(0), Some(0));
+
+                if !grouped {
+                    let pane = fixture.pane();
+                    pane.section.syncing.set(true);
+                    native_select_item(&pane.section.view, 0, false, false);
+                    native_select_item(&pane.section.view, 1, false, true);
+                    pane.section.syncing.set(false);
+                    assert_eq!(
+                        gtk_selected(&pane),
+                        [0, 1],
+                        "{mode:?}: plant GTK's leftover range origin on the first item"
+                    );
+                }
+
+                assert!(
+                    fixture.views.resume_native_selection(),
+                    "{mode:?} grouped={grouped}: seed the cursor when filled selection is empty"
+                );
+                assert_eq!(fixture.browser.selected_positions(0), [1]);
+                assert_eq!(
+                    fixture.browser.selection_anchor_position(0),
+                    Some(1),
+                    "{mode:?} grouped={grouped}: leftover range anchor must not be reused"
+                );
+                if !grouped {
+                    let view = fixture.pane().section.view.clone();
+                    native_select_item(&view, 2, false, true);
+                    assert_eq!(
+                        gtk_selected(&fixture.pane()),
+                        [1, 2],
+                        "{mode:?}: native Shift must not re-include the old range origin"
+                    );
+                }
+                assert!(
+                    !fixture.views.resume_native_selection(),
+                    "{mode:?} grouped={grouped}: a filled selection must keep native Shift movement"
+                );
+            }
+        },
+    );
+}

--- a/src/ui/window/keyboard/items.rs
+++ b/src/ui/window/keyboard/items.rs
@@ -102,8 +102,9 @@ impl Dispatcher {
             return Propagation::Stop;
         }
         self.view.commit_selection();
-        if !event.control() {
-            self.view.resume_native_selection();
+        let started_from_empty = !event.control() && self.view.resume_native_selection();
+        if event.shift() && started_from_empty {
+            return Propagation::Stop;
         }
         if event.without(Modifiers::CONTROL_MASK | Modifiers::SHIFT_MASK)
             && let Some(direction) = sidebar_focus_direction(event.key)

--- a/src/ui/window/tests/keyboard_dispatch.rs
+++ b/src/ui/window/tests/keyboard_dispatch.rs
@@ -22,7 +22,7 @@ impl KeyboardFixture {
         ThemeManager::seed_saved_preferences_for_test();
         let preferences = ThemeManager::shared();
         let directory = tempfile::tempdir().expect("fixture");
-        for name in ["a.txt", "b.txt"] {
+        for name in ["a.txt", "b.txt", "c.txt"] {
             std::fs::write(directory.path().join(name), b"preview").expect("fixture file");
         }
         let view = browser_for_window();
@@ -218,7 +218,10 @@ fn ctrl_a_during_rename_selects_only_unicode_entry_text_in_every_view() {
                 field.set_text("résumé-💾.txt");
                 field.set_position(-1);
 
-                assert!(fixture.press(Key::a, ModifierType::CONTROL_MASK), "{mode:?}");
+                assert!(
+                    fixture.press(Key::a, ModifierType::CONTROL_MASK),
+                    "{mode:?}"
+                );
                 assert_eq!(
                     field.selection_bounds(),
                     Some((0, field.text().chars().count() as i32)),
@@ -226,7 +229,10 @@ fn ctrl_a_during_rename_selects_only_unicode_entry_text_in_every_view() {
                 );
                 assert_eq!(fixture.selected(), [0], "{mode:?}");
 
-                assert!(fixture.press(Key::Escape, ModifierType::empty()), "{mode:?}");
+                assert!(
+                    fixture.press(Key::Escape, ModifierType::empty()),
+                    "{mode:?}"
+                );
                 assert!(!fixture.view.rename_is_active(), "{mode:?}");
                 assert_eq!(fixture.selected(), [0], "{mode:?}");
             }
@@ -316,6 +322,62 @@ fn single_pane_arrows_preserve_native_propagation_and_sidebar_focus_return() {
                 });
                 assert!(fixture.press(Key::Right, ModifierType::empty()));
                 assert!(fixture.view.item_view_has_focus());
+            }
+        },
+    );
+}
+
+#[test]
+fn shift_after_escape_starts_on_the_focused_entry() {
+    crate::test_support::gtk_test(
+        "ui::window::tests::keyboard_dispatch::shift_after_escape_starts_on_the_focused_entry",
+        || {
+            let fixture = KeyboardFixture::new();
+            for (mode, next) in [
+                (BrowserMode::Columns, Key::Down),
+                (BrowserMode::List, Key::Down),
+                (BrowserMode::Icons, Key::Right),
+            ] {
+                fixture.view.set_view_mode(mode);
+                fixture.view.browser().select(0, 0);
+                fixture.view.browser().focus_active();
+                wait_until(|| fixture.view.item_view_has_focus() && fixture.selected() == [0]);
+
+                assert!(fixture.press(Key::Escape, ModifierType::empty()));
+                assert!(
+                    fixture.selected().is_empty(),
+                    "{mode:?}: Escape must clear filled selection"
+                );
+
+                assert!(
+                    fixture.press(next, ModifierType::SHIFT_MASK),
+                    "{mode:?}: first Shift after Escape must start on the cursor"
+                );
+                assert_eq!(fixture.selected(), [0], "{mode:?}");
+                assert_eq!(
+                    fixture.view.browser().selection_anchor_position(0),
+                    Some(0),
+                    "{mode:?}"
+                );
+
+                if mode == BrowserMode::Columns {
+                    assert!(fixture.press(next, ModifierType::SHIFT_MASK));
+                    assert_eq!(fixture.selected(), [0, 1], "{mode:?}");
+
+                    assert!(fixture.press(Key::Escape, ModifierType::empty()));
+                    assert!(fixture.selected().is_empty(), "{mode:?}");
+                    assert!(fixture.press(next, ModifierType::SHIFT_MASK));
+                    assert_eq!(
+                        fixture.selected(),
+                        [1],
+                        "{mode:?}: leftover range anchor must not expand after Escape"
+                    );
+                } else {
+                    assert!(
+                        !fixture.press(next, ModifierType::SHIFT_MASK),
+                        "{mode:?}: further Shift arrows stay native once a range exists"
+                    );
+                }
             }
         },
     );

--- a/tests/e2e/scenarios/test_escape_selection.py
+++ b/tests/e2e/scenarios/test_escape_selection.py
@@ -100,3 +100,47 @@ def test_escape_dismisses_transient_before_selection(strata, mode, surface):
     strata.keyboard.press("Escape")
     strata.wait_for_selection([], root)
     assert strata.pane_names() == [root]
+
+
+@pytest.mark.parametrize("mode", ALL_MODES)
+@pytest.mark.preferences(single_click_previews=False)
+def test_shift_after_escape_starts_on_the_focused_entry(strata, mode):
+    root = strata.fixture.root.name
+    next_key = NEXT_ENTRY_KEY[mode]
+    strata.wait_for_focused_entry("archive")
+    strata.wait_for_selection(["archive"], root)
+    strata.keyboard.press("Escape")
+    strata.wait_for_selection([], root)
+    strata.wait_for_focused_entry("archive")
+
+    strata.keyboard.press(f"shift+{next_key}")
+    strata.wait_for_selection(["archive"], root)
+    strata.wait_for_focused_entry("archive")
+
+    strata.keyboard.press(f"shift+{next_key}")
+    strata.wait_for_selection(["archive", "documents"], root)
+    strata.wait_for_focused_entry("documents")
+
+
+@pytest.mark.parametrize("mode", ALL_MODES)
+@pytest.mark.preferences(single_click_previews=False)
+def test_shift_after_escape_does_not_reuse_a_range_anchor(strata, mode):
+    root = strata.fixture.root.name
+    next_key = NEXT_ENTRY_KEY[mode]
+    strata.wait_for_focused_entry("archive")
+    strata.wait_for_selection(["archive"], root)
+    strata.keyboard.press(f"shift+{next_key}")
+    strata.wait_for_selection(["archive", "documents"], root)
+    strata.wait_for_focused_entry("documents")
+
+    strata.keyboard.press("Escape")
+    strata.wait_for_selection([], root)
+    strata.wait_for_focused_entry("documents")
+
+    strata.keyboard.press(f"shift+{next_key}")
+    strata.wait_for_selection(["documents"], root)
+    strata.wait_for_focused_entry("documents")
+
+    strata.keyboard.press(f"shift+{next_key}")
+    strata.wait_for_selection(["documents", "pictures"], root)
+    strata.wait_for_focused_entry("pictures")


### PR DESCRIPTION
## Description

`extend_selection` with no current selection takes the first visible entry as `current` and then steps to the next visible entry as `focused`, so Shift+Down from an unselected column selects rows 0 and 1 (and Shift+Up selects the last two). A plain arrow key in the same state lands on a single row.

When there is no current selection, treat the edge entry as both the anchor and the focused entry instead of stepping past it.

This is based on the analysis and patch on [@nixfred](https://github.com/nixfred)'s [`fix/extend-selection-from-empty`](https://github.com/lgse/strata/compare/main...nixfred:strata:fix/extend-selection-from-empty) branch from #660. The commit was recreated on current `main` without agent attribution so it can be submitted under project contribution policy.

## Visual evidence

N/A — no visual change; behaviour is covered by the linked regression test.

## How to test

1. Open a folder with several entries, press Escape until nothing is selected.
2. Press Shift+Down.
3. Press Shift+Down again.

**Expected result:** The first Shift+Down selects only the first entry; the next Shift+Down extends to two.

## Related issue

Closes #660