### PR TITLE
feat(columns): reveal adjacent column peek margin when navigating

### DIFF
--- a/src/ui/browser/columns.rs
+++ b/src/ui/browser/columns.rs
@@ -359,6 +359,8 @@ pub(in crate::ui) fn max_child_natural_width(widget: &gtk::Widget) -> i32 {
     max_natural
 }
 
+pub(super) const COLUMN_PEEK_WIDTH: f64 = 48.0;
+
 fn horizontal_reveal_target(
     current: f64,
     page_size: f64,
@@ -367,11 +369,22 @@ fn horizontal_reveal_target(
     item_left: f64,
     item_right: f64,
 ) -> f64 {
-    let viewport_right = current + page_size;
-    let target = if item_right > viewport_right {
-        item_right - page_size
-    } else if item_left < current {
+    let peek_right = if item_right < upper {
+        (item_right + COLUMN_PEEK_WIDTH).min(upper)
+    } else {
+        item_right
+    };
+    let peek_left = if item_left > lower {
+        (item_left - COLUMN_PEEK_WIDTH).max(lower)
+    } else {
         item_left
+    };
+
+    let viewport_right = current + page_size;
+    let target = if peek_right > viewport_right {
+        peek_right - page_size
+    } else if peek_left < current {
+        peek_left
     } else {
         current
     };

--- a/src/ui/browser/columns/tests.rs
+++ b/src/ui/browser/columns/tests.rs
@@ -104,17 +104,25 @@ fn reveal_target_scrolls_only_enough_to_show_the_new_column() {
 }
 
 #[test]
-fn reveal_target_is_stable_when_the_column_is_already_visible() {
+fn reveal_target_includes_peek_of_next_column() {
     assert_eq!(
         horizontal_reveal_target(300.0, 900.0, 0.0, 1_500.0, 900.0, 1_200.0),
-        300.0
+        348.0
     );
 }
 
 #[test]
-fn reveal_target_can_scroll_back_to_an_earlier_column() {
+fn reveal_target_can_scroll_back_with_parent_peek() {
     assert_eq!(
         horizontal_reveal_target(600.0, 900.0, 0.0, 1_500.0, 300.0, 600.0),
-        300.0
+        252.0
+    );
+}
+
+#[test]
+fn reveal_target_for_first_column_aligns_to_start() {
+    assert_eq!(
+        horizontal_reveal_target(300.0, 900.0, 0.0, 1_500.0, 0.0, 300.0),
+        0.0
     );
 }


### PR DESCRIPTION
## Description

In Miller Columns mode, when focusing or navigating columns, adjacent offscreen columns (such as the next child column on the right or parent column on the left) were not visible unless manually scrolled into view.

This change adds a 48px peek margin to \`horizontal_reveal_target\` when scrolling forward or backward, allowing users to see a sliver of the adjacent column and discover/click into it directly, while keeping the root and leaf columns cleanly aligned to boundaries.

## Visual evidence

https://github.com/user-attachments/assets/512cb619-7e4d-4b51-9b81-aad4f438ae46

## How to test

1. Open Strata in Miller Columns mode.
2. Navigate deep into nested folders so multiple columns exist across the viewport width.
3. Click or navigate between columns.

**Expected result:**
When revealing a column forward, a 48px peek of the next child column is visible on the right edge (if not at the boundary). When revealing backward, a 48px peek of the parent column is visible on the left edge.

## Related issue

Closes #874