### PR TITLE
fix(settings): ignore launch requests while a modal is visible

### DIFF
--- a/src/ui/window/composition/settings.rs
+++ b/src/ui/window/composition/settings.rs
@@ -18,6 +18,9 @@ use super::{
     WindowContent,
 };
 
+#[cfg(test)]
+mod tests;
+
 type AvailableUpdate = Rc<RefCell<Option<(ReleaseMetadata, String, UpdateMethod)>>>;
 
 pub(super) fn install(
@@ -85,6 +88,13 @@ impl SettingsLauncher {
     }
 
     fn show(&self) {
+        let mut child = self.overlay.first_child();
+        while let Some(widget) = child {
+            child = widget.next_sibling();
+            if widget.is_visible() && widget.has_css_class("app-modal-layer") {
+                return;
+            }
+        }
         let layer = self.layer();
         self.blurred_root.set_blurred(true);
         layer.set_visible(true);

--- a/src/ui/window/composition/settings/tests.rs
+++ b/src/ui/window/composition/settings/tests.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+
+use super::*;
+
+#[test]
+fn settings_launcher_refuses_to_open_over_another_modal() {
+    crate::test_support::gtk_test(
+        "ui::window::composition::settings::tests::settings_launcher_refuses_to_open_over_another_modal",
+        || {
+            crate::ui::prepare_portal_ui();
+            let content = gtk::Box::new(gtk::Orientation::Vertical, 0);
+            let blurred_root = BlurBin::new(&content);
+            let overlay = gtk::Overlay::new();
+            overlay.set_child(Some(&blurred_root));
+            let window = gtk::Window::builder().child(&overlay).build();
+            let launcher = SettingsLauncher {
+                layer: RefCell::new(None),
+                button: gtk::Button::new(),
+                blurred_root,
+                overlay: overlay.clone(),
+                preferences: ThemeManager::shared(),
+                notice: Rc::new(|_| {}),
+                guard: settings::install_guard(),
+            };
+            let action = crate::ui::modal::modal_layer(
+                &gtk::Button::with_label("Action"),
+                &overlay,
+                Some(launcher.blurred_root.clone()),
+                None,
+            );
+            overlay.add_overlay(&action);
+            window.present();
+            action.grab_focus();
+            let focus = gtk::prelude::RootExt::focus(&window);
+
+            launcher.show();
+            assert!(launcher.layer.borrow().is_none());
+            assert!(!launcher.button.has_css_class("active"));
+            assert_eq!(gtk::prelude::RootExt::focus(&window), focus);
+
+            overlay.remove_overlay(&action);
+            launcher.show();
+            let settings = launcher.layer.borrow().clone().expect("Settings layer");
+            assert!(settings.is_visible());
+            assert!(launcher.button.has_css_class("active"));
+            settings.set_visible(false);
+            launcher.button.remove_css_class("active");
+            overlay.add_overlay(&action);
+            action.grab_focus();
+            let focus = gtk::prelude::RootExt::focus(&window);
+
+            launcher.show();
+            assert!(!settings.is_visible());
+            assert!(!launcher.button.has_css_class("active"));
+            assert_eq!(gtk::prelude::RootExt::focus(&window), focus);
+            assert_eq!(overlay.last_child(), Some(action.clone().upcast()));
+
+            action.set_visible(false);
+            launcher.show();
+            assert!(
+                settings.is_visible(),
+                "hidden modals must not block Settings"
+            );
+            assert_eq!(launcher.layer.borrow().as_ref(), Some(&settings));
+            window.destroy();
+        },
+    );
+}


### PR DESCRIPTION
## Description

Ignore Settings launch requests while any modal layer is visible. This prevents both the header button and Ctrl+, from opening Settings behind an action dialog, without changing focus, blur, or overlay order. Once the dialog closes, Settings can open normally.

The original behind-dialog reproduction requires opening and closing Settings once first, because its lazy overlay is retained. Regression coverage exercises both first-time opening and reuse, and ensures hidden modals do not block Settings.

## Visual evidence

N/A — launch eligibility only; no layout or styling changes. The existing action dialog remains unchanged when Settings is requested.

## How to test

1. Open Settings, then close it. Select a file and open Properties.
2. Press Ctrl+,. Properties should remain focused and Settings should stay closed.
3. Press Escape. Properties should close without revealing Settings underneath.
4. Press Ctrl+, again. Settings should open normally.
5. In a fresh window, open Properties before ever opening Settings and repeat steps 2–4.

**Expected result:** Settings requests are ignored while an action dialog is visible and work after it is dismissed.

## Related issue

Closes #865
