### PR TITLE
fix(browser): exclude hidden rows from select all

### DIFF
--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -1276,17 +1276,28 @@ impl Browser {
     }
 
     pub fn select_all(&self, depth: usize) {
-        let count = self
+        let show_hidden = self
+            .column_preferences(depth)
+            .unwrap_or_else(|| self.preferences())
+            .show_hidden;
+        let positions: Vec<usize> = self
             .state
             .borrow()
             .columns
             .get(depth)
-            .map_or(0, |column| column.entries.len());
-        if count == 0 {
+            .map(|column| {
+                column
+                    .entries
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, entry)| show_hidden || !entry.is_hidden)
+                    .map(|(position, _)| position)
+                    .collect()
+            })
+            .unwrap_or_default();
+        let Some(&focused) = positions.last() else {
             return;
-        }
-        let positions: Vec<_> = (0..count).collect();
-        let focused = count - 1;
+        };
         self.commit_selection();
         if self
             .state

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -3085,6 +3085,23 @@ fn escape_clears_only_the_active_selection_and_preserves_the_cursor() {
     }
 }
 
+#[test]
+fn select_all_excludes_hidden_entries_unless_shown() {
+    let source = ScriptedSource::scripted(vec!["visible.txt", ".hidden.txt"], Vec::new());
+    let browser = Browser::new(Rc::new(source));
+    browser.navigate(Location::local("/fixture"));
+
+    browser.select_all(0);
+    let selected = browser.selected_positions(0);
+    assert_eq!(selected.len(), 1, "{selected:?}");
+    let entry = browser.entry_at(0, selected[0]).expect("selected entry");
+    assert_eq!(entry.display_name, "visible.txt");
+
+    browser.toggle_hidden();
+    browser.select_all(0);
+    assert_eq!(browser.selected_positions(0).len(), 2);
+}
+
 type CapturedLoad = Rc<RefCell<Option<(RequestId, Rc<dyn Fn(DirectoryEvent)>)>>>;
 
 struct BatchReplaySource {
@@ -3536,7 +3553,7 @@ impl ScriptedSource {
             size: MetadataValue::Unknown,
             modified_unix_seconds: MetadataValue::Unknown,
             mode: MetadataValue::Unknown,
-            is_hidden: false,
+            is_hidden: name.starts_with('.'),
         }
     }
     fn answer(


### PR DESCRIPTION
## Description

`Browser::select_all` selected every position in a column's raw `entries` list, which always includes hidden entries (each tagged `is_hidden`) regardless of the show-hidden preference -- only the GTK filter model excludes them from the visible listing. With hidden files off, Ctrl+A therefore selected `.hidden.txt` even though it was never shown, and a multiple-select file chooser returned its URI in the result.

Filter to entries the current preference actually shows (`column_preferences(depth)`, falling back to the global preference) before building the selection. Columns mode was already correct -- it selects through the GTK model directly via `column.selection.select_all()`, which is bound to the already-filtered view -- so this only affects List/Icons and the chooser (which share the same helper).

## Visual evidence

N/A -- this is a selection-logic fix with no visual change.

## How to test

1. With Hidden files off, open a folder containing a dotfile and a visible file in List or Icons mode (or an Open dialog with `multiple=true`).
2. Select the visible file, press Ctrl+A.
3. Before this fix, the hidden file is also selected (and would be returned by a chooser). After, only the visible file is selected.

Added `select_all_excludes_hidden_entries_unless_shown`, confirmed it fails against the pre-fix code (selects 2 instead of 1) and passes after; also confirms toggling hidden files back on selects both.

## Related issue

Closes #856
