### PR TITLE
feat(columns): reveal next column when clicking column background

### DIFF
--- a/src/ui/browser/columns.rs
+++ b/src/ui/browser/columns.rs
@@ -1266,50 +1266,66 @@ impl ViewState {
             };
             state.browser.set_active_column(depth);
             state.browser.focus_active();
-            let shell = state
-                .columns
-                .borrow()
-                .get(depth)
-                .map(|column| column.shell.clone());
-            if let Some(shell) = shell {
-                state.reveal_column(shell);
+            let columns = state.columns.borrow();
+            let left_shell = columns.get(depth).map(|column| column.shell.clone());
+            let right_shell = columns.get(depth + 1).map(|column| column.shell.clone());
+            drop(columns);
+            if let Some(left_shell) = left_shell {
+                state.reveal_column_span(left_shell, right_shell);
             }
         });
         surface.add_controller(click.clone());
         click
     }
 
-    pub(super) fn reveal_column(self: &Rc<Self>, shell: gtk::Box) {
+    pub(super) fn reveal_column_span(
+        self: &Rc<Self>,
+        left_shell: gtk::Box,
+        right_shell: Option<gtk::Box>,
+    ) {
         let animation_id = self.horizontal_scroll_generation.get().saturating_add(1);
         self.horizontal_scroll_generation.set(animation_id);
         let weak = Rc::downgrade(self);
-        let measured_shell = shell.downgrade();
+        let measured_left = left_shell.downgrade();
+        let measured_right = right_shell.as_ref().map(|s| s.downgrade());
         let _tick = self.scroller.add_tick_callback(move |_, _| {
             let Some(state) = weak.upgrade() else {
                 return glib::ControlFlow::Break;
             };
-            let Some(measured_shell) = measured_shell.upgrade() else {
+            let Some(measured_left) = measured_left.upgrade() else {
                 return glib::ControlFlow::Break;
             };
             if state.horizontal_scroll_generation.get() != animation_id
-                || measured_shell.parent().is_none()
+                || measured_left.parent().is_none()
             {
                 return glib::ControlFlow::Break;
             }
             let adjustment = state.scroller.hadjustment();
-            if measured_shell.width() <= 0 || adjustment.page_size() <= 0.0 {
+            if measured_left.width() <= 0 || adjustment.page_size() <= 0.0 {
                 return glib::ControlFlow::Continue;
             }
-            let Some(bounds) = measured_shell.compute_bounds(&state.columns_widget) else {
+            let Some(left_bounds) = measured_left.compute_bounds(&state.columns_widget) else {
                 return glib::ControlFlow::Continue;
+            };
+            let item_left = f64::from(left_bounds.x());
+            let item_right = if let Some(measured_right) =
+                measured_right.as_ref().and_then(|w| w.upgrade())
+            {
+                if let Some(right_bounds) = measured_right.compute_bounds(&state.columns_widget) {
+                    f64::from(right_bounds.x() + right_bounds.width())
+                } else {
+                    f64::from(left_bounds.x() + left_bounds.width())
+                }
+            } else {
+                f64::from(left_bounds.x() + left_bounds.width())
             };
             let target = horizontal_reveal_target(
                 adjustment.value(),
                 adjustment.page_size(),
                 adjustment.lower(),
                 adjustment.upper(),
-                f64::from(bounds.x()),
-                f64::from(bounds.x() + bounds.width()),
+                item_left,
+                item_right,
             );
             animate_horizontal_scroll(
                 &state.scroller,
@@ -1320,6 +1336,10 @@ impl ViewState {
             );
             glib::ControlFlow::Break
         });
+    }
+
+    pub(super) fn reveal_column(self: &Rc<Self>, shell: gtk::Box) {
+        self.reveal_column_span(shell, None);
     }
 
     pub(super) fn truncate(self: &Rc<Self>, len: usize) {

--- a/src/ui/browser/columns/tests.rs
+++ b/src/ui/browser/columns/tests.rs
@@ -118,3 +118,28 @@ fn reveal_target_can_scroll_back_to_an_earlier_column() {
         300.0
     );
 }
+
+#[test]
+fn reveal_target_for_child_column_advances_viewport_rightward() {
+    // 600px viewport with 300px columns:
+    // Clicking column 0 (0..300) when child column 1 (300..600) is already visible does not scroll.
+    assert_eq!(
+        horizontal_reveal_target(0.0, 600.0, 0.0, 1_200.0, 300.0, 600.0),
+        0.0
+    );
+    // Clicking column 1 (300..600) reveals child column 2 (600..900) by scrolling to 300.0.
+    assert_eq!(
+        horizontal_reveal_target(0.0, 600.0, 0.0, 1_200.0, 600.0, 900.0),
+        300.0
+    );
+    // Clicking column 2 (600..900) reveals child column 3 (900..1200) by scrolling to 600.0.
+    assert_eq!(
+        horizontal_reveal_target(300.0, 600.0, 0.0, 1_200.0, 900.0, 1_200.0),
+        600.0
+    );
+    // Clicking last column 3 (900..1200) with no child column targets itself and stays at 600.0.
+    assert_eq!(
+        horizontal_reveal_target(600.0, 600.0, 0.0, 1_200.0, 900.0, 1_200.0),
+        600.0
+    );
+}


### PR DESCRIPTION
## Description

In Miller Columns mode, clicking a column's background to focus it previously only ensured that the clicked column itself was visible. When child columns were positioned off-screen to the right, there was no indication they existed and the viewport remained stationary.

This change introduces `reveal_column_span`, which ensures the visible span covers both the clicked column and its immediate child column (`depth + 1`), if present. When a user clicks a column's background, the viewport advances rightward just enough to fully reveal the child column, allowing single-click discovery and direct interaction.

Key behaviors:
- **Child column reveal:** Clicking column `depth` advances the horizontal scroller to reveal column `depth + 1` if it is off-screen.
- **Stable when visible:** If the child column (or clicked column) is already fully visible, no redundant scroll is performed.
- **Last column fallback:** If the clicked column is the rightmost column with no child, it targets the clicked column itself without extra motion.
- **Preserved isolation:** Directory descending (`append_column`) and branch truncation (`truncate`) continue using their dedicated column reveal paths.

## Visual evidence

N/A

## How to test

1. Launch Strata in Miller Columns mode:
   ```bash
   cargo run
   ```
2. Navigate deep into subfolders so that 3 or more columns are populated and exceed the window width.
3. Scroll back to column 0 or 1.
4. Click the empty background or header area of column 1.

**Expected result:**
The viewport smoothly scrolls to the right to reveal column 2 into view. Clicking column 2 reveals column 3, until the final column is reached.

## Related issue

Closes #874