### PR TITLE
fix(ui): reserve space for modal dialog shadows

### DIFF
--- a/src/ui/modal.rs
+++ b/src/ui/modal.rs
@@ -62,7 +62,8 @@ pub(super) fn modal_layer(
 
     let click = gtk::GestureClick::new();
     let weak_layer = layer.downgrade();
-    let weak_content = viewport.downgrade();
+    let weak_viewport = viewport.downgrade();
+    let weak_content = content.as_ref().downgrade();
     let overlay = overlay.clone();
     let root = root.clone();
     let block = block_dismiss.clone();
@@ -78,15 +79,20 @@ pub(super) fn modal_layer(
         let Some(content) = weak_content.upgrade() else {
             return;
         };
-        let on_dialog = content
-            .translate_coordinates(&layer, 0.0, 0.0)
-            .is_some_and(|(cx, cy)| {
-                let alloc = content.allocation();
-                x >= cx
-                    && x < cx + alloc.width() as f64
-                    && y >= cy
-                    && y < cy + alloc.height() as f64
-            });
+        let Some(viewport) = weak_viewport.upgrade() else {
+            return;
+        };
+        let on_dialog = [content, viewport.upcast()].iter().all(|widget| {
+            widget
+                .translate_coordinates(&layer, 0.0, 0.0)
+                .is_some_and(|(cx, cy)| {
+                    let alloc = widget.allocation();
+                    x >= cx
+                        && x < cx + alloc.width() as f64
+                        && y >= cy
+                        && y < cy + alloc.height() as f64
+                })
+        });
         if !on_dialog {
             dismiss_modal_layer(&layer, &overlay, root.as_ref());
         }

--- a/src/ui/modal/layout.rs
+++ b/src/ui/modal/layout.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use gtk::{glib, graphene, gsk, prelude::*, subclass::prelude::*};
+use gtk::{glib, prelude::*, subclass::prelude::*};
 
 mod imp {
     use super::*;
@@ -32,30 +32,8 @@ mod imp {
             let Some(scroll) = widget.first_child().and_downcast::<gtk::ScrolledWindow>() else {
                 return;
             };
-            let Some(viewport) = scroll.child() else {
-                return;
-            };
-            let available_width = (width - 24).max(1);
-            let available_height = (height - 24).max(1);
-            let child_width = viewport
-                .measure(gtk::Orientation::Horizontal, -1)
-                .1
-                .min(available_width)
-                .max(1);
-            let child_height = viewport
-                .measure(gtk::Orientation::Vertical, child_width)
-                .1
-                .min(available_height)
-                .max(1);
-            scroll.allocate(
-                child_width,
-                child_height,
-                baseline,
-                Some(gsk::Transform::new().translate(&graphene::Point::new(
-                    ((width - child_width) / 2) as f32,
-                    ((height - child_height) / 2) as f32,
-                ))),
-            );
+            // Keep overflow controls at the window edges, not beside the dialog.
+            scroll.allocate(width.max(1), height.max(1), baseline, None);
         }
     }
 }
@@ -71,6 +49,8 @@ pub(in crate::ui) fn install(
     // ScrolledWindow clips its child, including CSS shadows. Reserve room inside
     // the clip for the largest dialog shadow (the settings panel's 28px blur).
     let shadow_space = gtk::Box::new(gtk::Orientation::Vertical, 0);
+    shadow_space.set_halign(gtk::Align::Center);
+    shadow_space.set_valign(gtk::Align::Center);
     shadow_space.set_margin_top(42);
     shadow_space.set_margin_bottom(42);
     shadow_space.set_margin_start(42);

--- a/src/ui/modal/layout.rs
+++ b/src/ui/modal/layout.rs
@@ -68,10 +68,18 @@ pub(in crate::ui) fn install(
     layer: &gtk::Box,
     content: &impl IsA<gtk::Widget>,
 ) -> gtk::ScrolledWindow {
+    // ScrolledWindow clips its child, including CSS shadows. Reserve room inside
+    // the clip for the largest dialog shadow (the settings panel's 28px blur).
+    let shadow_space = gtk::Box::new(gtk::Orientation::Vertical, 0);
+    shadow_space.set_margin_top(42);
+    shadow_space.set_margin_bottom(42);
+    shadow_space.set_margin_start(42);
+    shadow_space.set_margin_end(42);
+    shadow_space.append(content);
     let scroll = gtk::ScrolledWindow::builder()
         .hscrollbar_policy(gtk::PolicyType::Automatic)
         .vscrollbar_policy(gtk::PolicyType::Automatic)
-        .child(content)
+        .child(&shadow_space)
         .build();
     scroll.add_css_class("modal-viewport");
     layer.append(&scroll);


### PR DESCRIPTION
## Description

Reserve transparent space inside the shared modal scroller so dialog shadows can extend beyond their rounded surfaces without being clipped. Keep shadow-space clicks dismissing the dialog, and constrain hit testing to the visible viewport.

Implemented in the existing checkout at the owner’s request. The owner requested opening the PR without an added test or further local validation; Rust/E2E suites, formatting/Clippy gates, and visual capture were not completed. `git diff --check` passed. Rendering remains unverified locally.

## Visual evidence
<img width="892" height="1006" alt="image" src="https://github.com/user-attachments/assets/efd97a4e-6487-4cc0-ab49-5c42f3050163" />


## How to test

1. Select a file or folder and open Properties with Alt+Enter. Inspect all edges and corners; repeat with Settings and another action dialog.
2. Click inside the dialog, then in the surrounding shadow. Also resize the window until the dialog needs scrolling and verify its controls remain reachable.

**Expected result:** Shadows fade outside rounded surfaces without a hard cutoff. Inside clicks preserve the dialog; backdrop/shadow clicks dismiss it. Oversized dialogs remain scrollable.

## Related issue

Closes #906