### PR TITLE
fix(selection): claim gesture on modified press regardless of hit location

### DIFF
--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -3174,12 +3174,11 @@ fn install_modified_selection_click(
         }
         if let Some(widget) = gesture.widget()
             && super::pointer::hits_item_content(&widget, x, y)
+            && let Some(item_widget) = widget.parent()
         {
-            if let Some(item_widget) = widget.parent() {
-                item_widget.grab_focus();
-            }
-            gesture.set_state(gtk::EventSequenceState::Claimed);
+            item_widget.grab_focus();
         }
+        gesture.set_state(gtk::EventSequenceState::Claimed);
     });
     click.connect_released(|gesture, _, _, _| {
         if gesture


### PR DESCRIPTION
## Description

Shift+Left-click on List view leftover (inert row space) with Shift released before mouse-up collapsed the range selection to the clicked row. The press-time `select_range` ran but the gesture was only claimed when `hits_item_content` was true, so the unmodified release handler overwrote it. Claim the gesture whenever a modifier selection runs; gate only the focus grab on `hits_item_content`.

## Visual evidence

Before:

https://github.com/user-attachments/assets/4981238a-26e3-43ba-8dcb-16b8043848ed

After:

https://github.com/user-attachments/assets/c0cc5af1-0648-480f-86c5-85f1aac4f3cf

## How to test

1. Open a folder with several files in List view.
2. Single-click `a.txt` to anchor the selection.
3. Shift+click on the leftover (empty) space of `f.txt`'s row, and release Shift before releasing the mouse button.

**Expected result:** The range `a.txt`–`f.txt` stays selected instead of collapsing to just `f.txt`. Repeat several times — consistent.

## Related issue

Closes #771