### PR TITLE
ci: cap E2E fan-out with a soft scheduling target

### DIFF
--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -437,13 +437,18 @@ a workflow that does not have a mutation yet.
 
 The matrix is generated from `harness/sharding.py`, not a fixed runner count or
 file list. Tests are scheduled longest-first using committed setup+call+teardown
-CI measurements from `tests/e2e/durations.json`, with 25% headroom and a 30-second
-estimated worker budget. New tests automatically receive a conservative five-second
-weight. More tests or longer measured durations add runners. Baselines stay in
-one serial scheduling group. An indivisible group over budget or a plan requiring
-more than GitHub's 256 matrix jobs fails explicitly instead of silently extending
-the gate. There is no `max-parallel` throttle; the runner provider must have enough
-concurrent capacity. Runner queues affect reported timing, not test correctness.
+CI measurements from `tests/e2e/durations.json`, with 25% headroom and a 90-second
+soft target per worker (two workers per runner). New tests automatically receive a
+conservative five-second weight. More tests or longer measured durations add runners
+up to a maximum of eight shards, reducing duplicated runtime setup and bounding
+fan-out. At the cap, shards run longer rather than failing planning or dropping tests.
+Baselines stay in one serial scheduling group, even when that group exceeds the soft
+target. Estimated time alone never fails the gate; hang-protection timeouts still apply.
+Tune `TARGET_SECONDS` and `MAX_SHARDS` in `tests/e2e/harness/sharding.py` manually as
+runtime and cost needs change. The shard cap is not a spending cap: longer runs still
+consume more runner-minutes. There is no `max-parallel` throttle; the runner provider
+must have enough concurrent capacity for up to eight shards. Runner queues affect
+reported timing, not test correctness.
 
 Shards validate their entire collection against the plan before selecting tests.
 A missing, extra, skipped, failed, or stale result fails the aggregate gate.

--- a/scripts/test_e2e_sharding.py
+++ b/scripts/test_e2e_sharding.py
@@ -15,7 +15,7 @@ from e2e_bundle import create, image_key, verify
 from e2e_ci import report_timing, critical_path, main as ci_main, workflow_jobs
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tests/e2e"))
-from harness.sharding import TARGET_SECONDS, make_plan, validate_plan, verify_reports
+from harness.sharding import MAX_SHARDS, TARGET_SECONDS, make_plan, validate_plan, verify_reports
 
 
 def inventory(count):
@@ -53,7 +53,7 @@ class ShardingTests(unittest.TestCase):
                            len(make_plan(inventory(100), {})["shards"]))
 
     def test_tighter_worker_budget_adds_runners_without_dropping_tests(self):
-        tests = inventory(100)
+        tests = inventory(60)
         normal = make_plan(tests, {}, target=40)
         tighter = make_plan(tests, {}, target=30)
         self.assertGreater(len(tighter["shards"]), len(normal["shards"]))
@@ -61,7 +61,7 @@ class ShardingTests(unittest.TestCase):
         self.assertTrue(all(shard["estimated_seconds"] <= 30 for shard in tighter["shards"]))
 
     def test_new_tests_receive_a_nonzero_conservative_weight(self):
-        tests = inventory(25)
+        tests = inventory(50)
         self.assertGreater(len(make_plan(tests, {})["shards"]),
                            len(make_plan(tests, {test["nodeid"]: 0.1 for test in tests})["shards"]))
 
@@ -79,16 +79,42 @@ class ShardingTests(unittest.TestCase):
             with self.subTest(tests=tests, times=times), self.assertRaises(ValueError):
                 make_plan(tests, times)
 
-    def test_oversized_serial_group_is_not_hidden_by_more_runners(self):
-        tests = inventory(10)
+    def test_oversized_serial_group_remains_intact_above_soft_target(self):
+        tests = inventory(20)
         for test in tests:
             test["group"] = "serial"
-        with self.assertRaisesRegex(ValueError, "serial group"):
-            make_plan(tests, {})
+        plan = make_plan(tests, {})
+        validate_plan(plan, tests)
+        self.assertEqual(len(plan["shards"]), 1)
+        self.assertGreater(plan["shards"][0]["estimated_seconds"], TARGET_SECONDS)
 
-    def test_matrix_limit_is_an_error_not_silently_throttled_capacity(self):
-        with self.assertRaisesRegex(ValueError, "matrix limit"):
-            make_plan(inventory(257), {}, target=7, workers=1)
+    def test_defaults_reduce_fanout_and_preserve_coverage(self):
+        tests = inventory(100)
+        plan = make_plan(tests, {})
+        validate_plan(plan, tests)
+        self.assertEqual(TARGET_SECONDS, 90)
+        self.assertEqual(MAX_SHARDS, 8)
+        self.assertEqual(plan["workers"], 2)
+        self.assertEqual(len(plan["shards"]), 4)
+
+    def test_growth_above_cap_extends_runtime_without_dropping_tests(self):
+        for count in (224, 225, 1000):
+            with self.subTest(count=count):
+                tests = inventory(count)
+                plan = make_plan(tests, {})
+                validate_plan(plan, tests)
+                self.assertEqual(len(plan["shards"]), MAX_SHARDS)
+                self.assertEqual(plan["target_seconds"], TARGET_SECONDS)
+                if count > 224:
+                    self.assertGreater(max(shard["estimated_seconds"]
+                                           for shard in plan["shards"]), TARGET_SECONDS)
+                self.assertEqual(len(verify_reports(plan, passing_reports(plan))), count)
+
+    def test_single_worker_over_budget_still_covers_every_test(self):
+        tests = inventory(257)
+        plan = make_plan(tests, {}, target=7, workers=1)
+        validate_plan(plan, tests)
+        self.assertEqual(len(plan["shards"]), MAX_SHARDS)
 
     def test_stale_or_incomplete_plan_is_rejected(self):
         tests = inventory(25)

--- a/tests/e2e/harness/sharding.py
+++ b/tests/e2e/harness/sharding.py
@@ -9,9 +9,9 @@ import math
 
 SCHEMA = 1
 UNKNOWN_SECONDS = 5.0
-TARGET_SECONDS = 30.0
+TARGET_SECONDS = 90.0
 WORKERS = 2
-MAX_SHARDS = 256
+MAX_SHARDS = 8
 
 
 def inventory_digest(tests: list[dict]) -> str:
@@ -38,12 +38,10 @@ def make_plan(tests: list[dict], durations: dict[str, float], *,
         group["nodeids"].append(nodeid)
         group["seconds"] += estimate
     ordered = sorted(groups.values(), key=lambda group: (-group["seconds"], group["nodeids"]))
-    if ordered[0]["seconds"] > target:
-        raise ValueError(f"one serial group exceeds {target:g}s; split the scenario/group: "
-                         f"{ordered[0]['nodeids']}")
-
-    minimum = max(1, math.ceil(sum(group["seconds"] for group in ordered) / (target * workers)))
-    for count in range(minimum, min(len(ordered), MAX_SHARDS) + 1):
+    maximum = min(len(ordered), MAX_SHARDS)
+    minimum = min(maximum, max(1, math.ceil(
+        sum(group["seconds"] for group in ordered) / (target * workers))))
+    for count in range(minimum, maximum + 1):
         lanes = [[0.0] * workers for _ in range(count)]
         shards = [[] for _ in range(count)]
         for group in ordered:
@@ -51,13 +49,12 @@ def make_plan(tests: list[dict], durations: dict[str, float], *,
                               key=lambda pair: (lanes[pair[0]][pair[1]], pair))
             lanes[shard][lane] += group["seconds"]
             shards[shard].extend(group["nodeids"])
-        if max(max(lane) for lane in lanes) <= target:
+        if max(max(lane) for lane in lanes) <= target or count == maximum:
             return {"schema": SCHEMA, "inventory": inventory_digest(tests),
                     "workers": workers, "target_seconds": target,
                     "shards": [{"index": index, "nodeids": nodeids,
                                 "estimated_seconds": round(max(lanes[index]), 2)}
                                for index, nodeids in enumerate(shards) if nodeids]}
-    raise ValueError(f"suite exceeds the {MAX_SHARDS}-runner matrix limit")
 
 
 def validate_plan(plan: dict, tests: list[dict] | None = None) -> None:


### PR DESCRIPTION
## Description
Use a 90-second soft target and at most eight E2E shards to reduce duplicated runner setup. At the cap, allow longer runs without dropping tests or failing on estimated time. Preserve serial groups, exact coverage, and existing hang-protection timeouts. Document manual tuning; cancellation settings are unchanged.

## Visual evidence
N/A — CI scheduling only.

## How to test
1. Generate a plan with `STRATA_CONTAINER_ENGINE=podman ./scripts/e2e.sh --collect-only --e2e-write-plan=target/e2e-plan.json`.
2. Inspect the shard count, estimates, and assigned node IDs in `target/e2e-plan.json`.

**Expected result:** All 749 currently collected tests are assigned exactly once across eight shards. Estimates above 90 seconds are accepted; the current estimates are approximately 178 seconds per shard.

## Related issue
Closes #780