### PR TITLE
feat(cli): print the installed version with --version

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Launch Strata with an optional local directory:
 ```bash
 strata                 # home directory
 strata ~/Documents     # a specific directory
+strata --version       # print the installed version
 ```
 
 Useful shortcuts include <kbd>Ctrl</kbd>+<kbd>K</kbd> for recursive search, <kbd>Ctrl</kbd>+<kbd>L</kbd> for a path or URI, <kbd>Ctrl</kbd>+<kbd>F</kbd> to filter the current pane, <kbd>Ctrl</kbd>+<kbd>Z</kbd> to undo the latest move or move to Trash, <kbd>Space</kbd> for preview, <kbd>F2</kbd> to rename, and <kbd>Alt</kbd>+arrow keys for history and parent navigation.

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ enum LaunchMode {
     InstallPortal,
     DismissPortalPrompt,
     UninstallPortal,
+    Version,
     Application,
 }
 
@@ -49,8 +50,17 @@ fn launch_mode(arguments: &[OsString]) -> LaunchMode {
         Some("--install-portal") => LaunchMode::InstallPortal,
         Some("--dismiss-portal-prompt") => LaunchMode::DismissPortalPrompt,
         Some("--uninstall-portal") => LaunchMode::UninstallPortal,
+        Some("--version") => LaunchMode::Version,
         _ => LaunchMode::Application,
     }
+}
+
+fn version_line() -> String {
+    format!(
+        "{} {}",
+        env!("CARGO_PKG_NAME"),
+        build_info::installed_version()
+    )
 }
 
 fn main() -> gtk::glib::ExitCode {
@@ -77,6 +87,10 @@ fn main() -> gtk::glib::ExitCode {
             return finish_portal_setup(portal_setup::dismiss_prompt());
         }
         LaunchMode::UninstallPortal => return finish_portal_setup(portal_setup::uninstall()),
+        LaunchMode::Version => {
+            println!("{}", version_line());
+            return gtk::glib::ExitCode::SUCCESS;
+        }
         LaunchMode::Application => {}
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,6 +5,7 @@ use std::{ffi::OsString, os::unix::ffi::OsStringExt};
 use super::{
     GIO_FALLBACK_BACKENDS, LaunchMode, encode_daemon_pids, gvfs_daemon_pids,
     gvfs_probe_marker_is_fresh_at, gvfs_probe_marker_path_in, launch_mode, run_preview_helper,
+    version_line,
 };
 
 #[test]
@@ -32,6 +33,7 @@ fn launch_mode_recognizes_only_the_first_argument_as_a_mode() {
         ("--install-portal", LaunchMode::InstallPortal),
         ("--dismiss-portal-prompt", LaunchMode::DismissPortalPrompt),
         ("--uninstall-portal", LaunchMode::UninstallPortal),
+        ("--version", LaunchMode::Version),
     ] {
         assert_eq!(launch_mode(&["strata".into(), flag.into()]), mode);
         assert_eq!(
@@ -39,6 +41,24 @@ fn launch_mode_recognizes_only_the_first_argument_as_a_mode() {
             LaunchMode::Application
         );
     }
+}
+
+#[test]
+fn version_line_is_the_package_name_and_installed_version() {
+    let line = version_line();
+    assert!(
+        line.starts_with("strata "),
+        "the --version line should start with the package name"
+    );
+    assert!(
+        line.contains(&crate::build_info::installed_version().to_string()),
+        "the --version line should include the installed version"
+    );
+    assert_eq!(
+        line.lines().count(),
+        1,
+        "the --version line should be a single line"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Description

`strata --version` was treated as an ordinary application launch, so packaging checks and scripts had no way to print the installed version without starting the GUI. `docs/packaging.md` already documents this flag as the post-install verification step.

Recognize `--version` in the existing first-argument launch-mode dispatch, print `strata <installed-version>` from `build_info::installed_version()`, and exit successfully without starting GTK. Document the flag next to the other launch examples in the README.

## Visual evidence

N/A — this is a CLI-only launch-mode change with no GUI.

## How to test

1. Build Strata from this branch.
2. Run `strata --version`.
3. Run `strata --version ~/Documents` as well, then `strata ~/Documents --version`.

**Expected result:** the first two print a single line `strata <installed-version>` (matching Settings / the updater, including prerelease identity) and exit without opening a window. The third still launches the application, because only the first argument is a launch mode.

## Related issue

Closes #917