### PR TITLE
fix(browser): exclusive-select unselected Icons/List drag source

### DIFF
--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -1827,6 +1827,7 @@ fn build_icons_view(context: &Rc<IconsContext>, model: &impl IsA<gio::ListModel>
             &card,
             item,
             browser_for_setup.clone(),
+            selection_for_setup.clone(),
             transfers_for_setup.clone(),
             depth,
             Some((source_index_for_setup.clone(), filtered_for_setup.clone())),
@@ -2899,6 +2900,17 @@ fn install_mode_directory_drop_target(
     widget.add_controller(drop);
 }
 
+fn drag_source_entries(selected: &[FileEntry], item: &FileEntry) -> (Vec<FileEntry>, bool) {
+    if selected
+        .iter()
+        .any(|selected| selected.location == item.location)
+    {
+        (selected.to_vec(), false)
+    } else {
+        (vec![item.clone()], true)
+    }
+}
+
 #[expect(
     clippy::too_many_arguments,
     reason = "drag setup wires every GTK signal it needs"
@@ -2907,6 +2919,7 @@ fn install_list_drag_drop(
     row: &impl IsA<gtk::Widget>,
     item: &gtk::ListItem,
     browser: Weak<Browser>,
+    selection: gtk::MultiSelection,
     transfer_handler: TransferHandlerSlot,
     depth: usize,
     position_map: Option<(SourceIndexMap, gio::ListModel)>,
@@ -2950,25 +2963,21 @@ fn install_list_drag_drop(
         ));
         let browser = browser_for_drag.upgrade()?;
         let dragged_item = dragged_item.upgrade()?;
-        let position = dragged_item.position();
-        if position == gtk::INVALID_LIST_POSITION {
+        let view_position = dragged_item.position();
+        if view_position == gtk::INVALID_LIST_POSITION {
             return None;
         }
         let position = map_for_drag
             .as_ref()
-            .map_or(Some(position as usize), |(source, filtered)| {
-                source_position_for_view(source, Some(filtered), position)
+            .map_or(Some(view_position as usize), |(source, filtered)| {
+                source_position_for_view(source, Some(filtered), view_position)
             })?;
         let entry = browser.entry_at(depth, position)?;
         let selected = browser.selected_entries();
-        let entries = if selected
-            .iter()
-            .any(|selected| selected.location == entry.location)
-        {
-            selected
-        } else {
-            vec![entry]
-        };
+        let (entries, exclusive_select) = drag_source_entries(&selected, &entry);
+        if exclusive_select {
+            selection.select_item(view_position, true);
+        }
         let compact_icon = drag_icon.as_ref().and_then(glib::WeakRef::upgrade);
         let multi_drag_icon = multi_drag_icon.as_ref().and_then(glib::WeakRef::upgrade);
         if let Some((texture, hot_x, hot_y)) = multi_drag_icon

--- a/src/ui/browser_modes/list_factory.rs
+++ b/src/ui/browser_modes/list_factory.rs
@@ -88,6 +88,7 @@ impl ListFactory {
             &row.widget,
             item,
             self.browser.clone(),
+            self.selection.clone(),
             self.transfers.clone(),
             self.depth,
             Some((self.positions.index.clone(), self.positions.view.clone())),

--- a/src/ui/browser_modes/tests.rs
+++ b/src/ui/browser_modes/tests.rs
@@ -3,9 +3,9 @@
 use super::{
     BrowserDensity, BrowserMode, ClickActivation, ClickCount, LIST_COLUMN_MIN_WIDTHS,
     LIST_COLUMN_WIDTHS, MAX_ICONS_THUMBNAIL_SIZE, MIN_ICONS_THUMBNAIL_SIZE, SourceIndexMap,
-    compare_type_groups, icons_card_extent, icons_card_icon_slot, list_column_width,
-    metadata_fill_position, should_activate_filtered_pointer, should_activate_pointer_click,
-    type_group_sorter, type_groups_of, value_type_group,
+    compare_type_groups, drag_source_entries, icons_card_extent, icons_card_icon_slot,
+    list_column_width, metadata_fill_position, should_activate_filtered_pointer,
+    should_activate_pointer_click, type_group_sorter, type_groups_of, value_type_group,
 };
 use crate::model::{EntryKind, FileEntry, Location, MetadataValue};
 use crate::test_support::gtk_test;
@@ -36,6 +36,47 @@ impl super::ModeViews {
 /// Model values as the panes store them: kind, hidden flag, then the display name.
 fn value(kind: char, name: &str) -> String {
     format!("{kind}v\t{name}")
+}
+
+fn drag_entry(name: &str) -> FileEntry {
+    FileEntry {
+        location: Location::local(format!("/fixture/{name}")),
+        thumbnail_path: None,
+        native_name: name.into(),
+        display_name: name.into(),
+        kind: EntryKind::File,
+        size: MetadataValue::Unknown,
+        modified_unix_seconds: MetadataValue::Unknown,
+        mode: MetadataValue::Unknown,
+        is_hidden: false,
+    }
+}
+
+#[test]
+fn drag_source_entries_exclusive_selects_an_unselected_item() {
+    let selected = [drag_entry("a.txt")];
+    let item = drag_entry("b.txt");
+    let (entries, exclusive_select) = drag_source_entries(&selected, &item);
+    assert_eq!(entries, vec![item]);
+    assert!(exclusive_select);
+}
+
+#[test]
+fn drag_source_entries_keeps_a_multi_selection() {
+    let selected = vec![drag_entry("a.txt"), drag_entry("b.txt")];
+    let item = drag_entry("b.txt");
+    let (entries, exclusive_select) = drag_source_entries(&selected, &item);
+    assert_eq!(entries, selected);
+    assert!(!exclusive_select);
+}
+
+#[test]
+fn drag_source_entries_leaves_the_only_selected_item() {
+    let item = drag_entry("a.txt");
+    let selected = [item.clone()];
+    let (entries, exclusive_select) = drag_source_entries(&selected, &item);
+    assert_eq!(entries, vec![item]);
+    assert!(!exclusive_select);
 }
 
 #[test]

--- a/tests/e2e/scenarios/test_drag_and_drop.py
+++ b/tests/e2e/scenarios/test_drag_and_drop.py
@@ -91,6 +91,26 @@ def test_dragging_onto_the_pane_background_is_a_no_op(strata):
     )
 
 
+@pytest.mark.parametrize("mode", ALL_MODES)
+def test_dragging_an_unselected_file_selects_it(strata, mode):
+    """#770: dragging B while A is selected makes B the selection."""
+
+    fixture = strata.fixture
+    before = fixture.listing()
+    strata.select_entry("readme.md")
+    source = strata.entry("todo.txt")
+    pane = strata.pane()
+    bounds = pane.screen_bounds()
+    empty_point = (bounds.x + bounds.width // 2, bounds.y + bounds.height - 20)
+
+    strata.pointer.drag_to_point(source, empty_point)
+
+    strata.wait_for_selection(["todo.txt"])
+    assert fixture.listing() == before, (
+        "cancelling the drag on empty pane space must not move anything"
+    )
+
+
 def test_dragging_a_folder_into_another_folder_moves_its_contents(strata):
     fixture = strata.fixture
     source = strata.select_entry("pictures")


### PR DESCRIPTION
## Description

When a drag starts on an unselected Icons or List item, that item becomes both the drag payload and the highlighted selection. Previously the payload was already B, but Icons/List left A selected because Capture-phase `DragSource` claimed the gesture before GTK's native list click completed.

The fix exclusive-selects B in `install_list_drag_drop` `connect_prepare` when the drag source is not already selected (`selection.select_item` at the view position). Already-selected and multi-selection drags keep the current set. Columns pointer policy is unchanged.

## Visual evidence

N/A — selection chrome was verified via AT-SPI in headless E2E (Icons, List, and Columns). Pixel screenshots of during-drag `.dragging` CSS were not captured.

## How to test

1. Open a folder with at least two files in Icons (Ctrl+2) or List (Ctrl+3).
2. Single-click file A so it is the only highlighted file.
3. Press and drag a different file B into empty pane space (confirm the ghost is B).
4. Release with no drop target.

**Expected result:** B is the only highlighted file during and after the drag. A is not selected. Nothing is moved.

Also check: dragging a selected member of a multi-selection still moves/keeps the group; List unused row padding still starts a drag (#631); dropping unselected B onto a folder moves only B.

## Related issue

Closes #770