### PR TITLE
fix(settings): keep controls and dependency hints aligned

### DIFF
--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -206,6 +206,7 @@ const DIALOG_MARGIN: i32 = 24;
 const COMPACT_NAVIGATION_BREAKPOINT: i32 = 900;
 // Reflow the content before collapsing navigation: desktop toolbars need more room.
 const COMPACT_CONTENT_BREAKPOINT: i32 = 1250;
+const STACK_TEXT_SIZE_BREAKPOINT: i32 = 600;
 
 mod responsive_bin {
     use super::*;
@@ -326,7 +327,11 @@ mod responsive_bin {
                     }
                 }
             }
-            reflow_settings(&child, compact_content);
+            reflow_settings(
+                &child,
+                compact_content,
+                logical_width < f64::from(STACK_TEXT_SIZE_BREAKPOINT),
+            );
             let x = ((width - child_width) / 2) as f32;
             let y = ((height - child_height) / 2) as f32;
             let transform = gtk::gsk::Transform::new().translate(&gtk::graphene::Point::new(x, y));
@@ -405,7 +410,7 @@ impl ResponsiveBin {
     }
 }
 
-fn reflow_settings(widget: &gtk::Widget, compact: bool) {
+fn reflow_settings(widget: &gtk::Widget, compact: bool, stack_text_size: bool) {
     if widget.has_css_class("settings-dialog") {
         if compact {
             widget.add_css_class("compact");
@@ -429,7 +434,13 @@ fn reflow_settings(widget: &gtk::Widget, compact: bool) {
         let switch_row = row
             .last_child()
             .is_some_and(|child| child.is::<gtk::Switch>());
-        let orientation = if compact && !switch_row {
+        // Short numeric controls can stay beside wrapping copy after other rows stack.
+        let stack_row = if row.has_css_class("settings-text-size-row") {
+            stack_text_size
+        } else {
+            compact
+        };
+        let orientation = if stack_row && !switch_row {
             gtk::Orientation::Vertical
         } else {
             gtk::Orientation::Horizontal
@@ -488,7 +499,7 @@ fn reflow_settings(widget: &gtk::Widget, compact: bool) {
     let mut child = widget.first_child();
     while let Some(next) = child {
         child = next.next_sibling();
-        reflow_settings(&next, compact);
+        reflow_settings(&next, compact, stack_text_size);
     }
 }
 
@@ -2543,7 +2554,17 @@ fn control_row(title: &str, description: &str, control: &impl IsA<gtk::Widget>) 
 fn indent_row(row: &gtk::Box) {
     let arrow = crate::assets::primary_icon(icons::CORNER_DOWN_RIGHT, 18);
     arrow.add_css_class("settings-indent");
-    row.prepend(&arrow);
+    arrow.set_valign(gtk::Align::Center);
+    // Keep the dependency marker with its heading when the control stacks below.
+    if let Some(copy) = row.first_child().and_downcast::<gtk::Box>()
+        && let Some(title) = copy.first_child()
+    {
+        copy.remove(&title);
+        let heading = gtk::Box::new(gtk::Orientation::Horizontal, 4);
+        heading.append(&arrow);
+        heading.append(&title);
+        copy.prepend(&heading);
+    }
     row.add_css_class("settings-dependent");
 }
 

--- a/src/ui/settings/theme.rs
+++ b/src/ui/settings/theme.rs
@@ -270,6 +270,7 @@ fn append_text_size_option(content: &gtk::Box, manager: &Rc<ThemeManager>) {
     controls.append(&text_size_control);
     let text_size_row = gtk::Box::new(gtk::Orientation::Horizontal, 16);
     text_size_row.add_css_class("settings-option");
+    text_size_row.add_css_class("settings-text-size-row");
     super::search::tag(&text_size_row, "Text size");
     let text_size_copy = gtk::Box::new(gtk::Orientation::Vertical, 2);
     text_size_copy.set_hexpand(true);
@@ -281,12 +282,12 @@ fn append_text_size_option(content: &gtk::Box, manager: &Rc<ThemeManager>) {
     ));
     text_size_description.set_xalign(0.0);
     text_size_description.set_wrap(true);
+    text_size_description.set_wrap_mode(gtk::pango::WrapMode::WordChar);
     text_size_description.add_css_class("settings-option-description");
-    let description = gtk::Box::new(gtk::Orientation::Horizontal, 8);
-    description.add_css_class("settings-inline-description");
+    let description = gtk::Box::new(gtk::Orientation::Vertical, 8);
     description.append(&text_size_description);
     let keys = super::wrap::WrapRow::new(6);
-    keys.add_css_class("settings-inline-keys");
+    keys.set_halign(gtk::Align::Start);
     keys.set_hexpand(false);
     keys.set_valign(gtk::Align::Center);
     for key in ["Ctrl", "+", "/", "−", "/", "0"] {


### PR DESCRIPTION
## Description

Keep the text-size selector beside wrapping copy until the dialog is below 600 typography-adjusted logical pixels, rather than stacking at the general 1,250-pixel breakpoint. Give shortcut hints their own wrapping line and keep dependency arrows attached to their headings, including Decoding backend.

The owner manually verified the updated app and explicitly requested no tests be added or run. Automated regression tests were therefore skipped; runtime behavior is covered only by that manual verification.

## Visual evidence

The owner supplied before recordings/screenshots in the development session and verified the updated app manually. These local assets are not attached here; a public before/after attachment remains outstanding.

## How to test

1. Open Settings → Appearance, vary text size, and resize the window from wide to narrow.
2. Confirm the description wraps, shortcut hints remain visible beneath it, and the selector stays alongside until very narrow widths.
3. Open General → Performance and resize with Decoding backend visible. Also inspect dependent browsing settings.

**Expected result:** No clipped shortcuts or isolated dependency arrows; arrows remain beside their headings when controls stack below.

## Related issue

Closes #923
