### PR TITLE
fix(dnd): preserve filesystem identity through network aliases

### DIFF
--- a/src/adapters/volume.rs
+++ b/src/adapters/volume.rs
@@ -139,7 +139,6 @@ fn lookup_drop_volumes_with_mounts(
 
 struct Directory<'a> {
     location: &'a Location,
-    is_remote: bool,
     synchronous: bool,
 }
 
@@ -155,7 +154,6 @@ impl<'a> Directory<'a> {
                 .is_some_and(|path| !native_query_may_leave_mount(path));
         Self {
             location,
-            is_remote,
             synchronous,
         }
     }
@@ -215,9 +213,10 @@ impl PendingVolumeLookup {
                 state.remaining -= 1;
                 continue;
             }
-            let is_remote = directory.is_remote;
+            let file = gio_file_for_location(directory.location);
+            let backend = file.uri_scheme().unwrap_or_default().to_string();
             let state = state.clone();
-            gio_file_for_location(directory.location).query_info_async(
+            file.query_info_async(
                 gio::FILE_ATTRIBUTE_ID_FILESYSTEM,
                 gio::FileQueryInfoFlags::NONE,
                 glib::Priority::DEFAULT,
@@ -225,7 +224,7 @@ impl PendingVolumeLookup {
                 move |result| {
                     let identity = result
                         .ok()
-                        .and_then(|info| identity_from_gio(&info, is_remote));
+                        .and_then(|info| identity_from_gio(&info, &backend));
                     PendingState::resolve(&state, index, identity);
                 },
             );
@@ -326,7 +325,7 @@ fn native_volume_identity_with(
             None::<&gio::Cancellable>,
         )
         .ok()?;
-    identity_from_gio(&info, false)
+    identity_from_gio(&info, "file")
 }
 
 pub(crate) fn location_is_remote(location: &Location) -> bool {
@@ -339,13 +338,13 @@ pub(crate) fn location_is_remote(location: &Location) -> bool {
     }
 }
 
-fn identity_from_gio(info: &gio::FileInfo, is_remote: bool) -> Option<VolumeIdentity> {
+fn identity_from_gio(info: &gio::FileInfo, backend: &str) -> Option<VolumeIdentity> {
     let filesystem_id = info.attribute_string(gio::FILE_ATTRIBUTE_ID_FILESYSTEM)?;
     if filesystem_id.is_empty() {
         return None;
     }
     Some(VolumeIdentity {
         filesystem_id: filesystem_id.to_string(),
-        is_remote,
+        backend: backend.into(),
     })
 }

--- a/src/adapters/volume/tests.rs
+++ b/src/adapters/volume/tests.rs
@@ -270,11 +270,9 @@ fn uri_lookup_is_pending_then_reports_once_resolved() {
     assert!(was_pending);
     let lookup = lookup.expect("file uri lookup should resolve");
     assert_eq!(lookup.relation, VolumeRelation::Same);
-    assert!(
-        lookup
-            .dest
-            .is_some_and(|identity| { !identity.filesystem_id.is_empty() && !identity.is_remote })
-    );
+    assert!(lookup.dest.is_some_and(|identity| {
+        !identity.filesystem_id.is_empty() && identity.backend == "file"
+    }));
 }
 
 #[test]
@@ -319,11 +317,67 @@ fn native_path_on_a_remote_mount_is_looked_up_asynchronously() {
     );
     let lookup = lookup.expect("remote native lookup should resolve");
     assert_eq!(lookup.relation, VolumeRelation::Same);
-    assert!(lookup.dest.is_some_and(|identity| identity.is_remote));
+    assert!(
+        lookup
+            .dest
+            .is_some_and(|identity| identity.backend == "file")
+    );
 }
 
 #[test]
-fn remote_and_local_native_paths_never_match() {
+fn network_mount_aliases_preserve_identity_and_plain_drop_move_policy() {
+    use crate::services::{
+        CrossVolumeDropStrategy, DropActionInput, DropCommit, DropOverride, drop_commit,
+    };
+
+    let root = tempfile::tempdir().expect("tempdir");
+    let nas = root.path().join("nas");
+    let alias = root.path().join("alias");
+    fs::create_dir_all(nas.join("a")).expect("source directory");
+    fs::create_dir(nas.join("b")).expect("destination directory");
+    fs::write(nas.join("a/file"), b"x").expect("source file");
+    std::os::unix::fs::symlink(&nas, &alias).expect("mount alias");
+    let mounts = mounts_treating_as_nfs(&nas);
+
+    for (source_root, dest_root) in [(&nas, &alias), (&alias, &nas)] {
+        let query = DropVolumeQuery::with_mounts(
+            &Location::local(dest_root.join("b")),
+            &[Location::local(source_root.join("a/file"))],
+            &mounts,
+        );
+        let (lookup, was_pending) = resolve_with_mounts(&query, &mounts, Duration::from_secs(5));
+        assert!(
+            was_pending,
+            "mounts and aliases require asynchronous lookup"
+        );
+        let lookup = lookup.expect("alias lookup should resolve");
+        let dest = lookup.dest.as_ref().expect("destination identity");
+        let source = lookup.sources[0].as_ref().expect("source identity");
+        assert_eq!(dest.filesystem_id, source.filesystem_id);
+        assert_eq!(lookup.relation, VolumeRelation::Same);
+        for strategy in [CrossVolumeDropStrategy::Copy, CrossVolumeDropStrategy::Ask] {
+            for (override_with, expected) in [
+                (DropOverride::None, DropCommit::Move),
+                (DropOverride::ForceCopy, DropCommit::Copy),
+                (DropOverride::ForceMove, DropCommit::Move),
+            ] {
+                assert_eq!(
+                    drop_commit(DropActionInput {
+                        can_copy: true,
+                        can_move: true,
+                        volume: lookup.relation,
+                        override_with,
+                        strategy,
+                    }),
+                    expected
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn mount_classification_does_not_override_native_filesystem_identity() {
     let root = tempfile::tempdir().expect("tempdir");
     let remote = root.path().join("remote");
     let local = root.path().join("local");
@@ -337,7 +391,7 @@ fn remote_and_local_native_paths_never_match() {
     let mounts = mounts_treating_as_nfs(&remote);
     let (lookup, _) = resolve_with_mounts(&query, &mounts, Duration::from_secs(5));
     let lookup = lookup.expect("mixed lookup should resolve");
-    assert_eq!(lookup.relation, VolumeRelation::Different);
+    assert_eq!(lookup.relation, VolumeRelation::Same);
 }
 
 fn local_only_mounts() -> MountTable {
@@ -446,7 +500,7 @@ fn timeout_finishes_with_partial_results_and_ignores_late_callbacks() {
     }));
     let dest = VolumeIdentity {
         filesystem_id: "l1".into(),
-        is_remote: true,
+        backend: "sftp".into(),
     };
     PendingState::resolve(&state, 0, Some(dest.clone()));
     assert!(reported.borrow().is_empty());

--- a/src/services/transfer_action.rs
+++ b/src/services/transfer_action.rs
@@ -10,14 +10,15 @@ use crate::model::Location;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct VolumeIdentity {
     pub filesystem_id: String,
-    pub is_remote: bool,
+    /// GIO URI scheme; native paths and file URIs share the `file` namespace.
+    pub backend: String,
 }
 
 impl VolumeIdentity {
     pub(crate) fn matches(&self, other: &Self) -> bool {
         !self.filesystem_id.is_empty()
             && self.filesystem_id == other.filesystem_id
-            && self.is_remote == other.is_remote
+            && self.backend == other.backend
     }
 }
 

--- a/src/services/transfer_action/tests.rs
+++ b/src/services/transfer_action/tests.rs
@@ -6,10 +6,10 @@ use super::{
 };
 use crate::model::Location;
 
-fn identity(id: &str, is_remote: bool) -> VolumeIdentity {
+fn identity(id: &str, backend: &str) -> VolumeIdentity {
     VolumeIdentity {
         filesystem_id: id.into(),
-        is_remote,
+        backend: backend.into(),
     }
 }
 
@@ -57,14 +57,14 @@ fn commit(
 
 #[test]
 fn volume_relation_treats_empty_sources_as_unknown() {
-    let dest = identity("dev:1", false);
+    let dest = identity("dev:1", "file");
     assert_eq!(volume_relation(Some(&dest), &[]), VolumeRelation::Unknown);
 }
 
 #[test]
 fn volume_relation_is_unknown_when_dest_or_any_source_is_missing() {
-    let dest = identity("dev:1", false);
-    let same = identity("dev:1", false);
+    let dest = identity("dev:1", "file");
+    let same = identity("dev:1", "file");
     assert_eq!(
         volume_relation(None, &[Some(same.clone())]),
         VolumeRelation::Unknown
@@ -77,9 +77,9 @@ fn volume_relation_is_unknown_when_dest_or_any_source_is_missing() {
 
 #[test]
 fn volume_relation_is_different_if_any_source_disagrees() {
-    let dest = identity("dev:1", false);
-    let same = identity("dev:1", false);
-    let other = identity("dev:2", false);
+    let dest = identity("dev:1", "file");
+    let same = identity("dev:1", "file");
+    let other = identity("dev:2", "file");
     assert_eq!(
         volume_relation(Some(&dest), &[Some(same.clone())]),
         VolumeRelation::Same
@@ -91,13 +91,21 @@ fn volume_relation_is_different_if_any_source_disagrees() {
 }
 
 #[test]
-fn volume_relation_treats_remote_flag_mismatch_as_different() {
-    let local = identity("same-id", false);
-    let remote = identity("same-id", true);
-    assert_eq!(
-        volume_relation(Some(&local), &[Some(remote)]),
-        VolumeRelation::Different
-    );
+fn volume_relation_preserves_backend_namespaces() {
+    for backend in ["file", "trash", "sftp", "smb"] {
+        let dest = identity("same-id", backend);
+        for source_backend in ["file", "trash", "sftp", "smb"] {
+            let source = identity("same-id", source_backend);
+            assert_eq!(
+                volume_relation(Some(&dest), &[Some(source)]),
+                if backend == source_backend {
+                    VolumeRelation::Same
+                } else {
+                    VolumeRelation::Different
+                }
+            );
+        }
+    }
 }
 
 #[test]

--- a/src/ui/window/tests/keyboard_dispatch.rs
+++ b/src/ui/window/tests/keyboard_dispatch.rs
@@ -116,6 +116,9 @@ fn rendered_name(widget: &gtk::Widget, name: &str) -> bool {
     if widget
         .downcast_ref::<gtk::Label>()
         .is_some_and(|label| label.label() == name)
+        || widget
+            .downcast_ref::<gtk::Inscription>()
+            .is_some_and(|label| label.text().as_deref() == Some(name))
     {
         return true;
     }
@@ -218,7 +221,10 @@ fn ctrl_a_during_rename_selects_only_unicode_entry_text_in_every_view() {
                 field.set_text("résumé-💾.txt");
                 field.set_position(-1);
 
-                assert!(fixture.press(Key::a, ModifierType::CONTROL_MASK), "{mode:?}");
+                assert!(
+                    fixture.press(Key::a, ModifierType::CONTROL_MASK),
+                    "{mode:?}"
+                );
                 assert_eq!(
                     field.selection_bounds(),
                     Some((0, field.text().chars().count() as i32)),
@@ -226,7 +232,10 @@ fn ctrl_a_during_rename_selects_only_unicode_entry_text_in_every_view() {
                 );
                 assert_eq!(fixture.selected(), [0], "{mode:?}");
 
-                assert!(fixture.press(Key::Escape, ModifierType::empty()), "{mode:?}");
+                assert!(
+                    fixture.press(Key::Escape, ModifierType::empty()),
+                    "{mode:?}"
+                );
                 assert!(!fixture.view.rename_is_active(), "{mode:?}");
                 assert_eq!(fixture.selected(), [0], "{mode:?}");
             }


### PR DESCRIPTION
## Description

Separate lookup blocking risk from GIO filesystem identity. Native paths on network mounts and their symlink aliases now share the `file` backend namespace, while other URI backends remain distinct. Add regressions for both alias directions, Copy/Ask policies, and modifier overrides.

Side note: fix pre-existing keyboard-test formatting and teach its filename helper to recognize `GtkInscription`, preventing the icon-view fixture timeout. No keyboard behavior changes.

An unrelated updater ownership-probe test failed once during validation, then passed in isolation and in the final full run; its intermittent cause remains unverified.

## Visual evidence

N/A — filesystem identity classification and test-helper changes; no interface layout changes. A live-NAS smoke test has not been performed.

## How to test

1. With an existing NFS/FUSE mount, create disposable `a` and `b` directories and a symlink alias to the mount outside its lexical path. Put a test file in `a`.
2. Set the cross-device strategy to Always Copy, then drag the file from the direct `a` path to `b` through the alias without modifiers. Repeat with Always Ask and with the direct/alias spellings reversed.
3. Repeat with Ctrl held to request a copy.

**Expected result:** Plain drops move the file without a device-difference prompt in either direction. Ctrl-drops copy and retain the source.

## Related issue

Closes #734
