### PR TITLE
fix(keyboard): give inline editing priority over window commands

### DIFF
--- a/src/ui/window/keyboard/commands.rs
+++ b/src/ui/window/keyboard/commands.rs
@@ -24,6 +24,9 @@ use crate::{
 
 impl Dispatcher {
     pub(super) fn window_commands(&self, event: &KeyEvent) -> KeyResult {
+        if event.text_has_focus() {
+            return None;
+        }
         if event.control()
             && event.without(Modifiers::SHIFT_MASK | Modifiers::ALT_MASK)
             && let Some(mode) = browser_mode_for_digit(event.key)

--- a/src/ui/window/tests/keyboard_dispatch.rs
+++ b/src/ui/window/tests/keyboard_dispatch.rs
@@ -31,6 +31,7 @@ impl KeyboardFixture {
         let header = gtk::Box::new(gtk::Orientation::Horizontal, 0);
         let toggle = gtk::ToggleButton::builder().active(true).build();
         header.append(&toggle);
+        header.append(&view.location_widget());
         let top_bar = TopBarNavigation::new(&header, &sidebar.widget, &toggle);
         let preview = PreviewDrawer::new(Rc::new(super::type_to_search::TextPreview), false);
         let row = gtk::Box::new(gtk::Orientation::Horizontal, 0);
@@ -178,9 +179,9 @@ fn modal_ownership_precedes_window_shortcuts() {
 }
 
 #[test]
-fn inline_editing_owns_filter_keys_but_not_global_search() {
+fn inline_editing_and_location_edit_own_filter_and_global_search_keys() {
     crate::test_support::gtk_test(
-        "ui::window::tests::keyboard_dispatch::inline_editing_owns_filter_keys_but_not_global_search",
+        "ui::window::tests::keyboard_dispatch::inline_editing_and_location_edit_own_filter_and_global_search_keys",
         || {
             let fixture = KeyboardFixture::new();
             let searches = Rc::new(Cell::new(0));
@@ -188,15 +189,36 @@ fn inline_editing_owns_filter_keys_but_not_global_search() {
             let action = gio::SimpleAction::new("search", None);
             action.connect_activate(move |_, _| observed.set(observed.get() + 1));
             fixture.window.add_action(&action);
+
             assert!(fixture.press(Key::F2, ModifierType::empty()));
             assert!(fixture.view.rename_is_active());
             assert!(!fixture.press(Key::f, ModifierType::CONTROL_MASK));
             assert!(!fixture.view.filter_has_focus());
-            assert!(fixture.press(Key::k, ModifierType::CONTROL_MASK));
-            assert_eq!(searches.get(), 1);
+            assert!(!fixture.press(Key::k, ModifierType::CONTROL_MASK));
+            assert_eq!(searches.get(), 0);
+            assert!(!fixture.press(Key::_2, ModifierType::CONTROL_MASK));
+            assert_eq!(fixture.view.view_mode(), BrowserMode::Columns);
+            assert!(fixture.view.rename_is_active());
             assert!(fixture.press(Key::Escape, ModifierType::empty()));
             assert!(!fixture.view.rename_is_active());
             assert_eq!(fixture.selected(), [0]);
+            wait_until(|| {
+                !gtk::prelude::RootExt::focus(&fixture.window)
+                    .is_some_and(|focused| focused.is::<gtk::Entry>() || focused.is::<gtk::Text>())
+            });
+
+            assert!(fixture.press(Key::l, ModifierType::CONTROL_MASK));
+            wait_until(|| fixture.view.location_has_focus());
+            assert!(!fixture.press(Key::k, ModifierType::CONTROL_MASK));
+            assert_eq!(searches.get(), 0);
+            assert!(!fixture.press(Key::_2, ModifierType::CONTROL_MASK));
+            assert_eq!(fixture.view.view_mode(), BrowserMode::Columns);
+            assert!(fixture.view.location_has_focus());
+            assert!(fixture.press(Key::Escape, ModifierType::empty()));
+            assert!(!fixture.view.location_has_focus());
+
+            assert!(fixture.press(Key::k, ModifierType::CONTROL_MASK));
+            assert_eq!(searches.get(), 1);
         },
     );
 }


### PR DESCRIPTION
## Description

`Dispatcher::handle_key` runs `window_commands` before `inline_editing` in its chain, so window-level chords (Ctrl+1/2/3 view-mode switching, Ctrl+K global search) were handled unconditionally, before inline editing or location editing ever got a chance to claim the key for its own field. Pressing Ctrl+2 mid-F2-rename switched view mode and committed the half-typed name; Ctrl+K while renaming or editing the location bar (Ctrl+L) opened global search over the field instead of reaching it.

`window_commands` now returns early when a text field currently has focus (`KeyEvent::text_has_focus`, the same signal `inline_editing`'s catch-all `Propagation::Proceed` and `text_input`'s location-edit handling already rely on), letting the key fall through to whichever field owns it.

## Visual evidence

N/A -- this is a keyboard-dispatch ordering fix with no visual change.

## How to test

1. Select a file, press F2, and start typing a new name.
2. Press Ctrl+2. Before this fix, the view switches to Icons and the half-typed name is committed. After, the keystroke reaches the rename field and editing continues.
3. Press Escape, then Ctrl+L to edit the location bar, then press Ctrl+K. Before this fix, global search opens over the field. After, the key reaches the location entry.

Updated `inline_editing_owns_filter_keys_but_not_global_search` (renamed `inline_editing_and_location_edit_own_filter_and_global_search_keys`) to cover both the rename and location-edit cases for Ctrl+K and Ctrl+2/mode-switch; confirmed it fails against the pre-fix code and passes after.

## Related issue

Closes #861
