### PR TITLE
fix(desktop): reveal hidden files requested through ShowItems

### DIFF
--- a/src/app/browser.rs
+++ b/src/app/browser.rs
@@ -3303,6 +3303,23 @@ impl Browser {
         depth: usize,
         matches: impl Fn(&FileEntry) -> bool,
     ) -> bool {
+        // A caller selecting a specific entry (e.g. FileManager1's ShowItems) means
+        // to reveal it; a hidden match must actually become visible, not just
+        // "selected" in a list the current filter still hides it from.
+        let has_hidden_match = self
+            .state
+            .borrow()
+            .columns
+            .get(depth)
+            .is_some_and(|column| {
+                column
+                    .entries
+                    .iter()
+                    .any(|entry| matches(entry) && entry.is_hidden)
+            });
+        if has_hidden_match && !self.preferences.get().show_hidden {
+            self.toggle_hidden();
+        }
         let state = self.state.borrow();
         let Some(column) = state.columns.get(depth) else {
             return false;

--- a/src/app/browser/tests.rs
+++ b/src/app/browser/tests.rs
@@ -1955,6 +1955,22 @@ fn selecting_entries_by_name_preserves_the_full_matching_selection() {
 }
 
 #[test]
+fn selecting_a_hidden_entry_by_name_shows_it() {
+    let source = ScriptedSource::scripted(vec!["visible.txt", ".secret.txt"], Vec::new());
+    let browser = Browser::new(Rc::new(source));
+    browser.navigate(Location::local("/fixture"));
+    assert!(!browser.preferences().show_hidden);
+
+    browser.select_entries_by_name(&[".secret.txt".to_owned()]);
+
+    assert!(browser.preferences().show_hidden);
+    let selected = browser.selected_positions(0);
+    assert_eq!(selected.len(), 1, "{selected:?}");
+    let entry = browser.entry_at(0, selected[0]).expect("selected entry");
+    assert_eq!(entry.display_name, ".secret.txt");
+}
+
+#[test]
 fn reload_active_preserves_a_multi_selection() {
     let browser = Browser::new(Rc::new(RestoredSortingSource));
     browser.navigate(Location::local("/fixture"));


### PR DESCRIPTION
## Description

Revealing a specific entry by name or location (`select_entries_by_name_at` / `select_entries_by_location_at`) finds the matching entry's position in the column's raw entry list and applies it through the UI's raw-position-to-view-position translation (`ColumnView`'s `ViewMap`). A hidden entry has no view position while hidden files are off -- the filtered view simply doesn't contain it -- so the translation silently drops it and nothing gets selected. `ShowItems` on a hidden file therefore opened its parent directory but left the selection empty, contrary to the README's promise that named items are selected.

`select_entries_matching_at` now checks whether any matching entry is hidden and, if hidden files are currently off, turns them on first (via the same path the Toggle Hidden action uses) before resolving positions -- so the row actually exists in the view by the time selection is applied.

This is shared by `ShowItems` and the CLI file-argument reveal path (`open_argument.rs`), which route through the same selection helper, so both get the fix.

## Visual evidence

N/A -- this is desktop-integration/selection logic with no visual design change (the visible effect is hidden files becoming shown, which is the existing Toggle Hidden behavior, not new UI).

## How to test

1. With Hidden files off (default), in a directory with a dotfile and a visible file, call `org.freedesktop.FileManager1.ShowItems` on the dotfile's URI (e.g. via `gdbus call --session --dest org.freedesktop.FileManager1 --object-path /org/freedesktop/FileManager1 --method org.freedesktop.FileManager1.ShowItems "['file:///path/to/.secret.txt']" ""`).
2. Before this fix, the parent opens but nothing is selected and the dotfile stays hidden. After, hidden files turn on and the dotfile is selected.

Added `selecting_a_hidden_entry_by_name_shows_it`, confirmed it fails against the pre-fix code and passes after.

## Related issue

Closes #858
