### PR TITLE
feat(ui): distinguish hidden and cut items visually

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -3396,10 +3396,6 @@ colorchooser colorswatch overlay {
   margin-top: 4px;
 }
 
-.file-row.cut {
-  opacity: 0.45;
-}
-
 .file-row.dragging {
   opacity: 0.48;
 }
@@ -4189,11 +4185,6 @@ menubutton.icons-thumbnail-menu > button:focus-visible {
 
 .icons-card.dragging {
   opacity: 0.52;
-}
-
-.icons-card.cut,
-.list-row.cut {
-  opacity: 0.46;
 }
 
 .file-icons > child:selected .icons-card-label,

--- a/src/ui/browser/columns.rs
+++ b/src/ui/browser/columns.rs
@@ -356,6 +356,12 @@ pub(super) fn set_cut_path_style(row: &gtk::Box, cut: bool) {
     } else {
         row.remove_css_class("cut");
     }
+    if let Some(icon) = row
+        .first_child()
+        .and_downcast::<crate::ui::thumbnail::ThumbnailSlot>()
+    {
+        icon.set_cut(cut);
+    }
 }
 
 fn animate_column_entry(column: &gtk::Box, generation: &Rc<Cell<u64>>) {

--- a/src/ui/browser/columns/rows.rs
+++ b/src/ui/browser/columns/rows.rs
@@ -680,6 +680,9 @@ pub(super) fn column_rows(
                 .as_ref()
                 .and_then(|state| state.pending_rename_name(entry));
             label.set_label(pending_name.as_deref().unwrap_or(&entry.display_name));
+            label.set_opacity(if entry.is_hidden { 0.65 } else { 1.0 });
+        } else {
+            label.set_opacity(1.0);
         }
         let origin = entry
             .as_ref()
@@ -729,7 +732,8 @@ pub(super) fn column_rows(
             } else {
                 crate::ui::thumbnail::show_fallback_icon(&icon, entry_icon(entry), 17);
             }
-            icon.set_opacity(if entry.is_directory() { 1.0 } else { 0.72 });
+            icon.set_hidden(entry.is_hidden);
+            icon.set_base_opacity(if entry.is_directory() { 1.0 } else { 0.72 });
             chevron.set_visible(entry.is_directory());
             if mode_active
                 && let Some(state) = state.as_ref()
@@ -742,7 +746,9 @@ pub(super) fn column_rows(
             }
         } else {
             crate::ui::thumbnail::show_fallback_icon(&icon, crate::assets::icons::DOCUMENTS, 17);
-            icon.set_opacity(0.72);
+            icon.set_hidden(false);
+            icon.set_cut(false);
+            icon.set_base_opacity(0.72);
             chevron.set_visible(false);
         }
         let size_text = column_size_text(entry.as_ref());

--- a/src/ui/browser_modes.rs
+++ b/src/ui/browser_modes.rs
@@ -3745,6 +3745,15 @@ fn set_mode_cut_style(widget: &impl IsA<gtk::Widget>, cut: bool) {
     } else {
         widget.remove_css_class("cut");
     }
+    if let Some((icon, _)) = super::icons_cell::parts(widget) {
+        icon.set_cut(cut);
+    } else if let Some((icon, ..)) = widget
+        .upcast_ref()
+        .downcast_ref::<gtk::Box>()
+        .and_then(list_row_parts)
+    {
+        icon.set_cut(cut);
+    }
 }
 
 fn refresh_cut_pane(pane: &Pane, browser: &Browser, cuts: &[Location]) {
@@ -3943,6 +3952,9 @@ fn apply_icons_entry(
             super::browser::entry_icon(entry),
             thumbnail_size,
         );
+        icon.set_hidden(entry.is_hidden);
+        icon.set_base_opacity(if entry.is_directory() { 1.0 } else { 0.72 });
+        label.set_opacity(if entry.is_hidden { 0.65 } else { 1.0 });
     } else {
         super::thumbnail::set_thumbnail_or_icon(
             &icon,
@@ -3971,8 +3983,11 @@ fn refresh_icons_card_chrome(
     if let Some(item) = item {
         super::accessibility::describe_entry(item, &entry.display_name, Some(entry));
     }
-    set_mode_cut_style(card, cuts.contains(&entry.location));
-    icon.set_opacity(if entry.is_directory() { 1.0 } else { 0.72 });
+    let is_cut = cuts.contains(&entry.location);
+    set_mode_cut_style(card, is_cut);
+    icon.set_hidden(entry.is_hidden);
+    icon.set_base_opacity(if entry.is_directory() { 1.0 } else { 0.72 });
+    label.set_opacity(if entry.is_hidden { 0.65 } else { 1.0 });
 }
 
 fn refresh_icons_section(

--- a/src/ui/browser_modes/list_factory.rs
+++ b/src/ui/browser_modes/list_factory.rs
@@ -136,12 +136,12 @@ impl ListFactory {
         if self.scrolling.get() {
             set_label_if_changed(&row.modified, &crate::util::modified_date(&binding.entry));
         } else {
-            set_mode_cut_style(
-                &row.widget,
-                self.cuts.borrow().contains(&binding.entry.location),
-            );
+            let is_cut = self.cuts.borrow().contains(&binding.entry.location);
+            set_mode_cut_style(&row.widget, is_cut);
             binding.refresh_details(&row);
         }
+        row.icon.set_hidden(binding.entry.is_hidden);
+        row.icon.set_base_opacity(1.0);
     }
 }
 
@@ -193,6 +193,8 @@ impl ListRow {
         self.name.set_visible(true);
         self.field.set_visible(false);
         set_label_if_changed(&self.name, pending_name.unwrap_or(&entry.display_name));
+        self.name
+            .set_opacity(if entry.is_hidden { 0.65 } else { 1.0 });
         set_label_if_changed(&self.mode, &entry_mode(entry));
         set_label_if_changed(&self.size, &entry_size(entry));
         set_label_if_changed(&self.kind, entry_type(entry));
@@ -204,9 +206,12 @@ impl ListRow {
     }
 
     fn clear(&self) {
-        self.widget.remove_css_class("cut-item");
+        set_mode_cut_style(&self.widget, false);
         thumbnail::show_fallback_icon(&self.icon, crate::assets::icons::DOCUMENTS, 18);
+        self.icon.set_hidden(false);
+        self.icon.set_base_opacity(1.0);
         self.name.set_label("");
+        self.name.set_opacity(1.0);
         self.name.set_visible(true);
         self.field.set_visible(false);
         self.mode.set_label("");
@@ -267,7 +272,10 @@ pub(super) fn refresh_list_section(
         let Some(entry) = browser.entry_at(depth, position) else {
             return;
         };
-        set_mode_cut_style(&row.widget, cuts.contains(&entry.location));
+        let is_cut = cuts.contains(&entry.location);
+        let is_hidden = entry.is_hidden;
+        set_mode_cut_style(&row.widget, is_cut);
+        row.name.set_opacity(if is_hidden { 0.65 } else { 1.0 });
         ListBinding {
             browser: browser.clone(),
             depth,
@@ -275,6 +283,8 @@ pub(super) fn refresh_list_section(
             entry,
         }
         .refresh_details(&row);
+        row.icon.set_hidden(is_hidden);
+        row.icon.set_base_opacity(1.0);
     });
 }
 

--- a/src/ui/browser_modes/tests.rs
+++ b/src/ui/browser_modes/tests.rs
@@ -609,6 +609,7 @@ fn icons_scrolling_bind_still_requests_thumbnail_and_settle_fills_chrome() {
             super::refresh_icons_card_chrome(None, &card, &icon, &label, &entry, &cuts);
             assert_eq!(label.tooltip_text().as_deref(), Some("icons-scroll.png"));
             assert!(card.has_css_class("cut"));
+            assert_eq!(icon.opacity(), 1.0);
             assert_eq!(crate::ui::thumbnail::pending_thumbnail_id(&path), job);
             crate::ui::thumbnail::clear_thumbnail_runtime();
         },

--- a/src/ui/thumbnail.rs
+++ b/src/ui/thumbnail.rs
@@ -1018,7 +1018,6 @@ fn known_metadata<T: Copy>(value: &MetadataValue<T>) -> Option<T> {
 
 fn apply_thumbnail(image: &ThumbnailSlot, texture: &gdk::Texture, path: &Path) {
     image.set_texture(texture);
-    image.set_opacity(1.0);
     register_displayed_thumbnail(image, path);
 }
 

--- a/src/ui/thumbnail/slot.rs
+++ b/src/ui/thumbnail/slot.rs
@@ -16,6 +16,9 @@ mod imp {
         pub texture: RefCell<Option<gdk::Texture>>,
         pub fallback: RefCell<Option<gdk::Texture>>,
         pub fallback_icon: RefCell<Option<String>>,
+        pub cut: Cell<bool>,
+        pub hidden: Cell<bool>,
+        pub base_opacity: Cell<f64>,
         #[cfg(test)]
         pub resize_calls: Cell<u32>,
     }
@@ -50,22 +53,33 @@ mod imp {
             if width <= 0.0 || height <= 0.0 {
                 return;
             }
-            let texture = self
-                .texture
-                .borrow()
-                .clone()
-                .or_else(|| self.fallback.borrow().clone());
+            let is_cut = self.cut.get();
+
+            let texture = if is_cut {
+                crate::assets::primary_icon_paintable(crate::assets::icons::SCISSORS)
+                    .or_else(|| self.texture.borrow().clone())
+                    .or_else(|| self.fallback.borrow().clone())
+            } else {
+                self.texture
+                    .borrow()
+                    .clone()
+                    .or_else(|| self.fallback.borrow().clone())
+            };
+
             let Some(texture) = texture else {
                 return;
             };
-            let scale = if self.texture.borrow().is_none() {
-                self.fallback_scale.get()
-            } else {
+
+            let scale = if self.texture.borrow().is_some() || is_cut {
                 1.0
+            } else {
+                self.fallback_scale.get()
             };
+
             let inset = f64::from(self.content_inset.get())
                 .min((width - 1.0) / 2.0)
                 .min((height - 1.0) / 2.0);
+
             snapshot.save();
             let draw_width = (width - 2.0 * inset) * scale;
             let draw_height = (height - 2.0 * inset) * scale;
@@ -133,6 +147,7 @@ impl ThumbnailSlot {
         let widget: Self = glib::Object::new();
         widget.set_overflow(gtk::Overflow::Hidden);
         widget.imp().fallback_scale.set(1.0);
+        widget.imp().base_opacity.set(1.0);
         widget.set_slot(slot);
         widget
     }
@@ -170,6 +185,7 @@ impl ThumbnailSlot {
             return;
         }
         self.imp().texture.replace(Some(texture.clone()));
+        self.update_state_opacity();
         self.queue_draw();
     }
 
@@ -190,11 +206,45 @@ impl ThumbnailSlot {
         self.imp().fallback_scale.set(scale);
         self.imp().fallback_icon.replace(Some(icon.to_owned()));
         self.imp().fallback.replace(texture.cloned());
+        self.update_state_opacity();
         self.queue_draw();
     }
 
     pub(crate) fn texture(&self) -> Option<gdk::Texture> {
         self.imp().texture.borrow().clone()
+    }
+
+    pub(crate) fn set_cut(&self, cut: bool) {
+        if self.imp().cut.replace(cut) != cut {
+            self.update_state_opacity();
+            self.queue_draw();
+        }
+    }
+
+    pub(crate) fn set_hidden(&self, hidden: bool) {
+        if self.imp().hidden.replace(hidden) != hidden {
+            self.update_state_opacity();
+        }
+    }
+
+    pub(crate) fn set_base_opacity(&self, opacity: f64) {
+        let opacity = opacity.clamp(0.0, 1.0);
+        let current = self.imp().base_opacity.get();
+        if (current - opacity).abs() > 1e-4 {
+            self.imp().base_opacity.set(opacity);
+            self.update_state_opacity();
+        }
+    }
+
+    fn update_state_opacity(&self) {
+        let opacity = if self.imp().hidden.get() {
+            0.65
+        } else if self.imp().cut.get() || self.imp().texture.borrow().is_some() {
+            1.0
+        } else {
+            self.imp().base_opacity.get()
+        };
+        self.set_opacity(opacity);
     }
 
     #[cfg(test)]

--- a/src/ui/thumbnail/slot/tests.rs
+++ b/src/ui/thumbnail/slot/tests.rs
@@ -94,3 +94,78 @@ fn rendering_inset_preserves_measurement_and_texture_aspect_ratio() {
         },
     );
 }
+
+fn rendered_texture(node: &gtk::gsk::RenderNode) -> Option<gdk::Texture> {
+    if let Some(texture) = node.downcast_ref::<gtk::gsk::TextureNode>() {
+        return Some(texture.texture());
+    }
+    if let Some(transform) = node.downcast_ref::<gtk::gsk::TransformNode>() {
+        return rendered_texture(&transform.child());
+    }
+    None
+}
+
+#[test]
+fn cut_replaces_thumbnail_and_hidden_controls_its_opacity() {
+    gtk_test(
+        "ui::thumbnail::slot::tests::cut_replaces_thumbnail_and_hidden_controls_its_opacity",
+        || {
+            crate::ui::prepare_portal_ui();
+            let slot = ThumbnailSlot::new(64);
+            slot.allocate(64, 64, -1, None);
+            slot.set_base_opacity(0.72);
+
+            let pixels = glib::Bytes::from_owned(vec![255_u8; 32 * 32 * 4]);
+            let thumbnail =
+                gdk::MemoryTexture::new(32, 32, gdk::MemoryFormat::R8g8b8a8, &pixels, 32 * 4);
+            slot.set_texture(thumbnail.upcast_ref());
+
+            slot.set_cut(true);
+            assert_eq!(slot.opacity(), 1.0);
+            let snapshot = gtk::Snapshot::new();
+            slot.imp().snapshot(&snapshot);
+            let rendered = rendered_texture(&snapshot.to_node().expect("cut node"))
+                .expect("rendered scissors");
+            let scissors = crate::assets::primary_icon_paintable(crate::assets::icons::SCISSORS)
+                .expect("scissors icon");
+            assert_eq!(rendered, scissors);
+
+            slot.set_hidden(true);
+            assert!((slot.opacity() - 0.65).abs() < 0.01);
+
+            slot.set_cut(false);
+            assert!((slot.opacity() - 0.65).abs() < 0.01);
+            let snapshot = gtk::Snapshot::new();
+            slot.imp().snapshot(&snapshot);
+            let rendered = rendered_texture(&snapshot.to_node().expect("thumbnail node"))
+                .expect("rendered thumbnail");
+            assert_eq!(rendered, thumbnail.upcast::<gdk::Texture>());
+
+            slot.set_hidden(false);
+            assert_eq!(slot.opacity(), 1.0);
+        },
+    );
+}
+
+#[test]
+fn fallback_restores_base_opacity_after_thumbnail() {
+    gtk_test(
+        "ui::thumbnail::slot::tests::fallback_restores_base_opacity_after_thumbnail",
+        || {
+            crate::ui::prepare_portal_ui();
+            let slot = ThumbnailSlot::new(64);
+            slot.set_base_opacity(0.72);
+
+            let pixels = glib::Bytes::from_owned(vec![255_u8; 32 * 32 * 4]);
+            let thumbnail =
+                gdk::MemoryTexture::new(32, 32, gdk::MemoryFormat::R8g8b8a8, &pixels, 32 * 4);
+            slot.set_texture(thumbnail.upcast_ref());
+            assert_eq!(slot.opacity(), 1.0);
+
+            let fallback = crate::assets::primary_icon_paintable(crate::assets::icons::DOCUMENTS)
+                .expect("document icon");
+            slot.set_fallback(crate::assets::icons::DOCUMENTS, Some(&fallback));
+            assert!((slot.opacity() - 0.72).abs() < 0.01);
+        },
+    );
+}


### PR DESCRIPTION
## Description

Give hidden and cut items distinct visual treatments across Columns, Icons, and List views.

Hidden items now display their icon or thumbnail and name at 65% opacity. Cut items replace their icon or thumbnail with the existing scissors icon without reducing the item's opacity. When both states apply, the scissors and name use the hidden-item opacity.

Selection backgrounds and focus outlines remain fully opaque. This change affects presentation only and preserves the existing clipboard behavior.

## Visual evidence

### Before

Hidden files and folders are visually indistinguishable from normal items and Cut items are indicated only by reduced opacity:
<img width="358" height="480" alt="image" src="https://github.com/user-attachments/assets/bb37553b-3f28-419c-abab-93d2ea91d176" />

### After

<img width="372" height="459" alt="image" src="https://github.com/user-attachments/assets/2f390a0c-50e8-46a4-ad42-0d8379c3828c" />

## How to test

1. Open a directory containing normal and hidden files or folders.
2. Press `Ctrl+H` or `Ctrl+.` to show hidden items.
3. Compare normal and hidden items in Columns, Icons, and List views.
4. Select a normal item and press `Ctrl+X`.
5. Repeat with a hidden item and with a file that has a thumbnail.
6. Press `Ctrl+C` on another item or complete the paste operation to clear the cut state.

**Expected result:**

Hidden items display their icon or thumbnail and name at 65% opacity. Cut items display the scissors icon at full opacity, including when replacing a thumbnail. Hidden-and-cut items display the scissors and name at 65% opacity. Selection and focus styling remain fully opaque, and clearing the cut state immediately restores the original icon or thumbnail.

## Related issue

Closes #926