### PR TITLE
fix(dnd): defer autofs volume probes off the GTK thread

### DIFF
--- a/src/adapters/volume.rs
+++ b/src/adapters/volume.rs
@@ -144,14 +144,22 @@ struct Directory<'a> {
 
 impl<'a> Directory<'a> {
     fn classify(location: &'a Location, mounts: &MountTable) -> Self {
-        let is_remote = match location.native_path() {
-            Some(path) => mounts.is_remote_path(path),
+        Self::classify_with_probe(location, mounts, native_query_may_leave_mount)
+    }
+
+    fn classify_with_probe(
+        location: &'a Location,
+        mounts: &MountTable,
+        native_probe: impl FnOnce(&Path) -> bool,
+    ) -> Self {
+        let may_block = match location.native_path() {
+            Some(path) => mounts.query_may_block(path),
             None => location_is_remote(location),
         };
-        let synchronous = !is_remote
+        let synchronous = !may_block
             && location
                 .native_path()
-                .is_some_and(|path| !native_query_may_leave_mount(path));
+                .is_some_and(|path| !native_probe(path));
         Self {
             location,
             synchronous,

--- a/src/adapters/volume/mounts.rs
+++ b/src/adapters/volume/mounts.rs
@@ -48,6 +48,15 @@ impl MountTable {
         self.fs_type_for(path).is_some_and(is_remote_fs_type)
     }
 
+    pub(super) fn query_may_block(&self, path: &Path) -> bool {
+        // Prefix probes can trigger autofs even when a nested mount is local.
+        self.is_remote_path(path)
+            || self
+                .entries
+                .iter()
+                .any(|(mount_point, fs_type)| fs_type == "autofs" && path.starts_with(mount_point))
+    }
+
     pub(super) fn is_mount_point(&self, path: &Path) -> bool {
         self.entries
             .iter()

--- a/src/adapters/volume/tests.rs
+++ b/src/adapters/volume/tests.rs
@@ -294,34 +294,40 @@ fn native_path_and_file_uri_of_the_same_directory_share_an_identity() {
     );
 }
 
-fn mounts_treating_as_nfs(path: &Path) -> MountTable {
+fn mounts_treating_as(path: &Path, fs_type: &str) -> MountTable {
+    let mount_point = path
+        .to_str()
+        .expect("UTF-8 fixture path")
+        .replace('\\', "\\134")
+        .replace(' ', "\\040")
+        .replace('\t', "\\011")
+        .replace('\n', "\\012");
     MountTable::parse(format!(
-        "1 0 0:1 / / rw - ext4 /dev/root rw\n2 1 0:2 / {} rw - nfs4 server:/export rw\n",
-        path.display()
+        "1 0 0:1 / / rw - ext4 /dev/root rw\n\
+         2 1 0:2 / {mount_point} rw - {fs_type} fixture rw\n",
     ))
 }
 
 #[test]
-fn native_path_on_a_remote_mount_is_looked_up_asynchronously() {
+fn native_path_on_a_blocking_mount_is_looked_up_asynchronously() {
     let root = tempfile::tempdir().expect("tempdir");
     let dest = root.path().join("dest");
     let file = root.path().join("file");
     fs::create_dir(&dest).expect("dest");
     fs::write(&file, b"x").expect("file");
     let query = DropVolumeQuery::new(&Location::local(&dest), &[Location::local(&file)]);
-    let mounts = mounts_treating_as_nfs(root.path());
-    let (lookup, was_pending) = resolve_with_mounts(&query, &mounts, Duration::from_secs(5));
-    assert!(
-        was_pending,
-        "a remote-mounted native path must not stat on the caller"
-    );
-    let lookup = lookup.expect("remote native lookup should resolve");
-    assert_eq!(lookup.relation, VolumeRelation::Same);
-    assert!(
-        lookup
-            .dest
-            .is_some_and(|identity| identity.backend == "file")
-    );
+    for fs_type in ["nfs4", "autofs"] {
+        let mounts = mounts_treating_as(root.path(), fs_type);
+        let (lookup, was_pending) = resolve_with_mounts(&query, &mounts, Duration::from_secs(5));
+        assert!(was_pending, "{fs_type} must not stat on the caller");
+        let lookup = lookup.expect("asynchronous native lookup should resolve");
+        assert_eq!(lookup.relation, VolumeRelation::Same, "{fs_type}");
+        assert!(
+            lookup
+                .dest
+                .is_some_and(|identity| identity.backend == "file")
+        );
+    }
 }
 
 #[test]
@@ -337,7 +343,7 @@ fn network_mount_aliases_preserve_identity_and_plain_drop_move_policy() {
     fs::create_dir(nas.join("b")).expect("destination directory");
     fs::write(nas.join("a/file"), b"x").expect("source file");
     std::os::unix::fs::symlink(&nas, &alias).expect("mount alias");
-    let mounts = mounts_treating_as_nfs(&nas);
+    let mounts = mounts_treating_as(&nas, "nfs4");
 
     for (source_root, dest_root) in [(&nas, &alias), (&alias, &nas)] {
         let query = DropVolumeQuery::with_mounts(
@@ -384,14 +390,22 @@ fn mount_classification_does_not_override_native_filesystem_identity() {
     fs::create_dir(&remote).expect("remote");
     fs::create_dir(&local).expect("local");
     fs::write(local.join("file"), b"x").expect("file");
-    let query = DropVolumeQuery::new(
-        &Location::local(&remote),
-        &[Location::local(local.join("file"))],
-    );
-    let mounts = mounts_treating_as_nfs(&remote);
-    let (lookup, _) = resolve_with_mounts(&query, &mounts, Duration::from_secs(5));
-    let lookup = lookup.expect("mixed lookup should resolve");
-    assert_eq!(lookup.relation, VolumeRelation::Same);
+    fs::write(remote.join("file"), b"x").expect("file");
+    for fs_type in ["nfs4", "autofs"] {
+        let mounts = mounts_treating_as(&remote, fs_type);
+        for (dest, source) in [(&remote, &local), (&local, &remote)] {
+            let query = DropVolumeQuery::with_mounts(
+                &Location::local(dest),
+                &[Location::local(source.join("file"))],
+                &mounts,
+            );
+            let (lookup, was_pending) =
+                resolve_with_mounts(&query, &mounts, Duration::from_secs(5));
+            assert!(was_pending, "{fs_type} destination or source must be async");
+            let lookup = lookup.expect("mixed lookup should resolve");
+            assert_eq!(lookup.relation, VolumeRelation::Same, "{fs_type}");
+        }
+    }
 }
 
 fn local_only_mounts() -> MountTable {

--- a/src/adapters/volume/tests/lookup_regressions.rs
+++ b/src/adapters/volume/tests/lookup_regressions.rs
@@ -3,6 +3,36 @@
 use super::*;
 
 #[test]
+fn autofs_classification_skips_caller_thread_prefix_probes() {
+    let mounts = MountTable::parse(
+        "1 0 0:1 / / rw - ext4 /dev/root rw\n\
+         2 1 0:2 / /automount rw - autofs systemd-1 rw\n\
+         3 2 8:1 / /automount/local rw - ext4 /dev/disk rw\n",
+    );
+    for path in ["/automount", "/automount/share", "/automount/local/file"] {
+        let location = Location::local(path);
+        let directory = Directory::classify_with_probe(&location, &mounts, |_| {
+            panic!("autofs path {path} must not probe prefixes on the caller");
+        });
+        assert!(!directory.resolves_synchronously(), "{path}");
+        assert!(!mounts.is_remote_path(Path::new(path)), "{path}");
+    }
+
+    let sibling = Location::local("/automount-data/file");
+    let probed = std::cell::Cell::new(false);
+    let directory = Directory::classify_with_probe(&sibling, &mounts, |path| {
+        assert_eq!(path, sibling.native_path().expect("native path"));
+        probed.set(true);
+        false
+    });
+    assert!(
+        probed.get(),
+        "ordinary local paths still check for symlinks"
+    );
+    assert!(directory.resolves_synchronously());
+}
+
+#[test]
 fn pending_lookup_uses_its_original_classification_and_finishes_promptly() {
     let root = tempfile::tempdir().expect("fixture");
     let link = root.path().join("destination");


### PR DESCRIPTION
## Description

Detect autofs ancestors from mountinfo before drag/drop volume classification can probe path prefixes on the GTK thread. Use the existing asynchronous, cancellable lookup and timeout, including for nested local mounts beneath autofs.

Keep this scheduling decision separate from remote classification and filesystem identity; Copy/Move/Ask policy and Trash restore safeguards are unchanged. Add a no-probe regression and extend existing async/identity fixtures with synthetic autofs mounts.

## Visual evidence

N/A — scheduling-only fix with no visual changes. No live-server outage or UI hang was induced; reproduction uses synthetic mount tables.

## How to test

1. In a disposable isolated session only, prepare an expendable autofs share backed by an unavailable test server. Do not interrupt a live/user mount.
2. Hover a file drag over a destination beneath the untriggered automount, then leave the target or cancel the drag.
3. Repeat ordinary local and cross-volume drops in Columns, List, and Icons, using the Copy/Move/Ask preferences.

**Expected result:** Drag-hover remains responsive and unresolved identity falls back through the existing timeout behavior. Leaving cancels feedback. Ordinary local drops and cross-volume policy remain unchanged; autofs scheduling alone does not mean the filesystems differ.

## Related issue

Closes #732
