### PR TITLE
fix(search): award the adjacency bonus for contiguous multibyte matches

### DIFF
--- a/src/services/search.rs
+++ b/src/services/search.rs
@@ -780,12 +780,12 @@ fn fuzzy_subsequence_score(haystack: &str, needle: &str) -> Option<i64> {
         return fuzzy_ascii_subsequence_score(haystack.as_bytes(), needle.as_bytes());
     }
     let mut chars = haystack.char_indices();
-    let mut previous = None;
+    let mut previous_end = None;
     let mut score = 1_000i64;
     for wanted in needle.chars() {
         let (position, _) = chars.find(|(_, candidate)| *candidate == wanted)?;
         score -= position as i64;
-        if previous.is_some_and(|previous| previous + wanted.len_utf8() == position) {
+        if previous_end == Some(position) {
             score += 80;
         }
         if position == 0
@@ -796,7 +796,7 @@ fn fuzzy_subsequence_score(haystack: &str, needle: &str) -> Option<i64> {
         {
             score += 45;
         }
-        previous = Some(position);
+        previous_end = Some(position + wanted.len_utf8());
     }
     Some(score)
 }

--- a/src/services/search/tests.rs
+++ b/src/services/search/tests.rs
@@ -12,8 +12,8 @@ use std::{
 mod scope;
 
 use super::{
-    SearchEvent, SearchItem, fuzzy_score_normalized, index_tree, index_trees,
-    index_trees_with_budget,
+    SearchEvent, SearchItem, fuzzy_score_normalized, fuzzy_subsequence_score, index_tree,
+    index_trees, index_trees_with_budget,
 };
 
 fn score_path(path: &str, query: &str, root: &Path) -> Option<i64> {
@@ -40,6 +40,17 @@ fn exact_names_rank_above_substrings_and_fuzzy_matches() {
         .expect("an ordered fuzzy subsequence should match");
     assert!(exact > substring);
     assert!(substring > fuzzy);
+}
+
+#[test]
+fn contiguous_multibyte_matches_outrank_separated_ones() {
+    let contiguous = fuzzy_subsequence_score("éa", "éa").expect("a contiguous match");
+    let separated = fuzzy_subsequence_score("é_a", "éa").expect("a separated match");
+    assert!(contiguous > separated);
+
+    let contiguous = fuzzy_subsequence_score("配置", "配置").expect("a contiguous match");
+    let separated = fuzzy_subsequence_score("配/置", "配置").expect("a separated match");
+    assert!(contiguous > separated);
 }
 
 #[test]

--- a/src/ui/window/tests/keyboard_dispatch.rs
+++ b/src/ui/window/tests/keyboard_dispatch.rs
@@ -218,7 +218,10 @@ fn ctrl_a_during_rename_selects_only_unicode_entry_text_in_every_view() {
                 field.set_text("résumé-💾.txt");
                 field.set_position(-1);
 
-                assert!(fixture.press(Key::a, ModifierType::CONTROL_MASK), "{mode:?}");
+                assert!(
+                    fixture.press(Key::a, ModifierType::CONTROL_MASK),
+                    "{mode:?}"
+                );
                 assert_eq!(
                     field.selection_bounds(),
                     Some((0, field.text().chars().count() as i32)),
@@ -226,7 +229,10 @@ fn ctrl_a_during_rename_selects_only_unicode_entry_text_in_every_view() {
                 );
                 assert_eq!(fixture.selected(), [0], "{mode:?}");
 
-                assert!(fixture.press(Key::Escape, ModifierType::empty()), "{mode:?}");
+                assert!(
+                    fixture.press(Key::Escape, ModifierType::empty()),
+                    "{mode:?}"
+                );
                 assert!(!fixture.view.rename_is_active(), "{mode:?}");
                 assert_eq!(fixture.selected(), [0], "{mode:?}");
             }


### PR DESCRIPTION
## Description

In `fuzzy_subsequence_score` (the non-ASCII path), adjacency is tested as `previous + wanted.len_utf8() == position`, using the current character's byte width instead of the previous one's. Adjacent characters of different widths never receive the +80 bonus, so a separated match with a word boundary can outrank a contiguous one.

Track the byte offset where the previous match ended and compare that to the next match position, matching the ASCII scorer.

This is based on the analysis and patch on [@nixfred](https://github.com/nixfred)'s [`fix/search-multibyte-adjacency`](https://github.com/lgse/strata/compare/main...nixfred:strata:fix/search-multibyte-adjacency) branch from #659. The commit was recreated on current `main` without agent attribution so it can be submitted under project contribution policy.

## Visual evidence

N/A — no visual change; behaviour is covered by the linked regression test.

## How to test

1. Compare `fuzzy_subsequence_score("éa", "éa")` with `fuzzy_subsequence_score("é_a", "éa")`.
2. Confirm the contiguous match ranks higher, matching the ASCII scorer.

**Expected result:** Contiguous multibyte matches outrank separated ones.

## Related issue

Closes #659