### PR TITLE
fix(selection): claim Columns leftover Shift+click

### DIFF
--- a/src/ui/browser/columns/rows.rs
+++ b/src/ui/browser/columns/rows.rs
@@ -393,11 +393,11 @@ pub(super) fn column_rows(
                     selection_for_click.select_item(position, true);
                 }
             }
-            if (control || shift)
-                && let Some(widget) = gesture.widget()
-                && crate::ui::pointer::hits_item_content(&widget, x, y)
-            {
-                if let Some(item_widget) = widget.parent() {
+            if control || shift {
+                if let Some(widget) = gesture.widget()
+                    && crate::ui::pointer::hits_item_content(&widget, x, y)
+                    && let Some(item_widget) = widget.parent()
+                {
                     item_widget.grab_focus();
                 }
                 gesture.set_state(gtk::EventSequenceState::Claimed);

--- a/tests/e2e/harness/interaction.py
+++ b/tests/e2e/harness/interaction.py
@@ -176,12 +176,7 @@ class Pointer:
         at: tuple[int, int] | None = None,
         modifiers: Sequence[str],
     ) -> None:
-        """Click after releasing modifiers between button-down and button-up.
-
-        `click(..., modifiers=)` keeps Shift/Ctrl held through mouse-up. GTK's
-        native list selection treats that unmodified release as a plain click
-        unless the press already claimed the sequence.
-        """
+        """GTK treats an unmodified release as a plain click unless press claimed it."""
 
         x, y = self._target(node, at)
         self.move_to(x, y)

--- a/tests/e2e/harness/interaction.py
+++ b/tests/e2e/harness/interaction.py
@@ -168,6 +168,42 @@ class Pointer:
                 time.sleep(EVENT_GAP)
         time.sleep(POINTER_GAP)
 
+    def click_releasing_modifiers_before_up(
+        self,
+        node: Node,
+        *,
+        button: int = 1,
+        at: tuple[int, int] | None = None,
+        modifiers: Sequence[str],
+    ) -> None:
+        """Click after releasing modifiers between button-down and button-up.
+
+        `click(..., modifiers=)` keeps Shift/Ctrl held through mouse-up. GTK's
+        native list selection treats that unmodified release as a plain click
+        unless the press already claimed the sequence.
+        """
+
+        x, y = self._target(node, at)
+        self.move_to(x, y)
+        held = [MODIFIER_KEYSYMS[modifier.lower()] for modifier in modifiers]
+        for modifier in held:
+            self.connection.key(modifier, True)
+            time.sleep(EVENT_GAP)
+        try:
+            self.connection.button(button, True)
+            time.sleep(EVENT_GAP)
+            for modifier in reversed(held):
+                self.connection.key(modifier, False)
+                time.sleep(EVENT_GAP)
+            self.connection.button(button, False)
+            self._last_release = time.monotonic()
+            time.sleep(EVENT_GAP)
+        finally:
+            for modifier in reversed(held):
+                self.connection.key(modifier, False)
+                time.sleep(EVENT_GAP)
+        time.sleep(POINTER_GAP)
+
     def double_click(self, node: Node, *, at: tuple[int, int] | None = None) -> None:
         x, y = self._target(node, at)
         self.move_to(x, y)

--- a/tests/e2e/scenarios/test_selection.py
+++ b/tests/e2e/scenarios/test_selection.py
@@ -7,6 +7,16 @@ import pytest
 
 from harness.modes import ALL_MODES
 
+ROW_MODES = [mode for mode in ALL_MODES if mode.id != "icons"]
+
+
+def _name_label_point(entry, *, leftover: bool) -> tuple[int, int]:
+    label = entry.find(role="label", name=entry.name)
+    assert label is not None
+    bounds = label.screen_bounds()
+    x = bounds.x + bounds.width - 2 if leftover else bounds.x + 4
+    return (x, bounds.center[1])
+
 
 @pytest.fixture
 def root(strata) -> str:
@@ -59,7 +69,8 @@ def test_shift_click_revisits_a_file_after_opening_a_folder(strata, root, target
     strata.wait_for_directory("documents")
     strata.wait_for_selection([], "documents")
     click("todo.txt", ("shift",))
-    strata.wait_for_focused_entry("todo.txt")
+    if target == "name":
+        strata.wait_for_focused_entry("todo.txt")
     names = [entry.name for entry in strata.entries(root)]
     strata.wait_for_selection(names[names.index("documents"):names.index("todo.txt") + 1], root)
 
@@ -185,6 +196,53 @@ def test_shift_click_ranges_from_the_entry_a_fresh_listing_selected(strata, mode
         == ["notes.txt", "report.md", "spreadsheet.csv"],
         "a shift-click to range from the entry the listing selected on load",
     )
+
+
+@pytest.mark.parametrize("mode", ROW_MODES)
+@pytest.mark.parametrize("target", ["content", "row-space"])
+def test_shift_click_keeps_range_when_shift_releases_before_mouseup(
+    strata, mode, root, target
+):
+    strata.open_directory("documents", directory=root)
+    strata.select_entry("notes.txt", directory="documents")
+
+    entry = strata.entry("spreadsheet.csv", "documents")
+    point = _name_label_point(entry, leftover=(target == "row-space"))
+    strata.pointer.click_releasing_modifiers_before_up(
+        entry, at=point, modifiers=("shift",)
+    )
+
+    strata.wait_for_selection(
+        ["notes.txt", "report.md", "spreadsheet.csv"], "documents"
+    )
+
+
+@pytest.mark.preferences(browser_mode="columns")
+def test_control_click_leftover_toggles_when_ctrl_releases_before_mouseup(strata, root):
+    strata.open_directory("documents", directory=root)
+    strata.select_entry("notes.txt", directory="documents")
+
+    entry = strata.entry("spreadsheet.csv", "documents")
+    strata.pointer.click_releasing_modifiers_before_up(
+        entry,
+        at=_name_label_point(entry, leftover=True),
+        modifiers=("ctrl",),
+    )
+
+    strata.wait_for_selection(["notes.txt", "spreadsheet.csv"], "documents")
+
+
+@pytest.mark.parametrize("mode", ROW_MODES)
+def test_unmodified_leftover_click_replaces_the_selection(strata, mode, root):
+    strata.open_directory("documents", directory=root)
+    strata.select_entry("notes.txt", directory="documents")
+
+    entry = strata.entry("spreadsheet.csv", "documents")
+    strata.pointer.click(
+        entry, at=_name_label_point(entry, leftover=True)
+    )
+
+    strata.wait_for_selection(["spreadsheet.csv"], "documents")
 
 
 @pytest.mark.parametrize("mode", ALL_MODES)


### PR DESCRIPTION
## Description

Columns leftover Shift+click collapsed the range if Shift was released before mouse-up. Press-time `select_range` already ran, but `src/ui/browser/columns/rows.rs` only claimed the gesture when `hits_item_content` was true, so GTK’s unmodified release replaced the range with the clicked row.

This mirrors #786 in the Columns press handler only: claim whenever a Control/Shift selection runs, and gate only `grab_focus` on `hits_item_content`. Unmodified leftover clicks still replace the selection. List/Icons, `hits_item_content`, and the held-through release claim are unchanged.

E2E now has a click helper that releases Shift/Ctrl between button-down and button-up, plus leftover/glyph early Shift-up, leftover Ctrl-up, and unmodified leftover replacement cases.

## Visual evidence

N/A — selection state after a leftover modifier click; no layout, theme, or icon change. Covered by the new E2E cases in `tests/e2e/scenarios/test_selection.py`.

## How to test

1. Open a folder with short names (`a.txt`…`l.txt`). Ctrl+1 for Columns; close preview.
2. Click `a.txt` on the filename text.
3. Hold Shift and press in the leftover of the `f.txt` name cell (right of the glyphs, still on the row).
4. Release Shift while the mouse button is still down, then release the button.

**Expected result:** The press-time range `a.txt`–`f.txt` stays selected. The same leftover click with Shift held through mouse-up, leftover Shift-click on List, and leftover Shift-click on filename glyphs also keep that range. A leftover Ctrl-click with Ctrl released before mouse-up adds the row. A plain leftover click still selects only the clicked row. Dragging from leftover still starts a drag.

## Related issue

Closes #795

## Review validation exception

The repository owner explicitly authorized pushing despite the two local Rust search-budget failures, both reproduced on unchanged main: `bounded_index_reaches_a_deep_file_while_broad_folders_compete` and `fair_directory_scheduling_makes_deep_progress_in_every_root`. These failures are not reported as passes; required CI checks remain applicable. Guided manual verification is pending.
