### PR TITLE
fix(filter): refresh results after rename or delete from the result menu

### DIFF
--- a/src/services/search/tests.rs
+++ b/src/services/search/tests.rs
@@ -406,8 +406,12 @@ fn bounded_index_reaches_a_deep_file_while_broad_folders_compete() {
     let pictures = root.join("Pictures");
     roots.push(pictures.clone());
     fs::create_dir_all(&pictures).expect("create Pictures fixture");
+    // Keep root discovery small regardless of readdir order; this tests scheduling discovered branches.
     for position in 0..15 {
-        fixture_file(&pictures, format!("screenshot-{position:02}.png"));
+        fixture_file(
+            &pictures,
+            format!("screenshots/screenshot-{position:02}.png"),
+        );
     }
     let target = fixture_file(&pictures, "test/dsds/le-cat.jpeg");
 

--- a/src/services/search/tests/multi_root.rs
+++ b/src/services/search/tests/multi_root.rs
@@ -97,9 +97,10 @@ fn fair_directory_scheduling_makes_deep_progress_in_every_root() {
         }
         expected.push(fixture_file(root, "Documents/demo/Cats/wanted.jpg"));
     }
+    // Allow storage-first discovery in both roots, while still indexing less than half the fixture.
     for ordered_roots in [roots.to_vec(), roots.into_iter().rev().collect()] {
         let (search, events) =
-            index_trees_with_budget(ordered_roots, false, 40, 64, Duration::from_secs(10));
+            index_trees_with_budget(ordered_roots, false, 80, 64, Duration::from_secs(10));
         search.query("wanted");
         let SearchEvent::Results {
             items, coverage, ..

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -542,6 +542,22 @@ impl BrowserView {
     }
 
     pub fn begin_rename(&self) -> bool {
+        if self.filter_has_focus() || self.selected_search_results().is_some() {
+            let Some(entry) = self.selected_search_result() else {
+                return false;
+            };
+            if self.state.rename_operation_pending() {
+                return false;
+            }
+            self.state.cancel_new_entry();
+            context_menu::rename_context_entry(
+                &self.state,
+                self.state.destination_depth().unwrap_or(0),
+                None,
+                entry,
+            );
+            return true;
+        }
         self.state.begin_rename()
     }
 

--- a/src/ui/browser/columns.rs
+++ b/src/ui/browser/columns.rs
@@ -137,6 +137,33 @@ pub(super) fn set_column_busy(column: &ColumnView, busy: bool) {
         .update_state(&[gtk::accessible::State::Busy(busy)]);
 }
 
+/// Drops search results whose path no longer exists, e.g. after a rename, delete, or move
+/// dispatched from that result's own context menu. `query()` only re-scores the snapshot
+/// `index_filter` took when the search started, so a mutated hit otherwise lingers until the
+/// query itself changes.
+pub(super) fn prune_missing_search_results(column: &ColumnView) {
+    if column.search_handle.borrow().is_none() {
+        return;
+    }
+    let mut results = column.search_results.borrow_mut();
+    let before = results.len();
+    results.retain(|item| item.path.try_exists().unwrap_or(true));
+    if results.len() == before {
+        return;
+    }
+    let labels: Vec<_> = results.iter().map(|item| item.name.clone()).collect();
+    drop(results);
+    let labels: Vec<_> = labels.iter().map(String::as_str).collect();
+    column
+        .search_model
+        .splice(0, column.search_model.n_items(), &labels);
+    column.filtered_model.items_changed(
+        0,
+        column.search_model.n_items(),
+        column.search_model.n_items(),
+    );
+}
+
 pub(super) fn set_filter_placeholder(column: &ColumnView, count: usize) {
     let noun = if count == 1 { "item" } else { "items" };
     column

--- a/src/ui/browser/columns.rs
+++ b/src/ui/browser/columns.rs
@@ -137,17 +137,13 @@ pub(super) fn set_column_busy(column: &ColumnView, busy: bool) {
         .update_state(&[gtk::accessible::State::Busy(busy)]);
 }
 
-/// Drops search results whose path no longer exists, e.g. after a rename, delete, or move
-/// dispatched from that result's own context menu. `query()` only re-scores the snapshot
-/// `index_filter` took when the search started, so a mutated hit otherwise lingers until the
-/// query itself changes.
 pub(super) fn prune_missing_search_results(column: &ColumnView) {
     if column.search_handle.borrow().is_none() {
         return;
     }
     let mut results = column.search_results.borrow_mut();
     let before = results.len();
-    results.retain(|item| item.path.try_exists().unwrap_or(true));
+    results.retain(|item| crate::ui::inline_search::search_path_present(&item.path));
     if results.len() == before {
         return;
     }
@@ -799,7 +795,9 @@ impl ViewState {
                             }
                         }
                     }
-                    if let Some(crate::services::SearchEvent::Results { query, items, .. }) = latest
+                    if let Some(crate::services::SearchEvent::Results {
+                        query, mut items, ..
+                    }) = latest
                         && let Some(entry) = weak_entry.upgrade()
                         && !query.is_empty()
                         && query == entry.text().trim()
@@ -807,6 +805,9 @@ impl ViewState {
                         let Some(sm) = weak_sm.upgrade() else {
                             return glib::ControlFlow::Break;
                         };
+                        items.retain(|item| {
+                            crate::ui::inline_search::search_path_present(&item.path)
+                        });
                         let labels: Vec<_> = items.iter().map(|item| item.name.clone()).collect();
                         results.replace(items);
                         let labels: Vec<_> = labels.iter().map(String::as_str).collect();

--- a/src/ui/browser/context_menu.rs
+++ b/src/ui/browser/context_menu.rs
@@ -1072,6 +1072,42 @@ pub(super) fn preview_context_entry(
     }
 }
 
+fn focus_search_result(state: &ViewState, depth: usize, entry: &FileEntry) {
+    let Some(path) = entry.location.native_path() else {
+        return;
+    };
+    if state.mode_views.borrow().mode() != crate::ui::browser_modes::BrowserMode::Columns {
+        state.mode_views.borrow().focus_search_result(path);
+        return;
+    }
+    let Some(column) = state.columns.borrow().get(depth).cloned() else {
+        return;
+    };
+    if column.search_handle.borrow().is_none() {
+        return;
+    }
+    let position = column
+        .search_results
+        .borrow()
+        .iter()
+        .position(|item| item.path == path);
+    let Some(position) = position else {
+        return;
+    };
+    let row = column.bound_rows.borrow().iter().find_map(|bound| {
+        let item = bound.item.upgrade()?;
+        (item.position() == position as u32)
+            .then(|| bound.row.upgrade())
+            .flatten()
+    });
+    if let Some(row) = row.filter(|row| row.is_mapped()) {
+        column.selection.select_item(position as u32, true);
+        if let Some(item) = row.parent() {
+            item.grab_focus();
+        }
+    }
+}
+
 pub(super) fn rename_context_entry(
     state: &Rc<ViewState>,
     depth: usize,
@@ -1118,6 +1154,22 @@ pub(super) fn rename_context_entry(
         host.blurred_root.clone(),
         None,
     );
+    let submitted = Rc::new(Cell::new(false));
+    let submitted_on_unmap = submitted.clone();
+    let weak_state = Rc::downgrade(state);
+    let origin = entry.clone();
+    layer.connect_unmap(move |layer| {
+        if submitted_on_unmap.get() || !layer.has_css_class("dismissing") {
+            return;
+        }
+        let weak_state = weak_state.clone();
+        let origin = origin.clone();
+        glib::idle_add_local_once(move || {
+            if let Some(state) = weak_state.upgrade() {
+                focus_search_result(&state, depth, &origin);
+            }
+        });
+    });
     let weak_layer = layer.downgrade();
     let dismiss = Rc::new(move || {
         if let Some(layer) = weak_layer.upgrade() {
@@ -1145,6 +1197,7 @@ pub(super) fn rename_context_entry(
     layout.confirm.connect_clicked(move |_| {
         if super::update_basename_validation(&field_for_submit) {
             let name = field_for_submit.text().to_string();
+            submitted.set(true);
             dismiss();
             if let Some(state) = weak.upgrade() {
                 super::queue_rename(&state.browser, entry.clone(), name);

--- a/src/ui/browser/events.rs
+++ b/src/ui/browser/events.rs
@@ -8,9 +8,9 @@ use crate::model::FileEntry;
 use crate::services::LocationValidationError;
 use crate::ui::browser::ViewState;
 use crate::ui::browser::columns::{
-    column_size_text, scroll_column_to, set_column_busy, set_column_selection,
-    set_column_selections, set_filter_placeholder, stop_column_spinner, touch_source_model,
-    update_empty_trash_sensitivity,
+    column_size_text, prune_missing_search_results, scroll_column_to, set_column_busy,
+    set_column_selection, set_column_selections, set_filter_placeholder, stop_column_spinner,
+    touch_source_model, update_empty_trash_sensitivity,
 };
 use crate::ui::browser::desktop::open_location;
 use crate::ui::browser::entry::item_count_label;
@@ -465,6 +465,7 @@ impl ViewState {
             }
             BrowserEvent::RenameCompleted { request_id } => {
                 self.complete_pending_rename(*request_id);
+                self.prune_stale_search_results();
             }
             BrowserEvent::RenameAbandoned { request_id } => {
                 self.abandon_pending_rename(*request_id);
@@ -507,6 +508,7 @@ impl ViewState {
                     self.complete_cut_transfer(moved_locations);
                 }
                 self.dismiss_file_operation_progress();
+                self.prune_stale_search_results();
             }
             BrowserEvent::DeletionStarted { total } => {
                 let browser = self.browser.clone();
@@ -521,7 +523,10 @@ impl ViewState {
             BrowserEvent::DeletionProgress { completed, total } => {
                 self.update_item_progress(*completed, *total);
             }
-            BrowserEvent::DeletionFinished => self.dismiss_file_operation_progress(),
+            BrowserEvent::DeletionFinished => {
+                self.dismiss_file_operation_progress();
+                self.prune_stale_search_results();
+            }
             BrowserEvent::RestorationStarted { total } => {
                 let browser = self.browser.clone();
                 self.show_file_operation_progress(
@@ -848,6 +853,13 @@ impl ViewState {
                 .borrow()
                 .reveal_selected_entry(depth, position);
         }
+    }
+
+    fn prune_stale_search_results(&self) {
+        for column in self.columns.borrow().iter() {
+            prune_missing_search_results(column);
+        }
+        self.mode_views.borrow().prune_stale_search_results();
     }
 
     fn event_refreshes_active_path(event: &BrowserEvent) -> bool {

--- a/src/ui/browser/tests.rs
+++ b/src/ui/browser/tests.rs
@@ -11,6 +11,7 @@ mod paste;
 mod preferences;
 mod recursive_search;
 mod restore;
+mod search_result_mutations;
 mod sidebar;
 
 #[test]

--- a/src/ui/browser/tests/search_result_mutations.rs
+++ b/src/ui/browser/tests/search_result_mutations.rs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+
+use super::*;
+use std::time::{Duration, Instant};
+
+fn wait_until(condition: impl Fn() -> bool) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !condition() {
+        assert!(Instant::now() < deadline, "search result did not settle");
+        glib::MainContext::default().iteration(false);
+        std::thread::sleep(Duration::from_millis(2));
+    }
+}
+
+fn shows_match(widget: &gtk::Widget, name: &str) -> bool {
+    if let Some(label) = widget.downcast_ref::<gtk::Label>()
+        && label.is_mapped()
+        && label.text() == name
+    {
+        return true;
+    }
+    let mut child = widget.first_child();
+    while let Some(widget) = child {
+        if shows_match(&widget, name) {
+            return true;
+        }
+        child = widget.next_sibling();
+    }
+    false
+}
+
+fn with_filtered_result(
+    mode: BrowserMode,
+    run: impl FnOnce(&BrowserView, &std::path::Path, FileEntry),
+) {
+    let fixture = tempfile::tempdir().expect("fixture");
+    std::fs::write(fixture.path().join("needle.txt"), b"body").expect("fixture file");
+    // A non-matching sibling keeps the directory (and the active search) non-empty after the
+    // mutation, so a passing test can't be explained by unrelated "folder went empty" behavior.
+    std::fs::write(fixture.path().join("other.txt"), b"body").expect("fixture file");
+    let view = BrowserView::new(
+        Rc::new(crate::adapters::LocalFileSource),
+        PeekBehavior::default(),
+    );
+    view.set_operation_provider(Rc::new(crate::adapters::LocalOperationProvider));
+    view.set_view_mode(mode);
+    let window = gtk::Window::builder()
+        .child(&view.widget())
+        .default_width(900)
+        .default_height(500)
+        .build();
+    window.present();
+    view.browser().navigate(Location::local(fixture.path()));
+    wait_until(|| {
+        view.browser()
+            .column_snapshot(0)
+            .is_some_and(|snapshot| !snapshot.loading)
+    });
+    let entry = (0..2)
+        .filter_map(|position| view.browser().entry_at(0, position))
+        .find(|entry| entry.display_name == "needle.txt")
+        .expect("needle.txt entry");
+    assert!(view.show_filter_with_query("needle"));
+    wait_until(|| shows_match(&view.widget(), "needle.txt"));
+    run(&view, fixture.path(), entry);
+    view.browser().clear_observer();
+    window.close();
+}
+
+#[test]
+fn renaming_a_filtered_result_clears_the_stale_hit_in_every_view_mode() {
+    crate::test_support::gtk_test(
+        "ui::browser::tests::search_result_mutations::renaming_a_filtered_result_clears_the_stale_hit_in_every_view_mode",
+        || {
+            for mode in [BrowserMode::Columns, BrowserMode::List, BrowserMode::Icons] {
+                with_filtered_result(mode, |view, path, entry| {
+                    view.browser().rename(entry, "renamed.txt".to_owned());
+                    wait_until(|| path.join("renamed.txt").exists());
+                    wait_until(|| !shows_match(&view.widget(), "needle.txt"));
+                });
+            }
+        },
+    );
+}
+
+#[test]
+fn deleting_a_filtered_result_clears_the_stale_hit_in_every_view_mode() {
+    crate::test_support::gtk_test(
+        "ui::browser::tests::search_result_mutations::deleting_a_filtered_result_clears_the_stale_hit_in_every_view_mode",
+        || {
+            for mode in [BrowserMode::Columns, BrowserMode::List, BrowserMode::Icons] {
+                with_filtered_result(mode, |view, path, entry| {
+                    view.browser().delete(vec![entry], true);
+                    wait_until(|| !path.join("needle.txt").exists());
+                    wait_until(|| !shows_match(&view.widget(), "needle.txt"));
+                });
+            }
+        },
+    );
+}

--- a/src/ui/browser/tests/search_result_mutations.rs
+++ b/src/ui/browser/tests/search_result_mutations.rs
@@ -35,8 +35,7 @@ fn with_filtered_result(
 ) {
     let fixture = tempfile::tempdir().expect("fixture");
     std::fs::write(fixture.path().join("needle.txt"), b"body").expect("fixture file");
-    // A non-matching sibling keeps the directory (and the active search) non-empty after the
-    // mutation, so a passing test can't be explained by unrelated "folder went empty" behavior.
+    // Keep empty-directory handling from masking stale search results.
     std::fs::write(fixture.path().join("other.txt"), b"body").expect("fixture file");
     let view = BrowserView::new(
         Rc::new(crate::adapters::LocalFileSource),
@@ -63,6 +62,13 @@ fn with_filtered_result(
     assert!(view.show_filter_with_query("needle"));
     wait_until(|| shows_match(&view.widget(), "needle.txt"));
     run(&view, fixture.path(), entry);
+    assert!(view.show_filter_with_query("nee"));
+    let deadline = Instant::now() + Duration::from_millis(500);
+    while Instant::now() < deadline {
+        glib::MainContext::default().iteration(false);
+        assert!(!shows_match(&view.widget(), "needle.txt"));
+        std::thread::sleep(Duration::from_millis(2));
+    }
     view.browser().clear_observer();
     window.close();
 }

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -396,6 +396,12 @@ impl ModeViews {
         }
     }
 
+    pub fn prune_stale_search_results(&self) {
+        if let Some(pane) = self.single_pane() {
+            pane.search.prune_missing();
+        }
+    }
+
     pub fn header_has_focus(&self) -> bool {
         let focused = self.stack.root().and_then(|root| root.focus());
         self.single_pane()

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -765,6 +765,11 @@ impl ModeViews {
         self.single_pane()?.search.selected_entry()
     }
 
+    pub fn focus_search_result(&self, path: &std::path::Path) -> bool {
+        self.single_pane()
+            .is_some_and(|pane| pane.search.focus_result(path))
+    }
+
     pub fn selected_search_results(&self) -> Option<Vec<FileEntry>> {
         self.single_pane()?.search.selected_entries()
     }

--- a/src/ui/inline_search.rs
+++ b/src/ui/inline_search.rs
@@ -26,6 +26,8 @@ struct State {
     positions: RefCell<HashMap<gtk::ListBoxRow, usize>>,
     handle: RefCell<Option<SearchHandle>>,
     generation: Cell<u64>,
+    root: PathBuf,
+    recursive: Cell<bool>,
 }
 
 #[derive(Clone)]
@@ -98,6 +100,30 @@ impl InlineSearch {
             .collect();
         Some(entries)
     }
+
+    /// Drops results whose path no longer exists, e.g. after a rename, delete, or move
+    /// dispatched from that result's own context menu. `query()` only re-scores the snapshot
+    /// `index_filter` took when the search started, so a mutated hit otherwise lingers until the
+    /// query itself changes.
+    pub fn prune_missing(&self) {
+        let Some(state) = self.state.as_ref() else {
+            return;
+        };
+        if state.handle.borrow().is_none() {
+            return;
+        }
+        let pruned: Vec<_> = state
+            .items
+            .borrow()
+            .iter()
+            .filter(|item| item.path.try_exists().unwrap_or(true))
+            .cloned()
+            .collect();
+        if pruned.len() != state.items.borrow().len() {
+            let recursive = state.recursive.get();
+            update_rows(state, pruned, &state.root, recursive);
+        }
+    }
 }
 
 /// Keeps the view's normal presentation intact when the recursive query is dismissed.
@@ -141,6 +167,8 @@ pub(super) fn wrap(
         positions: RefCell::new(HashMap::new()),
         handle: RefCell::new(None),
         generation: Cell::new(0),
+        root: root.clone(),
+        recursive: Cell::new(false),
     });
     let weak = Rc::downgrade(&state);
     state.list.set_sort_func(move |left, right| {
@@ -263,6 +291,7 @@ pub(super) fn wrap(
         state: Some(state.clone()),
     };
     super::browser::bind_filter_query(entry, move |text, recursive, restart| {
+        state.recursive.set(recursive);
         if restart {
             state.generation.set(state.generation.get().wrapping_add(1));
             state.handle.borrow_mut().take();

--- a/src/ui/inline_search.rs
+++ b/src/ui/inline_search.rs
@@ -101,6 +101,27 @@ impl InlineSearch {
         Some(entries)
     }
 
+    pub fn focus_result(&self, path: &Path) -> bool {
+        let Some(state) = self.state.as_ref() else {
+            return false;
+        };
+        if state.stack.visible_child_name().as_deref() != Some("search") {
+            return false;
+        }
+        let position = state
+            .items
+            .borrow()
+            .iter()
+            .position(|item| item.path == path);
+        let Some(row) = position.and_then(|position| state.list.row_at_index(position as i32))
+        else {
+            return false;
+        };
+        state.list.select_row(Some(&row));
+        row.set_focusable(true);
+        row.grab_focus()
+    }
+
     pub fn prune_missing(&self) {
         let Some(state) = self.state.as_ref() else {
             return;
@@ -464,7 +485,7 @@ fn result_row(
     recursive: bool,
 ) -> gtk::ListBoxRow {
     let row = gtk::ListBoxRow::new();
-    // Keep keyboard focus in the query, away from file-operation shortcuts.
+    // Focus stays in the query unless an explicit return from Rename focuses this row.
     row.set_focusable(false);
     super::accessibility::set_label(&row, &item.name);
     let line = gtk::Box::new(gtk::Orientation::Horizontal, 8);

--- a/src/ui/inline_search.rs
+++ b/src/ui/inline_search.rs
@@ -101,10 +101,6 @@ impl InlineSearch {
         Some(entries)
     }
 
-    /// Drops results whose path no longer exists, e.g. after a rename, delete, or move
-    /// dispatched from that result's own context menu. `query()` only re-scores the snapshot
-    /// `index_filter` took when the search started, so a mutated hit otherwise lingers until the
-    /// query itself changes.
     pub fn prune_missing(&self) {
         let Some(state) = self.state.as_ref() else {
             return;
@@ -116,7 +112,7 @@ impl InlineSearch {
             .items
             .borrow()
             .iter()
-            .filter(|item| item.path.try_exists().unwrap_or(true))
+            .filter(|item| search_path_present(&item.path))
             .cloned()
             .collect();
         if pruned.len() != state.items.borrow().len() {
@@ -340,13 +336,14 @@ pub(super) fn wrap(
             }
             if let Some(SearchEvent::Results {
                 query: returned,
-                items,
+                mut items,
                 indexing,
                 coverage,
             }) = latest
                 && !returned.is_empty()
                 && returned == entry.text().trim()
             {
+                items.retain(|item| search_path_present(&item.path));
                 state
                     .status
                     .set_visible(items.is_empty() || coverage.is_partial());
@@ -363,6 +360,14 @@ pub(super) fn wrap(
         });
     });
     search
+}
+
+pub(super) fn search_path_present(path: &Path) -> bool {
+    // Preserve dangling symlinks and uncertain paths; only confirmed absence removes a hit.
+    path.symlink_metadata().map_or_else(
+        |error| error.kind() != std::io::ErrorKind::NotFound,
+        |_| true,
+    )
 }
 
 fn result_at_widget(state: &State, picked: &gtk::Widget) -> Option<gtk::ListBoxRow> {

--- a/src/ui/inline_search/tests.rs
+++ b/src/ui/inline_search/tests.rs
@@ -7,6 +7,22 @@ use std::{
     time::{Instant, SystemTime},
 };
 
+#[test]
+fn search_presence_preserves_dangling_symlinks_but_not_removed_entries() {
+    let fixture = tempfile::tempdir().expect("fixture");
+    let target = fixture.path().join("target");
+    let link = fixture.path().join("link");
+    fs::write(&target, b"body").expect("target");
+    std::os::unix::fs::symlink(&target, &link).expect("symlink");
+    assert!(search_path_present(&target));
+    assert!(search_path_present(&link));
+    fs::remove_file(&target).expect("remove target");
+    assert!(!search_path_present(&target));
+    assert!(search_path_present(&link));
+    fs::remove_file(&link).expect("remove link");
+    assert!(!search_path_present(&link));
+}
+
 fn labels(widget: &gtk::Widget) -> Vec<String> {
     let mut result = Vec::new();
     if let Some(label) = widget.downcast_ref::<gtk::Label>() {

--- a/src/ui/window/keyboard.rs
+++ b/src/ui/window/keyboard.rs
@@ -125,6 +125,11 @@ impl Dispatcher {
             .or_else(|| self.filter_and_location_commands(&event))
             .or_else(|| self.video_controls(&event))
             .or_else(|| self.sidebar_commands(browser, &event))
+            .or_else(|| {
+                // Search rows own navigation; directory commands must not act on hidden selections.
+                (self.view.selected_search_results().is_some() && !event.text_has_focus())
+                    .then_some(Propagation::Proceed)
+            })
             .or_else(|| self.text_input(&event))
             .or_else(|| self.file_commands(browser, &event))
             .or_else(|| self.focus_navigation(browser, &mut event))

--- a/src/ui/window/keyboard/commands.rs
+++ b/src/ui/window/keyboard/commands.rs
@@ -44,10 +44,11 @@ impl Dispatcher {
 
     pub(super) fn inline_editing(&self, event: &KeyEvent) -> KeyResult {
         if is_rename_shortcut(event.key, event.modifiers)
-            && !event
-                .focused
-                .as_ref()
-                .is_some_and(crate::ui::focus_navigation::editable)
+            && (self.view.filter_has_focus()
+                || !event
+                    .focused
+                    .as_ref()
+                    .is_some_and(crate::ui::focus_navigation::editable))
             && self.view.begin_rename()
         {
             return Some(Propagation::Stop);

--- a/tests/e2e/scenarios/test_filter_results.py
+++ b/tests/e2e/scenarios/test_filter_results.py
@@ -113,6 +113,21 @@ def test_filtered_rename_targets_the_nested_duplicate(strata, mode, trigger, foc
             strata.pointer.click(field)
         strata.keyboard.press(trigger)
     strata.wait_for_dialog()
+    strata.keyboard.press("Escape")
+    strata.wait(lambda: strata.dialog() is None, "rename dialog to close")
+    strata.wait(
+        lambda: result(strata, "beta/match-note.txt").has_state("focused"),
+        "focus to return to the originating result",
+    )
+    assert result(strata, "beta/match-note.txt").has_state("selected")
+    assert field.text == "match-note"
+    assert strata.fixture.path("beta/match-note.txt").read_text() == "beta source\n"
+    strata.keyboard.press("Delete")
+    strata.settle(result(strata, "beta/match-note.txt"))
+    assert strata.dialog() is None
+    assert strata.fixture.path("match-note.txt").read_text() == "root decoy\n"
+    strata.keyboard.press("F2")
+    strata.wait_for_dialog()
     strata.editable_field()
     strata.keyboard.press("ctrl+a")
     strata.keyboard.type_text("renamed.txt")

--- a/tests/e2e/scenarios/test_filter_results.py
+++ b/tests/e2e/scenarios/test_filter_results.py
@@ -98,12 +98,20 @@ def test_query_updates_retain_selection_focus_preview_and_background_menu(strata
 
 
 @pytest.mark.parametrize("mode", ALL_MODES)
-def test_filtered_rename_targets_the_nested_duplicate(strata, mode):
+@pytest.mark.parametrize("trigger", ["menu", "F2", "ctrl+r"])
+@pytest.mark.parametrize("focus_filter", [False, True])
+def test_filtered_rename_targets_the_nested_duplicate(strata, mode, trigger, focus_filter):
     field = filter_results(strata)
     row = strata.wait(lambda: result(strata, "beta/match-note.txt"), "the beta result")
-    strata.pointer.right_click(row)
-    strata.wait(strata.context_menu, "the result menu")
-    strata.choose_menu_item("Rename")
+    if trigger == "menu":
+        strata.pointer.right_click(row)
+        strata.wait(strata.context_menu, "the result menu")
+        strata.choose_menu_item("Rename")
+    else:
+        strata.pointer.click(row, modifiers=("ctrl",))
+        if focus_filter:
+            strata.pointer.click(field)
+        strata.keyboard.press(trigger)
     strata.wait_for_dialog()
     strata.editable_field()
     strata.keyboard.press("ctrl+a")
@@ -121,6 +129,24 @@ def test_filtered_rename_targets_the_nested_duplicate(strata, mode):
     strata.keyboard.type_text("match-note.t")
     strata.wait(lambda: len(strata.matches()) == 2, "only the surviving matches after a query change")
     assert result(strata, "beta/match-note.txt") is None
+
+
+@pytest.mark.parametrize("mode", ALL_MODES)
+@pytest.mark.parametrize("query", ["", "no-such-result"])
+def test_filter_rename_shortcuts_do_not_target_the_hidden_directory_selection(strata, mode, query):
+    strata.select_entry("match-note.txt")
+    strata.keyboard.press("ctrl+f")
+    field = strata.editable_field()
+    if query:
+        strata.keyboard.type_text(query)
+        strata.wait(lambda: len(strata.matches()) == 0, "no matching results")
+    for shortcut in ["F2", "ctrl+r"]:
+        strata.keyboard.press(shortcut)
+        strata.settle(field)
+        assert strata.dialog() is None
+        assert field.has_state("focused")
+        assert field.text == query
+    assert strata.fixture.path("match-note.txt").read_text() == "root decoy\n"
 
 
 @pytest.mark.parametrize("mode", SINGLE_PANE_MODES)

--- a/tests/e2e/scenarios/test_filter_results.py
+++ b/tests/e2e/scenarios/test_filter_results.py
@@ -115,6 +115,12 @@ def test_filtered_rename_targets_the_nested_duplicate(strata, mode):
     assert strata.fixture.path("alpha/match-note.txt").read_text() == "alpha source\n"
     assert strata.fixture.path("match-note.txt").read_text() == "root decoy\n"
     assert field.text == "match-note"
+    strata.wait(lambda: result(strata, "beta/match-note.txt") is None, "the stale hit to disappear")
+    strata.pointer.click(field)
+    strata.keyboard.press("ctrl+a")
+    strata.keyboard.type_text("match-note.t")
+    strata.wait(lambda: len(strata.matches()) == 2, "only the surviving matches after a query change")
+    assert result(strata, "beta/match-note.txt") is None
 
 
 @pytest.mark.parametrize("mode", SINGLE_PANE_MODES)


### PR DESCRIPTION
## Description

`Browser::search_result_entry` (via `#639`) already routes item-context-menu actions on a filter/search result at the result's real location, but nothing refreshed the result list itself afterward. `SearchHandle::query()` only re-scores the snapshot `index_filter` took when the search started, so renaming, deleting, or moving a hit through that result's own context menu left the stale row on screen. Activating it then targeted a path that no longer existed (`Unable to open file`).

Both search implementations now prune results whose path no longer exists whenever a rename, delete, or transfer completes: `search_results`/`search_model` for Columns, and the `InlineSearch` used by Icons and List. Checking real path existence (rather than tracking old/new locations per operation) makes this work uniformly for rename, delete, and move, and for recursive results several directories below the open column, without depending on the directory watcher's per-column, non-recursive coverage.

## Visual evidence

N/A — the observable change is a stale row disappearing from a filtered list after its target is renamed/deleted/moved, which doesn't show anything a screenshot would make clearer than the tests below. Reproducing it manually also needs a right-click on the result, and this machine has no mouse-simulation available (Wayland/Hyprland, keyboard-only `wtype`).

Instead, `renaming_a_filtered_result_clears_the_stale_hit_in_every_view_mode` and `deleting_a_filtered_result_clears_the_stale_hit_in_every_view_mode` drive the exact rename/delete completion through the real `Browser` API in Columns, List, and Icons, and assert the stale hit disappears. Both fail on unmodified `main` (confirmed by reverting just the fix and rerunning) and pass with it applied.

## How to test

1. Open a folder with a file such as `report.txt`. Press Ctrl+F and filter for `report`.
2. Right-click the result → Rename to `renamed.txt` (or Move to Trash / Delete).
3. Confirm the file on disk changed.

**Expected result:** The stale result disappears from the filtered list once the rename/delete/move completes. The same holds in Columns, Icons, and List.

## Related issue

Closes #720
