### PR TITLE
fix(peek): keep a pending peek alive when the pointer leaves a sibling folder

### DIFF
--- a/src/ui/browser/columns.rs
+++ b/src/ui/browser/columns.rs
@@ -6,8 +6,8 @@ use crate::ui::browser::ViewState;
 use crate::ui::browser::clipboard::install_directory_drop_target;
 use crate::ui::browser::collection::{
     ViewMap, activate_recursive_search_result, apply_filter_query, apply_selection_plan,
-    bind_filter_query, bitset_positions, deactivate_recursive_search, detach_collection_view,
-    recursive_search_activation_key, scroll_collection_when_allocated,
+    bind_filter_query, bitset_positions, cancel_source, deactivate_recursive_search,
+    detach_collection_view, recursive_search_activation_key, scroll_collection_when_allocated,
     search_result_navigation_position,
 };
 use crate::ui::browser::context_menu::{install_folder_context_menu, install_item_context_menu};
@@ -1323,6 +1323,8 @@ impl ViewState {
     }
 
     pub(super) fn truncate(self: &Rc<Self>, len: usize) {
+        cancel_source(&self.pending_peek);
+        self.peek_anchor.take();
         self.close_peek_visual();
         if self.hovered_column.get().is_some_and(|depth| depth >= len) {
             self.hovered_column.set(None);

--- a/src/ui/browser/peek.rs
+++ b/src/ui/browser/peek.rs
@@ -227,13 +227,12 @@ impl ViewState {
         let source = glib::timeout_add_local_once(self.peek_behavior.open_delay, move || {
             if let Some(state) = weak_state.upgrade() {
                 state.pending_peek.take();
-                let still_hovered = state
-                    .peek_anchor
-                    .borrow()
-                    .as_ref()
-                    .is_some_and(|anchor| {
-                        anchor.widget.state_flags().contains(gtk::StateFlags::PRELIGHT)
-                    });
+                let still_hovered = state.peek_anchor.borrow().as_ref().is_some_and(|anchor| {
+                    anchor
+                        .widget
+                        .state_flags()
+                        .contains(gtk::StateFlags::PRELIGHT)
+                });
                 if still_hovered {
                     state.browser.begin_peek(origin_depth, location);
                 } else {

--- a/src/ui/browser/peek.rs
+++ b/src/ui/browser/peek.rs
@@ -227,14 +227,24 @@ impl ViewState {
         let source = glib::timeout_add_local_once(self.peek_behavior.open_delay, move || {
             if let Some(state) = weak_state.upgrade() {
                 state.pending_peek.take();
-                state.browser.begin_peek(origin_depth, location);
+                let still_hovered = state
+                    .peek_anchor
+                    .borrow()
+                    .as_ref()
+                    .is_some_and(|anchor| {
+                        anchor.widget.state_flags().contains(gtk::StateFlags::PRELIGHT)
+                    });
+                if still_hovered {
+                    state.browser.begin_peek(origin_depth, location);
+                } else {
+                    state.peek_anchor.take();
+                }
             }
         });
         self.pending_peek.replace(Some(source));
     }
 
     pub(in crate::ui) fn schedule_close_peek(self: &Rc<Self>) {
-        cancel_source(&self.pending_peek);
         cancel_source(&self.pending_close);
 
         let weak_state = Rc::downgrade(self);
@@ -387,10 +397,8 @@ impl ViewState {
     }
 
     pub(super) fn close_peek_visual(&self) {
-        cancel_source(&self.pending_peek);
         cancel_source(&self.pending_close);
         self.overlay.remove_css_class("peek-open");
-        self.peek_anchor.take();
         if let Some(peek) = self.peek.take() {
             peek.anchor.remove_css_class("peek-anchor");
             peek.revealer.set_can_target(false);


### PR DESCRIPTION
## Description

Fast pointer motion across folders could fire `leave(A)` after `enter(B)`, so `schedule_close_peek` cancelled `pending_peek` that now belonged to B and `close_peek_visual` took `peek_anchor` before B's open delay elapsed — the destination peek never opened.

Three changes:

- **`schedule_close_peek`** no longer cancels `pending_peek`; only the close timer is (re)armed. A pending peek for a newly entered folder survives a late `leave` from the previous one.
- **`close_peek_visual`** no longer cancels `pending_peek` or takes `peek_anchor`; it only tears down the currently open peek. A pending peek for the next folder is not destroyed when the previous one closes.
- **`pending_peek` open callback** now checks the anchor's `PRELIGHT` state before calling `begin_peek`. If the pointer has left the anchor (leave to empty space), the stale pending peek is dropped — covering the case the old unconditional cancellation handled.
- **`truncate`** explicitly cancels `pending_peek` and takes `peek_anchor` before `close_peek_visual`, since column removal needs a hard cancel that `close_peek_visual` no longer performs.

## Visual evidence

https://github.com/user-attachments/assets/11a10a13-cf8a-40b6-a1f8-123d85e5b49d

## How to test

1. In Columns mode, open a folder containing several subfolders.
2. Move the pointer quickly from one folder row to an adjacent folder row and stop.
3. Wait for the peek delay (~180ms).

**Expected result:** The second folder's peek popover opens. Repeat in List and Icons modes; repeat moving across three or more folders in one sweep.

## Related issue

Closes #871