### PR TITLE
fix(trash): refuse restore through a same-volume symlink parent

### DIFF
--- a/src/adapters/trash_restore.rs
+++ b/src/adapters/trash_restore.rs
@@ -641,6 +641,9 @@ fn canonical_restore_destination(path: &Path) -> Result<PathBuf, RestoreTargetEr
     let parent = path
         .parent()
         .ok_or_else(|| RestoreTargetError::new("The original location is invalid"))?;
+    if std::fs::symlink_metadata(parent).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+        return Err(symlinked_parent_error());
+    }
     let mut existing = parent.to_path_buf();
     let mut missing = Vec::new();
     while !existing.as_os_str().is_empty() && !existing.exists() {
@@ -678,4 +681,12 @@ fn escaped_restore_error() -> RestoreTargetError {
     RestoreTargetError::new(
         "The original location is outside the trash volume and cannot be restored.",
     )
+}
+
+/// The item's own parent no longer names the directory it was deleted from --
+/// something replaced it with a symlink, possibly to redirect the restore
+/// elsewhere on the same volume where the plain volume/mount checks below
+/// would not otherwise notice.
+fn symlinked_parent_error() -> RestoreTargetError {
+    RestoreTargetError::new("The original location's parent is a symlink and cannot be restored.")
 }

--- a/src/adapters/trash_restore/tests.rs
+++ b/src/adapters/trash_restore/tests.rs
@@ -279,6 +279,33 @@ fn symlink_parent_that_leaves_the_volume_is_rejected() -> std::io::Result<()> {
 }
 
 #[test]
+fn symlink_parent_that_stays_on_the_volume_is_still_rejected() {
+    let fixture = tempfile::tempdir().expect("fixture");
+    let uid = 1000;
+    let trash = volume_trash(fixture.path(), uid);
+    let source = trash.join("files/inner.txt");
+    fs::write(&source, b"secret").expect("source");
+    fs::create_dir_all(fixture.path().join("documents")).expect("documents dir");
+    fs::create_dir_all(fixture.path().join("pictures")).expect("pictures dir");
+    symlink(
+        fixture.path().join("pictures"),
+        fixture.path().join("documents/nested"),
+    )
+    .expect("nested symlink");
+    let context = context_for(&fixture.path().join("home-trash"), uid, fixture.path());
+    let error = plan_restore_from_known_paths(
+        &source,
+        Path::new("documents/nested/inner.txt"),
+        &trash,
+        None,
+        &context,
+    )
+    .expect_err("symlinked parent on the same volume");
+    assert!(error.message().contains("symlink"), "{}", error.message());
+    assert!(!fixture.path().join("pictures/inner.txt").exists());
+}
+
+#[test]
 fn destination_inside_the_trash_directory_is_rejected() {
     let fixture = tempfile::tempdir().expect("fixture");
     let uid = 1000;


### PR DESCRIPTION
## Description

Trash Restore resolves a destination by canonicalizing the closest existing ancestor of the original path, which silently follows a symlink if that ancestor has been replaced by one. The existing volume-identity and mount-point checks only catch an escape that *leaves* the volume (`symlink_parent_that_leaves_the_volume_is_rejected`), so a same-volume symlink parent -- e.g. a directory swapped for a symlink into a sibling folder on the same disk -- passed through untouched and wrote the restored file into the symlink's target instead of its real original location.

`canonical_restore_destination` now checks the destination's immediate parent with `symlink_metadata` (which does not follow the final component) before any canonicalization happens, and refuses outright if it's a symlink rather than a real directory.

## Visual evidence

N/A -- this is a backend safety check in the trash-restore path with no UI change.

## How to test

1. Trash `documents/nested/inner.txt`.
2. Replace `nested` with a symlink to another folder on the *same* volume (e.g. `pictures/`).
3. Try to restore the trashed file.
4. Before this fix, the restore silently succeeds and writes the file into `pictures/inner.txt`. After, it's refused with "The original location's parent is a symlink and cannot be restored."

Added `symlink_parent_that_stays_on_the_volume_is_still_rejected` alongside the existing leaves-the-volume test, confirmed it fails against the pre-fix code and passes after.

## Related issue

Closes #862
