### PR TITLE
fix(trash): reject cross-filesystem home-trash restore with a clear message

### DIFF
--- a/src/adapters/trash_restore.rs
+++ b/src/adapters/trash_restore.rs
@@ -105,7 +105,10 @@ pub(crate) fn plan_restore_from_known_paths(
     if !destination.starts_with(&allowed_root) {
         return Err(escaped_restore_error());
     }
-    if context.mounts.mount_point_for(&destination) != Some(allowed_root.as_path()) {
+    // Home trash collects items from any filesystem; only volume trash is confined to its mount (#478).
+    if trash_root != context.home_trash_root
+        && context.mounts.mount_point_for(&destination) != Some(allowed_root.as_path())
+    {
         return Err(RestoreTargetError::new(
             "The original location crosses a bind mount or subvolume boundary and cannot be restored",
         ));

--- a/src/adapters/trash_restore/tests.rs
+++ b/src/adapters/trash_restore/tests.rs
@@ -324,6 +324,40 @@ fn different_device_orig_path_is_rejected_by_volume_identity() -> std::io::Resul
 }
 
 #[test]
+fn home_trash_cross_filesystem_orig_path_is_rejected_with_clear_message() -> std::io::Result<()> {
+    let Some((home, stick)) = crate::test_support::distinct_device_dirs(
+        "home_trash_cross_filesystem_orig_path_is_rejected_with_clear_message",
+    ) else {
+        return Ok(());
+    };
+    let uid = rustix::process::getuid().as_raw();
+    let trash = home.path().join("Trash");
+    fs::create_dir_all(trash.join("files")).expect("files");
+    fs::create_dir_all(trash.join("info")).expect("info");
+    let source = trash.join("files/payload");
+    fs::write(&source, b"ok")?;
+    let dest = stick.path().join("payload");
+    let context = RestoreContext {
+        home_trash_root: trash.clone(),
+        uid,
+        mounts: MountTable::current(),
+    };
+    let error = plan_restore_from_known_paths(&source, &dest, &trash, None, &context)
+        .expect_err("cross-device home trash");
+    assert!(
+        error.message().contains("outside the trash volume"),
+        "expected 'outside the trash volume', got: {}",
+        error.message()
+    );
+    assert!(
+        !error.message().contains("bind mount or subvolume"),
+        "home trash should not report bind-mount/subvolume: {}",
+        error.message()
+    );
+    Ok(())
+}
+
+#[test]
 fn lexical_normalize_collapses_dot_and_rejects_parent_dir() {
     assert_eq!(
         lexically_normalize(Path::new("/media/usb/./docs/a.txt")).as_deref(),


### PR DESCRIPTION
## Description

Home trash aggregates items from any filesystem (per the XDG Trash spec), so the bind-mount/subvolume confinement check only applies to volume trash. A cross-filesystem home-trash restore was hitting the bind-mount error before the volume-relation check, producing the misleading "bind mount or subvolume boundary" message instead of the clearer "outside the trash volume" message.

Skip the bind-mount check when the trash root is the home trash root. The volume-relation check still catches cross-device destinations with the clearer message. Volume-trash confinement from #478 is unchanged.

## Visual evidence

N/A — backend restore-planning error message change; no interface layout changes.

## How to test

1. Create a home-trash entry whose `.trashinfo` `Path=` points to a different filesystem (e.g. a tmpfs like `/dev/shm`):
   ```bash
   TRASH="$XDG_DATA_HOME/Trash"
   mkdir -p "$TRASH/files" "$TRASH/info"
   echo "ok" > "$TRASH/files/notes.txt"
   printf '[Trash Info]\nPath=/dev/shm/notes.txt\nDeletionDate=2026-09-10T00:00:00\n' \
     > "$TRASH/info/notes.txt.trashinfo"
   ```
2. Open `trash:///` in Strata and select `notes.txt`.
3. Choose Restore.

**Expected result:** Restore is refused with "The original location is outside the trash volume and cannot be restored" (not "bind mount or subvolume boundary"). Payload and metadata remain intact.

## Related issue

Closes #735