### PR TITLE
fix(installer): read interactive pacman prompts from the terminal

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -192,13 +192,14 @@ run_pacman() {
     sudo -n pacman -S --needed --noconfirm -- "$@" \
       || die "Non-interactive package installation failed; passwordless sudo or cached credentials may be required."
   else
-    sudo pacman -S --needed -- "$@"
+    sudo pacman -S --needed -- "$@" </dev/tty
   fi
 }
 
 install_arch_dependencies() {
   local missing=() package
   for package in "${REQUIRED_PACKAGES[@]}"; do
+    [[ $package == github-cli ]] && command -v gh >/dev/null 2>&1 && continue
     pacman -Q "$package" >/dev/null 2>&1 || missing+=("$package")
   done
 

--- a/scripts/test_installer.py
+++ b/scripts/test_installer.py
@@ -2,6 +2,7 @@
 
 import os
 import pathlib
+import shutil
 import subprocess
 import tempfile
 import unittest
@@ -9,6 +10,7 @@ import unittest
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 INSTALLER = ROOT / "install.sh"
+BASH = shutil.which("bash")
 
 
 def bash(script: str, *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
@@ -17,7 +19,7 @@ def bash(script: str, *, env: dict[str, str] | None = None) -> subprocess.Comple
     if env:
         test_env.update(env)
     return subprocess.run(
-        ["bash", "-c", f'source "$1"; {script}', "bash", str(INSTALLER)],
+        [BASH, "-c", f'source "$1"; {script}', "bash", str(INSTALLER)],
         check=False,
         capture_output=True,
         text=True,
@@ -169,6 +171,40 @@ class InstallerTests(unittest.TestCase):
             result.stdout.splitlines(),
             ["-n", "pacman", "-S", "--needed", "--noconfirm", "--", "gvfs-smb"],
         )
+
+    def test_interactive_pacman_reads_from_the_terminal_not_stdin(self) -> None:
+        source = INSTALLER.read_text(encoding="utf-8")
+        self.assertIn('sudo pacman -S --needed -- "$@" </dev/tty', source)
+
+    def test_github_cli_requirement_is_skipped_when_gh_is_already_on_path(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fake_pacman = pathlib.Path(directory) / "pacman"
+            fake_pacman.write_text('#!/bin/sh\n[ "$1" = "-Q" ] && exit 1\nexit 0\n')
+            fake_pacman.chmod(0o755)
+            result = bash(
+                "REQUIRED_PACKAGES=(github-cli); NON_INTERACTIVE=yes; "
+                "gh() { :; }; "
+                'run_pacman() { printf "run_pacman called: %s\\n" "$*" >&2; }; '
+                "install_arch_dependencies",
+                env={"PATH": directory},
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("already installed", result.stdout)
+        self.assertNotIn("run_pacman called", result.stderr)
+
+    def test_github_cli_requirement_still_installs_when_gh_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fake_pacman = pathlib.Path(directory) / "pacman"
+            fake_pacman.write_text('#!/bin/sh\n[ "$1" = "-Q" ] && exit 1\nexit 0\n')
+            fake_pacman.chmod(0o755)
+            result = bash(
+                "REQUIRED_PACKAGES=(github-cli); NON_INTERACTIVE=yes; "
+                'run_pacman() { printf "run_pacman called: %s\\n" "$*" >&2; }; '
+                "install_arch_dependencies",
+                env={"PATH": directory},
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("run_pacman called: github-cli", result.stderr)
 
     def test_unknown_installer_option_is_rejected(self) -> None:
         result = bash("parse_args --definitely-unknown")


### PR DESCRIPTION
## Description

When `install.sh` is piped through `curl | bash`, stdin is bound to the installer pipe rather than the terminal. The interactive `pacman -S --needed --` invocation inherited that stdin, so pacman's confirmation prompt read from the pipe instead of the terminal, instead of the `/dev/tty` the rest of the installer's own prompts already use.

Separately, `github-cli` was always checked with `pacman -Q`, so a `gh` installed another way (e.g. via mise) was not recognized and the installer offered to install `github-cli` through pacman unnecessarily.

## Changes

- `run_pacman`'s interactive branch now redirects from `/dev/tty` (the installer already verifies `/dev/tty` is readable/writable before entering interactive mode, so this is always available on that path).
- `install_arch_dependencies` skips the `github-cli` package requirement when `gh` is already resolvable on `PATH`.
- Added focused tests in `scripts/test_installer.py` covering both cases.

## Visual evidence

N/A — shell script fix, no UI change.

## How to test

1. `python3 -m unittest scripts.test_installer -v`
2. Manually: `curl -fsSL <install.sh url> | bash` on an Arch-based system with an existing pacman package pending confirmation, and with `gh` installed via a non-pacman method (e.g. mise).

**Expected result:** pacman's confirmation prompt reads from the terminal instead of hanging/failing on the installer pipe, and `github-cli` is not listed as a required package when `gh` is already available.

## Related issue

Closes #682