### PR TITLE
fix(preview): skip VAAPI encode for cover-art audio

### DIFF
--- a/docs/preview-sandbox.md
+++ b/docs/preview-sandbox.md
@@ -34,9 +34,10 @@ packet crosses into an unsandboxed media parser.
 
 A media worker uses separate FFmpeg video and audio processes when both tracks
 exist. Each decodes only its selected track. This avoids cross-output pipe
-deadlocks with sparse/VFR video or attached cover art. Both processes remain in
-one sandbox, with access to the same single input. Cover art is decoded once in
-software and retained alongside audio; audio-only inputs need no video decoder.
+deadlocks with sparse/VFR video. Both processes remain in one sandbox, with
+access to the same single input. Attached pictures and cover art do not count as
+preview video; those files follow the audio-only path. Audio-only inputs need no
+video decoder.
 Video timing is normalized **inside the sandbox** to 30 fps, including holding
 VFR/GIF frames. Audio is 48 kHz, stereo, interleaved signed 16-bit little-endian
 PCM. Resampling preserves gaps/offsets relative to the common source timeline.

--- a/src/sandbox_helper/media.rs
+++ b/src/sandbox_helper/media.rs
@@ -123,12 +123,7 @@ fn metadata(bytes: &[u8], size: MediaPreviewSize, start_tick: u32) -> io::Result
         |stream: &serde_json::Value| stream["disposition"]["attached_pic"].as_u64() == Some(1);
     let video = streams
         .iter()
-        .find(|stream| stream["codec_type"] == "video" && !is_cover(stream))
-        .or_else(|| {
-            streams
-                .iter()
-                .find(|stream| stream["codec_type"] == "video")
-        });
+        .find(|stream| stream["codec_type"] == "video" && !is_cover(stream));
     let audio = streams
         .iter()
         .find(|stream| stream["codec_type"] == "audio");

--- a/src/sandbox_helper/media/tests.rs
+++ b/src/sandbox_helper/media/tests.rs
@@ -12,6 +12,73 @@ fn success(command: &mut Command) -> Vec<u8> {
     output.stdout
 }
 
+fn still_image(path: &Path, codec: &str) {
+    success(
+        Command::new("ffmpeg")
+            .args([
+                "-nostdin",
+                "-v",
+                "error",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=blue:size=64x48",
+                "-frames:v",
+                "1",
+                "-threads",
+                "1",
+                "-c:v",
+            ])
+            .arg(codec)
+            .arg(path),
+    );
+}
+
+fn attach_cover(audio: &Path, cover: &Path, output: &Path, encode: &[&str]) {
+    let mut command = Command::new("ffmpeg");
+    command
+        .args(["-v", "error", "-i"])
+        .arg(audio)
+        .arg("-i")
+        .arg(cover)
+        .args(["-map", "0:a", "-map", "1:v"])
+        .args(encode)
+        .args(["-disposition:v", "attached_pic"])
+        .arg(output);
+    success(&mut command);
+}
+
+fn probe_stream_indexes(path: &Path, specifier: &str) -> String {
+    String::from_utf8(success(
+        Command::new("ffprobe")
+            .args([
+                "-v",
+                "error",
+                "-select_streams",
+                specifier,
+                "-show_entries",
+                "stream=index",
+                "-of",
+                "csv=p=0",
+            ])
+            .arg(path),
+    ))
+    .expect("ffprobe stream indexes")
+    .trim()
+    .to_owned()
+}
+
+fn assert_probe_lists_cover_only(path: &Path) {
+    assert!(
+        !probe_stream_indexes(path, "v").is_empty(),
+        "{path:?} should list an attached picture under v"
+    );
+    assert!(
+        probe_stream_indexes(path, "V").is_empty(),
+        "{path:?} should list no motion video under V"
+    );
+}
+
 fn fixture(path: &Path, size: &str, rate: u32, duration: u32, audio: bool) {
     let mut command = Command::new("ffmpeg");
     command
@@ -152,51 +219,107 @@ fn audio_only_and_attached_cover_art_do_not_require_a_hardware_video_decoder() {
         assert!(h.audio);
         assert_eq!(h.width, 0);
     }
-    let cover = directory.path().join("cover.jpg");
+    let png = directory.path().join("cover.png");
+    still_image(&png, "png");
+    let jpeg = directory.path().join("cover.jpg");
+    still_image(&jpeg, "mjpeg");
+    let flac = directory.path().join("cover.flac");
+    attach_cover(&audio, &png, &flac, &["-c", "copy"]);
+    let jpeg_flac = directory.path().join("cover-jpeg.flac");
+    attach_cover(&audio, &jpeg, &jpeg_flac, &["-c", "copy"]);
+    let m4a = directory.path().join("cover.m4a");
+    attach_cover(&audio, &png, &m4a, &["-c:a", "aac", "-c:v", "png"]);
+    for attached in [&flac, &jpeg_flac, &m4a] {
+        assert_probe_lists_cover_only(attached);
+        let info = probe(attached, MediaPreviewSize::new(520, 800), 0).expect("cover metadata");
+        assert!(info.video.is_none());
+        assert!(!info.cover);
+        assert_eq!(info.audio, Some(0));
+        for policy in [
+            MediaPreviewBackend::Automatic,
+            MediaPreviewBackend::VaApi,
+            MediaPreviewBackend::Vulkan,
+            MediaPreviewBackend::Software,
+        ] {
+            let mut bytes = Vec::new();
+            stream(attached, "520x800", policy, 0, &mut bytes).expect("cover-art audio");
+            let header = Header::read(&mut Cursor::new(bytes), MediaPreviewSize::new(520, 800), 0)
+                .expect("cover-art header");
+            assert!(header.audio);
+            assert_eq!((header.width, header.height), (0, 0));
+        }
+        let audio_command = command_for_audio(&info);
+        assert!(audio_command.contains("-map 0:0"));
+        assert!(audio_command.contains("-vn"));
+        assert!(!audio_command.contains("-hwaccel"));
+        assert!(!audio_command.contains("0:v"));
+        assert!(!audio_command.contains("h264_vaapi"));
+    }
+}
+
+#[test]
+fn movie_with_attached_cover_keeps_the_motion_video_stream() {
+    let directory = tempfile::tempdir().expect("fixtures");
+    let clip = directory.path().join("clip.mkv");
+    fixture(&clip, "64x48", 1, 1, true);
+    let png = directory.path().join("cover.png");
+    still_image(&png, "png");
+    let movie = directory.path().join("movie.mp4");
     success(
         Command::new("ffmpeg")
-            .args([
-                "-nostdin",
-                "-v",
-                "error",
-                "-f",
-                "lavfi",
-                "-i",
-                "color=c=blue:size=64x48",
-                "-frames:v",
-                "1",
-                "-threads",
-                "1",
-            ])
-            .arg(&cover),
-    );
-    let attached = directory.path().join("cover.flac");
-    success(
-        Command::new("ffmpeg")
-            .arg("-v")
-            .arg("error")
+            .args(["-v", "error", "-i"])
+            .arg(&clip)
             .arg("-i")
-            .arg(&audio)
-            .arg("-i")
-            .arg(&cover)
+            .arg(&png)
             .args([
+                "-map",
+                "0:v",
                 "-map",
                 "0:a",
                 "-map",
                 "1:v",
-                "-c",
-                "copy",
-                "-disposition:v",
+                "-c:v:0",
+                "libx264",
+                "-threads",
+                "1",
+                "-c:a",
+                "aac",
+                "-c:v:1",
+                "png",
+                "-disposition:v:1",
                 "attached_pic",
             ])
-            .arg(&attached),
+            .arg(&movie),
     );
-    let info = probe(&attached, MediaPreviewSize::new(520, 800), 0).expect("cover metadata");
-    assert!(info.cover);
-    let (header, frames, _) = decoded(&attached, "520x800", 0);
+    let listed_v = probe_stream_indexes(&movie, "v");
+    let listed_V = probe_stream_indexes(&movie, "V");
+    assert!(
+        listed_v.contains('0') && listed_v.contains('2'),
+        "{listed_v}"
+    );
+    assert_eq!(listed_V, "0");
+    let info = probe(&movie, MediaPreviewSize::new(520, 800), 0).expect("movie metadata");
+    assert_eq!(info.video, Some(0));
+    assert_eq!(info.audio, Some(1));
+    assert!(!info.cover);
+    let video = command(Path::new("/input"), &info, &Backend::Software, Track::Video);
+    let args = video
+        .get_args()
+        .map(|arg| arg.to_string_lossy())
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(args.contains("-map 0:0"));
+    assert!(!args.contains("-map 0:2"));
+    assert!(!args.contains("0:v:0"));
+    let (header, frames, _) = decoded(&movie, "520x800", 0);
     assert!(header.audio);
     assert_eq!((header.width, header.height), (64, 48));
-    assert_eq!(frames.len(), 30);
+    assert!(!frames.is_empty());
+    assert!(
+        frames
+            .iter()
+            .any(|frame| !frame.pixels.iter().all(|byte| *byte == 0))
+    );
 }
 
 #[test]
@@ -446,4 +569,27 @@ fn metadata_and_size_parsing_fail_closed_on_bad_sources_and_protocol_values() {
     assert_eq!(unknown.header.start_tick, 960);
     assert_eq!(unknown.header.duration_us, media::MAX_DURATION_US);
     assert!(probe(Path::new("/nonexistent-strata-media"), size, 0).is_err());
+    let cover_only = metadata(
+        br#"{"streams":[{"index":0,"codec_type":"audio"},{"index":1,"codec_type":"video","width":64,"height":48,"disposition":{"attached_pic":1}}],"format":{"duration":"1.0"}}"#,
+        size,
+        0,
+    )
+    .expect("attached pictures are not preview video");
+    assert!(cover_only.video.is_none());
+    assert!(!cover_only.cover);
+    assert_eq!(cover_only.audio, Some(0));
+    assert_eq!((cover_only.header.width, cover_only.header.height), (0, 0));
+    let movie_and_cover = metadata(
+        br#"{"streams":[{"index":0,"codec_type":"video","width":64,"height":48},{"index":1,"codec_type":"audio"},{"index":2,"codec_type":"video","width":32,"height":32,"disposition":{"attached_pic":1}}],"format":{"duration":"1.0"}}"#,
+        size,
+        0,
+    )
+    .expect("motion video keeps the video pipeline");
+    assert_eq!(movie_and_cover.video, Some(0));
+    assert_eq!(movie_and_cover.audio, Some(1));
+    assert!(!movie_and_cover.cover);
+    assert_eq!(
+        (movie_and_cover.header.width, movie_and_cover.header.height),
+        (64, 48)
+    );
 }

--- a/src/sandbox_helper/media/tests.rs
+++ b/src/sandbox_helper/media/tests.rs
@@ -291,13 +291,13 @@ fn movie_with_attached_cover_keeps_the_motion_video_stream() {
             ])
             .arg(&movie),
     );
-    let listed_v = probe_stream_indexes(&movie, "v");
-    let listed_V = probe_stream_indexes(&movie, "V");
+    let all_video = probe_stream_indexes(&movie, "v");
+    let motion_video = probe_stream_indexes(&movie, "V");
     assert!(
-        listed_v.contains('0') && listed_v.contains('2'),
-        "{listed_v}"
+        all_video.contains('0') && all_video.contains('2'),
+        "{all_video}"
     );
-    assert_eq!(listed_V, "0");
+    assert_eq!(motion_video, "0");
     let info = probe(&movie, MediaPreviewSize::new(520, 800), 0).expect("movie metadata");
     assert_eq!(info.video, Some(0));
     assert_eq!(info.audio, Some(1));

--- a/working-docs/773/code-notes.md
+++ b/working-docs/773/code-notes.md
@@ -1,0 +1,51 @@
+# Round 1 code notes: #773 cover-art audio vs hardware preview
+
+## What changed
+
+Latest `main` no longer has the plan’s encode path (`input_has_video`, `-select_streams v`, `-map 0:v:0`, `h264_vaapi`, Opus WebM). `preview-media` streams raw decoded frames (`src/sandbox_helper/media.rs`, #839). Cover-art FLAC/M4A still became a video track because probe metadata fell back to the first `attached_pic` stream.
+
+The equivalent of “probe/map with `V` and take the audio-only path”:
+
+- Select preview video only from streams that are not `attached_pic` (no fallback to the still).
+- Cover-art-only files now have `video: None` and follow the existing audio-only decoder (PCM, width 0, software only, no VAAPI/Vulkan).
+- Movie + cover still maps the motion stream by probed index (`-map 0:{movie}`), not the still.
+
+`media_backends`, VAAPI/Vulkan flags, timeouts, sandbox `prlimit` (`--core=0` on the current decode helper), and preferences are unchanged.
+
+## Files
+
+- `src/sandbox_helper/media.rs` — drop attached-pic fallback in `metadata`
+- `src/sandbox_helper/media/tests.rs` — FLAC/M4A/JPEG cover fixtures; movie+cover MP4; JSON probe cases
+- `docs/preview-sandbox.md` — attached pictures are not preview video
+
+## Tests run
+
+Private Xvfb; never `DISPLAY=:1`. Host needed GStreamer `-dev` packages and `CXX=g++` / gcc `libstdc++` `RUSTFLAGS` for `unrar_sys` on this Cloud image.
+
+```text
+cargo fmt --all --check
+cargo clippy --all-targets --all-features -- -D warnings
+xvfb-run -a env -u WAYLAND_DISPLAY GDK_BACKEND=x11 \
+  GTK_A11Y=none NO_AT_BRIDGE=1 STRATA_REQUIRE_GTK_TESTS=1 \
+  cargo test --all-targets --all-features sandbox_helper
+```
+
+- fmt: pass
+- clippy `-D warnings`: pass
+- `sandbox_helper`: **19 passed**, 0 failed, 0 ignored (1576 filtered out)
+
+Includes 773-01–773-06 coverage via:
+
+- `audio_only_and_attached_cover_art_do_not_require_a_hardware_video_decoder`
+- `movie_with_attached_cover_keeps_the_motion_video_stream`
+- `metadata_and_size_parsing_fail_closed_on_bad_sources_and_protocol_values`
+- existing audio-only, video, and hardware-order tests in the same filter
+
+Omitted: full `./scripts/quality.sh test` and `./scripts/e2e.sh` (bounded helper/probe; no GPU device or `prlimit` policy change). `cargo-deny` / `typos` are not installed here; not treated as a CI pass.
+
+## Remaining gaps
+
+- Intel `h264_vaapi` SIGSEGV cannot be reproduced on Cloud/CI (no `/dev/dri` encode). Manual: `test-cases.md` 773-08. Do not collect cores.
+- The retired encode cmdline from 0.14.0 is already gone on this branch; this round prevents the still from being treated as preview video on the current decoder.
+- Inconclusive probe still fails closed (`probe` error), not “assume video”. Missing files already fail.
+- Matroska attachment covers are still out of scope.

--- a/working-docs/773/plan.md
+++ b/working-docs/773/plan.md
@@ -1,0 +1,122 @@
+# Plan: skip VAAPI encode for cover-art audio previews
+
+Issue: [#773](https://github.com/lgse/strata/issues/773)
+Labels: `bug`, `P2` (unchanged)
+Assignee: `wmfeht`. No linked PR. One comment: Cloud Agent **partial repro** (cover-art becomes `-map 0:v:0`; Intel `h264_vaapi` SIGSEGV not reachable without `/dev/dri`).
+
+Do not request or attach a core dump. Cores can contain secrets or private document bytes.
+
+## Goal
+
+Quick-previewing a FLAC/M4A (and similar) file whose only video stream is embedded cover art must not spawn `h264_vaapi`. Use the existing audio-only preview path from [#817](https://github.com/lgse/strata/pull/817): Opus WebM, no hardware encoder, no `Process crashed: ffmpeg`, no core. Real motion video keeps the current hardware → software fallback.
+
+## Research
+
+### Reported failure
+
+- Strata 0.14.0 release tarball, Omarchy/Hyprland, Intel UHD 770 (`renderD129`) + NVIDIA, FFmpeg **9.0.1** / `libavcodec.so.63`.
+- Selecting cover-art audio with `video_preview_backend = "automatic"` or `"vaapi"` runs the sandboxed helper; **ffmpeg SIGSEGV** in `ff_hw_base_encode_receive_packet` (`h264_vaapi`). Strata stays up. Each attempt dumps a core and a desktop “Process crashed: ffmpeg” notice.
+- Command line in the core matches `media_command(VaApi)` in `src/sandbox_helper.rs`: `-hwaccel vaapi -hwaccel_device /dev/dri/renderD129 -map 0:v:0 -map 0:a:0? … -c:v h264_vaapi … pipe:1`.
+- Fault is a NULL deref in FFmpeg’s hardware-encode timestamp bookkeeping (`si_addr = 0x28`), not a GPU hang (#127) and not `SIGXFSZ` (#128). Turning off hardware acceleration is a working workaround.
+- Reporter’s expected product behavior: treat a crashing encoder as a backend failure, fall back to software, and stop dumping a core per attempt. The **smallest** way to get that outcome for this input is to never send a still attached picture into VAAPI.
+
+### Why cover-art audio takes the video path
+
+[#817](https://github.com/lgse/strata/pull/817) added `input_has_video` / an audio-only cmdline (`-map 0:a:0? -vn`, SoftwareVp8 only). The probe is:
+
+```text
+ffprobe -select_streams v -show_entries stream=index -of csv=p=0
+```
+
+FFmpeg stream specifiers: `v` matches **all** video streams, including attached pictures / cover art; `V` matches video that is **not** an attached picture, thumbnail, or cover. Cover-art FLAC/M4A therefore look like video, `render_media_preview` builds VAAPI/Vulkan/software-H264 backends, and `-map 0:v:0` encodes the still.
+
+Verified on this Cloud VM’s FFmpeg **6.1.1** with muxed fixtures (no GPU required):
+
+| File | `select_streams v` | `select_streams V` |
+| --- | --- | --- |
+| sine + PNG `attached_pic` FLAC | stream `1` (png) | empty |
+| sine + PNG `attached_pic` M4A | stream `1` (png) | empty |
+| H.264 movie + PNG cover MP4 | `0` and `2` | `0` only |
+
+`-map 0:v:0` on cover-art FLAC succeeds (maps the still). `-map 0:V:0` fails with “matches no streams” — so the probe change and the map change must stay paired.
+
+### Fallback today (do not rely on it for this bug)
+
+`run_media_backends` already skips a backend whose ffmpeg child is non-success or empty stdout and continues to software. Media helpers **do not** use `prlimit` (no `RLIMIT_CORE=0`); that was removed so Vulkan would not die with `SIGXFSZ` (#128 / `media_previews_use_bounded_streaming_instead_of_driver_wide_resource_limits`). ffmpeg stderr is discarded. On a machine where `h264_vaapi` actually SIGSEGVs:
+
+- systemd/kernel can still write a core and show “Process crashed: ffmpeg”;
+- software fallback is **untested** on Intel VAAPI (Cloud/CI never enter that encoder).
+
+Avoiding the encoder for attached-pic-only inputs removes the crash instead of racing it.
+
+### Hardware vs CI
+
+| Environment | VAAPI / `/dev/dri` | FFmpeg | What we can prove |
+| --- | --- | --- | --- |
+| Reporter (Intel i915 `renderD129`) | yes | 9.0.1 | Real SIGSEGV; owner/manual QA only |
+| Cursor Cloud Agent / this VM | **no** (`ffmpeg -init_hw_device vaapi` fails) | 6.1.1 | Probe + software transcode only |
+| Canonical `./scripts/e2e.sh` image | software raster, no Intel encode | pinned 1.98.1 + distro ffmpeg | Same; **do not** add an E2E that claims to hit `h264_vaapi` |
+| GitHub Actions | no GPU | CI ffmpeg | Same as targeted Rust tests |
+
+Cloud GUI note (issue comment): sandboxed ffmpeg on Ubuntu can fail on `libblas.so.3` because bwrap does not bind `/etc/alternatives`. That is a **distinct** Cloud/Ubuntu gap, not this bug, and not this fix.
+
+## Approach
+
+Smallest safe fix: **treat attached-picture-only files as audio-only**, same contract as #817.
+
+1. In `input_has_video`, change `-select_streams v` → `-select_streams V`. Successful empty stdout stays audio-only. Inconclusive probe still returns true (keep the existing video fallback comment).
+2. In `media_command`’s video branch, change `-map 0:v:0` → `-map 0:V:0` so a file that has both a movie and a cover encodes the movie, not the still (the same crash trigger if stream 0 is the attached pic).
+3. Leave `media_backends`, VAAPI/Vulkan flags, timeouts, `run_media_backends`, sandbox `prlimit` policy, and preferences unchanged.
+4. Docs: one sentence in `docs/preview-sandbox.md` that cover art / attached pictures do not count as preview video (they follow the audio-only path).
+
+No new preference, no crash blacklist, no `RLIMIT_CORE`, no FFmpeg upgrade, no sandbox bind for `/etc/alternatives`.
+
+## Touch points
+
+- `src/sandbox_helper.rs` — `input_has_video`, video `-map` in `media_command`
+- `src/sandbox_helper/tests.rs` — cmdline assertions (`0:V:0`), probe specifier if asserted
+- `src/sandbox_helper/tests/media.rs` — mux cover-art FLAC/M4A (+ JPEG cover if cheap); `input_has_video` false; `render_media_preview` for Automatic/VaApi/Software → Opus WebM; MP4 movie+cover still has video and maps `0:V:0`
+- `docs/preview-sandbox.md` — attached-pic sentence
+
+Tests stay in the adjacent `src/sandbox_helper/tests*.rs` modules (not inline in production). No new E2E file: `tests/e2e/scenarios/test_quick_preview.py` is text-only and cannot exercise Intel VAAPI.
+
+## Constraints
+
+- GTK 4 baseline unchanged; no UI widgets, icons, or theme tokens.
+- Private Xvfb for any GTK tests; never `DISPLAY=:1`. This change is helper/cmdline, so targeted `cargo test` filters on `sandbox_helper` are enough.
+- Do not restore media `prlimit --fsize/--as` (reopens #128).
+- Do not ask anyone for a core dump.
+
+## Risks
+
+- If probe is **inconclusive** on a cover-art-only file, we still take the video path; `-map 0:V:0` then fails every backend and the preview is unavailable. Cover-art FLAC/M4A probe **successfully** with empty `V` on FFmpeg 6.1.1; missing files already fail. Do not weaken the inconclusive→video invariant.
+- Genuine one-frame **motion** video (not `attached_pic`) can still hit the upstream encoder NULL deref. Out of scope; do not special-case `nb_frames=1`.
+- Matroska often stores covers as attachments, not `attached_pic` video; FLAC/M4A/MP4 are the reported and verified muxers. Do not chase MKV attachment mapping here.
+- Software encode of a still attached pic **works** today. After this fix we **stop** showing that still as a 30s video and play audio-only instead. That matches #817 and is the desired preview for an audio file.
+
+## Non-goals
+
+- Patching FFmpeg / shipping a private libavcodec.
+- `RLIMIT_CORE=0`, crash-count backend pinning, or skipping VAAPI after N SIGSEGVs.
+- Hardware fallback proof on CI/Cloud (impossible without Intel VAAPI + FFmpeg 9).
+- Ubuntu bwrap `/etc/alternatives` / `libblas.so.3`.
+- Changing `video_preview_backend` defaults, Polaris software default, or Settings copy.
+- Thumbnail (`ffmpegthumbnailer`) path.
+
+## Recommended verification (code stage)
+
+Bounded change: probe specifier + map specifier + fixtures. Not full `./scripts/quality.sh` / full `./scripts/e2e.sh` unless the edit grows into sandbox `prlimit` or GPU device policy.
+
+- Targeted: `./scripts/test-headless.py sandbox_helper` (or Cloud equivalent `xvfb-run -a env -u WAYLAND_DISPLAY GDK_BACKEND=x11 GTK_A11Y=none NO_AT_BRIDGE=1 STRATA_REQUIRE_GTK_TESTS=1 cargo test --all-targets --all-features sandbox_helper`). Confirm a **nonzero** test count including the new cover-art cases.
+- Pre-push (later): `cargo fmt --all --check` and `cargo clippy --all-targets --all-features -- -D warnings`.
+- Manual (Intel VAAPI host only): cases in `test-cases.md` 773-08. Do not collect cores.
+
+## Status (from working-docs/773/status.md)
+
+- stage: `plan complete; ready for code`
+- staging_pr: none
+- recommended_branch: `fix/773-cover-art-vaapi-sigsegv`
+- head_sha: n/a
+- agent_id: `bc-f270fc50-b7c9-51b5-8feb-079578e82bc0`
+
+Coordinator next: draft staging PR on `fix/773-cover-art-vaapi-sigsegv` from latest `lgse/strata` `main`, then `strata-code`. Do not implement in this step. P2 unchanged.

--- a/working-docs/773/qa.md
+++ b/working-docs/773/qa.md
@@ -1,0 +1,60 @@
+# Round 1 QA: #773 skip cover art as preview video
+
+- **verdict:** `pass-with-nits`
+- **staging_pr:** https://github.com/lgse/strata/pull/934 (draft, left draft)
+- **head_sha tested:** `3add247fb756ba8301628e76234bcc599c4dc91d` (PR tip at QA start)
+- **product code:** `fe16981ba1de0ba2f62af96235fa61640618fb27`
+- **n:** 773 (`working-docs/773/`)
+- **agent_id:** `bc-a02ab8a5-c849-5485-aeaa-9cc5b551789c`
+
+Functional/exploratory of the draft staging PR. Not a second code review.
+
+## Product non-nits
+
+None. Every planned case this environment can run passed.
+
+## Nits / process
+
+Same class as round 1 review (not product breaks):
+
+- `working-docs/773/test-cases.md` still names `input_has_video`, Opus WebM, and `-map 0:V:0`. On this tree the helper probes JSON, streams raw PCM / `rawvideo`, and maps `-map 0:{index}`. Cases were exercised against that contract.
+- Cover-art cmdline assertions inspect the audio argv (`h264_vaapi` was never on that argv). `stream()` width 0 under Automatic/VaApi/Vulkan is the useful check; those policies succeeded here without `/dev/dri`.
+- `Input.cover` remains unreachable leftover. Harmless.
+
+## Coverage
+
+| Case | Result |
+| --- | --- |
+| 773-01 cover-art FLAC is not preview video | pass (`audio_only_and_attached_cover_art…`; independent ffprobe `v` = png attached_pic, `V` empty; `probe` `video.is_none()`, width 0) |
+| 773-02 cover-art M4A and JPEG cover | pass (same test: `cover.m4a`, `cover-jpeg.flac`; independent ffprobe matches) |
+| 773-03 Automatic/VaApi/Vulkan/Software cover-art path | pass (all four policies: audio header, width/height 0, `-map 0:0 -vn`, no `-hwaccel` / `0:v`. Not Opus WebM — current helper is raw PCM) |
+| 773-04 movie+cover keeps motion video | pass (`movie_with_attached_cover…`; ffprobe `v` = 0+2, `V` = 0; map `-map 0:0` not `0:2` / `0:v:0`; decoded 64×48 with frames) |
+| 773-05 audio-only without cover; real video without cover | pass (tone.flac / tone.ogg audio-only; `raw_software_video…`, `clip.mkv`, GIF/VFR tests in the same filter) |
+| 773-06 hardware order / software last | pass (`hardware_order_and_commands_decode_only…`; decode-only argv, software last). Does **not** prove a live `h264_vaapi` SIGSEGV fallback |
+| 773-07 targeted `sandbox_helper` | pass — **19 passed**, 0 failed, 0 ignored, 1576 filtered out, 3.98s |
+| 773-08 Intel VAAPI SIGSEGV | **skipped** — no `/dev/dri`; `ffmpeg -init_hw_device vaapi=va` fails (`Device creation failed: -542398533`). FFmpeg here is 6.1.1, not reporter 9.0.1. Not a product fail |
+
+Adjacent (same private Xvfb, already-built test bin): sandbox GPU/sysfs policy, bounded streaming vs `prlimit`, decoder failure, preview MIME classification, quick-preview offer — **8 passed**. Thumbnail path still `ffmpegthumbnailer` (unchanged; out of scope). Image/PDF helper tests in the `sandbox_helper` filter passed. Preferences / `video_preview_backend` not in the product diff. Two-window UI N/A (helper-level). Missing-path probe still fails closed.
+
+## Gaps
+
+- Intel encode SIGSEGV (773-08) cannot be confirmed here. Owner/manual only. Do not collect cores.
+- Canonical `./scripts/e2e.sh` not run (bounded helper change; `test_quick_preview.py` is text-only).
+- Full `cargo test --all-targets --all-features` and pre-push fmt/clippy not rerun (QA scoped to planned helper cases).
+- Matroska attachment covers and genuine one-frame motion video remain out of scope.
+
+## Commands / results
+
+Private Xvfb (`xvfb-run -a`); never `DISPLAY=:1`. Outer `DISPLAY` unset for the test process.
+
+```bash
+xvfb-run -a env -u WAYLAND_DISPLAY GDK_BACKEND=x11 \
+  GTK_A11Y=none NO_AT_BRIDGE=1 STRATA_REQUIRE_GTK_TESTS=1 \
+  cargo test --all-targets --all-features sandbox_helper -- --nocapture
+```
+
+- `sandbox_helper`: **19 passed**, 0 failed
+- adjacent filter: **8 passed**, 0 failed
+- independent mux+ffprobe of cover FLAC/M4A/JPEG and movie+cover MP4 matches the plan table (`v` includes attached_pic; `V` does not)
+
+Did not implement, undraft, merge, squash, rebase, amend, force-push, file GitHub issues, or run strata-cleanup. William will resign/sign himself.

--- a/working-docs/773/review.md
+++ b/working-docs/773/review.md
@@ -1,0 +1,39 @@
+# Round 1 review: #773 skip cover art as preview video
+
+- **verdict:** `approve-with-comments`
+- **staging_pr:** https://github.com/lgse/strata/pull/934 (draft, left draft)
+- **head_sha reviewed:** `fe16981ba1de0ba2f62af96235fa61640618fb27`
+- **n:** 773 (`working-docs/773/`)
+- **agent_id:** `bc-7e858fdd-59b9-51da-8b89-159837d6c668`
+
+## Blockers
+
+None.
+
+## Nits / suggestions
+
+- `Input.cover` is now unreachable. Video is chosen with `!is_cover`, so `cover: video.is_some_and(is_cover)` is always false, `|| input_info.cover` never fires, and the one-frame still-decode branch in `command()` cannot run for `attached_pic`. Harmless leftover, not a behavior bug.
+- Cover-art tests assert `!info.cover` on files whose only video is cover art. True under the new meaning (“selected preview video is a cover”), but easy to misread. `video.is_none()` plus width 0 is the real contract.
+- `working-docs/773/test-cases.md` still describes `input_has_video`, Opus WebM, and `-map 0:V:0`. The code adapted those cases to `probe` / raw PCM / `-map 0:{index}` correctly; the case file was not retargeted.
+- Cover-art cmdline assertions inspect the audio command (`h264_vaapi` was never on that argv). `stream()` width 0 is the useful check; a `backends(...)` assertion on a cover-only `Input` would make the software-only policy explicit.
+
+## Notes
+
+The plan targeted 0.14.0’s encode helper (`input_has_video`, `-select_streams v`, `-map 0:v:0`, `-c:v h264_vaapi`). That encoder is already gone on current `main` (`preview-media` writes `rawvideo` / PCM; hardware is `-hwaccel vaapi|vulkan` decode only). The reported `ff_hw_base_encode_receive_packet` SIGSEGV cannot run on this tree even without this diff.
+
+On current `main` before this change, a successful `attached_pic` probe already set `cover` and forced `Backend::Software`, so cover-art FLAC/M4A also would not enter VAAPI decode. The remaining bug was product selection: metadata **fell back** to the still as preview video (software-decoded frozen frames). Dropping that fallback is the correct analogue of the plan’s `v` → `V` probe/map pair:
+
+- Cover-only files: `video: None` → audio-only decoder, no video child, no hwaccel.
+- Movie + cover: first non-cover stream by index (`-map 0:0` on the fixture), not the still.
+
+That matches the plan’s intended contract (#817-style audio-only for attached-pic-only files; motion video kept). It does **not** reintroduce or patch `h264_vaapi`. Closing #773 on this branch is still right: the encoder path is already retired, and cover art no longer becomes a video track.
+
+Residual risk (plan already allowed): Intel `h264_vaapi` SIGSEGV is owner/manual (773-08); Cloud/CI have no `/dev/dri` encode. Genuine one-frame motion video and Matroska attachment covers stay out of scope. Inconclusive `ffprobe` fails closed (preview error), which is pre-existing on the decode helper, not a weakening of the old inconclusive→video invariant.
+
+## CI / process
+
+- GitHub format/lint/test and E2E skipped (draft). Metadata policy failed: agent attribution. William will resign/sign; history was not rewritten.
+- `mergeable_state: blocked`. Did not rebase, amend, undraft, merge, or run cleanup.
+- Did not re-run full local CI. Code stage recorded `sandbox_helper` **19 passed** plus fmt/clippy; that scoped set covers the change.
+
+Did not implement a fix.

--- a/working-docs/773/status.md
+++ b/working-docs/773/status.md
@@ -5,16 +5,17 @@
 - staging_branch: fix/773-cover-art-vaapi-sigsegv
 - folder: working-docs/773
 - round: 1
-- stage: round 1 code complete
-- review_verdict: n/a
+- stage: round 1 review complete
+- review_verdict: approve-with-comments
 - qa_verdict: n/a
-- head_sha: 89bf2f5f5cebb0831f97c4e9526d0048d6d0f9b1
-- agent_id: bc-8d884726-7409-5068-b9dc-c8966a552761
+- head_sha: fe16981ba1de0ba2f62af96235fa61640618fb27
+- agent_id: bc-7e858fdd-59b9-51da-8b89-159837d6c668
 - recommended_branch: fix/773-cover-art-vaapi-sigsegv
-- notes: product fix skips attached_pic as preview video on the current raw-decode helper (encode path already removed on main). Draft PR left draft. Do not request core dumps. CI cannot hit Intel h264_vaapi. William will resign/sign himself.
+- notes: Round 1 review is approve-with-comments (nits only). Encoded h264_vaapi path is already gone on main; this diff correctly skips attached_pic as preview video on the raw-decode helper. Draft PR left draft. William will resign/sign himself.
 
 ## History
 
 - plan: complete (bc-f270fc50-b7c9-51b5-8feb-079578e82bc0, 2026-09-13)
 - staging PR: opened as draft #934 (bc-1ef393ed-48b8-56f9-95bc-c0130df6c879, 2026-09-13)
 - round 1 code: complete (bc-8d884726-7409-5068-b9dc-c8966a552761, 2026-09-13)
+- round 1 review: complete, approve-with-comments (bc-7e858fdd-59b9-51da-8b89-159837d6c668, 2026-09-13, reviewed fe16981ba1de0ba2f62af96235fa61640618fb27)

--- a/working-docs/773/status.md
+++ b/working-docs/773/status.md
@@ -1,19 +1,20 @@
 # Pipeline status
 
 - issue: https://github.com/lgse/strata/issues/773
-- staging_pr: none
+- staging_pr: https://github.com/lgse/strata/pull/934 (draft)
 - staging_branch: fix/773-cover-art-vaapi-sigsegv
 - folder: working-docs/773
 - round: 1
 - stage: plan complete; ready for code
 - review_verdict: n/a
 - qa_verdict: n/a
-- head_sha: n/a
+- head_sha: c1230ca054a7d095fe097a7ca6b80f4c488a4525
 - agent_id: bc-1ef393ed-48b8-56f9-95bc-c0130df6c879
 - recommended_branch: fix/773-cover-art-vaapi-sigsegv
-- notes: branch created from latest lgse/strata main; working-docs only; no product-code commit; do not implement in this step; do not request core dumps; CI cannot hit Intel h264_vaapi
+- notes: draft staging PR opened against lgse/strata main from wmfeht:fix/773-cover-art-vaapi-sigsegv; working-docs only; no product-code commit; ready for strata-code. Do not request core dumps. CI cannot hit Intel h264_vaapi.
 
 ## History
 
 - plan: complete (bc-f270fc50-b7c9-51b5-8feb-079578e82bc0, 2026-09-13)
+- staging PR: opened as draft #934 (bc-1ef393ed-48b8-56f9-95bc-c0130df6c879, 2026-09-13)
 - round 1 code: pending

--- a/working-docs/773/status.md
+++ b/working-docs/773/status.md
@@ -5,16 +5,16 @@
 - staging_branch: fix/773-cover-art-vaapi-sigsegv
 - folder: working-docs/773
 - round: 1
-- stage: plan complete; ready for code
+- stage: round 1 code complete
 - review_verdict: n/a
 - qa_verdict: n/a
-- head_sha: c1230ca054a7d095fe097a7ca6b80f4c488a4525
-- agent_id: bc-1ef393ed-48b8-56f9-95bc-c0130df6c879
+- head_sha: 89bf2f5f5cebb0831f97c4e9526d0048d6d0f9b1
+- agent_id: bc-8d884726-7409-5068-b9dc-c8966a552761
 - recommended_branch: fix/773-cover-art-vaapi-sigsegv
-- notes: draft staging PR opened against lgse/strata main from wmfeht:fix/773-cover-art-vaapi-sigsegv; working-docs only; no product-code commit; ready for strata-code. Do not request core dumps. CI cannot hit Intel h264_vaapi.
+- notes: product fix skips attached_pic as preview video on the current raw-decode helper (encode path already removed on main). Draft PR left draft. Do not request core dumps. CI cannot hit Intel h264_vaapi. William will resign/sign himself.
 
 ## History
 
 - plan: complete (bc-f270fc50-b7c9-51b5-8feb-079578e82bc0, 2026-09-13)
 - staging PR: opened as draft #934 (bc-1ef393ed-48b8-56f9-95bc-c0130df6c879, 2026-09-13)
-- round 1 code: pending
+- round 1 code: complete (bc-8d884726-7409-5068-b9dc-c8966a552761, 2026-09-13)

--- a/working-docs/773/status.md
+++ b/working-docs/773/status.md
@@ -5,13 +5,13 @@
 - staging_branch: fix/773-cover-art-vaapi-sigsegv
 - folder: working-docs/773
 - round: 1
-- stage: round 1 review complete
+- stage: round 1 QA complete
 - review_verdict: approve-with-comments
-- qa_verdict: n/a
-- head_sha: fe16981ba1de0ba2f62af96235fa61640618fb27
-- agent_id: bc-7e858fdd-59b9-51da-8b89-159837d6c668
+- qa_verdict: pass-with-nits
+- head_sha: 3add247fb756ba8301628e76234bcc599c4dc91d
+- agent_id: bc-a02ab8a5-c849-5485-aeaa-9cc5b551789c
 - recommended_branch: fix/773-cover-art-vaapi-sigsegv
-- notes: Round 1 review is approve-with-comments (nits only). Encoded h264_vaapi path is already gone on main; this diff correctly skips attached_pic as preview video on the raw-decode helper. Draft PR left draft. William will resign/sign himself.
+- notes: Round 1 QA is pass-with-nits (no product non-nits). Tested PR tip 3add247fb756ba8301628e76234bcc599c4dc91d (product code fe16981ba1de0ba2f62af96235fa61640618fb27). 773-08 Intel/VAAPI SIGSEGV skipped (no /dev/dri; vaapi init fails). Draft PR left draft. William will resign/sign himself.
 
 ## History
 
@@ -19,3 +19,4 @@
 - staging PR: opened as draft #934 (bc-1ef393ed-48b8-56f9-95bc-c0130df6c879, 2026-09-13)
 - round 1 code: complete (bc-8d884726-7409-5068-b9dc-c8966a552761, 2026-09-13)
 - round 1 review: complete, approve-with-comments (bc-7e858fdd-59b9-51da-8b89-159837d6c668, 2026-09-13, reviewed fe16981ba1de0ba2f62af96235fa61640618fb27)
+- round 1 QA: complete, pass-with-nits (bc-a02ab8a5-c849-5485-aeaa-9cc5b551789c, 2026-09-13, tested 3add247fb756ba8301628e76234bcc599c4dc91d)

--- a/working-docs/773/status.md
+++ b/working-docs/773/status.md
@@ -1,0 +1,19 @@
+# Pipeline status
+
+- issue: https://github.com/lgse/strata/issues/773
+- staging_pr: none
+- staging_branch: fix/773-cover-art-vaapi-sigsegv
+- folder: working-docs/773
+- round: 1
+- stage: plan complete; ready for code
+- review_verdict: n/a
+- qa_verdict: n/a
+- head_sha: n/a
+- agent_id: bc-1ef393ed-48b8-56f9-95bc-c0130df6c879
+- recommended_branch: fix/773-cover-art-vaapi-sigsegv
+- notes: branch created from latest lgse/strata main; working-docs only; no product-code commit; do not implement in this step; do not request core dumps; CI cannot hit Intel h264_vaapi
+
+## History
+
+- plan: complete (bc-f270fc50-b7c9-51b5-8feb-079578e82bc0, 2026-09-13)
+- round 1 code: pending

--- a/working-docs/773/test-cases.md
+++ b/working-docs/773/test-cases.md
@@ -1,0 +1,112 @@
+# Test cases: #773 cover-art audio vs VAAPI
+
+Narrow set. Automated cases run on Cloud/CI **without** `/dev/dri`. The Intel SIGSEGV case is owner/manual only. Never request a core dump.
+
+## 773-01 — Probe: cover-art FLAC is not preview video
+
+**Purpose.** Attached pictures must not trip `input_has_video`.
+
+**Setup.** Mux 1s sine + PNG with `-disposition:v attached_pic` into `cover.flac` (same recipe as the issue comment). FFmpeg must be on PATH.
+
+**Steps.**
+
+1. `ffprobe -select_streams v` lists a video stream; `-select_streams V` lists none.
+2. Call `input_has_video(&cover.flac)`.
+
+**Expected.** `input_has_video` is false. Existing sine-only OGG fixture stays false. Missing path stays true (inconclusive probe).
+
+## 773-02 — Probe: cover-art M4A and JPEG cover
+
+**Purpose.** Reporter formats, not only PNG-in-FLAC.
+
+**Setup.** `cover.m4a` (AAC + PNG attached pic) and `cover-jpeg.flac` (audio + MJPEG attached pic).
+
+**Steps.** Same as 773-01 for each file.
+
+**Expected.** `input_has_video` is false for both.
+
+## 773-03 — Helper: Automatic/VaApi/Software normalize cover-art to Opus WebM
+
+**Purpose.** Even with a VAAPI policy, cover-art audio must take the #817 audio-only cmdline (no `-hwaccel`, no `0:v:0`).
+
+**Setup.** Fixtures from 773-01/02. Call `render_media_preview` with `Automatic`, `VaApi`, `Vulkan`, and `Software` at `MediaPreviewSize::new(520, 800)`.
+
+**Steps.**
+
+1. Assert the bytes start with WebM EBML `\x1a\x45\xdf\xa3`.
+2. `ffprobe` the result: one audio stream, `opus`, no video stream.
+3. Assert `media_command(..., has_video=false)` contains `-map 0:a:0? -vn` and does not contain `-hwaccel`, `-c:v`, or `0:v:0`.
+
+**Expected.** All four policies succeed without needing a DRM node. No ffmpeg crash in the test process.
+
+## 773-04 — Cmdline: video maps `0:V:0`
+
+**Purpose.** Motion video must skip attached pictures at map time.
+
+**Setup.** Existing `media_commands_select_the_backend_and_preserve_limits` plus a movie+cover MP4 (H.264 + AAC + PNG `attached_pic`).
+
+**Steps.**
+
+1. Video `media_command` strings contain `-map 0:V:0 -map 0:a:0?` and do **not** contain `-map 0:v:0`.
+2. `input_has_video(&movie.mp4)` is true; `select_streams V` is the movie stream only.
+3. Software `render_media_preview` of that MP4 still has a video stream (not audio-only).
+
+**Expected.** Cover on a real movie does not demote the file to audio-only and does not map the still as `0:v:0`.
+
+## 773-05 — Regression: audio-only without cover, and real video without cover
+
+**Purpose.** #817 and the video pipeline stay intact.
+
+**Setup.** Existing `audio_only_inputs_normalize_to_opus_for_every_backend_policy` and `video_and_unreadable_inputs_keep_the_video_pipeline`.
+
+**Steps.** Re-run those tests; do not rewrite their fixtures.
+
+**Expected.** Unchanged: tone.ogg → Opus; clip.mkv and missing.mkv keep the video pipeline.
+
+## 773-06 — Regression: hardware failure still falls through to software
+
+**Purpose.** Do not break `run_media_backends` while avoiding VAAPI for covers.
+
+**Setup.** Existing `hardware_failures_fall_back_and_first_success_stops` and `forced_backend_failure_goes_directly_to_software`.
+
+**Steps.** Re-run; no GPU.
+
+**Expected.** Unchanged skip/success order. This does **not** prove a live `h264_vaapi` SIGSEGV falls back.
+
+## 773-07 — Targeted automated command (code stage)
+
+**Purpose.** Nonzero, scoped Rust coverage. Cloud: private Xvfb, never `DISPLAY=:1`.
+
+**Setup.** `/workspace` on the staging branch. FFmpeg/ffprobe installed (host image already has 6.1.1).
+
+**Steps.**
+
+```bash
+./scripts/test-headless.py sandbox_helper
+```
+
+Cloud equivalent:
+
+```bash
+xvfb-run -a env -u WAYLAND_DISPLAY GDK_BACKEND=x11 \
+  GTK_A11Y=none NO_AT_BRIDGE=1 STRATA_REQUIRE_GTK_TESTS=1 \
+  cargo test --all-targets --all-features sandbox_helper
+```
+
+Confirm collection includes 773-01–773-06 names (or the existing tests they extend). Count must be nonzero.
+
+**Expected.** All selected tests pass. Do not run full `e2e.sh` for this bounded helper change. Do not treat a local `cargo-deny`/`typos` skip as a CI pass.
+
+## 773-08 — Manual: Intel VAAPI host (not CI)
+
+**Purpose.** Confirm the reported crash is gone on hardware CI cannot see.
+
+**Setup.** Machine like the issue: Intel render node, FFmpeg 9 if available, Strata with hardware video previews **on**, `automatic` (then `vaapi`). Folder with cover-art `.flac` / `.m4a` and a normal `.mp4`. Single-click / Space quick preview. **Do not** upload cores; if a crash still happens, note `coredumpctl list` timestamps only.
+
+**Steps.**
+
+1. Preview cover-art audio: player appears (audio), no “Process crashed: ffmpeg”, no new ffmpeg SIGSEGV.
+2. Preview a normal video: hardware path may still run; playback works or software fallback works without a cover-art-style still-frame crash.
+3. Toggle hardware acceleration **off**: cover-art audio still previews (workaround remains valid).
+
+**Expected.** Step 1 is the acceptance test for #773. CI green without this host is **not** proof the SIGSEGV is fixed.


### PR DESCRIPTION
## Description

Quick-previewing FLAC/M4A whose only video stream is embedded cover art was still selecting that attached picture as the preview video track. Current main streams raw decoded frames rather than the retired `h264_vaapi` encode cmdline, but a cover-only file still spawned a video decoder for the still.

Skip `attached_pic` streams when choosing preview video so cover-art audio takes the existing audio-only path (no video decoder, no VAAPI/Vulkan). Real motion video that also has a cover still maps the movie stream.

## Visual evidence

N/A — helper/probe only; no new chrome. Cover art is skipped as preview video rather than shown as a still.

## How to test

1. Mux or open a FLAC/M4A with an `attached_pic` cover (PNG or JPEG) and hardware video previews on (`automatic` or `vaapi`).
2. Select the file for quick preview.
3. Also preview a normal MP4 that has both a movie stream and a cover.

**Expected result:** Cover-art audio previews as audio-only (no hardware video decoder, no `Process crashed: ffmpeg`). A real movie with a cover still uses the motion video stream. Targeted `sandbox_helper` tests cover probe/software without a GPU; Intel SIGSEGV confirmation is owner/manual only.

## Related issue

Closes #773