### PR TITLE
fix(archives): treat ZipCrypto wrong-password CRC as retryable

### DIFF
--- a/src/adapters/local_operations/archive/decoders.rs
+++ b/src/adapters/local_operations/archive/decoders.rs
@@ -26,7 +26,7 @@ use super::{
 mod tests;
 
 const INVALID_ARCHIVE: &str = "This file is not a valid archive or is damaged.";
-// Plain-header 7z cannot distinguish wrong passwords from content decode failures.
+// Plain-header 7z and ZipCrypto cannot distinguish a wrong password from a content checksum failure.
 const MAYBE_BAD_PASSWORD: &str = "The password may be incorrect.";
 
 pub(super) fn zip_error(error: zip::result::ZipError) -> ArchiveError {
@@ -70,7 +70,7 @@ fn archive_read_error(error: std::io::Error, password_supplied: bool) -> std::io
     if password_supplied
         && (matches!(
             error.kind(),
-            ErrorKind::InvalidData | ErrorKind::UnexpectedEof
+            ErrorKind::InvalidData | ErrorKind::UnexpectedEof | ErrorKind::InvalidInput
         ) || checksum_failed)
     {
         return std::io::Error::new(ErrorKind::InvalidData, MAYBE_BAD_PASSWORD);
@@ -146,6 +146,7 @@ pub(super) fn extract_zip_from_archive(
     if let Some(claimed) = archive.decompressed_size() {
         session.preflight_claimed_size(claimed)?;
     }
+    let password_supplied = password.is_some();
     let pw_bytes = password.map(str::as_bytes);
     let mut next_index = 0;
     let result = (|| {
@@ -161,7 +162,10 @@ pub(super) fn extract_zip_from_archive(
                 .ok_or_else(|| format!("Refusing unsafe ZIP path: {name}"))?;
             let declared_size = entry.size();
             let directory = entry.is_dir();
-            let mut reader = ArchiveReader::new(&mut entry);
+            let mut reader = ArchiveReader {
+                inner: &mut entry,
+                password_supplied,
+            };
             let content = if directory {
                 MemberContent::Directory
             } else {

--- a/src/adapters/local_operations/archive/decoders/tests.rs
+++ b/src/adapters/local_operations/archive/decoders/tests.rs
@@ -1272,7 +1272,7 @@ fn unencrypted_zip_checksum_failure_stays_damaged() -> Result<(), Box<dyn Error>
     super::super::fixtures::write_zip_stored(&archive, &[("file.txt", b"checksum-payload")])?;
     let mut bytes = fs::read(&archive)?;
     let offset = bytes
-        .windows(16)
+        .windows(b"checksum-payload".len())
         .position(|bytes| bytes == b"checksum-payload")
         .expect("stored payload");
     bytes[offset] ^= 1;

--- a/src/adapters/local_operations/archive/decoders/tests.rs
+++ b/src/adapters/local_operations/archive/decoders/tests.rs
@@ -11,7 +11,7 @@ use crate::{model::Location, services::ArchiveFormat};
 use std::{
     error::Error,
     fs,
-    io::{self, Cursor, Read, Seek, SeekFrom},
+    io::{self, Cursor, Read, Seek, SeekFrom, Write},
     path::Path,
     sync::{
         Arc,
@@ -1093,6 +1093,206 @@ fn error_translation_preserves_passwords_unsupported_formats_and_io_failures() {
     }
 }
 
+fn write_zipcrypto(
+    path: &Path,
+    password: &[u8],
+    name: &str,
+    contents: &[u8],
+    compression: zip::CompressionMethod,
+) -> Result<(), Box<dyn Error>> {
+    use zip::unstable::write::FileOptionsExt;
+    let mut writer = zip::ZipWriter::new(fs::File::create(path)?);
+    let options = zip::write::SimpleFileOptions::default()
+        .compression_method(compression)
+        .with_deprecated_encryption(password)?;
+    writer.start_file(name, options)?;
+    writer.write_all(contents)?;
+    writer.finish()?;
+    Ok(())
+}
+
+fn zipcrypto_crc_collision(archive_path: &Path) -> Result<String, Box<dyn Error>> {
+    for candidate in 0..4096u32 {
+        let password = candidate.to_string();
+        let file = fs::File::open(archive_path)?;
+        let mut archive = zip::ZipArchive::new(file)?;
+        let options = zip::read::ZipReadOptions::new().password(Some(password.as_bytes()));
+        let mut entry = match archive.by_index_with_options(0, options) {
+            Err(zip::result::ZipError::InvalidPassword) => continue,
+            Err(error) => return Err(error.into()),
+            Ok(entry) => entry,
+        };
+        let mut buf = Vec::new();
+        if entry.read_to_end(&mut buf).is_err() {
+            return Ok(password);
+        }
+    }
+    Err("no ZipCrypto CRC collision in 0..4096".into())
+}
+
+fn zipcrypto_fixture(root: &Path) -> Result<std::path::PathBuf, Box<dyn Error>> {
+    let archive = root.join("password.zip");
+    write_zipcrypto(
+        &archive,
+        b"zipsecret",
+        "some.txt",
+        b"hello from zipcrypto",
+        zip::CompressionMethod::Stored,
+    )?;
+    Ok(archive)
+}
+
+fn zipcrypto_collision_is_retryable(
+    compression: zip::CompressionMethod,
+    contents: &[u8],
+) -> Result<(), Box<dyn Error>> {
+    let root = tempfile::tempdir()?;
+    let archive = root.path().join("password.zip");
+    write_zipcrypto(&archive, b"zipsecret", "some.txt", contents, compression)?;
+    let collision = zipcrypto_crc_collision(&archive)?;
+
+    let destination = tempfile::tempdir()?;
+    let Err(error) = decode_fixture(
+        &archive,
+        destination.path(),
+        ArchiveFormat::Zip,
+        Some(&collision),
+        &Arc::new(AtomicUsize::new(0)),
+    ) else {
+        panic!("ZipCrypto {compression:?} collision {collision} extracted");
+    };
+    assert_eq!(error.to_string(), super::MAYBE_BAD_PASSWORD);
+    assert!(destination.path().read_dir()?.next().is_none());
+
+    let correct = tempfile::tempdir()?;
+    completed_extract(decode_fixture(
+        &archive,
+        correct.path(),
+        ArchiveFormat::Zip,
+        Some("zipsecret"),
+        &Arc::new(AtomicUsize::new(0)),
+    )?)?;
+    assert_eq!(fs::read(correct.path().join("some.txt"))?, contents);
+    Ok(())
+}
+
+#[test]
+fn zipcrypto_header_collision_is_retryable() -> Result<(), Box<dyn Error>> {
+    zipcrypto_collision_is_retryable(zip::CompressionMethod::Stored, b"hello from zipcrypto")
+}
+
+#[test]
+fn zipcrypto_deflated_header_collision_is_retryable() -> Result<(), Box<dyn Error>> {
+    zipcrypto_collision_is_retryable(
+        zip::CompressionMethod::Deflated,
+        &b"hello from zipcrypto\n".repeat(64),
+    )
+}
+
+#[test]
+fn zipcrypto_wrong_password_stays_invalid_password() -> Result<(), Box<dyn Error>> {
+    let root = tempfile::tempdir()?;
+    let archive = zipcrypto_fixture(root.path())?;
+    let destination = tempfile::tempdir()?;
+    let Err(error) = decode_fixture(
+        &archive,
+        destination.path(),
+        ArchiveFormat::Zip,
+        Some("wrong"),
+        &Arc::new(AtomicUsize::new(0)),
+    ) else {
+        panic!("ZipCrypto accepted a non-colliding wrong password");
+    };
+    assert_eq!(error.to_string(), "provided password is incorrect");
+    assert!(destination.path().read_dir()?.next().is_none());
+    Ok(())
+}
+
+#[test]
+fn zipcrypto_without_password_still_requires_one() -> Result<(), Box<dyn Error>> {
+    let root = tempfile::tempdir()?;
+    let archive = zipcrypto_fixture(root.path())?;
+    let destination = tempfile::tempdir()?;
+    let Err(error) = decode_fixture(
+        &archive,
+        destination.path(),
+        ArchiveFormat::Zip,
+        None,
+        &Arc::new(AtomicUsize::new(0)),
+    ) else {
+        panic!("ZipCrypto extracted without a password");
+    };
+    assert!(error.to_string().contains("Password required"), "{error}");
+    assert!(destination.path().read_dir()?.next().is_none());
+    Ok(())
+}
+
+#[test]
+fn aes_zip_wrong_password_stays_invalid_password() -> Result<(), Box<dyn Error>> {
+    let root = tempfile::tempdir()?;
+    let source = root.path().join("file.txt");
+    fs::write(&source, b"contents")?;
+    let archive = root.path().join("archive.zip");
+    write_compression_fixture(
+        &archive,
+        &[source],
+        ArchiveFormat::Zip,
+        Some("test-password"),
+    )?;
+
+    let destination = tempfile::tempdir()?;
+    let Err(error) = decode_fixture(
+        &archive,
+        destination.path(),
+        ArchiveFormat::Zip,
+        Some("wrong"),
+        &Arc::new(AtomicUsize::new(0)),
+    ) else {
+        panic!("AES zip accepted a wrong password");
+    };
+    assert_eq!(error.to_string(), "provided password is incorrect");
+    assert!(destination.path().read_dir()?.next().is_none());
+
+    let correct = tempfile::tempdir()?;
+    completed_extract(decode_fixture(
+        &archive,
+        correct.path(),
+        ArchiveFormat::Zip,
+        Some("test-password"),
+        &Arc::new(AtomicUsize::new(0)),
+    )?)?;
+    assert_eq!(fs::read(correct.path().join("file.txt"))?, b"contents");
+    Ok(())
+}
+
+#[test]
+fn unencrypted_zip_checksum_failure_stays_damaged() -> Result<(), Box<dyn Error>> {
+    let root = tempfile::tempdir()?;
+    let archive = root.path().join("archive.zip");
+    super::super::fixtures::write_zip_stored(&archive, &[("file.txt", b"checksum-payload")])?;
+    let mut bytes = fs::read(&archive)?;
+    let offset = bytes
+        .windows(16)
+        .position(|bytes| bytes == b"checksum-payload")
+        .expect("stored payload");
+    bytes[offset] ^= 1;
+    fs::write(&archive, &bytes)?;
+
+    let destination = tempfile::tempdir()?;
+    let Err(error) = decode_fixture(
+        &archive,
+        destination.path(),
+        ArchiveFormat::Zip,
+        None,
+        &Arc::new(AtomicUsize::new(0)),
+    ) else {
+        panic!("accepted a checksum-damaged zip");
+    };
+    assert_eq!(error.to_string(), super::INVALID_ARCHIVE);
+    assert!(destination.path().read_dir()?.next().is_none());
+    Ok(())
+}
+
 #[test]
 fn wrong_password_for_content_encrypted_7z_is_retryable() -> Result<(), Box<dyn Error>> {
     // Generated with `7z a -psecret -mhe=off` using 7-Zip 26.02.
@@ -1131,6 +1331,24 @@ fn checksum_failure_without_a_password_remains_damaged() {
     assert_eq!(
         super::archive_read_error(error, false).to_string(),
         super::INVALID_ARCHIVE
+    );
+}
+
+#[test]
+fn corrupt_deflate_stream_without_a_password_stays_damaged() {
+    let error = io::Error::new(io::ErrorKind::InvalidInput, "corrupt deflate stream");
+    assert_eq!(
+        super::archive_read_error(error, false).to_string(),
+        super::INVALID_ARCHIVE
+    );
+}
+
+#[test]
+fn corrupt_deflate_stream_after_a_password_is_retryable() {
+    let error = io::Error::new(io::ErrorKind::InvalidInput, "corrupt deflate stream");
+    assert_eq!(
+        super::archive_read_error(error, true).to_string(),
+        super::MAYBE_BAD_PASSWORD
     );
 }
 

--- a/tests/e2e/scenarios/test_archive_errors.py
+++ b/tests/e2e/scenarios/test_archive_errors.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: MIT
+import os
 import shutil
+import struct
 import zipfile
+import zlib
 from pathlib import Path
 
 import pytest
@@ -80,4 +83,173 @@ def test_wrong_extract_password_reopens_dialog_until_password_is_correct(strata)
     extracted = fixture.path("protected.txt")
     strata.wait(lambda: extracted.exists(), "the archive to extract with the correct password")
     assert extracted.read_text() == "password retry works\n"
+    strata.wait(lambda: strata.dialog() is None, "extraction progress dismissal")
+
+
+_CRCTABLE = None
+
+
+def _zipcrypto_crc32(ch, crc):
+    global _CRCTABLE
+    if _CRCTABLE is None:
+        table = []
+        for value in range(256):
+            for _ in range(8):
+                value = (value >> 1) ^ 0xEDB88320 if value & 1 else value >> 1
+            table.append(value)
+        _CRCTABLE = table
+    return (crc >> 8) ^ _CRCTABLE[(crc ^ ch) & 0xFF]
+
+
+def _zipcrypto_encrypt(password, data):
+    key0, key1, key2 = 305419896, 591751049, 878082192
+
+    def update(byte):
+        nonlocal key0, key1, key2
+        key0 = _zipcrypto_crc32(byte, key0)
+        key1 = (key1 + (key0 & 0xFF)) & 0xFFFFFFFF
+        key1 = (key1 * 134775813 + 1) & 0xFFFFFFFF
+        key2 = _zipcrypto_crc32(key1 >> 24, key2)
+
+    for byte in password:
+        update(byte)
+    out = bytearray()
+    for byte in data:
+        key = key2 | 2
+        out.append(byte ^ (((key * (key ^ 1)) >> 8) & 0xFF))
+        update(byte)
+    return bytes(out)
+
+
+def _raw_deflate(data):
+    compressor = zlib.compressobj(level=9, wbits=-15)
+    return compressor.compress(data) + compressor.flush()
+
+
+def _write_zipcrypto(path, password, name, contents, *, deflated=False):
+    crc = zlib.crc32(contents) & 0xFFFFFFFF
+    payload = _raw_deflate(contents) if deflated else contents
+    header = os.urandom(11) + bytes([(crc >> 24) & 0xFF])
+    encrypted = _zipcrypto_encrypt(password, header + payload)
+    name_b = name.encode("utf-8")
+    flags = 0x0001
+    method = 8 if deflated else 0
+    local = struct.pack(
+        "<IHHHHHIIIHH",
+        0x04034B50,
+        20,
+        flags,
+        method,
+        0,
+        0,
+        crc,
+        len(encrypted),
+        len(contents),
+        len(name_b),
+        0,
+    )
+    local_data = local + name_b + encrypted
+    central = struct.pack(
+        "<IHHHHHHIIIHHHHHII",
+        0x02014B50,
+        20,
+        20,
+        flags,
+        method,
+        0,
+        0,
+        crc,
+        len(encrypted),
+        len(contents),
+        len(name_b),
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    )
+    cd = central + name_b
+    eocd = struct.pack(
+        "<IHHHHIIH",
+        0x06054B50,
+        0,
+        0,
+        1,
+        1,
+        len(cd),
+        len(local_data),
+        0,
+    )
+    path.write_bytes(local_data + cd + eocd)
+
+
+def _zipcrypto_crc_collision(path, member="some.txt"):
+    for candidate in range(4096):
+        password = str(candidate).encode()
+        try:
+            with zipfile.ZipFile(path) as archive:
+                archive.read(member, pwd=password)
+        except RuntimeError as error:
+            if "Bad password" in str(error):
+                continue
+            return str(candidate)
+        except (zipfile.BadZipFile, OSError, zlib.error):
+            return str(candidate)
+    raise AssertionError("no ZipCrypto CRC collision in 0..4096")
+
+
+@pytest.mark.parametrize(
+    "deflated,contents",
+    [
+        pytest.param(False, b"hello from zipcrypto", id="stored"),
+        pytest.param(True, b"hello from zipcrypto\n" * 64, id="deflated"),
+    ],
+)
+def test_zipcrypto_collision_reopens_extract_dialog(strata, deflated, contents):
+    fixture = strata.fixture
+    archive_name = "password.zip"
+    archive_path = fixture.path(archive_name)
+    _write_zipcrypto(
+        archive_path, b"zipsecret", "some.txt", contents, deflated=deflated
+    )
+    collision = _zipcrypto_crc_collision(archive_path)
+    strata.keyboard.press("ctrl+r")
+    strata.pointer.right_click(strata.entry(archive_name))
+    strata.choose_menu_item("Extract here")
+
+    dialog = strata.wait(
+        lambda: (
+            dialog
+            if (dialog := strata.dialog()) is not None and dialog.name == "Extract"
+            else None
+        ),
+        "the password dialog to replace the progress dialog",
+    )
+    strata.pointer.click(strata.dialog_button("Extract"))
+    dialog = strata.wait_for_dialog()
+    assert dialog.find(role="label", name="Enter a password") is not None
+
+    strata.keyboard.type_text(collision)
+    strata.pointer.click(strata.dialog_button("Extract"))
+
+    dialog = strata.wait(
+        lambda: (
+            dialog
+            if (dialog := strata.dialog()) is not None
+            and dialog.name == "Extract"
+            and dialog.find(role="password text", states={"focused"}) is not None
+            else None
+        ),
+        "the password dialog to reopen after a ZipCrypto CRC collision",
+    )
+    assert dialog.find(role="label", name="Invalid password") is not None
+    assert dialog.find(role="label", name="Unable to complete operation") is None
+    assert dialog.find(role="label", name="This file is not a valid archive or is damaged.") is None
+
+    strata.keyboard.type_text("zipsecret")
+    strata.pointer.click(strata.dialog_button("Extract"))
+    extracted = fixture.path("some.txt")
+    strata.wait(lambda: extracted.exists(), "the archive to extract with the correct password")
+    assert extracted.read_text() == contents.decode()
     strata.wait(lambda: strata.dialog() is None, "extraction progress dismissal")


### PR DESCRIPTION
## Description

Traditional `zip -P` (ZipCrypto) archives that are given a wrong password must stay on the extract-password retry path. A colliding password can slip ZipCrypto’s 1-byte header check and then fail CRC or inflate; that used to stringify as “This file is not a valid archive or is damaged,” which has no `password` / `encrypt`, so `OperationFailed` showed the generic error dialog instead of reopening Extract.

This wires ZIP `ArchiveReader.password_supplied` the same way #751 did for content-encrypted 7z. After a supplied password, CRC (`InvalidData`), unexpected EOF, and inflate (`InvalidInput`, including `"corrupt deflate stream"`) map to “The password may be incorrect.” (`MAYBE_BAD_PASSWORD`), which reuses the existing #793 retry UI. `ZipError::InvalidPassword`, `PASSWORD_REQUIRED`, and structural `InvalidArchive` are unchanged. Truly corrupt ZIPs and gzip/deflate damage with no password still use the #638 wording.

## Visual evidence

N/A — decoder error classification. Extract retry UI already exists from #793; colliding ZipCrypto (stored CRC and deflated inflate) now hits that string instead of the damaged-archive dialog.

## How to test

1. Create a ZipCrypto archive. The tiny `echo 'hello from zipcrypto' > some.txt && zip -P zipsecret password.zip some.txt` path is stored and fails CRC. A compressible member (`deflated` in `zip -l`) is the common Info-ZIP path and fails inflate (`corrupt deflate stream`) after a header collision.
2. Find a colliding wrong password (loop `0..4096` until CRC or inflate fails after the header check; do not hard-code one).
3. In Strata, right-click `password.zip` → **Extract here**.
4. Confirm the first Extract prompt, then enter the colliding password.

**Expected result:** Extract reopens with “Invalid password”, not “This file is not a valid archive or is damaged.” Enter `zipsecret` and `some.txt` extracts. Fake/truncated ZIPs and unencrypted checksum damage still use the damaged-archive dialog. AES ZIP wrong passwords still report “provided password is incorrect.”

## Related issue

Closes #796
