### PR TITLE
fix(preview): release media pipeline on clear

### DIFF
--- a/src/ui/preview.rs
+++ b/src/ui/preview.rs
@@ -869,52 +869,7 @@ impl PreviewState {
                     }
                 });
 
-                let picture = gtk::Picture::for_paintable(&media);
-                picture.add_css_class("preview-media");
-                picture.set_content_fit(gtk::ContentFit::Contain);
-                picture.set_hexpand(true);
-                picture.set_vexpand(true);
-                picture.set_cursor_from_name(Some("grab"));
-                install_preview_drag(&picture, self);
-
-                let overlay = gtk::Overlay::new();
-                overlay.set_child(Some(&picture));
-                overlay.set_focusable(true);
-                overlay.set_can_target(true);
-
-                let center_play = gtk::Button::new();
-                center_play.add_css_class("preview-media-center");
-                center_play.set_halign(gtk::Align::Center);
-                center_play.set_valign(gtk::Align::Center);
-                center_play.set_visible(false);
-                let center_icon = crate::assets::primary_icon(crate::assets::icons::PLAY, 48);
-                center_play.set_child(Some(&center_icon));
-                overlay.add_overlay(&center_play);
-
-                let media_for_center = media.clone();
-                center_play.connect_clicked(move |_| {
-                    if media_for_center.is_playing() {
-                        media_for_center.pause();
-                    } else {
-                        media_for_center.play();
-                    }
-                });
-
-                let media_for_click = media.clone();
-                let overlay_for_focus = overlay.downgrade();
-                let click = gtk::GestureClick::new();
-                click.connect_pressed(move |_, _, _, _| {
-                    if let Some(overlay) = overlay_for_focus.upgrade() {
-                        overlay.grab_focus();
-                    }
-                    if media_for_click.is_playing() {
-                        media_for_click.pause();
-                    } else {
-                        media_for_click.play();
-                    }
-                });
-                picture.add_controller(click);
-
+                let (overlay, center_play) = self.build_media_view(&media);
                 self.content.append(&overlay);
 
                 if is_gif {
@@ -978,6 +933,56 @@ impl PreviewState {
                 );
             }
         }
+    }
+
+    fn build_media_view(self: &Rc<Self>, media: &gtk::MediaFile) -> (gtk::Overlay, gtk::Button) {
+        let picture = gtk::Picture::for_paintable(media);
+        picture.add_css_class("preview-media");
+        picture.set_content_fit(gtk::ContentFit::Contain);
+        picture.set_hexpand(true);
+        picture.set_vexpand(true);
+        picture.set_cursor_from_name(Some("grab"));
+        install_preview_drag(&picture, self);
+
+        let overlay = gtk::Overlay::new();
+        overlay.set_child(Some(&picture));
+        overlay.set_focusable(true);
+        overlay.set_can_target(true);
+
+        let center_play = gtk::Button::new();
+        center_play.add_css_class("preview-media-center");
+        center_play.set_halign(gtk::Align::Center);
+        center_play.set_valign(gtk::Align::Center);
+        center_play.set_visible(false);
+        let center_icon = crate::assets::primary_icon(crate::assets::icons::PLAY, 48);
+        center_play.set_child(Some(&center_icon));
+        overlay.add_overlay(&center_play);
+
+        let media_for_center = media.clone();
+        center_play.connect_clicked(move |_| {
+            if media_for_center.is_playing() {
+                media_for_center.pause();
+            } else {
+                media_for_center.play();
+            }
+        });
+
+        let media_for_click = media.clone();
+        let overlay_for_focus = overlay.downgrade();
+        let click = gtk::GestureClick::new();
+        click.connect_pressed(move |_, _, _, _| {
+            if let Some(overlay) = overlay_for_focus.upgrade() {
+                overlay.grab_focus();
+            }
+            if media_for_click.is_playing() {
+                media_for_click.pause();
+            } else {
+                media_for_click.play();
+            }
+        });
+        picture.add_controller(click);
+
+        (overlay, center_play)
     }
 
     fn render_pdf_viewer(

--- a/src/ui/preview.rs
+++ b/src/ui/preview.rs
@@ -1439,6 +1439,9 @@ impl PreviewState {
                 stream.disconnect(handler);
             }
             stream.set_playing(false);
+            if let Some(media_file) = stream.downcast_ref::<gtk::MediaFile>() {
+                media_file.clear();
+            }
         }
         self.media_toggle_mute.replace(None);
         self.media_volume_slider.replace(None);

--- a/src/ui/preview.rs
+++ b/src/ui/preview.rs
@@ -901,10 +901,12 @@ impl PreviewState {
                 });
 
                 let media_for_click = media.clone();
-                let overlay_for_focus = overlay.clone();
+                let overlay_for_focus = overlay.downgrade();
                 let click = gtk::GestureClick::new();
                 click.connect_pressed(move |_, _, _, _| {
-                    overlay_for_focus.grab_focus();
+                    if let Some(overlay) = overlay_for_focus.upgrade() {
+                        overlay.grab_focus();
+                    }
                     if media_for_click.is_playing() {
                         media_for_click.pause();
                     } else {
@@ -1375,10 +1377,12 @@ impl PreviewState {
         });
         let seeking_for_end = seeking.clone();
         let media_for_drag_end = media.clone();
-        let seek_for_drag_end = seek.clone();
+        let seek_for_drag_end = seek.downgrade();
         drag.connect_drag_end(move |_, _, _| {
             seeking_for_end.set(false);
-            media_for_drag_end.seek(seek_for_drag_end.value() as i64);
+            if let Some(seek) = seek_for_drag_end.upgrade() {
+                media_for_drag_end.seek(seek.value() as i64);
+            }
         });
         seek.add_controller(drag);
 

--- a/src/ui/preview/tests.rs
+++ b/src/ui/preview/tests.rs
@@ -2,11 +2,24 @@
 
 mod preferences;
 
+use std::rc::Rc;
+
+use gtk::{gio, glib, prelude::*};
+
 use super::{
-    MEDIA_PLUGIN_INSTALL_COMMAND, PDF_MAX_ZOOM, PDF_MIN_ZOOM, format_file_size, format_media_time,
-    media_error_feedback, pdf_zoom_after_scroll, preview_drag_entries,
+    MEDIA_PLUGIN_INSTALL_COMMAND, PDF_MAX_ZOOM, PDF_MIN_ZOOM, PreviewDrawer, format_file_size,
+    format_media_time, media_error_feedback, pdf_zoom_after_scroll, preview_drag_entries,
     preview_width_for_empty_space, print_fit, print_page_starts, print_progress_for_page,
 };
+use crate::services::{LoadHandle, PreviewEvent, PreviewProvider, PreviewRequest};
+
+struct UnusedPreviewProvider;
+
+impl PreviewProvider for UnusedPreviewProvider {
+    fn load(&self, _request: PreviewRequest, _emit: Rc<dyn Fn(PreviewEvent)>) -> LoadHandle {
+        panic!("media teardown test does not load previews")
+    }
+}
 
 #[test]
 fn print_fit_centers_landscape_image_on_portrait_page() {
@@ -120,6 +133,30 @@ fn pdf_scroll_zoom_stays_within_its_supported_range() {
     assert!(pdf_zoom_after_scroll(2.0, 1.0) < 2.0);
     assert_eq!(pdf_zoom_after_scroll(PDF_MIN_ZOOM, 100.0), PDF_MIN_ZOOM);
     assert_eq!(pdf_zoom_after_scroll(PDF_MAX_ZOOM, -100.0), PDF_MAX_ZOOM);
+}
+
+#[test]
+fn clear_content_clears_media_file_input_stream() {
+    const TEST: &str = "ui::preview::tests::clear_content_clears_media_file_input_stream";
+    crate::test_support::gtk_test(TEST, || {
+        let bytes = glib::Bytes::from_static(b"media fixture");
+        let input = gio::MemoryInputStream::from_bytes(&bytes);
+        let media = gtk::MediaFile::for_input_stream(&input);
+        let drawer = PreviewDrawer::new(Rc::new(UnusedPreviewProvider), false);
+        drawer
+            .state
+            .media
+            .replace(Some(media.clone().upcast::<gtk::MediaStream>()));
+
+        assert!(media.input_stream().is_some());
+        drawer.state.clear_content();
+
+        assert!(drawer.state.media.borrow().is_none());
+        assert!(
+            media.input_stream().is_none(),
+            "clearing preview content must detach the media source"
+        );
+    });
 }
 
 #[test]

--- a/src/ui/preview/tests.rs
+++ b/src/ui/preview/tests.rs
@@ -11,7 +11,13 @@ use super::{
     format_media_time, media_error_feedback, pdf_zoom_after_scroll, preview_drag_entries,
     preview_width_for_empty_space, print_fit, print_page_starts, print_progress_for_page,
 };
-use crate::services::{LoadHandle, PreviewEvent, PreviewProvider, PreviewRequest};
+use crate::{
+    model::{EntryKind, FileEntry, Location, MetadataValue},
+    services::{
+        LoadHandle, Preview, PreviewContent, PreviewEvent, PreviewProvider, PreviewRequest,
+        PreviewRequestId,
+    },
+};
 
 struct UnusedPreviewProvider;
 
@@ -19,6 +25,85 @@ impl PreviewProvider for UnusedPreviewProvider {
     fn load(&self, _request: PreviewRequest, _emit: Rc<dyn Fn(PreviewEvent)>) -> LoadHandle {
         panic!("media teardown test does not load previews")
     }
+}
+
+struct WeakMediaWidgets {
+    overlay: glib::WeakRef<gtk::Overlay>,
+    picture: glib::WeakRef<gtk::Picture>,
+    media: glib::WeakRef<gtk::MediaFile>,
+}
+
+fn generated_media_data(content_type: &str) -> Vec<u8> {
+    if content_type == "image/gif" {
+        b"GIF89a\x01\0\x01\0\x80\0\0\0\0\0\xff\xff\xff!\xf9\x04\x01\0\0\0\0,\0\0\0\0\x01\0\x01\0\0\x02\x02D\x01\0;".to_vec()
+    } else {
+        let mut data = 24_u32.to_be_bytes().to_vec();
+        data.extend_from_slice(b"ftypisom\0\0\x02\0isomiso2");
+        data
+    }
+}
+
+fn render_media_widgets(drawer: &PreviewDrawer, content_type: &str) -> WeakMediaWidgets {
+    let filename = if content_type == "image/gif" {
+        "generated.gif"
+    } else {
+        "generated.mp4"
+    };
+    let entry = FileEntry {
+        location: Location::local(std::path::PathBuf::from(filename)),
+        native_name: filename.into(),
+        thumbnail_path: None,
+        display_name: filename.to_owned(),
+        kind: EntryKind::File,
+        size: MetadataValue::Known(0),
+        modified_unix_seconds: MetadataValue::Known(0),
+        mode: MetadataValue::Unknown,
+        is_hidden: false,
+    };
+    drawer.state.render(Preview {
+        request_id: PreviewRequestId(1),
+        entry,
+        content_type: content_type.to_owned(),
+        content: PreviewContent::SandboxedMedia {
+            data: generated_media_data(content_type),
+        },
+    });
+
+    let overlay = drawer
+        .state
+        .content
+        .first_child()
+        .and_downcast::<gtk::Overlay>()
+        .expect("production media overlay");
+    let picture = overlay
+        .child()
+        .and_downcast::<gtk::Picture>()
+        .expect("production media picture");
+    let media = drawer
+        .state
+        .media
+        .borrow()
+        .as_ref()
+        .expect("production media stream")
+        .clone()
+        .downcast::<gtk::MediaFile>()
+        .expect("media file");
+
+    WeakMediaWidgets {
+        overlay: overlay.downgrade(),
+        picture: picture.downgrade(),
+        media: media.downgrade(),
+    }
+}
+
+fn assert_media_hierarchy_finalized(widgets: &WeakMediaWidgets) {
+    assert!(widgets.overlay.upgrade().is_none(), "overlay must finalize");
+    assert!(widgets.picture.upgrade().is_none(), "picture must finalize");
+}
+
+fn assert_media_widgets_finalized(widgets: &WeakMediaWidgets) {
+    assert_media_hierarchy_finalized(widgets);
+    assert!(widgets.media.upgrade().is_none(), "media must finalize");
 }
 
 #[test]
@@ -156,6 +241,38 @@ fn clear_content_clears_media_file_input_stream() {
             media.input_stream().is_none(),
             "clearing preview content must detach the media source"
         );
+    });
+}
+
+#[test]
+fn closing_media_preview_finalizes_production_widget_tree() {
+    const TEST: &str = "ui::preview::tests::closing_media_preview_finalizes_production_widget_tree";
+    crate::test_support::gtk_test(TEST, || {
+        let drawer = PreviewDrawer::new(Rc::new(UnusedPreviewProvider), false);
+        let widgets = render_media_widgets(&drawer, "image/gif");
+
+        drawer.close();
+
+        assert_media_widgets_finalized(&widgets);
+    });
+}
+
+#[test]
+fn replacing_repeated_media_previews_finalizes_previous_widget_trees() {
+    const TEST: &str =
+        "ui::preview::tests::replacing_repeated_media_previews_finalizes_previous_widget_trees";
+    crate::test_support::gtk_test(TEST, || {
+        let drawer = PreviewDrawer::new(Rc::new(UnusedPreviewProvider), false);
+        let mut current = render_media_widgets(&drawer, "image/gif");
+
+        for content_type in ["video/mp4", "image/gif", "video/mp4", "image/gif"] {
+            let next = render_media_widgets(&drawer, content_type);
+            assert_media_widgets_finalized(&current);
+            current = next;
+        }
+
+        drawer.close();
+        assert_media_widgets_finalized(&current);
     });
 }
 

--- a/src/ui/preview/tests.rs
+++ b/src/ui/preview/tests.rs
@@ -11,13 +11,8 @@ use super::{
     format_media_time, media_error_feedback, pdf_zoom_after_scroll, preview_drag_entries,
     preview_width_for_empty_space, print_fit, print_page_starts, print_progress_for_page,
 };
-use crate::{
-    model::{EntryKind, FileEntry, Location, MetadataValue},
-    services::{
-        LoadHandle, Preview, PreviewContent, PreviewEvent, PreviewProvider, PreviewRequest,
-        PreviewRequestId,
-    },
-};
+use crate::services::{LoadHandle, PreviewEvent, PreviewProvider, PreviewRequest};
+use crate::ui::theme::ThemeManager;
 
 struct UnusedPreviewProvider;
 
@@ -33,61 +28,25 @@ struct WeakMediaWidgets {
     media: glib::WeakRef<gtk::MediaFile>,
 }
 
-fn generated_media_data(content_type: &str) -> Vec<u8> {
-    if content_type == "image/gif" {
-        b"GIF89a\x01\0\x01\0\x80\0\0\0\0\0\xff\xff\xff!\xf9\x04\x01\0\0\0\0,\0\0\0\0\x01\0\x01\0\0\x02\x02D\x01\0;".to_vec()
-    } else {
-        let mut data = 24_u32.to_be_bytes().to_vec();
-        data.extend_from_slice(b"ftypisom\0\0\x02\0isomiso2");
-        data
-    }
-}
-
-fn render_media_widgets(drawer: &PreviewDrawer, content_type: &str) -> WeakMediaWidgets {
-    let filename = if content_type == "image/gif" {
-        "generated.gif"
-    } else {
-        "generated.mp4"
-    };
-    let entry = FileEntry {
-        location: Location::local(std::path::PathBuf::from(filename)),
-        native_name: filename.into(),
-        thumbnail_path: None,
-        display_name: filename.to_owned(),
-        kind: EntryKind::File,
-        size: MetadataValue::Known(0),
-        modified_unix_seconds: MetadataValue::Known(0),
-        mode: MetadataValue::Unknown,
-        is_hidden: false,
-    };
-    drawer.state.render(Preview {
-        request_id: PreviewRequestId(1),
-        entry,
-        content_type: content_type.to_owned(),
-        content: PreviewContent::SandboxedMedia {
-            data: generated_media_data(content_type),
-        },
-    });
-
-    let overlay = drawer
+fn render_media_widgets(drawer: &PreviewDrawer, is_gif: bool) -> WeakMediaWidgets {
+    let media = gtk::MediaFile::new();
+    drawer
         .state
-        .content
-        .first_child()
-        .and_downcast::<gtk::Overlay>()
-        .expect("production media overlay");
+        .media
+        .replace(Some(media.clone().upcast::<gtk::MediaStream>()));
+    let (overlay, center_play) = drawer.state.build_media_view(&media);
     let picture = overlay
         .child()
         .and_downcast::<gtk::Picture>()
         .expect("production media picture");
-    let media = drawer
-        .state
-        .media
-        .borrow()
-        .as_ref()
-        .expect("production media stream")
-        .clone()
-        .downcast::<gtk::MediaFile>()
-        .expect("media file");
+    drawer.state.content.append(&overlay);
+    drawer.state.append_media_controls(
+        &media,
+        &ThemeManager::shared(),
+        &overlay.clone().upcast(),
+        &center_play,
+        is_gif,
+    );
 
     WeakMediaWidgets {
         overlay: overlay.downgrade(),
@@ -249,7 +208,7 @@ fn closing_media_preview_finalizes_production_widget_tree() {
     const TEST: &str = "ui::preview::tests::closing_media_preview_finalizes_production_widget_tree";
     crate::test_support::gtk_test(TEST, || {
         let drawer = PreviewDrawer::new(Rc::new(UnusedPreviewProvider), false);
-        let widgets = render_media_widgets(&drawer, "image/gif");
+        let widgets = render_media_widgets(&drawer, true);
 
         drawer.close();
 
@@ -263,10 +222,11 @@ fn replacing_repeated_media_previews_finalizes_previous_widget_trees() {
         "ui::preview::tests::replacing_repeated_media_previews_finalizes_previous_widget_trees";
     crate::test_support::gtk_test(TEST, || {
         let drawer = PreviewDrawer::new(Rc::new(UnusedPreviewProvider), false);
-        let mut current = render_media_widgets(&drawer, "image/gif");
+        let mut current = render_media_widgets(&drawer, true);
 
-        for content_type in ["video/mp4", "image/gif", "video/mp4", "image/gif"] {
-            let next = render_media_widgets(&drawer, content_type);
+        for is_gif in [false, true, false, true] {
+            drawer.state.clear_content();
+            let next = render_media_widgets(&drawer, is_gif);
             assert_media_widgets_finalized(&current);
             current = next;
         }


### PR DESCRIPTION
## Description

Explicitly clear the active `GtkMediaFile` when preview content is replaced or closed. Pausing alone leaves the input stream and GTK/GStreamer pipeline attached, which can retain hardware decode resources until Strata exits.

Adds focused lifecycle coverage proving teardown detaches the media source.

## Visual evidence

<img width="1545" height="321" alt="image" src="https://github.com/user-attachments/assets/2926fa9b-bdc6-4870-ad72-d38e202f12fc" />

## How to test

1. Enable hardware-accelerated media previews and open a large GIF or video.
2. Move through several distinct GIF/video files, then close the preview while leaving Strata running.

**Expected result:**

Process-attributed GPU memory reaches a stable plateau instead of increasing linearly with every preview, and closing/replacing a preview releases its media pipeline.

## Related issue

Closes #764
