### PR TITLE
fix(archives): show friendly text for 7z password errors on retry

### DIFF
--- a/src/adapters/local_operations/archive/decoders.rs
+++ b/src/adapters/local_operations/archive/decoders.rs
@@ -46,6 +46,10 @@ fn sevenz_decode_error(error: sevenz_rust2::Error) -> ArchiveError {
         | Error::BadTerminatedPackInfo(_)
         | Error::BadTerminatedSubStreamsInfo
         | Error::BadTerminatedHeader(_) => archive_failed(INVALID_ARCHIVE),
+        Error::PasswordRequired => {
+            archive_failed("A password is required to extract this archive.")
+        }
+        Error::MaybeBadPassword(_) => archive_failed("The password may be incorrect."),
         Error::Other(message) if message.as_ref() == INVALID_ARCHIVE => archive_failed(message),
         Error::Io(error, _) => archive_failed(archive_read_error(error)),
         error => archive_failed(error),

--- a/src/adapters/local_operations/archive/decoders/tests.rs
+++ b/src/adapters/local_operations/archive/decoders/tests.rs
@@ -1056,9 +1056,18 @@ fn error_translation_preserves_passwords_unsupported_formats_and_io_failures() {
         let expected = error.to_string();
         assert_eq!(super::zip_error(error).to_string(), expected);
     }
+    assert_eq!(
+        super::sevenz_decode_error(SevenZError::PasswordRequired).to_string(),
+        "A password is required to extract this archive."
+    );
+    assert_eq!(
+        super::sevenz_decode_error(SevenZError::MaybeBadPassword(
+            io::ErrorKind::InvalidData.into()
+        ))
+        .to_string(),
+        "The password may be incorrect."
+    );
     for error in [
-        SevenZError::PasswordRequired,
-        SevenZError::MaybeBadPassword(io::ErrorKind::InvalidData.into()),
         SevenZError::UnsupportedVersion { major: 9, minor: 0 },
         SevenZError::UnsupportedCompressionMethod("unknown".into()),
         SevenZError::Unsupported("unsupported encryption".into()),

--- a/src/ui/browser/archive.rs
+++ b/src/ui/browser/archive.rs
@@ -580,12 +580,19 @@ impl ViewState {
         body.append(&password_label);
         body.append(&password_entry);
 
+        let extract_state = self.clone();
         let browser = self.browser.clone();
         let password_for_confirm = password_entry.clone();
         let dismiss_for_confirm = dismiss.clone();
         confirm.connect_clicked(move |_| {
             let pw = password_for_confirm.text().to_string();
             let password = if pw.is_empty() { None } else { Some(pw) };
+            let format = ArchiveFormat::from_extension(&entry.display_name);
+            if format.map(|f| f.supports_password()).unwrap_or(false) {
+                extract_state
+                    .pending_extract_retry
+                    .replace(Some((entry.clone(), destination.clone())));
+            }
             dismiss_for_confirm();
             browser.extract(entry.clone(), destination.clone(), password);
         });


### PR DESCRIPTION
## Description

`sevenz_rust2::Error` implements `Display` as `Debug`, so `PasswordRequired` and `MaybeBadPassword` reached the generic error modal as raw variant names. Map both to user-facing sentences in `sevenz_decode_error`. Re-arm `pending_extract_retry` in the extract password dialog confirm handler so a failed retry reopens the dialog instead of falling through to the generic error modal.

## Visual evidence
Before:
<img width="1496" height="808" alt="image" src="https://github.com/user-attachments/assets/93b1596f-ee8a-407b-af21-ad2eb6b6b9fa" />
After: The modal reopen if leave password input empty

## How to test

1. Create a password-protected `.7z` with header encryption:
   ```bash
   7z a -p"testpass123" -mhe=on protected.7z file.txt
   ```
2. Open the containing folder in Strata, right-click `protected.7z` → **Extract here**.
3. At the Extract password dialog, leave the password field empty and click **Extract**.

**Expected result:** The password dialog reopens instead of showing a raw `PasswordRequired` error modal. Entering a wrong password shows "The password may be incorrect." and reopens the dialog.

## Related issue

Closes #756