### PR TITLE
fix(columns): dismiss column filters on any outside click

### DIFF
--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -1511,10 +1511,7 @@ impl BrowserView {
                 return;
             };
             let inside = picked.as_ref().is_some_and(|p| {
-                p == column.filter_entry.upcast_ref::<gtk::Widget>()
-                    || p == column.filter_button.upcast_ref::<gtk::Widget>()
-                    || p.is_ancestor(&column.filter_entry)
-                    || p.is_ancestor(&column.filter_button)
+                p == column.shell.upcast_ref::<gtk::Widget>() || p.is_ancestor(&column.shell)
             });
             if inside {
                 return;

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -1499,6 +1499,30 @@ impl BrowserView {
         column.list.grab_focus();
         true
     }
+
+    pub fn dismiss_filter_on_outside_click(&self, root: &gtk::Widget, x: f64, y: f64) {
+        if self.view_mode() != BrowserMode::Columns {
+            return;
+        }
+        let picked = root.pick(x, y, gtk::PickFlags::DEFAULT);
+        let filter_button = {
+            let columns = self.state.columns.borrow();
+            let Some(column) = columns.iter().find(|c| c.filter_button.is_active()) else {
+                return;
+            };
+            let inside = picked.as_ref().is_some_and(|p| {
+                p == column.filter_entry.upcast_ref::<gtk::Widget>()
+                    || p == column.filter_button.upcast_ref::<gtk::Widget>()
+                    || p.is_ancestor(&column.filter_entry)
+                    || p.is_ancestor(&column.filter_button)
+            });
+            if inside {
+                return;
+            }
+            column.filter_button.clone()
+        };
+        filter_button.set_active(false);
+    }
 }
 
 impl ViewState {

--- a/src/ui/browser/columns.rs
+++ b/src/ui/browser/columns.rs
@@ -587,36 +587,19 @@ impl ViewState {
         header_actions.append(&column_sort_direction_toggle(&self.browser, depth));
         header_actions.append(&column_sort_menu(&self.browser, depth));
 
-        let filter_entry = gtk::Entry::builder()
-            .placeholder_text("Filter 0 items…")
-            .has_frame(false)
-            .hexpand(true)
-            .build();
-        filter_entry.add_css_class("column-filter-entry");
-        let filter_icon = crate::assets::chrome_icon(crate::assets::icons::FUNNEL);
-        let filter_control = gtk::Box::new(gtk::Orientation::Horizontal, 7);
-        filter_control.add_css_class("column-filter");
-        filter_control.append(&filter_icon);
-        filter_control.append(&filter_entry);
-        let filter_revealer = gtk::Revealer::builder()
-            .transition_type(gtk::RevealerTransitionType::SlideDown)
-            .child(&filter_control)
-            .build();
-        let filter_button = gtk::ToggleButton::builder()
-            .tooltip_text("Filter this pane (Ctrl+F)")
-            .build();
-        filter_button.set_child(Some(&crate::assets::chrome_icon(
-            crate::assets::icons::FUNNEL,
-        )));
-        crate::ui::controls::pane_header_action(&filter_button);
-        let shown_filter = filter_revealer.clone();
-        let focused_filter = filter_entry.clone();
+        let (filter_entry, filter_revealer, filter_button) =
+            crate::ui::browser_modes::filter_controls("Filter this pane (Ctrl+F)");
+        filter_entry.set_placeholder_text(Some("Filter 0 items…"));
+        let weak_self = Rc::downgrade(self);
         filter_button.connect_toggled(move |button| {
-            shown_filter.set_reveal_child(button.is_active());
-            if button.is_active() {
-                focused_filter.grab_focus();
-            } else {
-                focused_filter.set_text("");
+            if button.is_active()
+                && let Some(state) = weak_self.upgrade()
+            {
+                for (other_depth, other) in state.columns.borrow().iter().enumerate() {
+                    if other_depth != depth && other.filter_button.is_active() {
+                        other.filter_button.set_active(false);
+                    }
+                }
             }
         });
         header_actions.append(&filter_button);

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -1412,7 +1412,7 @@ struct IconsControls {
     empty_trash_button: Option<gtk::Button>,
 }
 
-fn filter_controls(tooltip: &str) -> (gtk::Entry, gtk::Revealer, gtk::ToggleButton) {
+pub(crate) fn filter_controls(tooltip: &str) -> (gtk::Entry, gtk::Revealer, gtk::ToggleButton) {
     let entry = gtk::Entry::builder()
         .placeholder_text("Filter items…")
         .has_frame(false)

--- a/src/ui/window/composition.rs
+++ b/src/ui/window/composition.rs
@@ -59,6 +59,18 @@ impl WindowContent {
         install_browser_actions(window, &self.browser);
         let notice = settings::install(window, self, preferences);
         window.set_child(Some(&self.overlay));
+        let click_browser = self.browser.clone();
+        let click_window = window.clone();
+        let click = gtk::GestureClick::new();
+        click.set_propagation_phase(gtk::PropagationPhase::Capture);
+        click.connect_pressed(move |_, _, x, y| {
+            click_browser.dismiss_filter_on_outside_click(
+                click_window.upcast_ref::<gtk::Widget>(),
+                x,
+                y,
+            );
+        });
+        window.add_controller(click);
         input::install_edit_cancellation(window, &self.browser);
         super::install_modal_focus_trap(window);
         let top_bar = crate::ui::top_bar_navigation::TopBarNavigation::new(


### PR DESCRIPTION
## Description

Columns mode duplicated the shared `filter_controls()` widget construction from `browser_modes.rs`. Replaced the inline copy with a call to the existing helper so List, Icons, and Columns all build filter controls the same way.

A single capture-phase `GtkGestureClick` on the `ApplicationWindow` dismisses the active column filter when a click lands outside the filter entry/button. This covers empty space, sidebar, header, other columns, and any non-focusable area — the previous focus-leave approach missed clicks on non-focusable widgets like the sidebar because GTK focus stayed in the entry.

Opening a filter in one column now deactivates any other column's active filter via the existing `set_active(false)` path (which clears text and hides the revealer), so only one filter is open at a time.

## Visual evidence

https://github.com/user-attachments/assets/6d88bb16-7e48-4e2b-ac0b-76212a67b773

## How to test

1. Switch to Columns view and open a directory with subfolders (2+ columns)
2. Press `Ctrl+F` in column 1 — the filter bar opens
3. Click on empty space (no column) — the filter closes
4. Press `Ctrl+F` in column 1 again, then click the sidebar — the filter closes
5. Press `Ctrl+F` in column 1, then `Ctrl+F` in column 2 — column 1's filter closes, only column 2's is open
6. Click the filter entry or toggle button — the filter stays open

**Expected result:** Clicking anywhere outside the filter entry/button closes the active column filter. Only one column filter is open at a time.

## Related issue

Closes #606