### PR TITLE
fix(install): allow installation without GitHub login

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,10 @@ Then:
   FFmpeg/GStreamer, and desktop-integration runtime dependencies using the system
   package manager. Add gvfs-smb only if I want SMB support.
 - Download the archive and its matching .sha256 file from the latest GitHub release.
-- Verify the checksum with sha256sum --check and verify GitHub Actions provenance
-  with `gh attestation verify <archive> --repo lgse/strata`. Stop on any failure;
-  never install an unverified binary.
+- Verify the checksum with sha256sum --check. If GitHub CLI is installed and
+  authenticated, also verify GitHub Actions provenance with
+  `gh attestation verify <archive> --repo lgse/strata`. Stop if either attempted
+  verification fails; never install a binary with an invalid checksum.
 - Extract it and install `strata` to ~/.local/bin/strata without overwriting an
   unrelated file. Ensure ~/.local/bin is on PATH.
 - Ask whether I want a per-user desktop entry and inode/directory association;
@@ -170,19 +171,26 @@ may be absent from Devices. SMB support remains optional.
 
 #### 2. Download and verify
 
-From the [latest release](https://github.com/lgse/strata/releases/latest), download the `.tar.gz` matching `$target` and its identically named `.sha256` file. Then verify both its digest and signed GitHub Actions provenance:
+From the [latest release](https://github.com/lgse/strata/releases/latest), download the `.tar.gz` matching `$target` and its identically named `.sha256` file over HTTPS. Then verify its digest:
 
 ```bash
 cd ~/Downloads
 archive="strata-<version>-${target}.tar.gz"
 sha256sum --check "${archive}.sha256"
-gh attestation verify "$archive" --repo lgse/strata
-tar -xzf "$archive"
 ```
 
-Both verification commands must succeed. Install the binary and confirm it starts:
+If GitHub CLI is installed and authenticated, you can additionally verify the
+archive's signed GitHub Actions provenance before extracting it:
 
 ```bash
+gh attestation verify "$archive" --repo lgse/strata
+```
+
+Every verification you run must succeed. Extract the archive, install the binary,
+and confirm it starts:
+
+```bash
+tar -xzf "$archive"
 install -Dm755 "${archive%.tar.gz}/strata" "$HOME/.local/bin/strata"
 command -v strata
 strata

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ APP_ID="io.github.lgse.Strata"
 MIN_GLIBC="2.39"
 REQUIRED_PACKAGES=(
   bubblewrap desktop-file-utils ffmpeg ffmpegthumbnailer fontconfig gst-libav
-  gst-plugins-good gtk4 gtksourceview5 gvfs poppler-glib github-cli xdg-utils
+  gst-plugins-good gtk4 gtksourceview5 gvfs poppler-glib xdg-utils
 )
 RAW_PREVIEW_PACKAGES=(imagemagick libraw dcraw)
 
@@ -31,6 +31,22 @@ warn() {
 die() {
   printf '\033[1;31merror:\033[0m %s\n' "$*" >&2
   exit 1
+}
+
+verify_provenance() {
+  local archive=$1
+
+  if ! command -v gh >/dev/null 2>&1; then
+    warn "GitHub CLI is unavailable; continuing after HTTPS download and checksum verification."
+    return
+  fi
+  if ! gh auth status --hostname github.com >/dev/null 2>&1; then
+    warn "GitHub CLI is not authenticated; continuing after HTTPS download and checksum verification."
+    return
+  fi
+
+  info "Verifying GitHub Actions provenance"
+  gh attestation verify "$archive" --repo "$REPOSITORY"
 }
 
 show_banner() {
@@ -432,7 +448,7 @@ main() {
       || die "Install the runtime dependencies, then run this installer again."
   fi
 
-  for command in curl tar sha256sum gh install sed; do
+  for command in curl tar sha256sum install sed; do
     command -v "$command" >/dev/null 2>&1 || die "Required command not found: $command"
   done
 
@@ -448,9 +464,9 @@ main() {
   curl --fail --location --show-error --progress-bar \
     --output "$TEMP_DIR/$archive.sha256" "$url/$archive.sha256"
 
-  info "Verifying checksum and GitHub Actions provenance"
+  info "Verifying checksum"
   (cd "$TEMP_DIR" && sha256sum --check "$archive.sha256")
-  gh attestation verify "$TEMP_DIR/$archive" --repo "$REPOSITORY"
+  verify_provenance "$TEMP_DIR/$archive"
 
   tar -xzf "$TEMP_DIR/$archive" -C "$TEMP_DIR"
   extracted=$TEMP_DIR/${archive%.tar.gz}

--- a/scripts/test_installer.py
+++ b/scripts/test_installer.py
@@ -39,6 +39,7 @@ class InstallerTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("gvfs", result.stdout.splitlines())
         self.assertNotIn("gvfs-smb", result.stdout.splitlines())
+        self.assertNotIn("github-cli", result.stdout.splitlines())
 
     def test_banner_remains_readable_without_terminal_color(self) -> None:
         result = bash("show_banner", env={"NO_COLOR": "1"})
@@ -47,6 +48,56 @@ class InstallerTests(unittest.TestCase):
         self.assertIn("Navigate every layer.", result.stdout)
         self.assertIn("Interactive installer", result.stdout)
         self.assertNotIn("\033", result.stdout)
+
+    def test_provenance_verification_is_optional_without_github_cli(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            result = bash(
+                'PATH="$EMPTY_PATH"; verify_provenance /tmp/strata.tar.gz',
+                env={"EMPTY_PATH": directory},
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("GitHub CLI is unavailable", result.stderr)
+
+    def test_provenance_verification_is_optional_without_github_authentication(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fake_gh = pathlib.Path(directory) / "gh"
+            fake_gh.write_text(
+                '#!/bin/sh\nprintf "%s\\n" "$*" >> "$CALLS"\nexit 1\n', encoding="utf-8"
+            )
+            fake_gh.chmod(0o755)
+            calls = pathlib.Path(directory) / "calls"
+            result = bash(
+                'PATH="$FAKE_PATH"; verify_provenance /tmp/strata.tar.gz',
+                env={"FAKE_PATH": directory, "CALLS": str(calls)},
+            )
+            recorded_calls = calls.read_text().splitlines()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(recorded_calls, ["auth status --hostname github.com"])
+        self.assertIn("GitHub CLI is not authenticated", result.stderr)
+
+    def test_authenticated_provenance_verification_remains_mandatory(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fake_gh = pathlib.Path(directory) / "gh"
+            fake_gh.write_text(
+                '#!/bin/sh\nprintf "%s\\n" "$*" >> "$CALLS"\n'
+                'case "$*" in "auth status"*) exit 0;; *) exit "$VERIFY_RESULT";; esac\n',
+                encoding="utf-8",
+            )
+            fake_gh.chmod(0o755)
+            calls = pathlib.Path(directory) / "calls"
+            result = bash(
+                'PATH="$FAKE_PATH"; verify_provenance /tmp/strata.tar.gz',
+                env={"FAKE_PATH": directory, "CALLS": str(calls), "VERIFY_RESULT": "9"},
+            )
+            recorded_calls = calls.read_text().splitlines()
+        self.assertEqual(result.returncode, 9, result.stderr)
+        self.assertEqual(
+            recorded_calls,
+            [
+                "auth status --hostname github.com",
+                "attestation verify /tmp/strata.tar.gz --repo lgse/strata",
+            ],
+        )
 
     def test_unattended_flags_select_only_requested_integrations(self) -> None:
         result = bash(


### PR DESCRIPTION
## Description

Make GitHub CLI and its authenticated provenance check optional for release installs. HTTPS archive download and SHA-256 verification remain mandatory; when an authenticated `gh` is available, attestation verification still runs and any failure still aborts installation. The manual and AI-assisted installation guidance now matches that behavior.

## Visual evidence

N/A — this changes command-line installer behavior and documentation only.

## How to test

1. Run the installer without `gh`, or with `gh` installed but logged out.
2. Confirm the HTTPS download and checksum verification complete without requesting GitHub authentication.
3. Run with an authenticated `gh` and confirm provenance verification is attempted.

**Expected result:** Installation does not require a GitHub login, while checksum verification remains mandatory and authenticated provenance failures still stop installation.

## Related issue

Closes #731
Related to #768