### PR TITLE
feat(preview): auto-show multi-selection summary in preview pane

### DIFF
--- a/src/adapters/directory_summary.rs
+++ b/src/adapters/directory_summary.rs
@@ -87,6 +87,61 @@ pub(crate) async fn summarize_directory(root: &gio::File) -> Result<DirectorySum
     summarize_directory_with_progress(root, |_| {}).await
 }
 
+/// Aggregates a mixed file/folder selection: files contribute their known size directly,
+/// directories are measured recursively via the same bounded walker as `summarize_directory`.
+/// `item_count` is the number of selected entries, not a recursive count.
+pub(crate) async fn summarize_selection(
+    entries: &[crate::model::FileEntry],
+    on_progress: impl Fn(DirectorySummary) + 'static,
+) -> Result<DirectorySummary, glib::Error> {
+    use crate::model::MetadataValue;
+
+    let selection_count = entries.len();
+    let mut summary = DirectorySummary {
+        item_count: selection_count,
+        ..Default::default()
+    };
+    let on_progress = Rc::new(on_progress);
+
+    for entry in entries {
+        if let MetadataValue::Known(bytes) = entry.size {
+            summary.total_size = summary.total_size.saturating_add(bytes);
+        }
+
+        if entry.is_directory()
+            && !entry.is_symbolic_link()
+            && let Some(path) = entry.location.native_path()
+        {
+            let file = gio::File::for_path(path);
+            let base_size = summary.total_size;
+            let callback = on_progress.clone();
+            match summarize_directory_with_progress(&file, move |partial| {
+                let report = DirectorySummary {
+                    item_count: selection_count,
+                    total_size: base_size.saturating_add(partial.total_size),
+                    issues: partial.issues,
+                    ..Default::default()
+                };
+                callback(report);
+            })
+            .await
+            {
+                Ok(folder) => {
+                    summary.total_size = summary.total_size.saturating_add(folder.total_size);
+                    summary.issues.unreadable |= folder.issues.unreadable;
+                    summary.issues.timed_out |= folder.issues.timed_out;
+                    summary.issues.depth_limited |= folder.issues.depth_limited;
+                }
+                Err(_) => summary.issues.unreadable = true,
+            }
+        }
+
+        on_progress(summary);
+    }
+
+    Ok(summary)
+}
+
 pub(crate) async fn summarize_directory_with_progress(
     root: &gio::File,
     on_progress: impl Fn(DirectorySummary) + 'static,

--- a/src/adapters/directory_summary/tests.rs
+++ b/src/adapters/directory_summary/tests.rs
@@ -304,3 +304,78 @@ fn directory_summary_does_not_stop_enumerating_siblings_after_one_branch_is_dept
          not just the first next_files_future batch"
     );
 }
+
+fn selection_entry(
+    path: &std::path::Path,
+    name: &str,
+    size: u64,
+    is_dir: bool,
+) -> crate::model::FileEntry {
+    use crate::model::{EntryKind, FileEntry, Location, MetadataValue};
+    FileEntry {
+        location: Location::local(path),
+        thumbnail_path: None,
+        native_name: std::ffi::OsString::from(name),
+        display_name: name.to_owned(),
+        kind: if is_dir {
+            EntryKind::Directory
+        } else {
+            EntryKind::File
+        },
+        size: MetadataValue::Known(size),
+        modified_unix_seconds: MetadataValue::Unknown,
+        mode: MetadataValue::Unknown,
+        is_hidden: false,
+    }
+}
+
+#[test]
+fn summarize_selection_aggregates_files_and_folders() {
+    let root = tempfile::tempdir().expect("fixture");
+    std::fs::write(root.path().join("a.txt"), b"aaa").expect("file a");
+    std::fs::write(root.path().join("b.txt"), b"bb").expect("file b");
+    std::fs::create_dir(root.path().join("folder")).expect("folder");
+    std::fs::write(root.path().join("folder/inner"), b"12345").expect("inner file");
+
+    let entries = vec![
+        selection_entry(&root.path().join("a.txt"), "a.txt", 3, false),
+        selection_entry(&root.path().join("b.txt"), "b.txt", 2, false),
+        selection_entry(&root.path().join("folder"), "folder", 0, true),
+    ];
+
+    let summary = glib::MainContext::new()
+        .block_on(summarize_selection(&entries, |_| {}))
+        .expect("selection summary");
+    assert_eq!(summary.item_count, 3, "item_count is the selection size");
+    assert_eq!(
+        summary.total_size, 10,
+        "total_size = 3 + 2 + 5 (recursive folder)"
+    );
+    assert!(!summary.truncated());
+}
+
+#[test]
+fn summarize_selection_reports_progress_with_running_total() {
+    let root = tempfile::tempdir().expect("fixture");
+    std::fs::write(root.path().join("a.txt"), b"aaa").expect("file a");
+    std::fs::create_dir(root.path().join("folder")).expect("folder");
+    std::fs::write(root.path().join("folder/inner"), b"12345").expect("inner file");
+
+    let entries = vec![
+        selection_entry(&root.path().join("a.txt"), "a.txt", 3, false),
+        selection_entry(&root.path().join("folder"), "folder", 0, true),
+    ];
+
+    let last_total = Rc::new(Cell::new(0u64));
+    let captured = last_total.clone();
+    let summary = glib::MainContext::new()
+        .block_on(summarize_selection(&entries, move |partial| {
+            captured.set(partial.total_size);
+        }))
+        .expect("selection summary");
+    assert_eq!(summary.total_size, 8);
+    assert!(
+        last_total.get() >= 8,
+        "progress callback should have seen the final total"
+    );
+}

--- a/src/ui/preview.rs
+++ b/src/ui/preview.rs
@@ -110,6 +110,8 @@ struct PreviewState {
     enabled_action: gio::SimpleAction,
     animating: Cell<bool>,
     animation_generation: Rc<Cell<u64>>,
+    selection_summary: Cell<bool>,
+    selection_task: RefCell<Option<glib::JoinHandle<()>>>,
 }
 
 pub(super) const PREVIEW_LABEL: &str = "Preview";
@@ -256,6 +258,8 @@ impl PreviewDrawer {
             ),
             animating: Cell::new(false),
             animation_generation: Rc::new(Cell::new(0)),
+            selection_summary: Cell::new(false),
+            selection_task: RefCell::new(None),
         });
         let weak = Rc::downgrade(&state);
         state.enabled_action.connect_activate(move |_, _| {
@@ -350,6 +354,14 @@ impl PreviewDrawer {
             BrowserEvent::PreviewRequested { entry } => {
                 self.show(entry.clone(), browser.active_depth());
             }
+            BrowserEvent::SelectionSetChanged {
+                depth,
+                positions,
+                focused,
+                ..
+            } => {
+                self.handle_selection_changed(browser, *depth, positions, *focused);
+            }
             BrowserEvent::FocusChanged {
                 depth,
                 position: Some(position),
@@ -357,12 +369,7 @@ impl PreviewDrawer {
             | BrowserEvent::SelectionSynced {
                 depth,
                 focused: Some(position),
-            }
-            | BrowserEvent::SelectionSetChanged {
-                depth,
-                focused: position,
-                ..
-            } if self.is_enabled() => {
+            } if self.is_enabled() && !self.state.selection_summary.get() => {
                 if let Some(entry) = browser
                     .entry_at(*depth, *position)
                     .and_then(|entry| preview_target(Some(entry)))
@@ -374,12 +381,13 @@ impl PreviewDrawer {
             }
             BrowserEvent::FocusChanged { position: None, .. }
             | BrowserEvent::SelectionSynced { focused: None, .. }
-                if self.is_enabled() =>
+                if self.is_enabled() && !self.state.selection_summary.get() =>
             {
                 self.clear_target()
             }
             BrowserEvent::EntriesSpliced { depth, splices }
                 if self.is_enabled()
+                    && !self.state.selection_summary.get()
                     && self.state.current_depth.get() == Some(*depth)
                     && splices.iter().any(|splice| splice.removed > 0) =>
             {
@@ -394,6 +402,39 @@ impl PreviewDrawer {
                 }
             }
             _ => {}
+        }
+    }
+
+    fn handle_selection_changed(
+        &self,
+        browser: &Browser,
+        depth: usize,
+        positions: &[usize],
+        focused: usize,
+    ) {
+        if positions.len() >= 2 {
+            let entries: Vec<FileEntry> = positions
+                .iter()
+                .filter_map(|&pos| browser.entry_at(depth, pos))
+                .collect();
+            if !entries.is_empty() {
+                self.state.show_selection_summary(entries, Some(depth));
+                return;
+            }
+        }
+        if self.state.selection_summary.get() {
+            self.state.close();
+            return;
+        }
+        if self.is_enabled() {
+            if let Some(entry) = browser
+                .entry_at(depth, focused)
+                .and_then(|entry| preview_target(Some(entry)))
+            {
+                self.show(entry, Some(depth));
+            } else {
+                self.clear_target();
+            }
         }
     }
 
@@ -502,6 +543,8 @@ impl Drop for PreviewState {
 
 impl PreviewState {
     fn show(self: &Rc<Self>, entry: FileEntry, depth: Option<usize>) {
+        self.cancel_selection_task();
+        self.selection_summary.set(false);
         self.current_depth.set(depth);
         self.set_enabled(true);
         let was_open = self.revealer.reveals_child() || self.sizing.is_suspended();

--- a/src/ui/preview/layout.rs
+++ b/src/ui/preview/layout.rs
@@ -296,7 +296,7 @@ impl PreviewState {
     }
 
     pub(super) fn sync_split(self: &Rc<Self>, split: &gtk::Paned) {
-        if self.current.borrow().is_none() {
+        if self.current.borrow().is_none() && !self.selection_summary.get() {
             if !self.reserves_empty_preview() {
                 if self.revealer.reveals_child() {
                     self.hide_panel();

--- a/src/ui/preview/session.rs
+++ b/src/ui/preview/session.rs
@@ -45,7 +45,93 @@ impl PreviewState {
         }
     }
 
+    pub(super) fn cancel_selection_task(&self) {
+        if let Some(task) = self.selection_task.borrow_mut().take() {
+            task.abort();
+        }
+    }
+
+    pub(super) fn show_selection_summary(
+        self: &Rc<Self>,
+        entries: Vec<FileEntry>,
+        depth: Option<usize>,
+    ) {
+        self.cancel_selection_task();
+        self.selection_summary.set(true);
+        self.current_depth.set(depth);
+        self.set_enabled(true);
+
+        self.current_request.set(None);
+        self.load.borrow_mut().take();
+        self.cancel_loading();
+        self.pdf_loads.borrow_mut().clear();
+        self.clear_content();
+        self.current.borrow_mut().take();
+
+        let count = entries.len();
+        self.title.set_text(&format!("{count} items selected"));
+        self.title.set_tooltip_text(None);
+        self.icon.set_visible(false);
+        self.open.set_sensitive(false);
+        self.open.set_visible(false);
+        self.print.set_visible(false);
+        self.wrap.set_visible(false);
+        self.header_handle.set_cursor_from_name(None);
+
+        self.metadata.set_visible(true);
+        self.size.set_text("Calculating…");
+        self.size.set_tooltip_text(None);
+        self.modified.set_text("—");
+        self.content_type.set_text("—");
+
+        let was_open = self.revealer.reveals_child() || self.sizing.is_suspended();
+        let split = self.split.borrow().clone();
+        if let Some(split) = split.as_ref()
+            && (!self.can_show_in(split) || self.sizing.is_suspended())
+        {
+            self.sizing.defer_load();
+        } else if !was_open {
+            self.show_panel();
+            if let Some(split) = split.as_ref() {
+                self.animate_open(split);
+            }
+        }
+
+        let weak = Rc::downgrade(self);
+        let progress_weak = weak.clone();
+        let task = glib::MainContext::default().spawn_local(async move {
+            let summary =
+                crate::adapters::directory_summary::summarize_selection(&entries, move |partial| {
+                    if let Some(state) = progress_weak.upgrade() {
+                        let prefix = if partial.truncated() { "≥ " } else { "" };
+                        state
+                            .size
+                            .set_text(&format!("{prefix}{}", format_file_size(partial.total_size)));
+                    }
+                })
+                .await;
+            let Some(state) = weak.upgrade() else {
+                return;
+            };
+            match summary {
+                Ok(summary) => {
+                    let prefix = if summary.truncated() { "≥ " } else { "" };
+                    state
+                        .size
+                        .set_text(&format!("{prefix}{}", format_file_size(summary.total_size)));
+                    state
+                        .size
+                        .set_tooltip_text(Some(&format!("{} items selected", summary.item_count)));
+                }
+                Err(_) => state.size.set_text("Unavailable"),
+            }
+        });
+        self.selection_task.replace(Some(task));
+    }
+
     pub(super) fn clear_target(&self) {
+        self.cancel_selection_task();
+        self.selection_summary.set(false);
         self.animating.set(false);
         self.sizing.close();
         self.animation_generation

--- a/src/ui/preview/tests.rs
+++ b/src/ui/preview/tests.rs
@@ -265,3 +265,76 @@ fn keyboard_opened_preview_closes_when_the_displayed_entry_is_spliced_out() {
         assert!(!preview.is_open());
     });
 }
+
+fn selection_set_changed(depth: usize, positions: &[usize], focused: usize) -> BrowserEvent {
+    BrowserEvent::SelectionSetChanged {
+        depth,
+        positions: positions.to_vec(),
+        focused,
+        take_focus: false,
+    }
+}
+
+#[test]
+fn multi_selection_auto_opens_the_preview_summary() {
+    const TEST: &str = "ui::preview::tests::multi_selection_auto_opens_the_preview_summary";
+    crate::test_support::gtk_test(TEST, || {
+        let fixture = tempfile::tempdir().expect("fixture");
+        std::fs::write(fixture.path().join("a.txt"), "aaa").expect("file a");
+        std::fs::write(fixture.path().join("b.txt"), "bb").expect("file b");
+        let browser = Browser::new(Rc::new(crate::adapters::LocalFileSource));
+        browser.navigate(Location::local(fixture.path()));
+        crate::ui::media::tests::wait(|| browser.column_snapshot(0).is_some_and(|s| !s.loading));
+        let preview = PreviewDrawer::new(Rc::new(NoopPreviewProvider), false);
+        assert!(!preview.is_open());
+        preview.handle_browser_event(&browser, &selection_set_changed(0, &[0, 1], 0));
+        assert!(preview.is_open());
+        assert!(preview.state.selection_summary.get());
+    });
+}
+
+#[test]
+fn selection_summary_auto_closes_below_two_selected() {
+    const TEST: &str = "ui::preview::tests::selection_summary_auto_closes_below_two_selected";
+    crate::test_support::gtk_test(TEST, || {
+        let fixture = tempfile::tempdir().expect("fixture");
+        std::fs::write(fixture.path().join("a.txt"), "aaa").expect("file a");
+        std::fs::write(fixture.path().join("b.txt"), "bb").expect("file b");
+        let browser = Browser::new(Rc::new(crate::adapters::LocalFileSource));
+        browser.navigate(Location::local(fixture.path()));
+        crate::ui::media::tests::wait(|| browser.column_snapshot(0).is_some_and(|s| !s.loading));
+        let preview = PreviewDrawer::new(Rc::new(NoopPreviewProvider), false);
+        preview.handle_browser_event(&browser, &selection_set_changed(0, &[0, 1], 0));
+        assert!(preview.is_open());
+        preview.handle_browser_event(&browser, &selection_set_changed(0, &[0], 0));
+        assert!(!preview.is_open());
+        assert!(!preview.state.selection_summary.get());
+    });
+}
+
+#[test]
+fn single_item_preview_still_works_alongside_selection_summary() {
+    const TEST: &str =
+        "ui::preview::tests::single_item_preview_still_works_alongside_selection_summary";
+    crate::test_support::gtk_test(TEST, || {
+        let fixture = tempfile::tempdir().expect("fixture");
+        std::fs::write(fixture.path().join("a.txt"), "aaa").expect("file a");
+        std::fs::write(fixture.path().join("b.txt"), "bb").expect("file b");
+        let browser = Browser::new(Rc::new(crate::adapters::LocalFileSource));
+        browser.navigate(Location::local(fixture.path()));
+        crate::ui::media::tests::wait(|| browser.column_snapshot(0).is_some_and(|s| !s.loading));
+        let entry = browser.entry_at(0, 0).expect("loaded entry");
+        let preview = PreviewDrawer::new(Rc::new(NoopPreviewProvider), false);
+
+        preview.handle_browser_event(&browser, &selection_set_changed(0, &[0, 1], 0));
+        assert!(preview.state.selection_summary.get());
+
+        preview.handle_browser_event(&browser, &selection_set_changed(0, &[0], 0));
+        assert!(!preview.is_open());
+        assert!(!preview.state.selection_summary.get());
+
+        preview.toggle(preview_target(Some(entry)), browser.active_depth());
+        assert!(preview.is_open());
+        assert!(!preview.state.selection_summary.get());
+    });
+}


### PR DESCRIPTION
## Summary

- When two or more files/folders are selected, the preview pane auto-opens with an item count and aggregate size summary — no Space required, matching Finder's column-view behavior.
- Files contribute known sizes immediately; selected folders are measured asynchronously via the existing bounded directory summary walker (`summarize_directory_with_progress`), with a `≥` prefix when measurement is truncated (same convention as Properties and Trash dialogs).
- The pane auto-closes when selection drops below two items. Single-item Space preview behavior is preserved unchanged.

## Changes

- **Adapter** (`src/adapters/directory_summary.rs`): new `summarize_selection` aggregates a mixed file/folder selection, reusing the existing bounded recursive walker for directories with progress reporting.
- **Preview pane** (`src/ui/preview.rs`, `session.rs`, `layout.rs`): new `show_selection_summary` mode renders count + size in the existing metadata row; `selection_summary` state flag distinguishes auto-opened summary from explicit single-item preview; in-flight measurement is cancelled on selection change, close, or target clear.
- **Browser event wiring** (`src/ui/preview.rs`): `SelectionSetChanged` now auto-opens the summary at 2+ items and auto-closes below 2, without affecting `FocusChanged`/`SelectionSynced` single-preview paths.

Closes #940

#### Test plan

- [x] `summarize_selection_aggregates_files_and_folders` — mixed files + folder, correct count and recursive size
- [x] `summarize_selection_reports_progress_with_running_total` — progress callback sees running total
- [x] `multi_selection_auto_opens_the_preview_summary` — 2+ selection auto-opens pane
- [x] `selection_summary_auto_closes_below_two_selected` — dropping below 2 auto-closes
- [x] `single_item_preview_still_works_alongside_selection_summary` — Space toggle still works after summary closes
- [x] `keyboard_opened_preview_closes_when_the_displayed_entry_is_spliced_out` — existing single-preview behavior unchanged
- [x] `./scripts/quality.sh fmt` — passes
- [x] `./scripts/quality.sh clippy` — passes