### PR TITLE
fix(delete): play dissolve after progress dismissal

### DIFF
--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -185,7 +185,9 @@ pub enum BrowserEvent {
         completed: usize,
         total: usize,
     },
-    DeletionFinished,
+    DeletionFinished {
+        succeeded: bool,
+    },
     RestorationStarted {
         total: usize,
     },
@@ -2005,7 +2007,9 @@ impl Browser {
                 });
             }
             if deleting {
-                browser.emit(BrowserEvent::DeletionFinished);
+                browser.emit(BrowserEvent::DeletionFinished {
+                    succeeded: matches!(&event, OperationEvent::Deleted { .. }),
+                });
             }
             if restoring {
                 browser.emit(BrowserEvent::RestorationFinished);

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -93,6 +93,12 @@ fn deletion_monitor_changes_publish_once_after_the_terminal_event() {
             .count(),
         1
     );
+    assert!(
+        events
+            .borrow()
+            .iter()
+            .any(|event| matches!(event, BrowserEvent::DeletionFinished { succeeded: true }))
+    );
 }
 
 #[test]
@@ -775,7 +781,7 @@ fn cancellation_refreshes_an_affected_remote_root_and_its_open_descendants() {
         !events
             .borrow()
             .iter()
-            .any(|event| matches!(event, BrowserEvent::DeletionFinished))
+            .any(|event| matches!(event, BrowserEvent::DeletionFinished { .. }))
     );
 
     emit(OperationEvent::Cancelled {
@@ -806,7 +812,7 @@ fn cancellation_refreshes_an_affected_remote_root_and_its_open_descendants() {
         events
             .borrow()
             .iter()
-            .any(|event| matches!(event, BrowserEvent::DeletionFinished))
+            .any(|event| matches!(event, BrowserEvent::DeletionFinished { succeeded: false }))
     );
     assert!(events.borrow().iter().any(|event| matches!(
         event,

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -187,7 +187,8 @@ pub(super) struct ViewState {
     /// failed only because the location doesn't support Trash can offer a
     /// permanent-delete retry for exactly those entries.
     pending_delete_entries: RefCell<Vec<FileEntry>>,
-    pending_delete_animation_cleanup: RefCell<Option<dissolve_delete::DissolveCleanup>>,
+    /// Visible permanent-delete rows captured before the operation mutates the model.
+    pending_delete_dissolve: RefCell<Option<dissolve_delete::PreparedDissolve>>,
     pending_navigate: RefCell<Option<Location>>,
     pending_location_credentials: RefCell<Option<MountCredentials>>,
     pending_trash_lookup: RefCell<Option<LoadHandle>>,
@@ -497,7 +498,7 @@ impl BrowserView {
             pending_extract_retry: RefCell::new(None),
             pending_archive_destination: RefCell::new(None),
             pending_delete_entries: RefCell::new(Vec::new()),
-            pending_delete_animation_cleanup: RefCell::new(None),
+            pending_delete_dissolve: RefCell::new(None),
             pending_navigate: RefCell::new(None),
             pending_location_credentials: RefCell::new(None),
             pending_trash_lookup: RefCell::new(None),

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -187,7 +187,6 @@ pub(super) struct ViewState {
     /// failed only because the location doesn't support Trash can offer a
     /// permanent-delete retry for exactly those entries.
     pending_delete_entries: RefCell<Vec<FileEntry>>,
-    /// Visible permanent-delete rows captured before the operation mutates the model.
     pending_delete_dissolve: RefCell<Option<dissolve_delete::PreparedDissolve>>,
     pending_navigate: RefCell<Option<Location>>,
     pending_location_credentials: RefCell<Option<MountCredentials>>,

--- a/src/ui/browser/dissolve_delete.rs
+++ b/src/ui/browser/dissolve_delete.rs
@@ -15,7 +15,11 @@ const MIN_FRAGMENT_BUDGET: usize = 80;
 const MAX_FRAGMENT_BUDGET: usize = 192;
 const FRAGMENTS_PER_ROW: usize = 48;
 
-pub(super) type DissolveCleanup = Box<dyn FnOnce()>;
+/// Render snapshots captured before deletion and retained until progress UI has dismissed.
+pub(super) struct PreparedDissolve {
+    overlay: gtk::Overlay,
+    rows: Vec<DissolveRow>,
+}
 
 #[derive(Clone)]
 struct FragmentMotion {
@@ -90,19 +94,14 @@ impl DissolveCanvas {
     }
 }
 
-pub(in crate::ui) fn dissolve_delete(
+pub(super) fn prepare_dissolve(
     source: &gtk::Widget,
     entries: &[FileEntry],
-    on_done: impl FnOnce(DissolveCleanup) + 'static,
-) {
+) -> Option<PreparedDissolve> {
     if !crate::ui::motion::animations_enabled() {
-        on_done(Box::new(|| {}));
-        return;
+        return None;
     }
-    let Some(overlay) = window_overlay(source) else {
-        on_done(Box::new(|| {}));
-        return;
-    };
+    let overlay = window_overlay(source)?;
     let targets = collect_entry_targets(source, entries);
     let measured: Vec<_> = targets
         .into_iter()
@@ -113,8 +112,7 @@ pub(in crate::ui) fn dissolve_delete(
         })
         .collect();
     if measured.is_empty() {
-        on_done(Box::new(|| {}));
-        return;
+        return None;
     }
 
     let fragment_budget = fragment_budget(measured.len());
@@ -126,7 +124,6 @@ pub(in crate::ui) fn dissolve_delete(
         fragment_budget,
     );
     let mut random = Random::new(0x9E37_79B9_7F4A_7C15);
-    let mut source_rows = Vec::with_capacity(measured.len());
     let mut rendered_rows = Vec::with_capacity(measured.len());
     for (index, (row, bounds)) in measured.iter().enumerate() {
         let Some(node) = snapshot_row(row, bounds.width(), bounds.height()) else {
@@ -149,39 +146,40 @@ pub(in crate::ui) fn dissolve_delete(
             origin: gtk::graphene::Point::new(bounds.x(), bounds.y()),
             fragments,
         });
-        source_rows.push((row.clone(), row.opacity()));
     }
     if rendered_rows.is_empty() {
-        on_done(Box::new(|| {}));
-        return;
+        return None;
     }
 
-    let canvas = DissolveCanvas::new(rendered_rows);
-    overlay.add_overlay(&canvas);
-    for (row, _) in &source_rows {
-        row.set_opacity(0.0);
-    }
+    Some(PreparedDissolve {
+        overlay,
+        rows: rendered_rows,
+    })
+}
 
-    let canvas_for_tick = canvas.clone();
-    let overlay_for_cleanup = overlay.clone();
-    let rows_for_cleanup = source_rows.clone();
-    let canvas_for_cleanup = canvas.clone();
-    animate(
-        &canvas,
-        DURATION,
-        move |elapsed| {
-            let progress = (elapsed.as_secs_f64() / DURATION.as_secs_f64()).clamp(0.0, 1.0);
-            canvas_for_tick.set_progress(progress);
-        },
-        move || {
-            overlay_for_cleanup.remove_overlay(&canvas_for_cleanup);
-            on_done(Box::new(move || {
-                for (row, opacity) in rows_for_cleanup {
-                    row.set_opacity(opacity);
-                }
-            }));
-        },
-    );
+impl PreparedDissolve {
+    pub(super) fn play(self) {
+        if !crate::ui::motion::animations_enabled() {
+            return;
+        }
+
+        let Self { overlay, rows } = self;
+        let canvas = DissolveCanvas::new(rows);
+        overlay.add_overlay(&canvas);
+
+        let canvas_for_tick = canvas.clone();
+        let overlay_for_cleanup = overlay.clone();
+        let canvas_for_cleanup = canvas.clone();
+        animate(
+            &canvas,
+            DURATION,
+            move |elapsed| {
+                let progress = (elapsed.as_secs_f64() / DURATION.as_secs_f64()).clamp(0.0, 1.0);
+                canvas_for_tick.set_progress(progress);
+            },
+            move || overlay_for_cleanup.remove_overlay(&canvas_for_cleanup),
+        );
+    }
 }
 
 fn snapshot_row(row: &gtk::Widget, width: f32, height: f32) -> Option<gtk::gsk::RenderNode> {

--- a/src/ui/browser/dissolve_delete.rs
+++ b/src/ui/browser/dissolve_delete.rs
@@ -15,7 +15,6 @@ const MIN_FRAGMENT_BUDGET: usize = 80;
 const MAX_FRAGMENT_BUDGET: usize = 192;
 const FRAGMENTS_PER_ROW: usize = 48;
 
-/// Render snapshots captured before deletion and retained until progress UI has dismissed.
 pub(super) struct PreparedDissolve {
     overlay: gtk::Overlay,
     rows: Vec<DissolveRow>,

--- a/src/ui/browser/events.rs
+++ b/src/ui/browser/events.rs
@@ -578,9 +578,20 @@ impl ViewState {
             BrowserEvent::DeletionProgress { completed, total } => {
                 self.update_item_progress(*completed, *total);
             }
-            BrowserEvent::DeletionFinished => {
-                self.clear_delete_animation();
-                self.dismiss_file_operation_progress();
+            BrowserEvent::DeletionFinished { succeeded } => {
+                if *succeeded {
+                    let weak = Rc::downgrade(self);
+                    self.dismiss_file_operation_progress_then(move || {
+                        glib::idle_add_local_once(move || {
+                            if let Some(state) = weak.upgrade() {
+                                state.play_delete_animation();
+                            }
+                        });
+                    });
+                } else {
+                    self.clear_delete_animation();
+                    self.dismiss_file_operation_progress();
+                }
                 self.prune_stale_search_results();
             }
             BrowserEvent::RestorationStarted { total } => {

--- a/src/ui/browser/events/tests.rs
+++ b/src/ui/browser/events/tests.rs
@@ -3,6 +3,7 @@
 use super::*;
 use crate::model::{EntryKind, FileEntry, Location, MetadataValue};
 use crate::ui::browser::{BrowserView, PeekBehavior};
+use std::cell::RefCell;
 use std::time::{Duration, Instant};
 
 fn wait_until(condition: impl Fn() -> bool, message: &str) {
@@ -54,6 +55,17 @@ fn progress_layer(overlay: &gtk::Overlay) -> gtk::Box {
     panic!("progress layer was not attached");
 }
 
+fn has_dissolve_canvas(overlay: &gtk::Overlay) -> bool {
+    let mut child = overlay.first_child();
+    while let Some(widget) = child {
+        child = widget.next_sibling();
+        if widget.type_().name() == "StrataDissolveCanvas" {
+            return true;
+        }
+    }
+    false
+}
+
 #[test]
 fn extract_error_needs_password_ignores_quoted_member_names() {
     assert!(extract_error_needs_password("Invalid password"));
@@ -98,6 +110,76 @@ fn extract_error_needs_password_ignores_backticks_inside_member_names() {
             assert!(!extract_error_needs_password(&message), "{message}");
         }
     }
+}
+
+#[test]
+fn successful_delete_dissolves_visible_rows_after_progress_dismissal() {
+    crate::test_support::gtk_test(
+        "ui::browser::events::tests::successful_delete_dissolves_visible_rows_after_progress_dismissal",
+        || {
+            crate::ui::motion::set_reduce_motion(false);
+            gtk::Settings::default()
+                .expect("GTK settings")
+                .set_gtk_enable_animations(true);
+            let directory = tempfile::tempdir().expect("delete directory");
+            let path = directory.path().join("visible.txt");
+            std::fs::write(&path, "visible").expect("delete fixture");
+            let (view, browser, window, overlay) = archive_view(directory.path());
+            let state = &view.state;
+            let entry = FileEntry {
+                location: Location::local(&path),
+                native_name: std::ffi::OsString::from("visible.txt"),
+                thumbnail_path: None,
+                display_name: "visible.txt".into(),
+                kind: EntryKind::File,
+                size: MetadataValue::Known(7),
+                modified_unix_seconds: MetadataValue::Unknown,
+                is_hidden: false,
+                mode: MetadataValue::Unknown,
+            };
+            let dissolve = RefCell::new(None);
+            wait_until(
+                || {
+                    if dissolve.borrow().is_none() {
+                        dissolve.replace(super::super::dissolve_delete::prepare_dissolve(
+                            state.overlay.upcast_ref(),
+                            std::slice::from_ref(&entry),
+                        ));
+                    }
+                    dissolve.borrow().is_some()
+                },
+                "visible row was not ready to snapshot",
+            );
+            state.pending_delete_dissolve.replace(dissolve.into_inner());
+            state.show_file_operation_progress(
+                16,
+                crate::assets::icons::TRASH,
+                "Deleting items",
+                "Cancelling will not undo completed changes",
+                Rc::new(|| {}),
+            );
+            let layer = progress_layer(&overlay);
+
+            state.handle(&BrowserEvent::DeletionFinished { succeeded: true });
+
+            assert!(layer.parent().is_some());
+            assert!(!has_dissolve_canvas(&overlay));
+            wait_until(
+                || layer.parent().is_none(),
+                "progress modal did not dismiss",
+            );
+            wait_until(
+                || has_dissolve_canvas(&overlay),
+                "dissolve did not start after progress dismissal",
+            );
+            wait_until(
+                || !has_dissolve_canvas(&overlay),
+                "dissolve animation did not finish",
+            );
+            window.destroy();
+            browser.clear_observer();
+        },
+    );
 }
 
 #[test]

--- a/src/ui/browser/trash.rs
+++ b/src/ui/browser/trash.rs
@@ -156,8 +156,12 @@ impl ViewState {
     }
 
     pub(super) fn clear_delete_animation(&self) {
-        if let Some(cleanup) = self.pending_delete_animation_cleanup.take() {
-            cleanup();
+        self.pending_delete_dissolve.take();
+    }
+
+    pub(super) fn play_delete_animation(&self) {
+        if let Some(dissolve) = self.pending_delete_dissolve.take() {
+            dissolve.play();
         }
     }
 
@@ -816,20 +820,16 @@ impl ViewState {
                 &confirmed_overlay,
                 confirmed_root.as_ref(),
                 move || {
-                    let browser_for_delete = browser.clone();
-                    let entries_for_delete = entries_for_dissolve.clone();
-                    super::dissolve_delete::dissolve_delete(
+                    let dissolve = super::dissolve_delete::prepare_dissolve(
                         overlay_for_dissolve.upcast_ref(),
                         &entries_for_dissolve,
-                        move |cleanup| {
-                            if let Some(ui) = weak_ui.upgrade() {
-                                ui.clear_delete_animation();
-                                ui.pending_delete_animation_cleanup.replace(Some(cleanup));
-                            }
-                            browser_for_delete.delete(entries_for_delete, true);
-                            browser_for_delete.focus_active();
-                        },
                     );
+                    if let Some(ui) = weak_ui.upgrade() {
+                        ui.clear_delete_animation();
+                        ui.pending_delete_dissolve.replace(dissolve);
+                    }
+                    browser.delete(entries_for_dissolve, true);
+                    browser.focus_active();
                 },
             );
         });

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -885,7 +885,7 @@ fn trash_contents_from_probe(probe: Result<bool, glib::Error>) -> TrashContents 
 fn event_changes_trash_contents(event: &BrowserEvent) -> bool {
     matches!(
         event,
-        BrowserEvent::DeletionFinished
+        BrowserEvent::DeletionFinished { .. }
             | BrowserEvent::RestorationFinished
             | BrowserEvent::TransferFinished { .. }
             | BrowserEvent::OperationCompletedWithErrors { .. }

--- a/src/ui/window/tests.rs
+++ b/src/ui/window/tests.rs
@@ -885,7 +885,7 @@ fn trash_probe_results_map_to_menu_state() {
 #[test]
 fn trash_mutating_operations_refresh_the_context_menu() {
     assert!(event_changes_trash_contents(
-        &BrowserEvent::DeletionFinished
+        &BrowserEvent::DeletionFinished { succeeded: true }
     ));
     assert!(event_changes_trash_contents(
         &BrowserEvent::RestorationFinished


### PR DESCRIPTION
## Description

Capture the visible rows selected for permanent deletion before the operation mutates the browser model, then play their dissolve animation only after the deletion progress dialog has fully dismissed. Failed, partial, and cancelled deletions discard the prepared animation.

This prevents the dissolve effect from competing visually with deletion progress while keeping off-screen rows out of the animation.

## Visual evidence

https://github.com/user-attachments/assets/f5e17b6b-89ee-461b-8969-b39356f35fee

## How to test

1. Open a directory containing at least 16 files, select all visible entries, and permanently delete them.
2. Confirm that deletion progress appears without a simultaneous dissolve effect.
3. Confirm that the visible deleted rows dissolve only after the progress dialog finishes closing.
4. Repeat with reduced motion enabled and confirm the dissolve is skipped.

**Expected result:**

Deletion progress and the dissolve animation never overlap. After successful deletion, only rows visible when deletion began dissolve after progress closes; failed or cancelled deletions do not play the dissolve.

## Related issue

Closes #895
