### PR TITLE
fix(archives): extract into a subfolder on double-click activation

### DIFF
--- a/src/ui/browser/archive.rs
+++ b/src/ui/browser/archive.rs
@@ -49,6 +49,20 @@ fn normalized_archive_name(name: &str, format: ArchiveFormat) -> String {
         .to_owned()
 }
 
+/// Strips any recognized archive extension from `name`, returning the stem
+/// used to name the extraction subfolder. Handles compound extensions like
+/// `.tar.gz` and alternate forms like `.tgz`.
+fn archive_stem(name: &str) -> &str {
+    const SUFFIXES: &[&str] = &[".tar.gz", ".tgz", ".tar", ".zip", ".7z", ".rar"];
+    let lower = name.to_ascii_lowercase();
+    for suffix in SUFFIXES {
+        if lower.ends_with(suffix) {
+            return &name[..name.len() - suffix.len()];
+        }
+    }
+    name
+}
+
 /// Whether `destination` already contains a child named `archive_name`.
 ///
 /// Collision checks use the final filename, including the format extension.
@@ -446,6 +460,41 @@ impl ViewState {
                 .replace(Some((entry.clone(), parent.clone())));
         }
         self.browser.extract(entry, parent, None);
+    }
+
+    /// Extracts `entry` into a subfolder of its parent named after the
+    /// archive (e.g. `archive.zip` → `archive/`), matching the behavior of
+    /// Nautilus and other file managers on double-click activation.
+    ///
+    /// Falls back to [`Self::extract_entry`] when the stem is empty or the
+    /// subfolder cannot be constructed.
+    pub(super) fn extract_entry_to_subfolder(self: &Rc<Self>, entry: FileEntry) {
+        if entry.location.native_path().is_none() {
+            return;
+        }
+        let Some(parent) = entry.location.parent() else {
+            show_error_dialog(
+                &self.overlay,
+                "Cannot extract",
+                "This archive has no parent directory.",
+            );
+            return;
+        };
+        let stem = archive_stem(&entry.display_name);
+        if stem.is_empty() || stem == "." || stem == ".." || stem.contains('/') {
+            self.extract_entry(entry);
+            return;
+        }
+        let Some(destination) = parent.child(std::ffi::OsStr::new(stem)) else {
+            self.extract_entry(entry);
+            return;
+        };
+        let format = ArchiveFormat::from_extension(&entry.display_name);
+        if format.map(|f| f.supports_password()).unwrap_or(false) {
+            self.pending_extract_retry
+                .replace(Some((entry.clone(), destination.clone())));
+        }
+        self.browser.extract(entry, destination, None);
     }
 
     /// Opens the "Extract to" folder picker for `entry`.

--- a/src/ui/browser/archive.rs
+++ b/src/ui/browser/archive.rs
@@ -49,9 +49,6 @@ fn normalized_archive_name(name: &str, format: ArchiveFormat) -> String {
         .to_owned()
 }
 
-/// Strips any recognized archive extension from `name`, returning the stem
-/// used to name the extraction subfolder. Handles compound extensions like
-/// `.tar.gz` and alternate forms like `.tgz`.
 fn archive_stem(name: &str) -> &str {
     const SUFFIXES: &[&str] = &[".tar.gz", ".tgz", ".tar", ".zip", ".7z", ".rar"];
     let lower = name.to_ascii_lowercase();
@@ -462,12 +459,6 @@ impl ViewState {
         self.browser.extract(entry, parent, None);
     }
 
-    /// Extracts `entry` into a subfolder of its parent named after the
-    /// archive (e.g. `archive.zip` → `archive/`), matching the behavior of
-    /// Nautilus and other file managers on double-click activation.
-    ///
-    /// Falls back to [`Self::extract_entry`] when the stem is empty or the
-    /// subfolder cannot be constructed.
     pub(super) fn extract_entry_to_subfolder(self: &Rc<Self>, entry: FileEntry) {
         if entry.location.native_path().is_none() {
             return;

--- a/src/ui/browser/events.rs
+++ b/src/ui/browser/events.rs
@@ -507,7 +507,7 @@ impl ViewState {
             BrowserEvent::PreviewRequested { .. } => {}
             BrowserEvent::ExtractRequested { entry } => {
                 if self.interactive {
-                    self.extract_entry(entry.clone());
+                    self.extract_entry_to_subfolder(entry.clone());
                 }
             }
             BrowserEvent::OpenRequested { location } => {

--- a/tests/e2e/scenarios/test_archive_activation.py
+++ b/tests/e2e/scenarios/test_archive_activation.py
@@ -40,6 +40,7 @@ def test_archive_activation_extracts_to_subfolder(strata, mode, activation, form
     strata.wait(lambda: extracted.exists(), "archive activation to extract into a subfolder")
     strata.wait(lambda: strata.dialog() is None, "extraction progress dismissal")
     assert extracted.read_text() == contents
+    assert not fixture.path(member).exists()
     assert fixture.path(archive_name).exists()
     assert strata.pane().name == fixture.root.name
     strata.entry("activation")

--- a/tests/e2e/scenarios/test_archive_activation.py
+++ b/tests/e2e/scenarios/test_archive_activation.py
@@ -15,7 +15,7 @@ from harness.modes import ALL_MODES
 @pytest.mark.parametrize("mode", ALL_MODES)
 @pytest.mark.parametrize("activation", ["keyboard", "double-click"])
 @pytest.mark.parametrize("format", ["zip", "rar"])
-def test_archive_activation_extracts_in_place(strata, mode, activation, format):
+def test_archive_activation_extracts_to_subfolder(strata, mode, activation, format):
     strata.wait_for_focused_entry("archive")
     fixture = strata.fixture
     archive_name = f"activation.{format}"
@@ -35,13 +35,14 @@ def test_archive_activation_extracts_in_place(strata, mode, activation, format):
     else:
         strata.double_click_entry(archive_name)
 
-    extracted = fixture.path(member)
-    strata.wait(lambda: extracted.exists(), "archive activation to extract in place")
+    subfolder = fixture.path("activation")
+    extracted = subfolder / member
+    strata.wait(lambda: extracted.exists(), "archive activation to extract into a subfolder")
     strata.wait(lambda: strata.dialog() is None, "extraction progress dismissal")
     assert extracted.read_text() == contents
     assert fixture.path(archive_name).exists()
     assert strata.pane().name == fixture.root.name
-    strata.entry(member)
+    strata.entry("activation")
     if format == "rar":
         collector = ArtifactCollector(test_name=f"rar-activation-{mode}-{activation}")
         strata.screenshot(collector.directory / "after.png")


### PR DESCRIPTION
## Description

Double-clicking an archive (or activating it with the keyboard) extracted its contents directly into the parent directory, scattering files alongside the archive. Nautilus and other file managers create a subfolder named after the archive (e.g. `archive.zip` → `archive/`) and extract into it.

Added `extract_entry_to_subfolder` which strips the archive extension to derive a subfolder name and extracts into `parent/subfolder`. The `ExtractRequested` handler (double-click/keyboard activation) now uses it, while the context menu "Extract here" keeps the existing in-place behavior. Falls back to in-place extraction when the stem is empty or invalid.

## Visual evidence

https://github.com/user-attachments/assets/71bf69cb-cc36-487d-bc0b-f89ce294068c

## How to test

1. Create a zip file containing several files (e.g. `test.zip` with `a.txt`, `b.txt`)
2. Double-click the archive in Strata
3. A folder named `test` is created and the files are extracted into it
4. Right-click the same archive → "Extract here" still extracts into the current directory

## Related issue

Closes #894