### PR TITLE
fix(browser): move selection to unselected file on press before drag

### DIFF
--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -60,6 +60,7 @@ pub(crate) use crate::ui::browser::collection::{
     search_result_navigation_position,
 };
 pub(super) use crate::ui::browser::columns::max_child_natural_width;
+pub(crate) use crate::ui::browser::columns::should_preserve_drag_selection;
 pub(super) use crate::ui::browser::context_menu::{
     install_folder_context_menu, install_item_context_menu, install_resolved_item_context_menu,
 };

--- a/src/ui/browser/columns.rs
+++ b/src/ui/browser/columns.rs
@@ -220,7 +220,7 @@ pub(super) fn is_column_background(surface: &gtk::Widget, picked: &gtk::Widget) 
     false
 }
 
-fn should_preserve_drag_selection(clicked_selected: bool, selected_count: u64) -> bool {
+pub(crate) fn should_preserve_drag_selection(clicked_selected: bool, selected_count: u64) -> bool {
     clicked_selected && selected_count > 1
 }
 

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -3153,6 +3153,12 @@ fn install_modified_selection_click(
         let modifiers = gesture.current_event_state();
         let control = modifiers.contains(gtk::gdk::ModifierType::CONTROL_MASK);
         let shift = modifiers.contains(gtk::gdk::ModifierType::SHIFT_MASK);
+        let preserve_group = !control
+            && !shift
+            && super::browser::should_preserve_drag_selection(
+                selection.is_selected(position),
+                selection.selection().size(),
+            );
         if shift {
             let anchor = browser
                 .selection_anchor_position(depth)
@@ -3170,6 +3176,9 @@ fn install_modified_selection_click(
             }
         } else {
             anchor_at(&browser, depth, &positions, position);
+            if !preserve_group {
+                selection.select_item(position, true);
+            }
             return;
         }
         if let Some(widget) = gesture.widget()

--- a/src/ui/browser_modes/list_factory/tests.rs
+++ b/src/ui/browser_modes/list_factory/tests.rs
@@ -156,11 +156,14 @@ impl Fixture {
             .find(|item| item.item().is_some() && item.position() == position)
     }
 
+    fn row_at(&self, position: u32) -> Option<(gtk::ListItem, ListRow)> {
+        let item = self.item_at(position)?;
+        let row = ListRow::from_widget(item.child().and_downcast::<gtk::Box>()?)?;
+        Some((item, row))
+    }
+
     fn first(&self) -> (gtk::ListItem, ListRow) {
-        let item = self.item_at(0).expect("bound first item");
-        let row = ListRow::from_widget(item.child().and_downcast::<gtk::Box>().expect("row"))
-            .expect("row parts");
-        (item, row)
+        self.row_at(0).expect("bound first item")
     }
 
     fn bind(&self, item: &gtk::ListItem) {
@@ -367,6 +370,72 @@ fn appearance_animation_is_suppressed_while_scrolling() {
                 assert_eq!(row.has_css_class("file-appear"), !scrolling);
                 pump_until(|| !row.has_css_class("file-appear"));
             }
+        },
+    );
+}
+
+fn selection_gesture(widget: &impl IsA<gtk::Widget>) -> gtk::GestureClick {
+    let controllers = widget.observe_controllers();
+    (0..controllers.n_items())
+        .find_map(|index| {
+            controllers
+                .item(index)
+                .and_downcast::<gtk::GestureClick>()
+                .filter(|gesture| gesture.propagation_phase() == gtk::PropagationPhase::Capture)
+        })
+        .expect("selection gesture")
+}
+
+#[test]
+fn pressing_unselected_item_moves_selection_on_press_and_preserves_multi_selection() {
+    gtk_test(
+        "ui::browser_modes::list_factory::tests::pressing_unselected_item_moves_selection_on_press_and_preserves_multi_selection",
+        || {
+            let fixture = Fixture::new();
+            pump_until(|| {
+                fixture.item_at(0).is_some()
+                    && fixture.item_at(1).is_some()
+                    && fixture.item_at(2).is_some()
+            });
+            let selection: gtk::MultiSelection = fixture
+                .view
+                .model()
+                .expect("selection")
+                .downcast()
+                .expect("multi selection");
+
+            let (_, row1) = fixture.row_at(1).expect("row 1");
+            let (_, row2) = fixture.row_at(2).expect("row 2");
+
+            let gesture1 = selection_gesture(&row1.widget);
+            let gesture2 = selection_gesture(&row2.widget);
+
+            // Initially select item 0.
+            selection.select_item(0, true);
+            assert!(selection.is_selected(0));
+            assert!(!selection.is_selected(1));
+
+            // Pressing on unselected item 1 moves selection to 1 immediately on press.
+            gesture1.emit_by_name::<()>("pressed", &[&1i32, &10.0f64, &10.0f64]);
+            assert!(!selection.is_selected(0));
+            assert!(selection.is_selected(1));
+
+            // Multi-select items 0 and 1.
+            selection.select_item(0, false);
+            assert!(selection.is_selected(0));
+            assert!(selection.is_selected(1));
+            assert!(!selection.is_selected(2));
+
+            // Pressing on already-selected item 1 preserves the multi-selection group for drag.
+            gesture1.emit_by_name::<()>("pressed", &[&1i32, &10.0f64, &10.0f64]);
+            assert!(selection.is_selected(0));
+            assert!(selection.is_selected(1));
+
+            // Pressing on unselected item 2 clears the group and selects item 2.
+            gesture2.emit_by_name::<()>("pressed", &[&1i32, &10.0f64, &10.0f64]);
+            assert!(!selection.is_selected(0));
+            assert!(!selection.is_selected(1));
+            assert!(selection.is_selected(2));
         },
     );
 }


### PR DESCRIPTION
## Description

In Icons and List views, starting a drag on an unselected item left the previously selected item visually highlighted because the selection click handler did not update the selection on mouse down for unmodified clicks. GTK drag gestures cancel the click sequence before release, so the selection was never moved to the dragged item.

This change shares `should_preserve_drag_selection` from Columns view and updates `install_modified_selection_click` to select unselected items on press when not preserving a multi-selection group, aligning Icons and List views with Columns view behavior.

## Visual evidence

Before:
<img width="960" height="518" alt="screenrecording-2026-09-11_02-11-33" src="https://github.com/user-attachments/assets/e2e8eef1-8726-4560-84bf-844f249e5a07" />

AFter:
<img width="960" height="540" alt="screenrecording-2026-09-11_02-41-13" src="https://github.com/user-attachments/assets/85de2557-89a6-4449-8270-96923c797c9f" />

## How to test

1. Open a directory in Icons or List view.
2. Single-click file A to select it.
3. Press and drag unselected file B into empty space.

**Expected result:**
File B becomes selected on press and remains the highlighted drag source; file A is unselected.

## Related issue

Closes #770