### PR TITLE
fix(theme): parse editor colours in every format GTK accepts

### DIFF
--- a/docs/742.md
+++ b/docs/742.md
@@ -1,0 +1,272 @@
+# Guided manual test plan — PR #742
+
+Do not execute these cases as part of writing this document. Fill the Results table when a tester later runs them.
+
+## Pull request
+
+| Field | Value |
+| --- | --- |
+| URL | https://github.com/lgse/strata/pull/742 |
+| Title | fix(theme): parse editor colours in every format GTK accepts |
+| State | draft |
+| Base | `lgse/strata` `main` at `7fd0e64d0660a2b6b82629337bd2b7c1a7dbd2f6` |
+| Head branch | `wmfeht/strata` `fix/655-theme-colour-parsing` |
+| Head SHA | `779cc63169ab070fb9cfdeeb0365c86cafa0f927` |
+| Issue | Closes [#655](https://github.com/lgse/strata/issues/655) |
+
+Review and QA used for case design: [issuecomment-5611513520](https://github.com/lgse/strata/pull/742#issuecomment-5611513520) (QA report on this head), [issuecomment-5611247756](https://github.com/lgse/strata/pull/742#issuecomment-5611247756) (private re-review), and [#655 comment](https://github.com/lgse/strata/issues/655#issuecomment-5592806770) (original GUI repro).
+
+## How cases were selected
+
+The change is bounded to colour parsing and GtkSourceView scheme emit:
+
+- `parse_rgb_channels` (`gdk::RGBA::parse`) feeds `blend` (string / constant / type tokens) and `theme_background_is_light` (packaged catalog Light / Dark).
+- `color_to_hex` canonicalizes every `<color value>` in `source_style_scheme_xml` to `#rrggbb` and, after a picker `rgba` notify, persists hex in the editor.
+- GTK CSS (`tokens_css`) already accepts `rgb(...)`; it is left unchanged on purpose.
+
+Cases map to those callers and to #655 / the PR “How to test” steps, then correct the catalog-filter wording from QA:
+
+1. **Picker `rgb(...)` themes must load.** GtkSourceView 5.12 rejects `rgb(...)` in colour tags. The scheme must emit `#rrggbb` so syntax highlighting is not discarded.
+2. **Syntax colours must not collapse.** Failed `blend` used to return the text colour, so string / constant / type matched body text.
+3. **Emit-path canonicalize covers old TOML.** Existing `rgb(...)` custom themes must work without a picker resave.
+4. **Editor persist is hex after notify.** New picker edits should store `#rrggbb`; untouched starter slots may keep their previous format until edited.
+5. **YOUR THEMES vs catalog filter.** `fill_theme_grids` appearance-filters packaged **THEMES** cards only. Custom cards under **YOUR THEMES** stay visible under Light and Dark. A light custom theme remaining listed while Dark is selected is expected, not a fail. Packaged Light / Dark classification is still in scope (`#ffffff`, `rgb(...)`, `#fff` via the shared helper).
+6. **Hex catalog regression.** Bundled `#rrggbb` themes must still classify and colour previews.
+
+Out of scope for this plan (called out by QA, not this emit path): folder `rgba_to_hex`, `assets::contrasting_foreground`, Metadata policy / commit identity, full E2E (no theme-editor scenario exists).
+
+## Shared disposable fixture
+
+Use a throwaway XDG tree and listing. Do not point `HOME` or XDG variables at a real user profile. Stop Strata and delete the sandbox when finished.
+
+```bash
+WORKDIR=$(mktemp -d)
+export HOME="$WORKDIR/home"
+export XDG_CONFIG_HOME="$WORKDIR/config"
+export XDG_CACHE_HOME="$WORKDIR/cache"
+export XDG_DATA_HOME="$WORKDIR/data"
+export XDG_STATE_HOME="$WORKDIR/state"
+mkdir -p "$HOME" "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_DATA_HOME" \
+  "$XDG_STATE_HOME" "$WORKDIR/listing"
+
+cat > "$WORKDIR/listing/sample.rs" <<'EOF'
+const ORIGIN: i32 = 42;
+
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+fn greet(name: &str) -> String {
+    format!("hello, {name}")
+}
+
+fn main() {
+    let label = "alpha-repro";
+    let _ = greet(label);
+    let _p = Point { x: ORIGIN, y: 0 };
+}
+EOF
+
+printf 'notes\n' > "$WORKDIR/listing/notes.md"
+
+cargo build --bin strata
+# Launch from this shell so the process inherits the isolated XDG vars.
+cargo run --bin strata -- "$WORKDIR/listing"
+```
+
+Fresh config uses **Tokyo Night** (dark) and **Columns** view. Default single-click previews are on. Open Settings with the header **Settings** button. Theme UI is **Settings → Theme & appearance**.
+
+Useful sandbox files (relative to the isolated XDG dirs above, not a personal home):
+
+- Custom theme TOML: `$XDG_CONFIG_HOME/strata/themes/<slug>.toml`
+- Staged GtkSourceView scheme: `$XDG_CACHE_HOME/strata/source-styles/strata-current.xml`
+
+Colour dialog: each labelled swatch is a GTK `ColorDialogButton` (no hex field in the editor). Changing a swatch and confirming the dialog fires `rgba` notify.
+
+Status values for the Results table: `PASS`, `FAIL`, or `BLOCKED`.
+
+---
+
+## 742-01 — Light picker theme: scheme loads and syntax is not collapsed
+
+**Purpose.** Core #655 / PR fix: a custom theme created with colour pickers (GTK stores `rgb(r,g,b)` unless canonicalized) must load in GtkSourceView, and string / constant / type / keyword colours must stay distinct from body text.
+
+**Fixture.** Shared disposable sandbox. Isolated config. `sample.rs` in the listing. Do not reuse a previously saved custom theme.
+
+**Steps.**
+
+1. Launch Strata on `$WORKDIR/listing` with the isolated XDG environment.
+2. Open **Settings → Theme & appearance**.
+3. Under **YOUR THEMES**, click **Add a theme**.
+4. Name: `Paper Light 742`.
+5. Open each of these pickers, choose the stated colour, and confirm the dialog so notify runs:
+   - **Background** — white
+   - **Surface** — white or very light grey
+   - **Text** — black or near-black
+   - **Accent** — light blue close to `rgb(153,193,241)`
+6. Leave **Danger**, **Muted**, **Highlight**, **Border**, and **Dim text** unchanged unless a picker must be touched to enable Save.
+7. Click **Add theme**. Confirm a **YOUR THEMES** card named `Paper Light 742` appears with a light preview and is selected.
+8. Close Settings.
+9. Select `sample.rs` and open the source preview (single-click, or **Space** / **Quick preview** if the drawer is closed).
+10. Compare keywords (`fn`, `struct`, `const`), types (`String`, `i32`, `Point`), strings (`"hello, {name}"`, `"alpha-repro"`), and the constant `ORIGIN` / `42` against body text.
+
+**Expected result.** The window chrome is a light theme. In the `sample.rs` preview, keywords, types, strings, and constants are each visibly different from body text (not a single monochrome text colour on white). Preview is not unstyled / scheme-missing.
+
+---
+
+## 742-02 — GtkSourceView scheme XML is `#rrggbb` only
+
+**Purpose.** GtkSourceView 5.12 rejects `rgb(...)` in `<color value>` (`value in 'color' tag is not of the form '#RGB' or '#name'`). Every emitted colour must be canonical `#rrggbb` so the scheme id `strata-current` actually loads.
+
+**Fixture.** Continue 742-01 in the same sandbox with `Paper Light 742` still selected and `sample.rs` previewed at least once (scheme is written when a source buffer is registered).
+
+**Steps.**
+
+1. Keep Strata running with `Paper Light 742` applied (or re-select that card if needed) and preview `sample.rs` once.
+2. Open `$XDG_CACHE_HOME/strata/source-styles/strata-current.xml`.
+3. Confirm the scheme id is `strata-current`.
+4. Collect every `value="..."` on `<color>` tags (nine tags: background, surface, text, accent, selection, dim, string, constant, type).
+5. Confirm the file contains no `rgb(` substring.
+
+**Expected result.** All nine colour values match `#` plus six hex digits (for example text near `#000000` / `#1e1d1f`, accent near `#99c1f1` if the picker blue was `rgb(153,193,241)`). No `rgb(` in the XML. String, constant, and type values are `#rrggbb` and are **not** identical to the text colour.
+
+---
+
+## 742-03 — Picker notify persists `#rrggbb` in the saved TOML
+
+**Purpose.** After `rgba` notify, the editor writes `color_to_hex(picker.rgba().to_string())` so new saves are already `#rrggbb`. QA: fields never edited keep starter format until that picker fires.
+
+**Fixture.** Same sandbox. Theme created in 742-01.
+
+**Steps.**
+
+1. Open `$XDG_CONFIG_HOME/strata/themes/paper-light-742.toml` (slug is the lowercased name).
+2. Inspect `background`, `surface`, `text`, and `accent`.
+3. Inspect slots that were not opened in the colour dialog (`danger`, `muted`, `highlight`, `border`, `dim_text` if untouched).
+
+**Expected result.** Picker-touched fields are `#rrggbb` (not `rgb(...)`). Untouched starter fields may still be the Tokyo Night hex tokens; that is allowed. `name` is `Paper Light 742`.
+
+---
+
+## 742-04 — Packaged catalog Light/Dark vs YOUR THEMES
+
+**Purpose.** Document the QA catalog-filter nuance and still check luminance for packaged cards. PR “How to test” step 2 (“Open the catalog with the Dark filter and confirm the new theme is not listed”) is **wrong** for custom themes: All / Light / Dark only filters packaged **THEMES**. **YOUR THEMES** is not appearance-filtered.
+
+**Fixture.** Same sandbox. `Paper Light 742` present. Packaged **Solarized Light** and **Tokyo Night** in the catalog.
+
+**Steps.**
+
+1. Open **Settings → Theme & appearance**.
+2. In the packaged **THEMES** catalog (searchable grid under the **THEMES** heading, above **YOUR THEMES**), set the segmented control to **Dark**.
+3. Search or scroll: confirm **Tokyo Night** (or another dark packaged card) is visible and **Solarized Light** is hidden.
+4. Set the control to **Light**. Confirm **Solarized Light** is visible and **Tokyo Night** is hidden.
+5. Set the control to **Dark** again. Look at **YOUR THEMES** (separate heading below the catalog), not the packaged grid.
+6. Set the control to **Light**, then **All**. Watch **YOUR THEMES** the whole time.
+
+**Expected result.** Packaged **THEMES** Light/Dark matches background luminance (light packaged cards only under Light, dark only under Dark). **`Paper Light 742` remains visible under YOUR THEMES for All, Light, and Dark.** Do **not** fail this case because the custom light card is still listed while Dark is selected. Fail if a packaged light theme such as **Solarized Light** remains in the packaged grid under **Dark**, or a packaged dark theme remains under **Light**.
+
+---
+
+## 742-05 — Legacy `rgb(...)` TOML loads without a picker resave
+
+**Purpose.** Canonicalize is on the scheme emit path, not only on new picker writes. A pre-fix custom theme that still stores `rgb(...)` must highlight source without opening the editor.
+
+**Fixture.** Stop Strata. Same isolated XDG. Do not open **Add a theme** for this theme. Drop a new TOML (unique slug so it does not collide with 742-01).
+
+```bash
+mkdir -p "$XDG_CONFIG_HOME/strata/themes"
+cat > "$XDG_CONFIG_HOME/strata/themes/legacy-rgb-paper.toml" <<'EOF'
+name = "Legacy RGB Paper"
+background = "rgb(255,255,255)"
+surface = "rgb(245,245,245)"
+text = "rgb(30,29,31)"
+accent = "rgb(153,193,241)"
+danger = "rgb(229,72,77)"
+muted = "rgb(200,200,200)"
+highlight = "rgb(36,77,104)"
+border = "rgb(49,91,117)"
+dim_text = "rgb(111,141,163)"
+EOF
+```
+
+**Steps.**
+
+1. Quit Strata if it is running so custom themes are discovered on the next start.
+2. Launch with the same isolated XDG and `$WORKDIR/listing`.
+3. Open **Settings → Theme & appearance**. Confirm **Legacy RGB Paper** is under **YOUR THEMES**.
+4. Select that card (do not edit pickers). Close Settings.
+5. Preview `sample.rs`.
+6. Re-open `$XDG_CACHE_HOME/strata/source-styles/strata-current.xml`.
+
+**Expected result.** Syntax colours are distinct (keywords / types / strings / constants vs text), matching the 742-01 visual bar. Scheme XML has nine `#rrggbb` tags and no `rgb(`. Accent / `def:statement` is `#99c1f1`. The TOML on disk may still contain `rgb(...)`; do not require a rewrite.
+
+---
+
+## 742-06 — Packaged hex theme still colours source (regression)
+
+**Purpose.** Shared `gdk::RGBA` parsing must not break bundled `#rrggbb` catalog tokens (blend + scheme load for hex).
+
+**Fixture.** Same sandbox and `sample.rs`. Use packaged **Solarized Light** (`#fdf6e3` background) as the known-good contrast from the #655 repro.
+
+**Steps.**
+
+1. Open **Settings → Theme & appearance**.
+2. Set catalog filter to **Light** if needed, select **Solarized Light**, close Settings.
+3. Preview `sample.rs`. Confirm strings, types, and keywords are distinct from body text.
+4. Select packaged **Tokyo Night** (Dark / All). Preview `sample.rs` again.
+
+**Expected result.** Both packaged themes show distinct syntax colours on `sample.rs`. Solarized Light is a light chrome; Tokyo Night is dark. No scheme-missing / unstyled preview.
+
+---
+
+## 742-07 — Dark picker theme: syntax not collapsed
+
+**Purpose.** Canonicalize and blend must work for a dark editor-created theme, not only the white #655 repro.
+
+**Fixture.** Same sandbox. New custom theme (do not edit 742-01 / 742-05 files).
+
+**Steps.**
+
+1. **Settings → Theme & appearance → YOUR THEMES → Add a theme**.
+2. Name: `Ink Dark 742`.
+3. Confirm pickers for **Background** (near-black), **Surface** (dark grey), **Text** (near-white), **Accent** (distinct cyan or blue). Confirm each dialog.
+4. **Add theme**. Confirm the card appears under **YOUR THEMES** and is selected.
+5. Close Settings. Preview `sample.rs`.
+6. Optional: inspect `$XDG_CACHE_HOME/strata/source-styles/strata-current.xml` for `#rrggbb` and no `rgb(`.
+
+**Expected result.** Dark chrome. Preview syntax colours are distinct from text (not collapsed to one foreground). Scheme XML, if checked, is `#rrggbb` only.
+
+---
+
+## 742-08 — Short hex `#fff` luminance (packaged catalog helper)
+
+**Purpose.** Pre-fix `from_str_radix` treated `#fff` as near-black. `theme_background_is_light("#fff")` is now true. Custom themes are not catalog-filtered, so this case uses a **packaged** light theme as the GUI stand-in and records that `#fff` itself is unit-covered. Optional file drop only if the tester wants a custom card with `#fff`; it will still stay in **YOUR THEMES** under Dark (same as 742-04).
+
+**Fixture.** Same sandbox. Packaged **Solarized Light**. No need to invent a catalog entry.
+
+**Steps.**
+
+1. **Settings → Theme & appearance**. Catalog **All**, search `Solarized Light`, confirm the card is present.
+2. Filter **Dark**: **Solarized Light** is absent from the packaged grid.
+3. Filter **Light**: **Solarized Light** is present.
+4. Do not treat a custom `#fff` TOML disappearing from **YOUR THEMES** as required.
+
+**Expected result.** Packaged light hex themes classify as Light. This case passes on catalog behaviour. Parser `#fff` / `rgb(255,255,255)` is asserted by `theme_appearance_uses_background_luminance`; a GUI-only tester does not need to run that binary unless investigating a FAIL here.
+
+---
+
+## Results
+
+Leave **Actual** and **Status** empty until a tester runs the case. Status must be `PASS`, `FAIL`, or `BLOCKED`.
+
+| ID | Case | Actual | Status |
+| --- | --- | --- | --- |
+| 742-01 | Light picker theme: scheme loads; syntax not collapsed |  |  |
+| 742-02 | Scheme XML canonicalizes to `#rrggbb`; no `rgb(` |  |  |
+| 742-03 | Picker notify persists `#rrggbb` in custom TOML |  |  |
+| 742-04 | Packaged Light/Dark filter; YOUR THEMES stays listed |  |  |
+| 742-05 | Legacy `rgb(...)` TOML loads without resave |  |  |
+| 742-06 | Packaged hex themes still colour source |  |  |
+| 742-07 | Dark picker theme: syntax not collapsed |  |  |
+| 742-08 | Packaged hex luminance / Light-Dark catalog |  |  |

--- a/docs/742.md
+++ b/docs/742.md
@@ -117,7 +117,7 @@ Status values for the Results table: `PASS`, `FAIL`, or `BLOCKED`.
 
 ## 742-02 — GtkSourceView scheme XML is `#rrggbb` only
 
-**Purpose.** GtkSourceView 5.12 rejects `rgb(...)` in `<color value>` (`value in 'color' tag is not of the form '#RGB' or '#name'`). Every emitted colour must be canonical `#rrggbb` so the scheme id `strata-current` actually loads.
+**Purpose.** GtkSourceView 5.12 rejects `rgb(...)` in `<color value>` (`value in 'color' tag is not of the form '#RGB' or '#name'`). Strata emits every colour in canonical `#rrggbb`, a supported representation, so the scheme id `strata-current` actually loads.
 
 **Fixture.** Continue 742-01 in the same sandbox with `Paper Light 742` still selected and `sample.rs` previewed at least once (scheme is written when a source buffer is registered).
 

--- a/src/ui/settings/tests.rs
+++ b/src/ui/settings/tests.rs
@@ -131,6 +131,9 @@ fn theme_appearance_uses_background_luminance() {
     assert!(theme_background_is_light("#ffffff"));
     assert!(theme_background_is_light("#efecf4"));
     assert!(!theme_background_is_light("#1e1d1f"));
+    assert!(theme_background_is_light("rgb(255,255,255)"));
+    assert!(!theme_background_is_light("rgb(30,29,31)"));
+    assert!(theme_background_is_light("#fff"));
     assert!(!theme_background_is_light("invalid"));
 }
 

--- a/src/ui/settings/tests.rs
+++ b/src/ui/settings/tests.rs
@@ -134,6 +134,8 @@ fn theme_appearance_uses_background_luminance() {
     assert!(theme_background_is_light("rgb(255,255,255)"));
     assert!(!theme_background_is_light("rgb(30,29,31)"));
     assert!(theme_background_is_light("#fff"));
+    assert!(theme_background_is_light("white"));
+    assert!(!theme_background_is_light("black"));
     assert!(!theme_background_is_light("invalid"));
 }
 

--- a/src/ui/settings/theme.rs
+++ b/src/ui/settings/theme.rs
@@ -371,19 +371,18 @@ fn theme_is_light(tokens: &ThemeTokens) -> bool {
 }
 
 pub(super) fn theme_background_is_light(background: &str) -> bool {
-    let value = background.strip_prefix('#').unwrap_or_default();
-    let Ok(color) = u32::from_str_radix(value, 16) else {
+    let Some(color) = crate::ui::theme::parse_rgb_channels(background) else {
         return false;
     };
-    let channel = |shift| {
-        let value = f64::from((color >> shift) & 0xff_u32) / 255.0;
+    let channel = |index: usize| {
+        let value = f64::from(color[index]) / 255.0;
         if value <= 0.04045 {
             value / 12.92
         } else {
             ((value + 0.055) / 1.055).powf(2.4)
         }
     };
-    let luminance = 0.2126 * channel(16) + 0.7152 * channel(8) + 0.0722 * channel(0);
+    let luminance = 0.2126 * channel(0) + 0.7152 * channel(1) + 0.0722 * channel(2);
     luminance > 0.4
 }
 

--- a/src/ui/settings/theme/editor.rs
+++ b/src/ui/settings/theme/editor.rs
@@ -93,8 +93,7 @@ fn color_field_row(
     let values_for_color = values.clone();
     let manager_for_color = manager.clone();
     picker.connect_rgba_notify(move |picker| {
-        *field.slot(&mut values_for_color.borrow_mut()) =
-            color_to_hex(&picker.rgba().to_string());
+        *field.slot(&mut values_for_color.borrow_mut()) = color_to_hex(&picker.rgba().to_string());
         manager_for_color.preview(&values_for_color.borrow());
     });
     field_row.append(&picker);

--- a/src/ui/settings/theme/editor.rs
+++ b/src/ui/settings/theme/editor.rs
@@ -6,7 +6,7 @@ use gtk::{gdk, prelude::*};
 
 use crate::ui::{
     controls::form_entry,
-    theme::{ThemeManager, ThemeTokens},
+    theme::{ThemeManager, ThemeTokens, color_to_hex},
 };
 
 pub(super) fn theme_editor(manager: Rc<ThemeManager>) -> (gtk::Revealer, gtk::FlowBox) {
@@ -93,7 +93,8 @@ fn color_field_row(
     let values_for_color = values.clone();
     let manager_for_color = manager.clone();
     picker.connect_rgba_notify(move |picker| {
-        *field.slot(&mut values_for_color.borrow_mut()) = picker.rgba().to_string();
+        *field.slot(&mut values_for_color.borrow_mut()) =
+            color_to_hex(&picker.rgba().to_string());
         manager_for_color.preview(&values_for_color.borrow());
     });
     field_row.append(&picker);

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1370,7 +1370,7 @@ fn tokens_css(tokens: &ThemeTokens, root_font_px: f64) -> String {
 }
 
 /// Parses colours GTK accepts (`#rgb`, `#rrggbb`, `rgb(...)`, names) into 8-bit
-/// channels. GtkSourceView scheme XML still requires `#rrggbb`.
+/// channels. Strata emits these channels as `#rrggbb` in GtkSourceView schemes.
 pub(crate) fn parse_rgb_channels(value: &str) -> Option<[u8; 3]> {
     let color = gdk::RGBA::parse(value).ok()?;
     let channel = |component: f32| (f64::from(component).clamp(0.0, 1.0) * 255.0).round() as u8;
@@ -1385,7 +1385,7 @@ fn hex_from_channels(channels: [u8; 3]) -> String {
     format!("#{:02x}{:02x}{:02x}", channels[0], channels[1], channels[2])
 }
 
-/// Canonicalizes a colour token to `#rrggbb` for GtkSourceView scheme XML.
+/// Canonicalizes a colour token to Strata's `#rrggbb` scheme representation.
 pub(crate) fn color_to_hex(value: &str) -> String {
     parse_rgb_channels(value)
         .map(hex_from_channels)

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1369,17 +1369,28 @@ fn tokens_css(tokens: &ThemeTokens, root_font_px: f64) -> String {
     )
 }
 
+/// Parses any CSS colour GTK accepts (`#rgb`, `#rrggbb`, `rgb(...)`, names)
+/// into 8-bit channels. The theme editor stores colour pickers as `rgb(...)`.
+pub(crate) fn parse_rgb_channels(value: &str) -> Option<[u8; 3]> {
+    let color = gdk::RGBA::parse(value).ok()?;
+    let channel = |component: f32| (f64::from(component).clamp(0.0, 1.0) * 255.0).round() as u8;
+    Some([
+        channel(color.red()),
+        channel(color.green()),
+        channel(color.blue()),
+    ])
+}
+
 fn blend(left: &str, right: &str, amount: f64) -> String {
-    let parse = |value: &str| u32::from_str_radix(value.trim_start_matches('#'), 16).ok();
-    let (Some(left), Some(right)) = (parse(left), parse(right)) else {
+    let (Some(left), Some(right)) = (parse_rgb_channels(left), parse_rgb_channels(right)) else {
         return right.to_owned();
     };
-    let channel = |shift| {
-        let a = f64::from((left >> shift) & 0xff_u32);
-        let b = f64::from((right >> shift) & 0xff_u32);
+    let channel = |index: usize| {
+        let a = f64::from(left[index]);
+        let b = f64::from(right[index]);
         (a + (b - a) * amount).round() as u32
     };
-    format!("#{:02x}{:02x}{:02x}", channel(16), channel(8), channel(0))
+    format!("#{:02x}{:02x}{:02x}", channel(0), channel(1), channel(2))
 }
 
 fn slugify(name: &str) -> String {

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1309,15 +1309,15 @@ fn source_style_scheme_xml(tokens: &ThemeTokens) -> String {
   <style name="def:error" foreground="background" background="accent" bold="true"/>
 </style-scheme>
 "#,
-        tokens.background,
-        tokens.surface,
-        tokens.text,
-        tokens.accent,
-        tokens.highlight,
-        tokens.dim_text,
-        string,
-        constant,
-        type_color,
+        color_to_hex(&tokens.background),
+        color_to_hex(&tokens.surface),
+        color_to_hex(&tokens.text),
+        color_to_hex(&tokens.accent),
+        color_to_hex(&tokens.highlight),
+        color_to_hex(&tokens.dim_text),
+        color_to_hex(&string),
+        color_to_hex(&constant),
+        color_to_hex(&type_color),
     )
 }
 
@@ -1369,8 +1369,8 @@ fn tokens_css(tokens: &ThemeTokens, root_font_px: f64) -> String {
     )
 }
 
-/// Parses any CSS colour GTK accepts (`#rgb`, `#rrggbb`, `rgb(...)`, names)
-/// into 8-bit channels. The theme editor stores colour pickers as `rgb(...)`.
+/// Parses colours GTK accepts (`#rgb`, `#rrggbb`, `rgb(...)`, names) into 8-bit
+/// channels. GtkSourceView scheme XML still requires `#rrggbb`.
 pub(crate) fn parse_rgb_channels(value: &str) -> Option<[u8; 3]> {
     let color = gdk::RGBA::parse(value).ok()?;
     let channel = |component: f32| (f64::from(component).clamp(0.0, 1.0) * 255.0).round() as u8;
@@ -1379,6 +1379,17 @@ pub(crate) fn parse_rgb_channels(value: &str) -> Option<[u8; 3]> {
         channel(color.green()),
         channel(color.blue()),
     ])
+}
+
+fn hex_from_channels(channels: [u8; 3]) -> String {
+    format!("#{:02x}{:02x}{:02x}", channels[0], channels[1], channels[2])
+}
+
+/// Canonicalizes a colour token to `#rrggbb` for GtkSourceView scheme XML.
+pub(crate) fn color_to_hex(value: &str) -> String {
+    parse_rgb_channels(value)
+        .map(hex_from_channels)
+        .unwrap_or_else(|| value.to_owned())
 }
 
 fn blend(left: &str, right: &str, amount: f64) -> String {

--- a/src/ui/theme/tests.rs
+++ b/src/ui/theme/tests.rs
@@ -6,7 +6,7 @@ use std::{cell::RefCell, collections::HashSet};
 
 use super::{
     Preferences, TextSize, Theme, ThemeTokens, azure_tokens, blend, browser_mode_from_stored,
-    builtins, configured_hardware_acceleration, configured_video_preview_backend,
+    builtins, color_to_hex, configured_hardware_acceleration, configured_video_preview_backend,
     is_omarchy_theme_event, merge_builtin_and_custom_themes, notify_live, slugify,
     snapped_root_font_px, sort_preferences, source_style_scheme_xml, stored_browser_mode,
     text_scale_factor_from_xft_dpi, title_case_slug, tokens_from_quattro, validate_tokens,
@@ -120,6 +120,14 @@ fn colors_can_be_blended_into_semantic_tokens() {
     assert_eq!(blend("#000000", "#ffffff", 0.5), "#808080");
     assert_eq!(blend("rgb(0,0,0)", "rgb(255,255,255)", 0.5), "#808080");
     assert_eq!(blend("#000", "#fff", 0.5), "#808080");
+    assert_eq!(blend("black", "white", 0.5), "#808080");
+}
+
+#[test]
+fn gtk_color_formats_canonicalize_for_persistence_and_scheme_xml() {
+    assert_eq!(color_to_hex("rgb(153,193,241)"), "#99c1f1");
+    assert_eq!(color_to_hex("#fff"), "#ffffff");
+    assert_eq!(color_to_hex("rebeccapurple"), "#663399");
 }
 
 fn scheme_color_values(xml: &str) -> Vec<&str> {
@@ -156,7 +164,7 @@ fn source_style_scheme_xml_canonicalizes_rgb_tokens_for_gtksourceview() {
             for value in &values {
                 assert!(
                     value.starts_with('#') && value.len() == 7,
-                    "GtkSourceView requires #rrggbb, got {value}"
+                    "scheme colors must be canonical #rrggbb, got {value}"
                 );
             }
             assert!(

--- a/src/ui/theme/tests.rs
+++ b/src/ui/theme/tests.rs
@@ -117,6 +117,8 @@ fn omarchy_slugs_become_display_names() {
 #[test]
 fn colors_can_be_blended_into_semantic_tokens() {
     assert_eq!(blend("#000000", "#ffffff", 0.5), "#808080");
+    assert_eq!(blend("rgb(0,0,0)", "rgb(255,255,255)", 0.5), "#808080");
+    assert_eq!(blend("#000", "#fff", 0.5), "#808080");
 }
 
 #[test]

--- a/src/ui/theme/tests.rs
+++ b/src/ui/theme/tests.rs
@@ -5,16 +5,17 @@ mod preferences;
 use std::{cell::RefCell, collections::HashSet};
 
 use super::{
-    Preferences, TextSize, Theme, azure_tokens, blend, browser_mode_from_stored, builtins,
-    configured_hardware_acceleration, configured_video_preview_backend, is_omarchy_theme_event,
-    merge_builtin_and_custom_themes, notify_live, slugify, snapped_root_font_px, sort_preferences,
-    stored_browser_mode, text_scale_factor_from_xft_dpi, title_case_slug, tokens_from_quattro,
-    validate_tokens,
+    Preferences, TextSize, Theme, ThemeTokens, azure_tokens, blend, browser_mode_from_stored,
+    builtins, configured_hardware_acceleration, configured_video_preview_backend,
+    is_omarchy_theme_event, merge_builtin_and_custom_themes, notify_live, slugify,
+    snapped_root_font_px, sort_preferences, source_style_scheme_xml, stored_browser_mode,
+    text_scale_factor_from_xft_dpi, title_case_slug, tokens_from_quattro, validate_tokens,
 };
 use crate::{
     model::{SortDirection, SortKey, ViewPreferences},
     sandbox::MediaPreviewBackend,
     services::{Channel, CrossVolumeDropStrategy},
+    test_support::gtk_test,
     ui::browser_modes::BrowserMode,
 };
 
@@ -119,6 +120,65 @@ fn colors_can_be_blended_into_semantic_tokens() {
     assert_eq!(blend("#000000", "#ffffff", 0.5), "#808080");
     assert_eq!(blend("rgb(0,0,0)", "rgb(255,255,255)", 0.5), "#808080");
     assert_eq!(blend("#000", "#fff", 0.5), "#808080");
+}
+
+fn scheme_color_values(xml: &str) -> Vec<&str> {
+    xml.lines()
+        .filter_map(|line| {
+            let start = line.find("value=\"")? + 7;
+            let rest = line.get(start..)?;
+            let end = rest.find('"')?;
+            Some(&rest[..end])
+        })
+        .collect()
+}
+
+#[test]
+fn source_style_scheme_xml_canonicalizes_rgb_tokens_for_gtksourceview() {
+    gtk_test(
+        "ui::theme::tests::source_style_scheme_xml_canonicalizes_rgb_tokens_for_gtksourceview",
+        || {
+            let tokens = ThemeTokens {
+                name: "Picker".to_owned(),
+                background: "rgb(255,255,255)".to_owned(),
+                surface: "rgb(245,245,245)".to_owned(),
+                text: "rgb(30,29,31)".to_owned(),
+                accent: "rgb(153,193,241)".to_owned(),
+                danger: "rgb(229,72,77)".to_owned(),
+                muted: "rgb(200,200,200)".to_owned(),
+                highlight: "rgb(36,77,104)".to_owned(),
+                border: "rgb(49,91,117)".to_owned(),
+                dim_text: "rgb(111,141,163)".to_owned(),
+            };
+            let xml = source_style_scheme_xml(&tokens);
+            let values = scheme_color_values(&xml);
+            assert_eq!(values.len(), 9);
+            for value in &values {
+                assert!(
+                    value.starts_with('#') && value.len() == 7,
+                    "GtkSourceView requires #rrggbb, got {value}"
+                );
+            }
+            assert!(
+                !xml.contains("rgb("),
+                "scheme XML must not emit rgb() colour tags"
+            );
+
+            let directory = tempfile::tempdir().expect("scheme directory");
+            std::fs::write(directory.path().join("strata-current.xml"), xml.as_bytes())
+                .expect("write scheme");
+            let manager = sourceview5::StyleSchemeManager::new();
+            manager.set_search_path(&[directory.path().to_str().expect("utf-8 scheme path")]);
+            manager.force_rescan();
+            let scheme = manager
+                .scheme("strata-current")
+                .expect("GtkSourceView should load a #rrggbb scheme");
+            let statement = scheme
+                .style("def:statement")
+                .expect("def:statement should resolve");
+            assert_eq!(statement.foreground().as_deref(), Some("#99c1f1"));
+        },
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Description

The theme editor stores colour pickers as `rgb(r,g,b)`, but `blend()` and `theme_background_is_light()` parse only `#rrggbb`. Editor-created themes lose syntax colouring in code previews, and every light editor-created theme appears under the Dark catalog filter. Three-digit `#fff` is also misread as a near-black value.

Parse colours through `gdk::RGBA` in one shared helper so hex, short hex, `rgb()`, and named colours all work in both places.

This is based on the analysis and patch on [@nixfred](https://github.com/nixfred)'s [`fix/theme-colour-parsing`](https://github.com/lgse/strata/compare/main...nixfred:strata:fix/theme-colour-parsing) branch from #655. The commit was recreated on current `main` without agent attribution so it can be submitted under project contribution policy.

## Visual evidence

N/A — no visual change; behaviour is covered by the linked regression test.

## How to test

1. Settings → Themes → create a theme with a white background using the colour pickers.
2. Open the catalog with the Dark filter and confirm the new theme is not listed there.
3. Preview a source file and confirm syntax colouring is present.

**Expected result:** Colours are parsed in every format GTK accepts, so both helpers work for editor-created themes.

## Related issue

Closes #655